### PR TITLE
Sparse matrix class

### DIFF
--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -74,6 +74,8 @@ namespace micm
 
     SparseMatrixBuilder<T>& with_element(std::size_t x, std::size_t y)
     {
+      if (x >= block_size_ || y >= block_size_)
+        throw std::invalid_argument("SparseMatrix element out of range");
       non_zero_elements_.insert(std::make_pair(x, y));
       return *this;
     }

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -42,6 +42,25 @@ namespace micm
           row_start_(builder.RowStartVector())
     {
     }
+
+    std::vector<T>& AsVector() {
+      return data_;
+    }
+
+    std::size_t VectorIndex(std::size_t block, std::size_t row, std::size_t column) const {
+      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1 || block >= number_of_blocks_)
+        throw std::invalid_argument("SparseMatrix element out of range");
+      auto begin = std::next(row_ids_.begin(), row_start_[row]);
+      auto end   = std::next(row_ids_.begin(), row_start_[row + 1]);
+      auto elem = std::find(begin, end, column);
+      if (elem == end) throw std::invalid_argument("SparseMatrix zero element access not allowed");
+      return std::size_t { (elem - row_ids_.begin()) + block * row_ids_.size() };
+    }
+
+    std::size_t VectorIndex(std::size_t row, std::size_t column) const {
+      if (number_of_blocks_ != 1) throw std::invalid_argument("Multi-block SparseMatrix access must specify block index");
+      return VectorIndex(0, row, column);
+    }
   };
 
   template<class T>

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -1,0 +1,119 @@
+// Copyright (C) 2023 National Center for Atmospheric Research,
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cassert>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace micm
+{
+
+  template<class T>
+  class SparseMatrixBuilder;
+
+  /// @brief A sparse block-diagonal 2D matrix class with contiguous memory
+  ///
+  /// Each block sub-matrix is square and has the same structure of non-zero elements
+  ///
+  /// Sparse matrix data structure follows the Compressed Sparse Row (CSR) pattern
+  template<class T>
+  class SparseMatrix
+  {
+    std::size_t number_of_blocks_;        // Number of block sub-matrices in the overall matrix
+    std::vector<T> data_;                 // Value of each non-zero matrix element
+    std::vector<std::size_t> row_ids_;    // Row indices of each non-zero element in a block
+    std::vector<std::size_t> row_start_;  // Index in data_ and row_ids_ of the start of each column in a block
+
+    friend class SparseMatrixBuilder<T>;
+
+   public:
+    static SparseMatrixBuilder<T> create(std::size_t block_size)
+    {
+      return SparseMatrixBuilder<T>{ block_size };
+    }
+
+    SparseMatrix(SparseMatrixBuilder<T>& builder)
+        : number_of_blocks_(builder.number_of_blocks_),
+          data_(builder.NumberOfElements(), builder.initial_value_),
+          row_ids_(builder.RowIdsVector()),
+          row_start_(builder.RowStartVector())
+    {
+    }
+  };
+
+  template<class T>
+  class SparseMatrixBuilder
+  {
+    std::size_t number_of_blocks_{ 1 };
+    std::size_t block_size_;
+    std::set<std::pair<std::size_t, std::size_t>> non_zero_elements_{};
+    T initial_value_{};
+    friend class SparseMatrix<T>;
+
+   public:
+    SparseMatrixBuilder() = delete;
+
+    SparseMatrixBuilder(std::size_t block_size)
+        : block_size_(block_size)
+    {
+    }
+
+    operator SparseMatrix<T>() const
+    {
+      return SparseMatrix<T>(*this);
+    }
+
+    SparseMatrixBuilder<T>& number_of_blocks(std::size_t n)
+    {
+      number_of_blocks_ = n;
+      return *this;
+    }
+
+    SparseMatrixBuilder<T>& with_element(std::size_t x, std::size_t y)
+    {
+      non_zero_elements_.insert(std::make_pair(x, y));
+      return *this;
+    }
+
+    SparseMatrixBuilder<T>& initial_value(T inital_value)
+    {
+      initial_value_ = inital_value;
+      return *this;
+    }
+
+    std::size_t NumberOfElements() const
+    {
+      return non_zero_elements_.size() * number_of_blocks_;
+    }
+
+    std::vector<std::size_t> RowIdsVector() const
+    {
+      std::vector<std::size_t> ids;
+      ids.reserve(non_zero_elements_.size());
+      std::transform(
+          non_zero_elements_.begin(),
+          non_zero_elements_.end(),
+          std::back_inserter(ids),
+          [](const std::pair<std::size_t, std::size_t>& elem) { return elem.second; });
+      return ids;
+    }
+    std::vector<std::size_t> RowStartVector() const
+    {
+      std::vector<std::size_t> starts(block_size_ + 1, 0);
+      std::size_t total_elem = 0;
+      std::size_t curr_row = 0;
+      for (auto& elem : non_zero_elements_)
+      {
+        while (curr_row < elem.first)
+          starts[(curr_row++) + 1] = total_elem;
+        ++total_elem;
+      }
+      starts[curr_row + 1] = total_elem;
+      return starts;
+    }
+  };
+
+}  // namespace micm

