### PR TITLE
add driver for performance tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 # MICM library
 
 set(MICM_SRC constants.F90
-             core.F90
+  #             core.F90
              ODE_solver.F90
              ODE_solver_factory.F90
              ODE_solvers/mozart.F90

--- a/src/ODE_solver.F90
+++ b/src/ODE_solver.F90
@@ -42,8 +42,8 @@ interface
     import ODE_solver_t
     !> ODE solver
     class(ODE_solver_t), intent(inout) :: this
-    !> The solver variables
-    real(musica_dk), intent(inout) :: Y(:)
+    !> The solver variables (grid cell, species)
+    real(musica_dk), intent(inout) :: Y(:,:)
     !> Chemistry simulation start time [s]
     real(musica_dk), optional, intent(in) :: Tstart
     !> Chemistry simulation end time [s]

--- a/src/preprocessor_output/factor_solve_utilities.F90
+++ b/src/preprocessor_output/factor_solve_utilities.F90
@@ -12,7 +12,7 @@ use musica_constants, only: r8 => musica_dk
 
   integer, parameter :: number_sparse_factor_elements = 23
 
-  public :: factor, solve 
+  public :: factor, solve
 
   contains
 
@@ -24,27 +24,27 @@ subroutine backsolve_L_y_eq_b(ncell,LU,b,y)
   real(r8), intent(in) :: b(:,:)
   real(r8), intent(out) :: y(:,:)
 
-  integer : i
+  integer :: i
 
-  do i = 1, ncell 
-     y(i,1) = b(i,1)
-     y(i,2) = b(i,2)
-     y(i,3) = b(i,3)
-     y(i,4) = b(i,4)
-     y(i,5) = b(i,5)
-     y(i,6) = b(i,6)
-     y(i,6) = y(i,6) - LU(i,9) * y(i,5)
-     y(i,7) = b(i,7)
-     y(i,7) = y(i,7) - LU(i,2) * y(i,1)
-     y(i,7) = y(i,7) - LU(i,10) * y(i,5)
-     y(i,7) = y(i,7) - LU(i,12) * y(i,6)
-     y(i,8) = b(i,8)
-     y(i,8) = y(i,8) - LU(i,3) * y(i,1)
-     y(i,8) = y(i,8) - LU(i,14) * y(i,7)
-     y(i,9) = b(i,9)
-     y(i,9) = y(i,9) - LU(i,4) * y(i,1)
-     y(i,9) = y(i,9) - LU(i,15) * y(i,7)
-     y(i,9) = y(i,9) - LU(i,19) * y(i,8)
+  do i = 1, ncell
+    y(i,1) = b(i,1)
+    y(i,2) = b(i,2)
+    y(i,3) = b(i,3)
+    y(i,4) = b(i,4)
+    y(i,5) = b(i,5)
+    y(i,6) = b(i,6)
+    y(i,6) = y(i,6) - LU(i,9) * y(i,5)
+    y(i,7) = b(i,7)
+    y(i,7) = y(i,7) - LU(i,2) * y(i,1)
+    y(i,7) = y(i,7) - LU(i,10) * y(i,5)
+    y(i,7) = y(i,7) - LU(i,12) * y(i,6)
+    y(i,8) = b(i,8)
+    y(i,8) = y(i,8) - LU(i,3) * y(i,1)
+    y(i,8) = y(i,8) - LU(i,14) * y(i,7)
+    y(i,9) = b(i,9)
+    y(i,9) = y(i,9) - LU(i,4) * y(i,1)
+    y(i,9) = y(i,9) - LU(i,15) * y(i,7)
+    y(i,9) = y(i,9) - LU(i,19) * y(i,8)
   end do
 
 end subroutine backsolve_L_y_eq_b
@@ -62,80 +62,86 @@ subroutine backsolve_U_x_eq_y(ncell,LU,y,x)
   integer :: i
 
   do i = 1, ncell
-     temporary = y(i,9)
-     x(i,9) = LU(i,23) * temporary
-     temporary = y(i,8)
-     temporary = temporary - LU(i,22) * x(i,9)
-     x(i,8) = LU(i,18) * temporary
-     temporary = y(i,7)
-     temporary = temporary - LU(i,17) * x(i,8)
-     temporary = temporary - LU(i,21) * x(i,9)
-     x(i,7) = LU(i,13) * temporary
-     temporary = y(i,6)
-     temporary = temporary - LU(i,16) * x(i,8)
-     temporary = temporary - LU(i,20) * x(i,9)
-     x(i,6) = LU(i,11) * temporary
-     temporary = y(i,5)
-     x(i,5) = LU(i,8) * temporary
-     temporary = y(i,4)
-     x(i,4) = LU(i,7) * temporary
-     temporary = y(i,3)
-     x(i,3) = LU(i,6) * temporary
-     temporary = y(i,2)
-     x(i,2) = LU(i,5) * temporary
-     temporary = y(i,1)
-     x(i,1) = LU(i,1) * temporary
+    temporary = y(i,9)
+    x(i,9) = LU(i,23) * temporary
+    temporary = y(i,8)
+    temporary = temporary - LU(i,22) * x(i,9)
+    x(i,8) = LU(i,18) * temporary
+    temporary = y(i,7)
+    temporary = temporary - LU(i,17) * x(i,8)
+    temporary = temporary - LU(i,21) * x(i,9)
+    x(i,7) = LU(i,13) * temporary
+    temporary = y(i,6)
+    temporary = temporary - LU(i,16) * x(i,8)
+    temporary = temporary - LU(i,20) * x(i,9)
+    x(i,6) = LU(i,11) * temporary
+    temporary = y(i,5)
+    x(i,5) = LU(i,8) * temporary
+    temporary = y(i,4)
+    x(i,4) = LU(i,7) * temporary
+    temporary = y(i,3)
+    x(i,3) = LU(i,6) * temporary
+    temporary = y(i,2)
+    x(i,2) = LU(i,5) * temporary
+    temporary = y(i,1)
+    x(i,1) = LU(i,1) * temporary
   end do
 
 end subroutine backsolve_U_x_eq_y
 
+
+
 subroutine factor(ncell,LU)
 
   integer,  intent(in)    :: ncell
-  real(r8), intent(inout) :: LU(:)
+  real(r8), intent(inout) :: LU(:,:)
 
-  integer :: i
+integer :: i
 
-  do i = 1, ncell
-     LU(i,1) = 1./LU(i,1)
-     LU(i,2) = LU(i,2) * LU(i,1)
-     LU(i,3) = LU(i,3) * LU(i,1)
-     LU(i,4) = LU(i,4) * LU(i,1)
-     LU(i,5) = 1./LU(i,5)
-     LU(i,6) = 1./LU(i,6)
-     LU(i,7) = 1./LU(i,7)
-     LU(i,8) = 1./LU(i,8)
-     LU(i,9) = LU(i,9) * LU(i,8)
-     LU(i,10) = LU(i,10) * LU(i,8)
-     LU(i,11) = 1./LU(i,11)
-     LU(i,12) = LU(i,12) * LU(i,11)
-     LU(i,17) = LU(i,17) - LU(i,12)*LU(i,16)
-     LU(i,21) = LU(i,21) - LU(i,12)*LU(i,20)
-     LU(i,13) = 1./LU(i,13)
-     LU(i,14) = LU(i,14) * LU(i,13)
-     LU(i,15) = LU(i,15) * LU(i,13)
-     LU(i,18) = LU(i,18) - LU(i,14)*LU(i,17)
-     LU(i,19) = LU(i,19) - LU(i,15)*LU(i,17)
-     LU(i,22) = LU(i,22) - LU(i,14)*LU(i,21)
-     LU(i,23) = LU(i,23) - LU(i,15)*LU(i,21)
-     LU(i,18) = 1./LU(i,18)
-     LU(i,19) = LU(i,19) * LU(i,18)
-     LU(i,23) = LU(i,23) - LU(i,19)*LU(i,22)
-     LU(i,23) = 1./LU(i,23)
+do i = 1, ncell
+    LU(i,1) = 1./LU(i,1)
+    LU(i,2) = LU(i,2) * LU(i,1)
+    LU(i,3) = LU(i,3) * LU(i,1)
+    LU(i,4) = LU(i,4) * LU(i,1)
+    LU(i,5) = 1./LU(i,5)
+    LU(i,6) = 1./LU(i,6)
+    LU(i,7) = 1./LU(i,7)
+    LU(i,8) = 1./LU(i,8)
+    LU(i,9) = LU(i,9) * LU(i,8)
+    LU(i,10) = LU(i,10) * LU(i,8)
+    LU(i,11) = 1./LU(i,11)
+    LU(i,12) = LU(i,12) * LU(i,11)
+    LU(i,17) = LU(i,17) - LU(i,12)*LU(i,16)
+    LU(i,21) = LU(i,21) - LU(i,12)*LU(i,20)
+    LU(i,13) = 1./LU(i,13)
+    LU(i,14) = LU(i,14) * LU(i,13)
+    LU(i,15) = LU(i,15) * LU(i,13)
+    LU(i,18) = LU(i,18) - LU(i,14)*LU(i,17)
+    LU(i,19) = LU(i,19) - LU(i,15)*LU(i,17)
+    LU(i,22) = LU(i,22) - LU(i,14)*LU(i,21)
+    LU(i,23) = LU(i,23) - LU(i,15)*LU(i,21)
+    LU(i,18) = 1./LU(i,18)
+    LU(i,19) = LU(i,19) * LU(i,18)
+    LU(i,23) = LU(i,23) - LU(i,19)*LU(i,22)
+    LU(i,23) = 1./LU(i,23)
   end do
 
 end subroutine factor
 
-subroutine solve(ncell,LU, x, b) 
 
-  real(r8), intent(in) :: LU(:,:), b(:,:) ! solve LU * x = b 
-  real(r8), intent(out) :: x(:,:) 
-  real(r8) :: y(:,size(b,2)) 
+
+subroutine solve(ncelll,LU,x,b)
+
+  integer,  intent(in) :: ncell
+  real(r8), intent(in) :: LU(:,:), b(:,:) ! solve LU * x = b
+  real(r8), intent(out) :: x(:,:)
+
+  real(r8) :: y(ncell,size(b,2))
 
   call backsolve_L_y_eq_b(ncell, LU, b, y)
   call backsolve_U_x_eq_y(ncell, LU, y, x)
 
-end subroutine solve 
+end subroutine solve
 
 
 end module factor_solve_utilities

--- a/src/preprocessor_output/factor_solve_utilities.F90
+++ b/src/preprocessor_output/factor_solve_utilities.F90
@@ -130,7 +130,7 @@ end subroutine factor
 
 
 
-subroutine solve(ncelll,LU,x,b)
+subroutine solve(ncell,LU,x,b)
 
   integer,  intent(in) :: ncell
   real(r8), intent(in) :: LU(:,:), b(:,:) ! solve LU * x = b

--- a/src/preprocessor_output/kinetics_utilities.F90
+++ b/src/preprocessor_output/kinetics_utilities.F90
@@ -24,93 +24,79 @@ use musica_constants, only: r8 => musica_dk
 
 
 subroutine dforce_dy(ncell, LU, rate_constant, number_density, number_density_air)
-
-  ! Number of grid cells with chemical reactions
-  integer,  intent(in)  :: ncell
-
   ! Compute the derivative of the Forcing w.r.t. each chemical
   ! Also known as the Jacobian
+  integer,  intent(in) :: ncell ! number of grid cells with chemical reactions
   real(r8), intent(out) :: LU(:,:)
   real(r8), intent(in) :: rate_constant(:,:)
   real(r8), intent(in) :: number_density(:,:)
-  real(r8), intent(in) :: number_density_air
+  real(r8), intent(in) :: number_density_air(:)
 
   integer :: i
 
   LU(:,:) = 0
 
   do i = 1, ncell
-  ! df_O/d(M)
+    ! df_O/d(M)
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
     LU(i,2) = LU(i,2) - rate_constant(i,7) * number_density(i,7) * number_density(i,8)
 
-
-  ! df_O2/d(M)
+    ! df_O2/d(M)
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
     LU(i,3) = LU(i,3) - rate_constant(i,7) * number_density(i,7) * number_density(i,8)
 
-
-  ! df_O3/d(M)
+    ! df_O3/d(M)
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
     LU(i,4) = LU(i,4) + rate_constant(i,7) * number_density(i,7) * number_density(i,8)
 
-
-  ! df_O1D/d(N2)
+    ! df_O1D/d(N2)
     !  k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
     LU(i,9) = LU(i,9) - rate_constant(i,4) * number_density(i,6)
 
-
-  ! df_O/d(N2)
+    ! df_O/d(N2)
     !  k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
     LU(i,10) = LU(i,10) + rate_constant(i,4) * number_density(i,6)
 
-
-  ! df_O1D/d(O1D)
+    ! df_O1D/d(O1D)
     !  k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
     LU(i,11) = LU(i,11) - rate_constant(i,4) * number_density(i,5)
 
     !  k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
     LU(i,11) = LU(i,11) - rate_constant(i,5) * number_density(i,8)
 
-
-  ! df_O/d(O1D)
+    ! df_O/d(O1D)
     !  k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
     LU(i,12) = LU(i,12) + rate_constant(i,4) * number_density(i,5)
 
     !  k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
     LU(i,12) = LU(i,12) + rate_constant(i,5) * number_density(i,8)
 
-
-  ! df_O/d(O)
+    ! df_O/d(O)
     !  k_O_O3_1: O + O3 -> 2*O2
     LU(i,13) = LU(i,13) - rate_constant(i,6) * number_density(i,9)
 
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
     LU(i,13) = LU(i,13) - rate_constant(i,7) * number_density(i,1) * number_density(i,8)
 
-
-  ! df_O2/d(O)
+    ! df_O2/d(O)
     !  k_O_O3_1: O + O3 -> 2*O2
     LU(i,14) = LU(i,14) + 2*rate_constant(i,6) * number_density(i,9)
 
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
     LU(i,14) = LU(i,14) - rate_constant(i,7) * number_density(i,1) * number_density(i,8)
 
-
-  ! df_O3/d(O)
+    ! df_O3/d(O)
     !  k_O_O3_1: O + O3 -> 2*O2
     LU(i,15) = LU(i,15) - rate_constant(i,6) * number_density(i,9)
 
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
     LU(i,15) = LU(i,15) + rate_constant(i,7) * number_density(i,1) * number_density(i,8)
 
-
-  ! df_O1D/d(O2)
+    ! df_O1D/d(O2)
     !  k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
     LU(i,16) = LU(i,16) - rate_constant(i,5) * number_density(i,6)
 
-
-  ! df_O/d(O2)
+    ! df_O/d(O2)
     !  k_O2_1: O2 -> 2*O
     LU(i,17) = LU(i,17) + 2*rate_constant(i,1)
 
@@ -120,34 +106,29 @@ subroutine dforce_dy(ncell, LU, rate_constant, number_density, number_density_ai
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
     LU(i,17) = LU(i,17) - rate_constant(i,7) * number_density(i,1) * number_density(i,7)
 
-
-  ! df_O2/d(O2)
+    ! df_O2/d(O2)
     !  k_O2_1: O2 -> 2*O
     LU(i,18) = LU(i,18) - rate_constant(i,1)
 
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
     LU(i,18) = LU(i,18) - rate_constant(i,7) * number_density(i,1) * number_density(i,7)
 
-
-  ! df_O3/d(O2)
+    ! df_O3/d(O2)
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
     LU(i,19) = LU(i,19) + rate_constant(i,7) * number_density(i,1) * number_density(i,7)
 
-
-  ! df_O1D/d(O3)
+    ! df_O1D/d(O3)
     !  k_O3_1: O3 -> 1*O1D + 1*O2
     LU(i,20) = LU(i,20) + rate_constant(i,2)
 
-
-  ! df_O/d(O3)
+    ! df_O/d(O3)
     !  k_O3_2: O3 -> 1*O + 1*O2
     LU(i,21) = LU(i,21) + rate_constant(i,3)
 
     !  k_O_O3_1: O + O3 -> 2*O2
     LU(i,21) = LU(i,21) - rate_constant(i,6) * number_density(i,7)
 
-
-  ! df_O2/d(O3)
+    ! df_O2/d(O3)
     !  k_O3_1: O3 -> 1*O1D + 1*O2
     LU(i,22) = LU(i,22) + rate_constant(i,2)
 
@@ -157,8 +138,7 @@ subroutine dforce_dy(ncell, LU, rate_constant, number_density, number_density_ai
     !  k_O_O3_1: O + O3 -> 2*O2
     LU(i,22) = LU(i,22) + 2*rate_constant(i,6) * number_density(i,7)
 
-
-  ! df_O3/d(O3)
+    ! df_O3/d(O3)
     !  k_O3_1: O3 -> 1*O1D + 1*O2
     LU(i,23) = LU(i,23) - rate_constant(i,2)
 
@@ -173,11 +153,9 @@ subroutine dforce_dy(ncell, LU, rate_constant, number_density, number_density_ai
 end subroutine dforce_dy
 
 subroutine factored_alpha_minus_jac(ncell, LU, alpha, dforce_dy)
-  !compute LU decomposition of [alpha * I - dforce_dy]
+  ! Compute LU decomposition of [alpha * I - dforce_dy]
 
-  ! Number of grid cells with chemical reactions
-  integer,  intent(in) :: ncell
-
+  integer,  intent(in) :: ncell ! number of grid cells with chemical reactions
   real(r8), intent(in) :: dforce_dy(:,:)
   real(r8), intent(in) :: alpha
   real(r8), intent(out) :: LU(:,:)
@@ -186,127 +164,116 @@ subroutine factored_alpha_minus_jac(ncell, LU, alpha, dforce_dy)
 
   LU(:,:) = -dforce_dy(:,:)
 
-! add alpha to diagonal elements
-
+  ! add alpha to diagonal elements
   do i = 1, ncell
-     LU(i,1) = -dforce_dy(i,1) + alpha 
-     LU(i,5) = -dforce_dy(i,5) + alpha 
-     LU(i,6) = -dforce_dy(i,6) + alpha 
-     LU(i,7) = -dforce_dy(i,7) + alpha 
-     LU(i,8) = -dforce_dy(i,8) + alpha 
-     LU(i,11) = -dforce_dy(i,11) + alpha 
-     LU(i,13) = -dforce_dy(i,13) + alpha 
-     LU(i,18) = -dforce_dy(i,18) + alpha 
-     LU(i,23) = -dforce_dy(i,23) + alpha 
+    LU(i,1) = -dforce_dy(i,1) + alpha
+    LU(i,5) = -dforce_dy(i,5) + alpha
+    LU(i,6) = -dforce_dy(i,6) + alpha
+    LU(i,7) = -dforce_dy(i,7) + alpha
+    LU(i,8) = -dforce_dy(i,8) + alpha
+    LU(i,11) = -dforce_dy(i,11) + alpha
+    LU(i,13) = -dforce_dy(i,13) + alpha
+    LU(i,18) = -dforce_dy(i,18) + alpha
+    LU(i,23) = -dforce_dy(i,23) + alpha
   end do
 
-  call factor(LU) 
+  call factor(LU)
 
 end subroutine factored_alpha_minus_jac
 
 subroutine p_force(ncell, rate_constant, number_density, number_density_air, force)
   ! Compute force function for all molecules
 
-  ! Number of grid cells with chemical reactions
-  integer,  intent(in) :: ncell
-
+  integer,  intent(in) :: ncell ! Number of grid cells with chemical reactions
   real(r8), intent(in) :: rate_constant(:,:)
   real(r8), intent(in) :: number_density(:,:)
-  real(r8), intent(in) :: number_density_air
+  real(r8), intent(in) :: number_density_air(:)
   real(r8), intent(out) :: force(:,:)
 
   integer :: i
 
   do i = 1, ncell
-! M
-     force(i,1) = 0
 
+    ! M
+    force(i,1) = 0
 
-! Ar
-     force(i,2) = 0
+    ! Ar
+    force(i,2) = 0
 
+    ! CO2
+    force(i,3) = 0
 
-! CO2
-     force(i,3) = 0
+    ! H2O
+    force(i,4) = 0
 
+    ! N2
+    force(i,5) = 0
 
-! H2O
-     force(i,4) = 0
+    ! O1D
+    force(i,6) = 0
 
+    ! k_O3_1: O3 -> 1*O1D + 1*O2
+    force(i,6) = force(i,6) + rate_constant(i,2) * number_density(i,9)
 
-! N2
-     force(i,5) = 0
+    ! k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
+    force(i,6) = force(i,6) - rate_constant(i,4) * number_density(i,5) * number_density(i,6)
 
+    ! k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
+    force(i,6) = force(i,6) - rate_constant(i,5) * number_density(i,6) * number_density(i,8)
 
-! O1D
-     force(i,6) = 0
+    ! O
+    force(i,7) = 0
 
-     ! k_O3_1: O3 -> 1*O1D + 1*O2
-     force(i,6) = force(i,6) + rate_constant(i,2) * number_density(i,9)
-   
-     ! k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
-     force(i,6) = force(i,6) - rate_constant(i,4) * number_density(i,5) * number_density(i,6)
-   
-     ! k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
-     force(i,6) = force(i,6) - rate_constant(i,5) * number_density(i,6) * number_density(i,8)
+    ! k_O2_1: O2 -> 2*O
+    force(i,7) = force(i,7) + 2*rate_constant(i,1) * number_density(i,8)
 
+    ! k_O3_2: O3 -> 1*O + 1*O2
+    force(i,7) = force(i,7) + rate_constant(i,3) * number_density(i,9)
 
-! O
-     force(i,7) = 0
+    ! k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
+    force(i,7) = force(i,7) + rate_constant(i,4) * number_density(i,5) * number_density(i,6)
 
-     ! k_O2_1: O2 -> 2*O
-     force(i,7) = force(i,7) + 2*rate_constant(i,1) * number_density(i,8)
-   
-     ! k_O3_2: O3 -> 1*O + 1*O2
-     force(i,7) = force(i,7) + rate_constant(i,3) * number_density(i,9)
-   
-     ! k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
-     force(i,7) = force(i,7) + rate_constant(i,4) * number_density(i,5) * number_density(i,6)
-   
-     ! k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
-     force(i,7) = force(i,7) + rate_constant(i,5) * number_density(i,6) * number_density(i,8)
-   
-     ! k_O_O3_1: O + O3 -> 2*O2
-     force(i,7) = force(i,7) - rate_constant(i,6) * number_density(i,7) * number_density(i,9)
-   
-     ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-     force(i,7) = force(i,7) - rate_constant(i,7) * number_density(i,1) * number_density(i,7) * number_density(i,8)
+    ! k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
+    force(i,7) = force(i,7) + rate_constant(i,5) * number_density(i,6) * number_density(i,8)
 
+    ! k_O_O3_1: O + O3 -> 2*O2
+    force(i,7) = force(i,7) - rate_constant(i,6) * number_density(i,7) * number_density(i,9)
 
-! O2
-     force(i,8) = 0
-   
-     ! k_O2_1: O2 -> 2*O
-     force(i,8) = force(i,8) - rate_constant(i,1) * number_density(i,8)
-   
-     ! k_O3_1: O3 -> 1*O1D + 1*O2
-     force(i,8) = force(i,8) + rate_constant(i,2) * number_density(i,9)
-   
-     ! k_O3_2: O3 -> 1*O + 1*O2
-     force(i,8) = force(i,8) + rate_constant(i,3) * number_density(i,9)
-   
-     ! k_O_O3_1: O + O3 -> 2*O2
-     force(i,8) = force(i,8) + 2*rate_constant(i,6) * number_density(i,7) * number_density(i,9)
-   
-     ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-     force(i,8) = force(i,8) - rate_constant(i,7) * number_density(i,1) * number_density(i,7) * number_density(i,8)
+    ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
+    force(i,7) = force(i,7) - rate_constant(i,7) * number_density(i,1) * number_density(i,7) * number_density(i,8)
 
+    ! O2
+    force(i,8) = 0
 
-! O3
-     force(i,9) = 0
+    ! k_O2_1: O2 -> 2*O
+    force(i,8) = force(i,8) - rate_constant(i,1) * number_density(i,8)
 
-     ! k_O3_1: O3 -> 1*O1D + 1*O2
-     force(i,9) = force(i,9) - rate_constant(i,2) * number_density(i,9)
-   
-     ! k_O3_2: O3 -> 1*O + 1*O2
-     force(i,9) = force(i,9) - rate_constant(i,3) * number_density(i,9)
-   
-     ! k_O_O3_1: O + O3 -> 2*O2
-     force(i,9) = force(i,9) - rate_constant(i,6) * number_density(i,7) * number_density(i,9)
-   
-     ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-     force(i,9) = force(i,9) + rate_constant(i,7) * number_density(i,1) * number_density(i,7) * number_density(i,8)
+    ! k_O3_1: O3 -> 1*O1D + 1*O2
+    force(i,8) = force(i,8) + rate_constant(i,2) * number_density(i,9)
 
+    ! k_O3_2: O3 -> 1*O + 1*O2
+    force(i,8) = force(i,8) + rate_constant(i,3) * number_density(i,9)
+
+    ! k_O_O3_1: O + O3 -> 2*O2
+    force(i,8) = force(i,8) + 2*rate_constant(i,6) * number_density(i,7) * number_density(i,9)
+
+    ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
+    force(i,8) = force(i,8) - rate_constant(i,7) * number_density(i,1) * number_density(i,7) * number_density(i,8)
+
+    ! O3
+    force(i,9) = 0
+
+    ! k_O3_1: O3 -> 1*O1D + 1*O2
+    force(i,9) = force(i,9) - rate_constant(i,2) * number_density(i,9)
+
+    ! k_O3_2: O3 -> 1*O + 1*O2
+    force(i,9) = force(i,9) - rate_constant(i,3) * number_density(i,9)
+
+    ! k_O_O3_1: O + O3 -> 2*O2
+    force(i,9) = force(i,9) - rate_constant(i,6) * number_density(i,7) * number_density(i,9)
+
+    ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
+    force(i,9) = force(i,9) + rate_constant(i,7) * number_density(i,1) * number_density(i,7) * number_density(i,8)
   end do
 
 end subroutine p_force
@@ -314,38 +281,36 @@ end subroutine p_force
 function reaction_rates(ncell, rate_constant, number_density, number_density_air)
   ! Compute reaction rates
 
-  ! Number of grid cells with chemical reactions
-  integer,  intent(in) :: ncell
-
-  real(r8) :: reaction_rates(:,number_of_reactions)
+  integer,  intent(in) :: ncell ! Number of grid cells with chemical reactions
+  real(r8) :: reaction_rates(ncell,number_of_reactions)
   real(r8), intent(in) :: rate_constant(:,:)
   real(r8), intent(in) :: number_density(:,:)
-  real(r8), intent(in) :: number_density_air
+  real(r8), intent(in) :: number_density_air(:)
 
   integer :: i
 
   do i = 1, ncell
 
-     ! k_O2_1: O2 -> 2*O
-     reaction_rates(i,1) = rate_constant(i,1) * number_density(i,8)
-   
-     ! k_O3_1: O3 -> 1*O1D + 1*O2
-     reaction_rates(i,2) = rate_constant(i,2) * number_density(i,9)
-   
-     ! k_O3_2: O3 -> 1*O + 1*O2
-     reaction_rates(i,3) = rate_constant(i,3) * number_density(i,9)
-   
-     ! k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
-     reaction_rates(i,4) = rate_constant(i,4) * number_density(i,5) * number_density(i,6)
-   
-     ! k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
-     reaction_rates(i,5) = rate_constant(i,5) * number_density(i,6) * number_density(i,8)
-   
-     ! k_O_O3_1: O + O3 -> 2*O2
-     reaction_rates(i,6) = rate_constant(i,6) * number_density(i,7) * number_density(i,9)
-   
-     ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-     reaction_rates(i,7) = rate_constant(i,7) * number_density(i,1) * number_density(i,7) * number_density(i,8)
+    ! k_O2_1: O2 -> 2*O
+    reaction_rates(i,1) = rate_constant(i,1) * number_density(i,8)
+
+    ! k_O3_1: O3 -> 1*O1D + 1*O2
+    reaction_rates(i,2) = rate_constant(i,2) * number_density(i,9)
+
+    ! k_O3_2: O3 -> 1*O + 1*O2
+    reaction_rates(i,3) = rate_constant(i,3) * number_density(i,9)
+
+    ! k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
+    reaction_rates(i,4) = rate_constant(i,4) * number_density(i,5) * number_density(i,6)
+
+    ! k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
+    reaction_rates(i,5) = rate_constant(i,5) * number_density(i,6) * number_density(i,8)
+
+    ! k_O_O3_1: O + O3 -> 2*O2
+    reaction_rates(i,6) = rate_constant(i,6) * number_density(i,7) * number_density(i,9)
+
+    ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
+    reaction_rates(i,7) = rate_constant(i,7) * number_density(i,1) * number_density(i,7) * number_density(i,8)
 
   end do
 
@@ -383,7 +348,7 @@ end function photolysis_names
 function species_names()
   ! Chemical species names
 
-  character(i,len=128) :: species_names(number_of_species)
+  character(len=128) :: species_names(number_of_species)
 
   species_names(1) = 'M'
   species_names(2) = 'Ar'
@@ -399,13 +364,10 @@ end function species_names
 
 
 pure subroutine dforce_dy_times_vector(ncell, dforce_dy, vector, cummulative_product)
-
   !  Compute product of [ dforce_dy * vector ]
   !  Commonly used to compute time-truncation errors [dforce_dy * force ]
 
-  ! Number of grid cells with chemical reactions
-  integer,  intent(in) :: ncell
-
+  integer,  intent(in) :: ncell ! Number of grid cells with chemical reactions
   real(r8), intent(in) :: dforce_dy(:,:) ! Jacobian of forcing
   real(r8), intent(in) :: vector(:,:)    ! Vector ordered as the order of number density in dy
   real(r8), intent(out) :: cummulative_product(:,:)  ! Product of jacobian with vector
@@ -416,76 +378,59 @@ pure subroutine dforce_dy_times_vector(ncell, dforce_dy, vector, cummulative_pro
 
   do i = 1, ncell
 
-     ! df_O/d(M) * M_temporary
-     cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,2) * vector(i,1)
-   
-   
-     ! df_O2/d(M) * M_temporary
-     cummulative_product(i,8) = cummulative_product(i,8) + dforce_dy(i,3) * vector(i,1)
-   
-   
-     ! df_O3/d(M) * M_temporary
-     cummulative_product(i,9) = cummulative_product(i,9) + dforce_dy(i,4) * vector(i,1)
-   
-   
-     ! df_O1D/d(N2) * N2_temporary
-     cummulative_product(i,6) = cummulative_product(i,6) + dforce_dy(i,9) * vector(i,5)
-   
-   
-     ! df_O/d(N2) * N2_temporary
-     cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,10) * vector(i,5)
-   
-   
-     ! df_O1D/d(O1D) * O1D_temporary
-     cummulative_product(i,6) = cummulative_product(i,6) + dforce_dy(i,11) * vector(i,6)
-   
-   
-     ! df_O/d(O1D) * O1D_temporary
-     cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,12) * vector(i,6)
-   
-   
-     ! df_O/d(O) * O_temporary
-     cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,13) * vector(i,7)
-   
-   
-     ! df_O2/d(O) * O_temporary
-     cummulative_product(i,8) = cummulative_product(i,8) + dforce_dy(i,14) * vector(i,7)
-   
-   
-     ! df_O3/d(O) * O_temporary
-     cummulative_product(i,9) = cummulative_product(i,9) + dforce_dy(i,15) * vector(i,7)
-   
-   
-     ! df_O1D/d(O2) * O2_temporary
-     cummulative_product(i,6) = cummulative_product(i,6) + dforce_dy(i,16) * vector(i,8)
-   
-   
-     ! df_O/d(O2) * O2_temporary
-     cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,17) * vector(i,8)
-   
-   
-     ! df_O2/d(O2) * O2_temporary
-     cummulative_product(i,8) = cummulative_product(i,8) + dforce_dy(i,18) * vector(i,8)
-   
-   
-     ! df_O3/d(O2) * O2_temporary
-     cummulative_product(i,9) = cummulative_product(i,9) + dforce_dy(i,19) * vector(i,8)
-   
-   
-     ! df_O1D/d(O3) * O3_temporary
-     cummulative_product(i,6) = cummulative_product(i,6) + dforce_dy(i,20) * vector(i,9)
-   
-   
-     ! df_O/d(O3) * O3_temporary
-     cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,21) * vector(i,9)
-   
-   
-     ! df_O2/d(O3) * O3_temporary
-     cummulative_product(i,8) = cummulative_product(i,8) + dforce_dy(i,22) * vector(i,9)
-   
-   
-     ! df_O3/d(O3) * O3_temporary
-     cummulative_product(i,9) = cummulative_product(i,9) + dforce_dy(i,23) * vector(i,9)
+    ! df_O/d(M) * M_temporary
+    cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,2) * vector(i,1)
+
+    ! df_O2/d(M) * M_temporary
+    cummulative_product(i,8) = cummulative_product(i,8) + dforce_dy(i,3) * vector(i,1)
+
+    ! df_O3/d(M) * M_temporary
+    cummulative_product(i,9) = cummulative_product(i,9) + dforce_dy(i,4) * vector(i,1)
+
+    ! df_O1D/d(N2) * N2_temporary
+    cummulative_product(i,6) = cummulative_product(i,6) + dforce_dy(i,9) * vector(i,5)
+
+    ! df_O/d(N2) * N2_temporary
+    cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,10) * vector(i,5)
+
+    ! df_O1D/d(O1D) * O1D_temporary
+    cummulative_product(i,6) = cummulative_product(i,6) + dforce_dy(i,11) * vector(i,6)
+
+    ! df_O/d(O1D) * O1D_temporary
+    cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,12) * vector(i,6)
+
+    ! df_O/d(O) * O_temporary
+    cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,13) * vector(i,7)
+
+    ! df_O2/d(O) * O_temporary
+    cummulative_product(i,8) = cummulative_product(i,8) + dforce_dy(i,14) * vector(i,7)
+
+    ! df_O3/d(O) * O_temporary
+    cummulative_product(i,9) = cummulative_product(i,9) + dforce_dy(i,15) * vector(i,7)
+
+    ! df_O1D/d(O2) * O2_temporary
+    cummulative_product(i,6) = cummulative_product(i,6) + dforce_dy(i,16) * vector(i,8)
+
+    ! df_O/d(O2) * O2_temporary
+    cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,17) * vector(i,8)
+
+    ! df_O2/d(O2) * O2_temporary
+    cummulative_product(i,8) = cummulative_product(i,8) + dforce_dy(i,18) * vector(i,8)
+
+    ! df_O3/d(O2) * O2_temporary
+    cummulative_product(i,9) = cummulative_product(i,9) + dforce_dy(i,19) * vector(i,8)
+
+    ! df_O1D/d(O3) * O3_temporary
+    cummulative_product(i,6) = cummulative_product(i,6) + dforce_dy(i,20) * vector(i,9)
+
+    ! df_O/d(O3) * O3_temporary
+    cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,21) * vector(i,9)
+
+    ! df_O2/d(O3) * O3_temporary
+    cummulative_product(i,8) = cummulative_product(i,8) + dforce_dy(i,22) * vector(i,9)
+
+    ! df_O3/d(O3) * O3_temporary
+    cummulative_product(i,9) = cummulative_product(i,9) + dforce_dy(i,23) * vector(i,9)
 
   end do
 

--- a/src/preprocessor_output/kinetics_utilities.F90
+++ b/src/preprocessor_output/kinetics_utilities.F90
@@ -177,7 +177,7 @@ subroutine factored_alpha_minus_jac(ncell, LU, alpha, dforce_dy)
     LU(i,23) = -dforce_dy(i,23) + alpha
   end do
 
-  call factor(LU)
+  call factor(ncell,LU)
 
 end subroutine factored_alpha_minus_jac
 

--- a/src/preprocessor_output/rate_constants_utility.F90
+++ b/src/preprocessor_output/rate_constants_utility.F90
@@ -44,8 +44,8 @@ contains
     integer,              intent(in)  :: ncell
     !> Rate constant for each reaction [(molec cm-3)^(n-1) s-1]
     real(kind=musica_dk), intent(out) :: rate_constants(:,:)
-    !> Environmental state
-    type(environment_t),  intent(in)  :: environment
+    !> Environmental states for each grid cell
+    type(environment_t),  intent(in)  :: environment(:)
 
     type( rate_constant_arrhenius_t                   ) :: arrhenius
     type( rate_constant_photolysis_t                  ) :: photolysis
@@ -58,51 +58,52 @@ contains
     integer :: i
 
     do i = 1, ncell
-       !O2_1
-       !k_O2_1: O2 -> 2*O
-       photolysis = rate_constant_photolysis_t( &
-           photolysis_rate_constant_index = 1 )
-       rate_constants(i,1) = photolysis%calculate( environment )
+      !O2_1
+      !k_O2_1: O2 -> 2*O
+      photolysis = rate_constant_photolysis_t( &
+        photolysis_rate_constant_index = 1 )
+      rate_constants( i, 1 ) = photolysis%calculate( environment( i ) )
 