--- a/test/unit/util/CMakeLists.txt
+++ b/test/unit/util/CMakeLists.txt
@@ -7,3 +7,4 @@ include(test_util)
 # Tests
 
 create_standard_test(NAME matrix SOURCES test_matrix.cpp)
+create_standard_test(NAME sparse_matrix SOURCES test_sparse_matrix.cpp)

--- a/test/unit/util/test_sparse_matrix.cpp
+++ b/test/unit/util/test_sparse_matrix.cpp
@@ -17,6 +17,31 @@ TEST(SparseMatrix, ZeroMatrix)
   EXPECT_EQ(row_starts[3], 0);
 
   micm::SparseMatrix<double> matrix{ builder };
+
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(0, 0); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(6, 0); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(6, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
 }
 
 TEST(SparseMatrix, SingleBlockMatrix)
@@ -29,8 +54,8 @@ TEST(SparseMatrix, SingleBlockMatrix)
                      .with_element(2, 1);
   // 0 X 0 0
   // 0 0 0 0
-  // 0 1 0 1
-  // 0 0 1 0
+  // 0 X 0 X
+  // 0 0 X 0
   auto row_ids = builder.RowIdsVector();
   auto row_starts = builder.RowStartVector();
 
@@ -46,6 +71,52 @@ TEST(SparseMatrix, SingleBlockMatrix)
   EXPECT_EQ(row_starts[2], 1);
   EXPECT_EQ(row_starts[3], 3);
   EXPECT_EQ(row_starts[4], 4);
+
+  micm::SparseMatrix<int> matrix{ builder };
+
+  {
+    std::size_t elem = matrix.VectorIndex(3, 2);
+    EXPECT_EQ(elem, 3);
+    matrix.AsVector()[elem] = 42;
+    EXPECT_EQ(matrix.AsVector()[3], 42);
+  }
+  {
+    std::size_t elem = matrix.VectorIndex(2, 3);
+    EXPECT_EQ(elem, 2);
+    matrix.AsVector()[elem] = 21;
+    EXPECT_EQ(matrix.AsVector()[2], 21);
+  }
+
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(4, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 5); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 0, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 1); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(0, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
 }
 
 TEST(SparseMatrix, MultiBlockMatrix)
@@ -59,8 +130,8 @@ TEST(SparseMatrix, MultiBlockMatrix)
                      .number_of_blocks(3);
   // 0 X 0 0
   // 0 0 0 0
-  // 0 1 0 1
-  // 0 0 1 0
+  // 0 X 0 X
+  // 0 0 X 0
   auto row_ids = builder.RowIdsVector();
   auto row_starts = builder.RowStartVector();
 
@@ -76,6 +147,58 @@ TEST(SparseMatrix, MultiBlockMatrix)
   EXPECT_EQ(row_starts[2], 1);
   EXPECT_EQ(row_starts[3], 3);
   EXPECT_EQ(row_starts[4], 4);