-       !O3_1
-       !k_O3_1: O3 -> 1*O1D + 1*O2
-       photolysis = rate_constant_photolysis_t( &
-           photolysis_rate_constant_index = 2 )
-       rate_constants(i,2) = photolysis%calculate( environment )
+      !O3_1
+      !k_O3_1: O3 -> 1*O1D + 1*O2
+      photolysis = rate_constant_photolysis_t( &
+        photolysis_rate_constant_index = 2 )
+      rate_constants( i, 2 ) = photolysis%calculate( environment( i ) )
 
-       !O3_2
-       !k_O3_2: O3 -> 1*O + 1*O2
-       photolysis = rate_constant_photolysis_t( &
-           photolysis_rate_constant_index = 3 )
-       rate_constants(i,3) = photolysis%calculate( environment )
+      !O3_2
+      !k_O3_2: O3 -> 1*O + 1*O2
+      photolysis = rate_constant_photolysis_t( &
+        photolysis_rate_constant_index = 3 )
+      rate_constants( i, 3 ) = photolysis%calculate( environment( i ) )
 
-       !N2_O1D_1
-       !k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
-       arrhenius = rate_constant_arrhenius_t( &
-           A = real( 2.15e-11, kind=musica_dk ), &
-           C = real( 110, kind=musica_dk ) )
-       rate_constants(i,4) = arrhenius%calculate( environment )
+      !N2_O1D_1
+      !k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
+      arrhenius = rate_constant_arrhenius_t( &
+        A = real( 2.15e-11, kind=musica_dk ), &
+        C = real( 110, kind=musica_dk ) )
+      rate_constants( i, 4 ) = arrhenius%calculate( environment( i ) )
 
-       !O1D_O2_1
-       !k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
-       arrhenius = rate_constant_arrhenius_t( &
-           A = real( 3.3e-11, kind=musica_dk ), &
-           C = real( 55, kind=musica_dk ) )
-       rate_constants(i,5) = arrhenius%calculate( environment )
+      !O1D_O2_1
+      !k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
+      arrhenius = rate_constant_arrhenius_t( &
+        A = real( 3.3e-11, kind=musica_dk ), &
+        C = real( 55, kind=musica_dk ) )
+      rate_constants( i, 5 ) = arrhenius%calculate( environment( i ) )
 
-       !O_O3_1
-       !k_O_O3_1: O + O3 -> 2*O2
-       arrhenius = rate_constant_arrhenius_t( &
-           A = real( 8e-12, kind=musica_dk ), &
-           C = real( -2060, kind=musica_dk ) )
-       rate_constants(i,6) = arrhenius%calculate( environment )
+      !O_O3_1
+      !k_O_O3_1: O + O3 -> 2*O2
+      arrhenius = rate_constant_arrhenius_t( &
+        A = real( 8e-12, kind=musica_dk ), &
+        C = real( -2060, kind=musica_dk ) )
+      rate_constants( i, 6 ) = arrhenius%calculate( environment( i ) )
 
-       !M_O_O2_1
-       !k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-       arrhenius = rate_constant_arrhenius_t( &
-           A = real( 6e-34, kind=musica_dk ), &
-           B = real( 2.4, kind=musica_dk ) )
-       rate_constants(i,7) = arrhenius%calculate( environment )
+      !M_O_O2_1
+      !k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
+      arrhenius = rate_constant_arrhenius_t( &
+        A = real( 6e-34, kind=musica_dk ), &
+        B = real( 2.4, kind=musica_dk ) )
+      rate_constants( i, 7 ) = arrhenius%calculate( environment( i ) )
+
     end do
 
   end subroutine calculate_rate_constants

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -8,11 +8,10 @@ macro(add_std_test test_name)
 endmacro(add_std_test)
 
 ################################################################################
-# MICM tests
+# MICM performance tests
 
-add_executable(test_stub test_stub.F90)
-add_std_test(test_stub)
-
-add_subdirectory(performance)
+add_executable(test_performance driver.F90)
+add_std_test(test_performance)
 
 ################################################################################
+

--- a/test/performance/driver.F90
+++ b/test/performance/driver.F90
@@ -1,0 +1,153 @@
+! Copyright (C) 2022 National Center for Atmospheric Research
+! SPDX-License-Identifier: Apache-2.0
+!
+!> \file
+!> A driver for performance evaluation of MICM
+program performance_test
+
+  use musica_constants,                only : dk => musica_dk
+
+  implicit none
+
+  integer, parameter :: kNumberOfGridCells = 100
+  integer, parameter :: kNUmberOfTimeSteps = 100
+  real(kind=dk), parameter :: kTimeStep__min = 5.0_dk
+
+  call run_test( )
+
+contains
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Runs MICM under prescribed conditions and collect performance metrics
+  subroutine run_test( )
+
+    use micm_environment,              only : environment_t
+    use micm_kinetics,                 only : kinetics_t
+    use micm_ODE_solver,               only : ODE_solver_t
+    use micm_ODE_solver_factory,       only : ODE_solver_builder
+    use musica_assert,                 only : assert_msg
+    use musica_config,                 only : config_t
+    use musica_string,                 only : string_t, to_char
+
+    character(len=*), parameter :: my_name = "MICM performance test"
+    type(config_t) :: solver_config
+    class(ODE_solver_t), pointer :: solver => null( )
+    class(kinetics_t), pointer :: kinetics => null( )
+    type(string_t), allocatable :: species_names(:)
+    type(string_t), allocatable :: reaction_names(:)
+    type(string_t), allocatable :: photo_reaction_names(:)
+    ! Species number densities [molecule cm-3] (grid cell, species)
+    real(kind=dk), allocatable :: number_densities__molec_cm3(:,:)
+    type(environment_t) :: env(kNumberOfGridCells)
+    integer :: i_time, error_flag
+
+    ! Set up the kinetics calculator
+    kinetics => kinetics_t( )
+    call kinetics%species_names( species_names )
+    call kinetics%reaction_names( reaction_names )
+    call kinetics%photolysis_reaction_names( photo_reaction_names )
+
+    ! Set up the solver for the test
+    call solver_config%empty( )
+    call solver_config%add( "type", "Rosenbrock", my_name )
+    call solver_config%add( "chemistry time step", "min", kTimeStep__min,     &
+                            my_name )
+    call solver_config%add( "absolute tolerance", 1.0e-12, my_name )
+    call solver_config%add( "relative tolerance", 1.0e-4, my_name )
+    call solver_config%add( "number of variables", size( species_names ),     &
+                            my_name )
+    ! TODO determine if the solver needs to know the number of grid cells
+    !      during initialization
+    solver => ODE_solver_builder( solver_config )
+
+    ! Set up the state data strutures
+    allocate( number_densities__molec_cm3( kNumberOfGridCells,                &
+                                           size( species_names ) ) )
+
+    ! Solve chemistry for each grid cell and time step
+    do i_time = 1, kNumberOfTimeSteps
+      call update_species( number_densities__molec_cm3, species_names, i_time )
+      call update_environment( env, photo_reaction_names, i_time )
+      call kinetics%update( env )
+      call solver%solve( TStart      = 0.0_dk,                                &
+                         TEnd        = kTimeStep__min,                        &
+                         y           = number_densities__molec_cm3,           &
+                         theKinetics = kinetics,                              &
+                         IErr        = error_flag )
+      call assert_msg( 366068772, error_flag == 0,                            &
+                       "Chemistry solver failed with code "//                 &
+                       to_char( error_flag ) )
+      call output_state( number_densities__molec_cm3, species_names, i_time )
+    end do
+
+  end subroutine run_test
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Update the species concentrations for a given time step
+  subroutine update_species( number_densities__molec_cm3, species_names,      &
+      time_step )
+
+    use musica_string,                 only : string_t
+
+    !> Species number densities [molecule cm-3] (grid cell, species)
+    real(kind=dk),  intent(inout) :: number_densities__molec_cm3(:,:)
+    type(string_t), intent(in)    :: species_names(:)
+    integer,        intent(in)    :: time_step
+
+    ! TODO determine how we want to set species concentrations
+    number_densities__molec_cm3(:,:) = 1.0e-6_dk
+
+  end subroutine update_species
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Update the temperature, pressure, and photolysis reaction rate constants
+  !! for a given time step
+  subroutine update_environment( environment, photo_reaction_names, time_step )
+
+    use micm_environment,              only : environment_t
+    use musica_string,                 only : string_t
+
+    type(environment_t), intent(inout) :: environment(:)
+    type(string_t),      intent(in)    :: photo_reaction_names(:)
+    integer,             intent(in)    :: time_step
+
+    integer :: i_env
+
+    ! TODO determine how we want to set photolysis reaction rate constants
+    do i_env = 1, size( environment )
+      environment( i_env )%temperature                  = 298.15_dk   ! [K]
+      environment( i_env )%pressure                     = 101325.0_dk ! [Pa]
+      environment( i_env )%photolysis_rate_constants(:) = 1.0e-3_dk   ! [s-1]
+    end do
+  end subroutine update_environment
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Output the state at a given time step
+  subroutine output_state( number_densities__molec_cm3, species_names,        &
+      time_step )
+
+    use musica_string,                 only : string_t
+
+    !> Species number densities [molecule cm-3] (grid cell, species)
+    real(kind=dk),  intent(inout) :: number_densities__molec_cm3(:,:)
+    type(string_t), intent(in)    :: species_names(:)
+    integer,        intent(in)    :: time_step
+
+    integer :: i_species
+
+    ! TODO determine if/how we want to output state data
+    write(*,*) "time step", time_step*kTimeStep__min
+    do i_species = 1, size( species_names )
+      write(*,*) species_names( i_species ),                                  &
+                 number_densities__molec_cm3(:,i_species)
+    end do
+
+  end subroutine output_state
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+end program performance_test