+
+  micm::SparseMatrix<int> matrix{ builder };
+
+  {
+    std::size_t elem = matrix.VectorIndex(0, 2, 3);
+    EXPECT_EQ(elem, 2);
+    matrix.AsVector()[elem] = 21;
+    EXPECT_EQ(matrix.AsVector()[2], 21);
+  }
+  {
+    std::size_t elem = matrix.VectorIndex(2, 2, 1);
+    EXPECT_EQ(elem, 9);
+    matrix.AsVector()[elem] = 31;
+    EXPECT_EQ(matrix.AsVector()[9], 31);
+  }
+
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(0, 4, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(2, 1, 5); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(4, 0, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 1, 1); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(2, 0, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(0, 1); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "Multi-block SparseMatrix access must specify block index");
+        throw;
+      },
+      std::invalid_argument);
 }
 
 TEST(SparseMatrixBuilder, BadConfiguration)

--- a/test/unit/util/test_sparse_matrix.cpp
+++ b/test/unit/util/test_sparse_matrix.cpp
@@ -42,6 +42,30 @@ TEST(SparseMatrix, ZeroMatrix)
         throw;
       },
       std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][0][4] = 2.0; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[1][0][0] = 2.0; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][3][0] = 2.0; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][1][1] = 2.0; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
 }
 
 TEST(SparseMatrix, SingleBlockMatrix)
@@ -87,6 +111,9 @@ TEST(SparseMatrix, SingleBlockMatrix)
     EXPECT_EQ(matrix.AsVector()[2], 21);
   }
 
+  matrix[0][2][1] = 45;
+  EXPECT_EQ(matrix[0][2][1], 45);
+
   EXPECT_THROW(
       try { std::size_t elem = matrix.VectorIndex(4, 2); } catch (const std::invalid_argument& e) {
         EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
@@ -113,6 +140,30 @@ TEST(SparseMatrix, SingleBlockMatrix)
       std::invalid_argument);
   EXPECT_THROW(
       try { std::size_t elem = matrix.VectorIndex(0, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][0][4] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[1][0][0] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][5][0] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][1][1] = 2; } catch (const std::invalid_argument& e) {
         EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
         throw;
       },
@@ -163,6 +214,12 @@ TEST(SparseMatrix, MultiBlockMatrix)
     EXPECT_EQ(matrix.AsVector()[9], 31);
   }
 
+  matrix[0][2][1] = 45;
+  EXPECT_EQ(matrix[0][2][1], 45);
+
+  matrix[2][2][3] = 64;
+  EXPECT_EQ(matrix[2][2][3], 64);
+
   EXPECT_THROW(
       try { std::size_t elem = matrix.VectorIndex(0, 4, 2); } catch (const std::invalid_argument& e) {
         EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
@@ -196,6 +253,30 @@ TEST(SparseMatrix, MultiBlockMatrix)
   EXPECT_THROW(
       try { std::size_t elem = matrix.VectorIndex(0, 1); } catch (const std::invalid_argument& e) {
         EXPECT_STREQ(e.what(), "Multi-block SparseMatrix access must specify block index");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][0][4] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[3][0][0] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][5][0] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][1][1] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
         throw;
       },
       std::invalid_argument);

--- a/test/unit/util/test_sparse_matrix.cpp
+++ b/test/unit/util/test_sparse_matrix.cpp
@@ -77,3 +77,31 @@ TEST(SparseMatrix, MultiBlockMatrix)
   EXPECT_EQ(row_starts[3], 3);
   EXPECT_EQ(row_starts[4], 4);
 }