--- a/test/preprocessor_output/factor_solve_utilities.F90
+++ b/test/preprocessor_output/factor_solve_utilities.F90
@@ -12,124 +12,136 @@ use musica_constants, only: r8 => musica_dk
 
   integer, parameter :: number_sparse_factor_elements = 23
 
-  public :: factor, solve 
+  public :: factor, solve
 
   contains
 
 
-subroutine backsolve_L_y_eq_b(LU,b,y)
+subroutine backsolve_L_y_eq_b(ncell,LU,b,y)
 
+  integer,  intent(in) :: ncell
+  real(r8), intent(in) :: LU(:,:)
+  real(r8), intent(in) :: b(:,:)
+  real(r8), intent(out) :: y(:,:)
 
-  real(r8), intent(in) :: LU(:)
-  real(r8), intent(in) :: b(:)
-  real(r8), intent(out) :: y(:)
+  integer :: i
 
-
-  y(1) = b(1)
-  y(2) = b(2)
-  y(3) = b(3)
-  y(4) = b(4)
-  y(5) = b(5)
-  y(6) = b(6)
-  y(6) = y(6) - LU(9) * y(5)
-  y(7) = b(7)
-  y(7) = y(7) - LU(2) * y(1)
-  y(7) = y(7) - LU(10) * y(5)
-  y(7) = y(7) - LU(12) * y(6)
-  y(8) = b(8)
-  y(8) = y(8) - LU(3) * y(1)
-  y(8) = y(8) - LU(14) * y(7)
-  y(9) = b(9)
-  y(9) = y(9) - LU(4) * y(1)
-  y(9) = y(9) - LU(15) * y(7)
-  y(9) = y(9) - LU(19) * y(8)
-
+  do i = 1, ncell
+    y(i,1) = b(i,1)
+    y(i,2) = b(i,2)
+    y(i,3) = b(i,3)
+    y(i,4) = b(i,4)
+    y(i,5) = b(i,5)
+    y(i,6) = b(i,6)
+    y(i,6) = y(i,6) - LU(i,9) * y(i,5)
+    y(i,7) = b(i,7)
+    y(i,7) = y(i,7) - LU(i,2) * y(i,1)
+    y(i,7) = y(i,7) - LU(i,10) * y(i,5)
+    y(i,7) = y(i,7) - LU(i,12) * y(i,6)
+    y(i,8) = b(i,8)
+    y(i,8) = y(i,8) - LU(i,3) * y(i,1)
+    y(i,8) = y(i,8) - LU(i,14) * y(i,7)
+    y(i,9) = b(i,9)
+    y(i,9) = y(i,9) - LU(i,4) * y(i,1)
+    y(i,9) = y(i,9) - LU(i,15) * y(i,7)
+    y(i,9) = y(i,9) - LU(i,19) * y(i,8)
+  end do
 
 end subroutine backsolve_L_y_eq_b
 
 
 
-subroutine backsolve_U_x_eq_y(LU,y,x)
+subroutine backsolve_U_x_eq_y(ncell,LU,y,x)
 
-
-  real(r8), intent(in) :: LU(:)
-  real(r8), intent(in) :: y(:)
-  real(r8), intent(out) :: x(:)
+  integer,  intent(in) :: ncell
+  real(r8), intent(in) :: LU(:,:)
+  real(r8), intent(in) :: y(:,:)
+  real(r8), intent(out) :: x(:,:)
   real(r8) :: temporary
 
+  integer :: i
 
-  temporary = y(9)
-  x(9) = LU(23) * temporary
-  temporary = y(8)
-  temporary = temporary - LU(22) * x(9)
-  x(8) = LU(18) * temporary
-  temporary = y(7)
-  temporary = temporary - LU(17) * x(8)
-  temporary = temporary - LU(21) * x(9)
-  x(7) = LU(13) * temporary
-  temporary = y(6)
-  temporary = temporary - LU(16) * x(8)
-  temporary = temporary - LU(20) * x(9)
-  x(6) = LU(11) * temporary
-  temporary = y(5)
-  x(5) = LU(8) * temporary
-  temporary = y(4)
-  x(4) = LU(7) * temporary
-  temporary = y(3)
-  x(3) = LU(6) * temporary
-  temporary = y(2)
-  x(2) = LU(5) * temporary
-  temporary = y(1)
-  x(1) = LU(1) * temporary
-
+  do i = 1, ncell
+    temporary = y(i,9)
+    x(i,9) = LU(i,23) * temporary
+    temporary = y(i,8)
+    temporary = temporary - LU(i,22) * x(i,9)
+    x(i,8) = LU(i,18) * temporary
+    temporary = y(i,7)
+    temporary = temporary - LU(i,17) * x(i,8)
+    temporary = temporary - LU(i,21) * x(i,9)
+    x(i,7) = LU(i,13) * temporary
+    temporary = y(i,6)
+    temporary = temporary - LU(i,16) * x(i,8)
+    temporary = temporary - LU(i,20) * x(i,9)
+    x(i,6) = LU(i,11) * temporary
+    temporary = y(i,5)
+    x(i,5) = LU(i,8) * temporary
+    temporary = y(i,4)
+    x(i,4) = LU(i,7) * temporary
+    temporary = y(i,3)
+    x(i,3) = LU(i,6) * temporary
+    temporary = y(i,2)
+    x(i,2) = LU(i,5) * temporary
+    temporary = y(i,1)
+    x(i,1) = LU(i,1) * temporary
+  end do
 
 end subroutine backsolve_U_x_eq_y
 
-subroutine factor(LU)
 
 
-  real(r8), intent(inout) :: LU(:)
+subroutine factor(ncell,LU)
 
+  integer,  intent(in)    :: ncell
+  real(r8), intent(inout) :: LU(:,:)
 
-  LU(1) = 1./LU(1)
-  LU(2) = LU(2) * LU(1)
-  LU(3) = LU(3) * LU(1)
-  LU(4) = LU(4) * LU(1)
-  LU(5) = 1./LU(5)
-  LU(6) = 1./LU(6)
-  LU(7) = 1./LU(7)
-  LU(8) = 1./LU(8)
-  LU(9) = LU(9) * LU(8)
-  LU(10) = LU(10) * LU(8)
-  LU(11) = 1./LU(11)
-  LU(12) = LU(12) * LU(11)
-  LU(17) = LU(17) - LU(12)*LU(16)
-  LU(21) = LU(21) - LU(12)*LU(20)
-  LU(13) = 1./LU(13)
-  LU(14) = LU(14) * LU(13)
-  LU(15) = LU(15) * LU(13)
-  LU(18) = LU(18) - LU(14)*LU(17)
-  LU(19) = LU(19) - LU(15)*LU(17)
-  LU(22) = LU(22) - LU(14)*LU(21)
-  LU(23) = LU(23) - LU(15)*LU(21)
-  LU(18) = 1./LU(18)
-  LU(19) = LU(19) * LU(18)
-  LU(23) = LU(23) - LU(19)*LU(22)
-  LU(23) = 1./LU(23)
+integer :: i
 
+do i = 1, ncell
+    LU(i,1) = 1./LU(i,1)
+    LU(i,2) = LU(i,2) * LU(i,1)
+    LU(i,3) = LU(i,3) * LU(i,1)
+    LU(i,4) = LU(i,4) * LU(i,1)
+    LU(i,5) = 1./LU(i,5)
+    LU(i,6) = 1./LU(i,6)
+    LU(i,7) = 1./LU(i,7)
+    LU(i,8) = 1./LU(i,8)
+    LU(i,9) = LU(i,9) * LU(i,8)
+    LU(i,10) = LU(i,10) * LU(i,8)
+    LU(i,11) = 1./LU(i,11)
+    LU(i,12) = LU(i,12) * LU(i,11)
+    LU(i,17) = LU(i,17) - LU(i,12)*LU(i,16)
+    LU(i,21) = LU(i,21) - LU(i,12)*LU(i,20)
+    LU(i,13) = 1./LU(i,13)
+    LU(i,14) = LU(i,14) * LU(i,13)
+    LU(i,15) = LU(i,15) * LU(i,13)
+    LU(i,18) = LU(i,18) - LU(i,14)*LU(i,17)
+    LU(i,19) = LU(i,19) - LU(i,15)*LU(i,17)
+    LU(i,22) = LU(i,22) - LU(i,14)*LU(i,21)
+    LU(i,23) = LU(i,23) - LU(i,15)*LU(i,21)
+    LU(i,18) = 1./LU(i,18)
+    LU(i,19) = LU(i,19) * LU(i,18)
+    LU(i,23) = LU(i,23) - LU(i,19)*LU(i,22)
+    LU(i,23) = 1./LU(i,23)
+  end do
 
 end subroutine factor
 
-subroutine solve(LU, x, b) 
 
-  real(r8), intent(in) :: LU(:), b(:) ! solve LU * x = b 
-  real(r8), intent(out) :: x(:) 
-  real(r8) :: y(size(b)) 
 
-  call backsolve_L_y_eq_b(LU, b, y)
-  call backsolve_U_x_eq_y(LU, y, x)
+subroutine solve(ncell,LU,x,b)
 
-end subroutine solve 
+  integer,  intent(in) :: ncell
+  real(r8), intent(in) :: LU(:,:), b(:,:) ! solve LU * x = b
+  real(r8), intent(out) :: x(:,:)
+
+  real(r8) :: y(ncell,size(b,2))
+
+  call backsolve_L_y_eq_b(ncell, LU, b, y)
+  call backsolve_U_x_eq_y(ncell, LU, y, x)
+
+end subroutine solve
 
 
 end module factor_solve_utilities

--- a/test/preprocessor_output/kinetics_utilities.F90
+++ b/test/preprocessor_output/kinetics_utilities.F90
@@ -23,302 +23,296 @@ use musica_constants, only: r8 => musica_dk
   contains
 
 
-subroutine dforce_dy(LU, rate_constant, number_density, number_density_air)
-
+subroutine dforce_dy(ncell, LU, rate_constant, number_density, number_density_air)
   ! Compute the derivative of the Forcing w.r.t. each chemical
   ! Also known as the Jacobian
-  real(r8), intent(out) :: LU(:)
-  real(r8), intent(in) :: rate_constant(:)
-  real(r8), intent(in) :: number_density(:)
-  real(r8), intent(in) :: number_density_air
+  integer,  intent(in) :: ncell ! number of grid cells with chemical reactions
+  real(r8), intent(out) :: LU(:,:)
+  real(r8), intent(in) :: rate_constant(:,:)
+  real(r8), intent(in) :: number_density(:,:)
+  real(r8), intent(in) :: number_density_air(:)
 
-  LU(:) = 0
+  integer :: i
 
+  LU(:,:) = 0
 
-  ! df_O/d(M)
+  do i = 1, ncell
+    ! df_O/d(M)
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-    LU(2) = LU(2) - rate_constant(7) * number_density(7) * number_density(8)
+    LU(i,2) = LU(i,2) - rate_constant(i,7) * number_density(i,7) * number_density(i,8)
 
-
-  ! df_O2/d(M)
+    ! df_O2/d(M)
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-    LU(3) = LU(3) - rate_constant(7) * number_density(7) * number_density(8)
+    LU(i,3) = LU(i,3) - rate_constant(i,7) * number_density(i,7) * number_density(i,8)
 
-
-  ! df_O3/d(M)
+    ! df_O3/d(M)
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-    LU(4) = LU(4) + rate_constant(7) * number_density(7) * number_density(8)
+    LU(i,4) = LU(i,4) + rate_constant(i,7) * number_density(i,7) * number_density(i,8)
 
-
-  ! df_O1D/d(N2)
+    ! df_O1D/d(N2)
     !  k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
-    LU(9) = LU(9) - rate_constant(4) * number_density(6)
+    LU(i,9) = LU(i,9) - rate_constant(i,4) * number_density(i,6)
 
-
-  ! df_O/d(N2)
+    ! df_O/d(N2)
     !  k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
-    LU(10) = LU(10) + rate_constant(4) * number_density(6)
+    LU(i,10) = LU(i,10) + rate_constant(i,4) * number_density(i,6)
 
-
-  ! df_O1D/d(O1D)
+    ! df_O1D/d(O1D)
     !  k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
-    LU(11) = LU(11) - rate_constant(4) * number_density(5)
+    LU(i,11) = LU(i,11) - rate_constant(i,4) * number_density(i,5)
 
     !  k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
-    LU(11) = LU(11) - rate_constant(5) * number_density(8)
+    LU(i,11) = LU(i,11) - rate_constant(i,5) * number_density(i,8)
 
-
-  ! df_O/d(O1D)
+    ! df_O/d(O1D)
     !  k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
-    LU(12) = LU(12) + rate_constant(4) * number_density(5)
+    LU(i,12) = LU(i,12) + rate_constant(i,4) * number_density(i,5)
 
     !  k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
-    LU(12) = LU(12) + rate_constant(5) * number_density(8)
+    LU(i,12) = LU(i,12) + rate_constant(i,5) * number_density(i,8)
 
-
-  ! df_O/d(O)
+    ! df_O/d(O)
     !  k_O_O3_1: O + O3 -> 2*O2
-    LU(13) = LU(13) - rate_constant(6) * number_density(9)
+    LU(i,13) = LU(i,13) - rate_constant(i,6) * number_density(i,9)
 
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-    LU(13) = LU(13) - rate_constant(7) * number_density(1) * number_density(8)
+    LU(i,13) = LU(i,13) - rate_constant(i,7) * number_density(i,1) * number_density(i,8)
 
-
-  ! df_O2/d(O)
+    ! df_O2/d(O)
     !  k_O_O3_1: O + O3 -> 2*O2
-    LU(14) = LU(14) + 2*rate_constant(6) * number_density(9)
+    LU(i,14) = LU(i,14) + 2*rate_constant(i,6) * number_density(i,9)
 
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-    LU(14) = LU(14) - rate_constant(7) * number_density(1) * number_density(8)
+    LU(i,14) = LU(i,14) - rate_constant(i,7) * number_density(i,1) * number_density(i,8)
 
-
-  ! df_O3/d(O)
+    ! df_O3/d(O)
     !  k_O_O3_1: O + O3 -> 2*O2
-    LU(15) = LU(15) - rate_constant(6) * number_density(9)
+    LU(i,15) = LU(i,15) - rate_constant(i,6) * number_density(i,9)
 
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-    LU(15) = LU(15) + rate_constant(7) * number_density(1) * number_density(8)
+    LU(i,15) = LU(i,15) + rate_constant(i,7) * number_density(i,1) * number_density(i,8)
 
-
-  ! df_O1D/d(O2)
+    ! df_O1D/d(O2)
     !  k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
-    LU(16) = LU(16) - rate_constant(5) * number_density(6)
+    LU(i,16) = LU(i,16) - rate_constant(i,5) * number_density(i,6)
 
-
-  ! df_O/d(O2)
+    ! df_O/d(O2)
     !  k_O2_1: O2 -> 2*O
-    LU(17) = LU(17) + 2*rate_constant(1)
+    LU(i,17) = LU(i,17) + 2*rate_constant(i,1)
 
     !  k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
-    LU(17) = LU(17) + rate_constant(5) * number_density(6)
+    LU(i,17) = LU(i,17) + rate_constant(i,5) * number_density(i,6)
 
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-    LU(17) = LU(17) - rate_constant(7) * number_density(1) * number_density(7)
+    LU(i,17) = LU(i,17) - rate_constant(i,7) * number_density(i,1) * number_density(i,7)
 
-
-  ! df_O2/d(O2)
+    ! df_O2/d(O2)
     !  k_O2_1: O2 -> 2*O
-    LU(18) = LU(18) - rate_constant(1)
+    LU(i,18) = LU(i,18) - rate_constant(i,1)
 
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-    LU(18) = LU(18) - rate_constant(7) * number_density(1) * number_density(7)
+    LU(i,18) = LU(i,18) - rate_constant(i,7) * number_density(i,1) * number_density(i,7)
 
-
-  ! df_O3/d(O2)
+    ! df_O3/d(O2)
     !  k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-    LU(19) = LU(19) + rate_constant(7) * number_density(1) * number_density(7)
+    LU(i,19) = LU(i,19) + rate_constant(i,7) * number_density(i,1) * number_density(i,7)
 
-
-  ! df_O1D/d(O3)
+    ! df_O1D/d(O3)
     !  k_O3_1: O3 -> 1*O1D + 1*O2
-    LU(20) = LU(20) + rate_constant(2)
+    LU(i,20) = LU(i,20) + rate_constant(i,2)
 
-
-  ! df_O/d(O3)
+    ! df_O/d(O3)
     !  k_O3_2: O3 -> 1*O + 1*O2
-    LU(21) = LU(21) + rate_constant(3)
+    LU(i,21) = LU(i,21) + rate_constant(i,3)
 
     !  k_O_O3_1: O + O3 -> 2*O2
-    LU(21) = LU(21) - rate_constant(6) * number_density(7)
+    LU(i,21) = LU(i,21) - rate_constant(i,6) * number_density(i,7)
 
-
-  ! df_O2/d(O3)
+    ! df_O2/d(O3)
     !  k_O3_1: O3 -> 1*O1D + 1*O2
-    LU(22) = LU(22) + rate_constant(2)
+    LU(i,22) = LU(i,22) + rate_constant(i,2)
 
     !  k_O3_2: O3 -> 1*O + 1*O2
-    LU(22) = LU(22) + rate_constant(3)
+    LU(i,22) = LU(i,22) + rate_constant(i,3)
 
     !  k_O_O3_1: O + O3 -> 2*O2
-    LU(22) = LU(22) + 2*rate_constant(6) * number_density(7)
+    LU(i,22) = LU(i,22) + 2*rate_constant(i,6) * number_density(i,7)
 
-
-  ! df_O3/d(O3)
+    ! df_O3/d(O3)
     !  k_O3_1: O3 -> 1*O1D + 1*O2
-    LU(23) = LU(23) - rate_constant(2)
+    LU(i,23) = LU(i,23) - rate_constant(i,2)
 
     !  k_O3_2: O3 -> 1*O + 1*O2
-    LU(23) = LU(23) - rate_constant(3)
+    LU(i,23) = LU(i,23) - rate_constant(i,3)
 
     !  k_O_O3_1: O + O3 -> 2*O2
-    LU(23) = LU(23) - rate_constant(6) * number_density(7)
+    LU(i,23) = LU(i,23) - rate_constant(i,6) * number_density(i,7)
+
+  end do
 
 end subroutine dforce_dy
 
-subroutine factored_alpha_minus_jac(LU, alpha, dforce_dy)
-  !compute LU decomposition of [alpha * I - dforce_dy]
+subroutine factored_alpha_minus_jac(ncell, LU, alpha, dforce_dy)
+  ! Compute LU decomposition of [alpha * I - dforce_dy]
 
-  real(r8), intent(in) :: dforce_dy(:)
+  integer,  intent(in) :: ncell ! number of grid cells with chemical reactions
+  real(r8), intent(in) :: dforce_dy(:,:)
   real(r8), intent(in) :: alpha
-  real(r8), intent(out) :: LU(:)
+  real(r8), intent(out) :: LU(:,:)
 
-  LU(:) = -dforce_dy(:)
+  integer :: i
 
-! add alpha to diagonal elements
+  LU(:,:) = -dforce_dy(:,:)
 