+
+TEST(SparseMatrixBuilder, BadConfiguration)
+{
+  EXPECT_THROW(
+      try {
+        auto builder = micm::SparseMatrix<double>::create(3).with_element(3, 0);
+      } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try {
+        auto builder = micm::SparseMatrix<double>::create(3).with_element(2, 4);
+      } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try {
+        auto builder = micm::SparseMatrix<double>::create(3).with_element(6, 7);
+      } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+}

--- a/test/unit/util/test_sparse_matrix.cpp
+++ b/test/unit/util/test_sparse_matrix.cpp
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+
+#include <micm/util/sparse_matrix.hpp>
+
+TEST(SparseMatrix, ZeroMatrix)
+{
+  auto builder = micm::SparseMatrix<double>::create(3);
+  auto row_ids = builder.RowIdsVector();
+  auto row_starts = builder.RowStartVector();
+
+  EXPECT_EQ(builder.NumberOfElements(), 0);
+  EXPECT_EQ(row_ids.size(), 0);
+  EXPECT_EQ(row_starts.size(), 4);
+  EXPECT_EQ(row_starts[0], 0);
+  EXPECT_EQ(row_starts[1], 0);
+  EXPECT_EQ(row_starts[2], 0);
+  EXPECT_EQ(row_starts[3], 0);
+
+  micm::SparseMatrix<double> matrix{ builder };
+}
+
+TEST(SparseMatrix, SingleBlockMatrix)
+{
+  auto builder = micm::SparseMatrix<int>::create(4)
+                     .with_element(0, 1)
+                     .with_element(3, 2)
+                     .with_element(0, 1)
+                     .with_element(2, 3)
+                     .with_element(2, 1);
+  // 0 X 0 0
+  // 0 0 0 0
+  // 0 1 0 1
+  // 0 0 1 0
+  auto row_ids = builder.RowIdsVector();
+  auto row_starts = builder.RowStartVector();
+
+  EXPECT_EQ(builder.NumberOfElements(), 4);
+  EXPECT_EQ(row_ids.size(), 4);
+  EXPECT_EQ(row_ids[0], 1);
+  EXPECT_EQ(row_ids[1], 1);
+  EXPECT_EQ(row_ids[2], 3);
+  EXPECT_EQ(row_ids[3], 2);
+  EXPECT_EQ(row_starts.size(), 5);
+  EXPECT_EQ(row_starts[0], 0);
+  EXPECT_EQ(row_starts[1], 1);
+  EXPECT_EQ(row_starts[2], 1);
+  EXPECT_EQ(row_starts[3], 3);
+  EXPECT_EQ(row_starts[4], 4);
+}
+
+TEST(SparseMatrix, MultiBlockMatrix)
+{
+  auto builder = micm::SparseMatrix<int>::create(4)
+                     .with_element(0, 1)
+                     .with_element(3, 2)
+                     .with_element(0, 1)
+                     .with_element(2, 3)
+                     .with_element(2, 1)
+                     .number_of_blocks(3);
+  // 0 X 0 0
+  // 0 0 0 0
+  // 0 1 0 1
+  // 0 0 1 0
+  auto row_ids = builder.RowIdsVector();
+  auto row_starts = builder.RowStartVector();
+
+  EXPECT_EQ(builder.NumberOfElements(), 4 * 3);
+  EXPECT_EQ(row_ids.size(), 4);
+  EXPECT_EQ(row_ids[0], 1);
+  EXPECT_EQ(row_ids[1], 1);
+  EXPECT_EQ(row_ids[2], 3);
+  EXPECT_EQ(row_ids[3], 2);
+  EXPECT_EQ(row_starts.size(), 5);
+  EXPECT_EQ(row_starts[0], 0);
+  EXPECT_EQ(row_starts[1], 1);
+  EXPECT_EQ(row_starts[2], 1);
+  EXPECT_EQ(row_starts[3], 3);
+  EXPECT_EQ(row_starts[4], 4);
+}


### PR DESCRIPTION
Adds a `SparseMatrix` class. This will be used for the Jacobian and linear solver functions.

The data structure follows the CSR pattern with the underlying matrix data stored in a `std::vector<double>`. The matrix structure is block-diagonal where each block is square and of the same dimensions and sparse structure. For the chemical system, the blocks should correspond to individual grid cells.

The `VectorId()` function allows for lookups of the index in the underlying vector for matrix elements using their block, row, and column indices. This can be saved and used for fast access during solving. Normal array syntax `[block][row][column]` access to matrix data is also available for more convenient (but slower) access.

I wasn't sure what is the best way to handle attempts to access zero elements in the array. I set it up to throw exceptions if this happens, but maybe there is a better solution?