-  LU(1) = -dforce_dy(1) + alpha 
-  LU(5) = -dforce_dy(5) + alpha 
-  LU(6) = -dforce_dy(6) + alpha 
-  LU(7) = -dforce_dy(7) + alpha 
-  LU(8) = -dforce_dy(8) + alpha 
-  LU(11) = -dforce_dy(11) + alpha 
-  LU(13) = -dforce_dy(13) + alpha 
-  LU(18) = -dforce_dy(18) + alpha 
-  LU(23) = -dforce_dy(23) + alpha 
+  ! add alpha to diagonal elements
+  do i = 1, ncell
+    LU(i,1) = -dforce_dy(i,1) + alpha
+    LU(i,5) = -dforce_dy(i,5) + alpha
+    LU(i,6) = -dforce_dy(i,6) + alpha
+    LU(i,7) = -dforce_dy(i,7) + alpha
+    LU(i,8) = -dforce_dy(i,8) + alpha
+    LU(i,11) = -dforce_dy(i,11) + alpha
+    LU(i,13) = -dforce_dy(i,13) + alpha
+    LU(i,18) = -dforce_dy(i,18) + alpha
+    LU(i,23) = -dforce_dy(i,23) + alpha
+  end do
 
-  call factor(LU) 
+  call factor(ncell,LU)
 
 end subroutine factored_alpha_minus_jac
 
-subroutine p_force(rate_constant, number_density, number_density_air, force)
+subroutine p_force(ncell, rate_constant, number_density, number_density_air, force)
   ! Compute force function for all molecules
 
-  real(r8), intent(in) :: rate_constant(:)
-  real(r8), intent(in) :: number_density(:)
-  real(r8), intent(in) :: number_density_air
-  real(r8), intent(out) :: force(:)
+  integer,  intent(in) :: ncell ! Number of grid cells with chemical reactions
+  real(r8), intent(in) :: rate_constant(:,:)
+  real(r8), intent(in) :: number_density(:,:)
+  real(r8), intent(in) :: number_density_air(:)
+  real(r8), intent(out) :: force(:,:)
 
+  integer :: i
 
+  do i = 1, ncell
 
-! M
-  force(1) = 0
+    ! M
+    force(i,1) = 0
 
+    ! Ar
+    force(i,2) = 0
 
-! Ar
-  force(2) = 0
+    ! CO2
+    force(i,3) = 0
 
+    ! H2O
+    force(i,4) = 0
 
-! CO2
-  force(3) = 0
+    ! N2
+    force(i,5) = 0
 
+    ! O1D
+    force(i,6) = 0
 
-! H2O
-  force(4) = 0
+    ! k_O3_1: O3 -> 1*O1D + 1*O2
+    force(i,6) = force(i,6) + rate_constant(i,2) * number_density(i,9)
 
+    ! k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
+    force(i,6) = force(i,6) - rate_constant(i,4) * number_density(i,5) * number_density(i,6)
 
-! N2
-  force(5) = 0
+    ! k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
+    force(i,6) = force(i,6) - rate_constant(i,5) * number_density(i,6) * number_density(i,8)
 
+    ! O
+    force(i,7) = 0
 
-! O1D
-  force(6) = 0
+    ! k_O2_1: O2 -> 2*O
+    force(i,7) = force(i,7) + 2*rate_constant(i,1) * number_density(i,8)
 
-  ! k_O3_1: O3 -> 1*O1D + 1*O2
-  force(6) = force(6) + rate_constant(2) * number_density(9)
+    ! k_O3_2: O3 -> 1*O + 1*O2
+    force(i,7) = force(i,7) + rate_constant(i,3) * number_density(i,9)
 
-  ! k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
-  force(6) = force(6) - rate_constant(4) * number_density(5) * number_density(6)
+    ! k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
+    force(i,7) = force(i,7) + rate_constant(i,4) * number_density(i,5) * number_density(i,6)
 
-  ! k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
-  force(6) = force(6) - rate_constant(5) * number_density(6) * number_density(8)
+    ! k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
+    force(i,7) = force(i,7) + rate_constant(i,5) * number_density(i,6) * number_density(i,8)
 
+    ! k_O_O3_1: O + O3 -> 2*O2
+    force(i,7) = force(i,7) - rate_constant(i,6) * number_density(i,7) * number_density(i,9)
 
-! O
-  force(7) = 0
+    ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
+    force(i,7) = force(i,7) - rate_constant(i,7) * number_density(i,1) * number_density(i,7) * number_density(i,8)
 
-  ! k_O2_1: O2 -> 2*O
-  force(7) = force(7) + 2*rate_constant(1) * number_density(8)
+    ! O2
+    force(i,8) = 0
 
-  ! k_O3_2: O3 -> 1*O + 1*O2
-  force(7) = force(7) + rate_constant(3) * number_density(9)
+    ! k_O2_1: O2 -> 2*O
+    force(i,8) = force(i,8) - rate_constant(i,1) * number_density(i,8)
 
-  ! k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
-  force(7) = force(7) + rate_constant(4) * number_density(5) * number_density(6)
+    ! k_O3_1: O3 -> 1*O1D + 1*O2
+    force(i,8) = force(i,8) + rate_constant(i,2) * number_density(i,9)
 
-  ! k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
-  force(7) = force(7) + rate_constant(5) * number_density(6) * number_density(8)
+    ! k_O3_2: O3 -> 1*O + 1*O2
+    force(i,8) = force(i,8) + rate_constant(i,3) * number_density(i,9)
 
-  ! k_O_O3_1: O + O3 -> 2*O2
-  force(7) = force(7) - rate_constant(6) * number_density(7) * number_density(9)
+    ! k_O_O3_1: O + O3 -> 2*O2
+    force(i,8) = force(i,8) + 2*rate_constant(i,6) * number_density(i,7) * number_density(i,9)
 
-  ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-  force(7) = force(7) - rate_constant(7) * number_density(1) * number_density(7) * number_density(8)
+    ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
+    force(i,8) = force(i,8) - rate_constant(i,7) * number_density(i,1) * number_density(i,7) * number_density(i,8)
 
+    ! O3
+    force(i,9) = 0
 
-! O2
-  force(8) = 0
+    ! k_O3_1: O3 -> 1*O1D + 1*O2
+    force(i,9) = force(i,9) - rate_constant(i,2) * number_density(i,9)
 
-  ! k_O2_1: O2 -> 2*O
-  force(8) = force(8) - rate_constant(1) * number_density(8)
+    ! k_O3_2: O3 -> 1*O + 1*O2
+    force(i,9) = force(i,9) - rate_constant(i,3) * number_density(i,9)
 
-  ! k_O3_1: O3 -> 1*O1D + 1*O2
-  force(8) = force(8) + rate_constant(2) * number_density(9)
+    ! k_O_O3_1: O + O3 -> 2*O2
+    force(i,9) = force(i,9) - rate_constant(i,6) * number_density(i,7) * number_density(i,9)
 
-  ! k_O3_2: O3 -> 1*O + 1*O2
-  force(8) = force(8) + rate_constant(3) * number_density(9)
-
-  ! k_O_O3_1: O + O3 -> 2*O2
-  force(8) = force(8) + 2*rate_constant(6) * number_density(7) * number_density(9)
-
-  ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-  force(8) = force(8) - rate_constant(7) * number_density(1) * number_density(7) * number_density(8)
-
-
-! O3
-  force(9) = 0
-
-  ! k_O3_1: O3 -> 1*O1D + 1*O2
-  force(9) = force(9) - rate_constant(2) * number_density(9)
-
-  ! k_O3_2: O3 -> 1*O + 1*O2
-  force(9) = force(9) - rate_constant(3) * number_density(9)
-
-  ! k_O_O3_1: O + O3 -> 2*O2
-  force(9) = force(9) - rate_constant(6) * number_density(7) * number_density(9)
-
-  ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-  force(9) = force(9) + rate_constant(7) * number_density(1) * number_density(7) * number_density(8)
+    ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
+    force(i,9) = force(i,9) + rate_constant(i,7) * number_density(i,1) * number_density(i,7) * number_density(i,8)
+  end do
 
 end subroutine p_force
 
-function reaction_rates(rate_constant, number_density, number_density_air)
+function reaction_rates(ncell, rate_constant, number_density, number_density_air)
   ! Compute reaction rates
 
-  real(r8) :: reaction_rates(number_of_reactions)
-  real(r8), intent(in) :: rate_constant(:)
-  real(r8), intent(in) :: number_density(:)
-  real(r8), intent(in) :: number_density_air
+  integer,  intent(in) :: ncell ! Number of grid cells with chemical reactions
+  real(r8) :: reaction_rates(ncell,number_of_reactions)
+  real(r8), intent(in) :: rate_constant(:,:)
+  real(r8), intent(in) :: number_density(:,:)
+  real(r8), intent(in) :: number_density_air(:)
 
-  ! k_O2_1: O2 -> 2*O
-  reaction_rates(1) = rate_constant(1) * number_density(8)
+  integer :: i
 
-  ! k_O3_1: O3 -> 1*O1D + 1*O2
-  reaction_rates(2) = rate_constant(2) * number_density(9)
+  do i = 1, ncell
 
-  ! k_O3_2: O3 -> 1*O + 1*O2
-  reaction_rates(3) = rate_constant(3) * number_density(9)
+    ! k_O2_1: O2 -> 2*O
+    reaction_rates(i,1) = rate_constant(i,1) * number_density(i,8)
 
-  ! k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
-  reaction_rates(4) = rate_constant(4) * number_density(5) * number_density(6)
+    ! k_O3_1: O3 -> 1*O1D + 1*O2
+    reaction_rates(i,2) = rate_constant(i,2) * number_density(i,9)
 
-  ! k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
-  reaction_rates(5) = rate_constant(5) * number_density(6) * number_density(8)
+    ! k_O3_2: O3 -> 1*O + 1*O2
+    reaction_rates(i,3) = rate_constant(i,3) * number_density(i,9)
 
-  ! k_O_O3_1: O + O3 -> 2*O2
-  reaction_rates(6) = rate_constant(6) * number_density(7) * number_density(9)
+    ! k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
+    reaction_rates(i,4) = rate_constant(i,4) * number_density(i,5) * number_density(i,6)
 
-  ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-  reaction_rates(7) = rate_constant(7) * number_density(1) * number_density(7) * number_density(8)
+    ! k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
+    reaction_rates(i,5) = rate_constant(i,5) * number_density(i,6) * number_density(i,8)
+
+    ! k_O_O3_1: O + O3 -> 2*O2
+    reaction_rates(i,6) = rate_constant(i,6) * number_density(i,7) * number_density(i,9)
+
+    ! k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
+    reaction_rates(i,7) = rate_constant(i,7) * number_density(i,1) * number_density(i,7) * number_density(i,8)
+
+  end do
 
 end function reaction_rates
 
@@ -369,89 +363,76 @@ function species_names()
 end function species_names
 
 
-pure subroutine dforce_dy_times_vector(dforce_dy, vector, cummulative_product)
-
+pure subroutine dforce_dy_times_vector(ncell, dforce_dy, vector, cummulative_product)
   !  Compute product of [ dforce_dy * vector ]
   !  Commonly used to compute time-truncation errors [dforce_dy * force ]
 
-  real(r8), intent(in) :: dforce_dy(:) ! Jacobian of forcing
-  real(r8), intent(in) :: vector(:)    ! Vector ordered as the order of number density in dy
-  real(r8), intent(out) :: cummulative_product(:)  ! Product of jacobian with vector
+  integer,  intent(in) :: ncell ! Number of grid cells with chemical reactions
+  real(r8), intent(in) :: dforce_dy(:,:) ! Jacobian of forcing
+  real(r8), intent(in) :: vector(:,:)    ! Vector ordered as the order of number density in dy
+  real(r8), intent(out) :: cummulative_product(:,:)  ! Product of jacobian with vector
 
-  cummulative_product(:) = 0
+  integer :: i
 
+  cummulative_product(:,:) = 0
 
-  ! df_O/d(M) * M_temporary
-  cummulative_product(7) = cummulative_product(7) + dforce_dy(2) * vector(1)
+  do i = 1, ncell
 
+    ! df_O/d(M) * M_temporary
+    cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,2) * vector(i,1)
 
-  ! df_O2/d(M) * M_temporary
-  cummulative_product(8) = cummulative_product(8) + dforce_dy(3) * vector(1)
+    ! df_O2/d(M) * M_temporary
+    cummulative_product(i,8) = cummulative_product(i,8) + dforce_dy(i,3) * vector(i,1)
 
+    ! df_O3/d(M) * M_temporary
+    cummulative_product(i,9) = cummulative_product(i,9) + dforce_dy(i,4) * vector(i,1)
 
-  ! df_O3/d(M) * M_temporary
-  cummulative_product(9) = cummulative_product(9) + dforce_dy(4) * vector(1)
+    ! df_O1D/d(N2) * N2_temporary
+    cummulative_product(i,6) = cummulative_product(i,6) + dforce_dy(i,9) * vector(i,5)
 
+    ! df_O/d(N2) * N2_temporary
+    cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,10) * vector(i,5)
 
-  ! df_O1D/d(N2) * N2_temporary
-  cummulative_product(6) = cummulative_product(6) + dforce_dy(9) * vector(5)
+    ! df_O1D/d(O1D) * O1D_temporary
+    cummulative_product(i,6) = cummulative_product(i,6) + dforce_dy(i,11) * vector(i,6)
 
+    ! df_O/d(O1D) * O1D_temporary
+    cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,12) * vector(i,6)
 
-  ! df_O/d(N2) * N2_temporary
-  cummulative_product(7) = cummulative_product(7) + dforce_dy(10) * vector(5)
+    ! df_O/d(O) * O_temporary
+    cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,13) * vector(i,7)
 
+    ! df_O2/d(O) * O_temporary
+    cummulative_product(i,8) = cummulative_product(i,8) + dforce_dy(i,14) * vector(i,7)
 
-  ! df_O1D/d(O1D) * O1D_temporary
-  cummulative_product(6) = cummulative_product(6) + dforce_dy(11) * vector(6)
+    ! df_O3/d(O) * O_temporary
+    cummulative_product(i,9) = cummulative_product(i,9) + dforce_dy(i,15) * vector(i,7)
 
+    ! df_O1D/d(O2) * O2_temporary
+    cummulative_product(i,6) = cummulative_product(i,6) + dforce_dy(i,16) * vector(i,8)
 
-  ! df_O/d(O1D) * O1D_temporary
-  cummulative_product(7) = cummulative_product(7) + dforce_dy(12) * vector(6)
+    ! df_O/d(O2) * O2_temporary
+    cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,17) * vector(i,8)
 
+    ! df_O2/d(O2) * O2_temporary
+    cummulative_product(i,8) = cummulative_product(i,8) + dforce_dy(i,18) * vector(i,8)
 
-  ! df_O/d(O) * O_temporary
-  cummulative_product(7) = cummulative_product(7) + dforce_dy(13) * vector(7)
+    ! df_O3/d(O2) * O2_temporary
+    cummulative_product(i,9) = cummulative_product(i,9) + dforce_dy(i,19) * vector(i,8)
 
+    ! df_O1D/d(O3) * O3_temporary
+    cummulative_product(i,6) = cummulative_product(i,6) + dforce_dy(i,20) * vector(i,9)
 
-  ! df_O2/d(O) * O_temporary
-  cummulative_product(8) = cummulative_product(8) + dforce_dy(14) * vector(7)
+    ! df_O/d(O3) * O3_temporary
+    cummulative_product(i,7) = cummulative_product(i,7) + dforce_dy(i,21) * vector(i,9)
 
+    ! df_O2/d(O3) * O3_temporary
+    cummulative_product(i,8) = cummulative_product(i,8) + dforce_dy(i,22) * vector(i,9)
 
-  ! df_O3/d(O) * O_temporary
-  cummulative_product(9) = cummulative_product(9) + dforce_dy(15) * vector(7)
+    ! df_O3/d(O3) * O3_temporary
+    cummulative_product(i,9) = cummulative_product(i,9) + dforce_dy(i,23) * vector(i,9)
 
-
-  ! df_O1D/d(O2) * O2_temporary
-  cummulative_product(6) = cummulative_product(6) + dforce_dy(16) * vector(8)
-
-
-  ! df_O/d(O2) * O2_temporary
-  cummulative_product(7) = cummulative_product(7) + dforce_dy(17) * vector(8)
-
-
-  ! df_O2/d(O2) * O2_temporary
-  cummulative_product(8) = cummulative_product(8) + dforce_dy(18) * vector(8)
-
-
-  ! df_O3/d(O2) * O2_temporary
-  cummulative_product(9) = cummulative_product(9) + dforce_dy(19) * vector(8)
-
-
-  ! df_O1D/d(O3) * O3_temporary
-  cummulative_product(6) = cummulative_product(6) + dforce_dy(20) * vector(9)
-
-
-  ! df_O/d(O3) * O3_temporary
-  cummulative_product(7) = cummulative_product(7) + dforce_dy(21) * vector(9)
-
-
-  ! df_O2/d(O3) * O3_temporary
-  cummulative_product(8) = cummulative_product(8) + dforce_dy(22) * vector(9)
-
-
-  ! df_O3/d(O3) * O3_temporary
-  cummulative_product(9) = cummulative_product(9) + dforce_dy(23) * vector(9)
-
+  end do
 
 end subroutine dforce_dy_times_vector
 

--- a/test/preprocessor_output/rate_constants_utility.F90
+++ b/test/preprocessor_output/rate_constants_utility.F90
@@ -38,12 +38,14 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Calculate the rate constant for each reaction
-  subroutine calculate_rate_constants( rate_constants, environment )
+  subroutine calculate_rate_constants( ncell, rate_constants, environment )
 
+    !> Number of grid cells with chemical reactions
+    integer,              intent(in)  :: ncell
     !> Rate constant for each reaction [(molec cm-3)^(n-1) s-1]
-    real(kind=musica_dk), intent(out) :: rate_constants(:)
-    !> Environmental state
-    type(environment_t),  intent(in)  :: environment
+    real(kind=musica_dk), intent(out) :: rate_constants(:,:)
+    !> Environmental states for each grid cell
+    type(environment_t),  intent(in)  :: environment(:)
 
     type( rate_constant_arrhenius_t                   ) :: arrhenius
     type( rate_constant_photolysis_t                  ) :: photolysis
@@ -53,51 +55,56 @@ contains
     type( rate_constant_wennberg_nitrate_t            ) :: wennberg_nitrate
     type( rate_constant_wennberg_tunneling_t          ) :: wennberg_tunneling
 
-    !O2_1
-    !k_O2_1: O2 -> 2*O
-    photolysis = rate_constant_photolysis_t( &
+    integer :: i
+
+    do i = 1, ncell
+      !O2_1
+      !k_O2_1: O2 -> 2*O
+      photolysis = rate_constant_photolysis_t( &
         photolysis_rate_constant_index = 1 )
-    rate_constants(1) = photolysis%calculate( environment )
+      rate_constants( i, 1 ) = photolysis%calculate( environment( i ) )
 
-    !O3_1
-    !k_O3_1: O3 -> 1*O1D + 1*O2
-    photolysis = rate_constant_photolysis_t( &
+      !O3_1
+      !k_O3_1: O3 -> 1*O1D + 1*O2
+      photolysis = rate_constant_photolysis_t( &
         photolysis_rate_constant_index = 2 )
-    rate_constants(2) = photolysis%calculate( environment )
+      rate_constants( i, 2 ) = photolysis%calculate( environment( i ) )
 
-    !O3_2
-    !k_O3_2: O3 -> 1*O + 1*O2
-    photolysis = rate_constant_photolysis_t( &
+      !O3_2
+      !k_O3_2: O3 -> 1*O + 1*O2
+      photolysis = rate_constant_photolysis_t( &
         photolysis_rate_constant_index = 3 )
-    rate_constants(3) = photolysis%calculate( environment )
+      rate_constants( i, 3 ) = photolysis%calculate( environment( i ) )
 
-    !N2_O1D_1
-    !k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
-    arrhenius = rate_constant_arrhenius_t( &
+      !N2_O1D_1
+      !k_N2_O1D_1: N2 + O1D -> 1*O + 1*N2
+      arrhenius = rate_constant_arrhenius_t( &
         A = real( 2.15e-11, kind=musica_dk ), &
         C = real( 110, kind=musica_dk ) )
-    rate_constants(4) = arrhenius%calculate( environment )
+      rate_constants( i, 4 ) = arrhenius%calculate( environment( i ) )
 
-    !O1D_O2_1
-    !k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
-    arrhenius = rate_constant_arrhenius_t( &
+      !O1D_O2_1
+      !k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
+      arrhenius = rate_constant_arrhenius_t( &
         A = real( 3.3e-11, kind=musica_dk ), &
         C = real( 55, kind=musica_dk ) )
-    rate_constants(5) = arrhenius%calculate( environment )
+      rate_constants( i, 5 ) = arrhenius%calculate( environment( i ) )
 
-    !O_O3_1
-    !k_O_O3_1: O + O3 -> 2*O2
-    arrhenius = rate_constant_arrhenius_t( &
+      !O_O3_1
+      !k_O_O3_1: O + O3 -> 2*O2
+      arrhenius = rate_constant_arrhenius_t( &
         A = real( 8e-12, kind=musica_dk ), &
         C = real( -2060, kind=musica_dk ) )
-    rate_constants(6) = arrhenius%calculate( environment )
+      rate_constants( i, 6 ) = arrhenius%calculate( environment( i ) )
 
-    !M_O_O2_1
-    !k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
-    arrhenius = rate_constant_arrhenius_t( &
+      !M_O_O2_1
+      !k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
+      arrhenius = rate_constant_arrhenius_t( &
         A = real( 6e-34, kind=musica_dk ), &
         B = real( 2.4, kind=musica_dk ) )
-    rate_constants(7) = arrhenius%calculate( environment )
+      rate_constants( i, 7 ) = arrhenius%calculate( environment( i ) )
+
+    end do
 
   end subroutine calculate_rate_constants
 


### PR DESCRIPTION
closes #13 

- Introduces a test to the suite that can be expanded for use in the performance evaluation.
  - We will have to set initial and evolving conditions once we get these from the scientists
- Adds multi-grid preprocessor output to the micm source code.
- Adapts `ODE_solver_t` and `kinetics_t` classes to work accept multi-grid-point data.
  - For now, the solvers and kinetics classes only perform calculations for the first grid point, but the functions are now set up to accept multi-grid-point data
- I just bypassed the `core_t` class completely (excluding it from the build). This was easier than hacking in the multi-grid-point capability. The new test driver does the work that would have been handled by the `core_t` instance.