### PR TITLE
Rosenbrock dforce_dy function

### DIFF
--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -6,6 +6,7 @@
 #include <micm/process/process.hpp>
 #include <micm/solver/state.hpp>
 #include <micm/util/matrix.hpp>
+#include <micm/util/sparse_matrix.hpp>
 #include <vector>
 
 namespace micm
@@ -19,6 +20,7 @@ namespace micm
     std::vector<std::size_t> number_of_products_;
     std::vector<std::size_t> product_ids_;
     std::vector<double> yields_;
+    std::vector<std::size_t> jacobian_flat_ids_;
 
    public:
     /// @brief Default constructor
@@ -33,6 +35,10 @@ namespace micm
     /// @return Jacobian elements as a set of index pairs
     std::set<std::pair<std::size_t, std::size_t>> NonZeroJacobianElements() const;
 
+    /// @brief Sets the indicies for each non-zero Jacobian element in the underlying vector
+    /// @param matrix The sparse matrix used for the Jacobian
+    void SetJacobianFlatIds(const SparseMatrix<double>& matrix);
+
     /// @brief Add forcing terms for the set of processes for the current conditions
     /// @param rate_constants Current values for the process rate constants (grid cell, process)
     /// @param state_variables Current state variable values (grid cell, state variable)
@@ -41,6 +47,15 @@ namespace micm
         const Matrix<double>& rate_constants,
         const Matrix<double>& state_variables,
         Matrix<double>& forcing) const;
+
+    /// @brief Add Jacobian terms for the set of processes for the current conditions
+    /// @param rate_constants Current values for the process rate constants (grid cell, process)
+    /// @param state_variables Current state variable values (grid cell, state variable)
+    /// @param jacobian Jacobian matrix for the system (grid cell, dependent variable, independent variable)
+    void AddJacobianTerms(
+        const Matrix<double>& rate_constants,
+        const Matrix<double>& state_variables,
+        SparseMatrix<double>& jacobian) const;
   };
 
   inline ProcessSet::ProcessSet(const std::vector<Process>& processes, const State& state)
@@ -90,6 +105,29 @@ namespace micm
     return ids;
   }
 
+  void ProcessSet::SetJacobianFlatIds(const SparseMatrix<double>& matrix)
+  {
+    jacobian_flat_ids_.clear();
+    auto react_id = reactant_ids_.begin();
+    auto prod_id = product_ids_.begin();
+    for (std::size_t i_rxn = 0; i_rxn < number_of_reactants_.size(); ++i_rxn)
+    {
+      for (std::size_t i_ind = 0; i_ind < number_of_reactants_[i_rxn]; ++i_ind)
+      {
+        for (std::size_t i_dep = 0; i_dep < number_of_reactants_[i_rxn]; ++i_dep)
+        {
+          jacobian_flat_ids_.push_back(matrix.VectorIndex(0, react_id[i_dep], react_id[i_ind]));
+        }
+        for (std::size_t i_dep = 0; i_dep < number_of_products_[i_rxn]; ++i_dep)
+        {
+          jacobian_flat_ids_.push_back(matrix.VectorIndex(0, prod_id[i_dep], react_id[i_ind]));
+        }
+      }
+      react_id += number_of_reactants_[i_rxn];
+      prod_id += number_of_products_[i_rxn];
+    }
+  }
+
   inline void ProcessSet::AddForcingTerms(
       const Matrix<double>& rate_constants,
       const Matrix<double>& state_variables,
@@ -119,5 +157,42 @@ namespace micm
       }
     }
   };
+
+  inline void ProcessSet::AddJacobianTerms(
+      const Matrix<double>& rate_constants,
+      const Matrix<double>& state_variables,
+      SparseMatrix<double>& jacobian) const
+  {
+    auto cell_jacobian = jacobian.AsVector().begin();
+    // loop over grid cells
+    for (std::size_t i_cell = 0; i_cell < state_variables.size(); ++i_cell)
+    {
+      auto cell_rate_constants = rate_constants[i_cell];
+      auto cell_state = state_variables[i_cell];
+      auto react_id = reactant_ids_.begin();
+      auto yield = yields_.begin();
+      auto flat_id = jacobian_flat_ids_.begin();
+      for (std::size_t i_rxn = 0; i_rxn < number_of_reactants_.size(); ++i_rxn)
+      {
+        for (std::size_t i_ind = 0; i_ind < number_of_reactants_[i_rxn]; ++i_ind)
+        {
+          double d_rate_d_ind = cell_rate_constants[i_rxn];
+          for (std::size_t i_react = 0; i_react < number_of_reactants_[i_rxn]; ++i_react)
+          {
+            if (i_react == i_ind)
+              continue;
+            d_rate_d_ind *= cell_state[react_id[i_react]];
+          }
+          for (std::size_t i_dep = 0; i_dep < number_of_reactants_[i_rxn]; ++i_dep)
+            cell_jacobian[*(flat_id++)] -= d_rate_d_ind;
+          for (std::size_t i_dep = 0; i_dep < number_of_products_[i_rxn]; ++i_dep)
+            cell_jacobian[*(flat_id++)] += yield[i_dep] * d_rate_d_ind;
+        }
+        react_id += number_of_reactants_[i_rxn];
+        yield += number_of_products_[i_rxn];
+      }
+      cell_jacobian += jacobian.FlatBlockSize();
+    }
+  }
 
 }  // namespace micm

--- a/include/micm/solver/chapman_ode_solver.hpp
+++ b/include/micm/solver/chapman_ode_solver.hpp
@@ -24,6 +24,7 @@ namespace micm
    */
   class ChapmanODESolver : public RosenbrockSolver
   {
+    std::size_t number_sparse_factor_elements_ = 23;
    public:
     /// @brief Default constructor
     ChapmanODESolver();
@@ -96,7 +97,7 @@ namespace micm
     std::vector<double> dforce_dy(
         const std::vector<double>& rate_constants,
         const std::vector<double>& number_densities,
-        const double& number_density_air) override;
+        const double& number_density_air);
 
     /// @brief Prepare the rosenbrock ode solver matrix
     /// @param H time step (seconds)
@@ -109,7 +110,7 @@ namespace micm
         bool& singular,
         const std::vector<double>& number_densities,
         const double& number_density_air,
-        const std::vector<double>& rate_constants) override;
+        const std::vector<double>& rate_constants);
 
     /// @brief Factor
     /// @param jacobian

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -122,6 +122,11 @@ namespace micm
       return number_of_blocks_;
     }
 
+    std::size_t FlatBlockSize() const
+    {
+      return row_ids_.size();
+    }
+
     ProxyRow operator[](std::size_t b)
     {
       return ProxyRow(*this, b);

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -85,6 +85,8 @@ namespace micm
       return SparseMatrixBuilder<T>{ block_size };
     }
 
+    SparseMatrix() = default;
+
     SparseMatrix(SparseMatrixBuilder<T>& builder)
         : number_of_blocks_(builder.number_of_blocks_),
           data_(builder.NumberOfElements(), builder.initial_value_),

--- a/test/regression/RosenbrockChapman/CMakeLists.txt
+++ b/test/regression/RosenbrockChapman/CMakeLists.txt
@@ -6,4 +6,5 @@ include(test_util)
 ################################################################################
 # Tests
 
-create_standard_test(NAME regression_test_rosebrock_p_force SOURCES regression_test_p_force.cpp)
+create_standard_test(NAME regression_test_rosenbrock_p_force SOURCES regression_test_p_force.cpp)
+create_standard_test(NAME regression_test_rosenbrock_dforce_dy SOURCES regression_test_dforce_dy.cpp)

--- a/test/regression/RosenbrockChapman/regression_test_dforce_dy.cpp
+++ b/test/regression/RosenbrockChapman/regression_test_dforce_dy.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+
+#include <micm/solver/chapman_ode_solver.hpp>
+#include <micm/solver/rosenbrock.hpp>
+#include <random>
+
+#include "util.hpp"
+
+TEST(RegressionRosenbrock, dforce_dy)
+{
+  std::random_device rnd_device;
+  std::mt19937 engine{ rnd_device() };
+  std::lognormal_distribution dist{ -2.0, 4.0 };
+
+  micm::ChapmanODESolver fixed_solver{};
+  auto solver = getMultiCellChapmanSolver(3);
+
+  auto state = solver.GetState();
+
+  auto& state_vec = state.variables_.AsVector();
+  std::generate(state_vec.begin(), state_vec.end(), [&]() { return dist(engine); });
+  auto& rate_const_vec = state.rate_constants_.AsVector();
+  std::generate(state_vec.begin(), state_vec.end(), [&]() { return dist(engine); });
+
+  auto& jacobian = solver.jacobian_;
+  solver.dforce_dy(state.rate_constants_, state.variables_, jacobian);
+
+  for (std::size_t i{}; i < 3; ++i)
+  {
+    double number_density_air = 1.0;
+    std::vector<double> rate_constants = state.rate_constants_[i];
+    std::vector<double> variables = state.variables_[i];
+    std::vector<double> fixed_jacobian = fixed_solver.dforce_dy(rate_constants, variables, number_density_air);
+
+    // TODO: The sparse matrix data ordering in the hard-coded solver is different (maybe because of pivoting?)
+    //       As the remaining linear solver functions are generalized, use the logic in the preprocessor to
+    //       decipher the data elements in the hard-coded solver sparse matrix to finish this test.
+    //EXPECT_EQ(jacobian.FlatBlockSize(), fixed_jacobian.size());
+    for (std::size_t j{}; j < fixed_jacobian.size(); ++j)
+    {
+      //EXPECT_NEAR(jacobian.AsVector()[i * jacobian.FlatBlockSize() + j], fixed_jacobian[j], 1.0e-10);
+    }
+  }
+}

--- a/test/unit/process/test_process_set.cpp
+++ b/test/unit/process/test_process_set.cpp
@@ -64,11 +64,11 @@ TEST(ProcessSet, Constructor)
   auto non_zero_elements = set.NonZeroJacobianElements();
 
   // ---- foo  bar  baz  quz  quuz
-  // foo   X    X    X    0    0
-  // bar   X    X    X    0    0
-  // baz   X    0    X    0    0
-  // quz   0    X    0    X    0
-  // quuz  X    0    X    0    0
+  // foo   0    1    2    -    -
+  // bar   3    4    5    -    -
+  // baz   6    -    7    -    -
+  // quz   -    8    -    9    -
+  // quuz 10    -   11    -    -
 
   auto elem = non_zero_elements.begin();
   compare_pair(*elem, index_pair(0, 0));
@@ -83,4 +83,36 @@ TEST(ProcessSet, Constructor)
   compare_pair(*(++elem), index_pair(3, 3));
   compare_pair(*(++elem), index_pair(4, 0));
   compare_pair(*(++elem), index_pair(4, 2));
+
+  auto builder = micm::SparseMatrix<double>::create(5).number_of_blocks(2).initial_value(100.0);
+  for (auto& elem : non_zero_elements)
+    builder = builder.with_element(elem.first, elem.second);
+  micm::SparseMatrix<double> jacobian{ builder };
+  set.SetJacobianFlatIds(jacobian);
+  set.AddJacobianTerms(rate_constants, state.variables_, jacobian);
+
+  EXPECT_EQ(jacobian[0][0][0], 100.0 - 10.0 * 0.3);  // foo -> foo
+  EXPECT_EQ(jacobian[1][0][0], 100.0 - 110.0 * 1.3);
+  EXPECT_EQ(jacobian[0][0][1], 100.0 + 20.0);  // foo -> bar
+  EXPECT_EQ(jacobian[1][0][1], 100.0 + 120.0);
+  EXPECT_EQ(jacobian[0][0][2], 100.0 - 10.0 * 0.1);  // foo -> baz
+  EXPECT_EQ(jacobian[1][0][2], 100.0 - 110.0 * 1.1);
+  EXPECT_EQ(jacobian[0][1][0], 100.0 + 10.0 * 0.3);  // bar -> foo
+  EXPECT_EQ(jacobian[1][1][0], 100.0 + 110.0 * 1.3);
+  EXPECT_EQ(jacobian[0][1][1], 100.0 - 20.0);  // bar -> bar
+  EXPECT_EQ(jacobian[1][1][1], 100.0 - 120.0);
+  EXPECT_EQ(jacobian[0][1][2], 100.0 + 10.0 * 0.1);  // bar -> baz
+  EXPECT_EQ(jacobian[1][1][2], 100.0 + 110.0 * 1.1);
+  EXPECT_EQ(jacobian[0][2][0], 100.0 - 10.0 * 0.3);  // baz -> foo
+  EXPECT_EQ(jacobian[1][2][0], 100.0 - 110.0 * 1.3);
+  EXPECT_EQ(jacobian[0][2][2], 100.0 - 10.0 * 0.1);  // baz -> baz
+  EXPECT_EQ(jacobian[1][2][2], 100.0 - 110.0 * 1.1);
+  EXPECT_EQ(jacobian[0][3][1], 100.0 + 1.4 * 20.0);  // quz -> bar
+  EXPECT_EQ(jacobian[1][3][1], 100.0 + 1.4 * 120.0);
+  EXPECT_EQ(jacobian[0][3][3], 100.0 - 30.0);  // quz -> quz
+  EXPECT_EQ(jacobian[1][3][3], 100.0 - 130.0);
+  EXPECT_EQ(jacobian[0][4][0], 100.0 + 2.4 * 10.0 * 0.3);  // quuz -> foo
+  EXPECT_EQ(jacobian[1][4][0], 100.0 + 2.4 * 110.0 * 1.3);
+  EXPECT_EQ(jacobian[0][4][2], 100.0 + 2.4 * 10.0 * 0.1);  // quuz -> baz
+  EXPECT_EQ(jacobian[1][4][2], 100.0 + 2.4 * 110.0 * 1.1);
 }

--- a/test/unit/process/test_process_set.cpp
+++ b/test/unit/process/test_process_set.cpp
@@ -4,6 +4,13 @@
 #include <micm/process/process_set.hpp>
 
 using yields = std::pair<micm::Species, double>;
+using index_pair = std::pair<std::size_t, std::size_t>;
+
+void compare_pair(const index_pair& a, const index_pair& b)
+{
+  EXPECT_EQ(a.first, b.first);
+  EXPECT_EQ(a.second, b.second);
+}
 
 TEST(ProcessSet, Constructor)
 {
@@ -21,24 +28,14 @@ TEST(ProcessSet, Constructor)
                                             .number_of_rate_constants_ = 3 } };
 
   micm::Process r1 =
-      micm::Process::create()
-          .reactants({ foo, baz })
-          .products({ yields(bar, 1), yields(quuz, 2.4) })
-          .phase(gas_phase);
-          
-  micm::Process r2 =
-      micm::Process::create()
-          .reactants({ bar })
-          .products({ yields(foo, 1), yields(quz, 1.4) })
-          .phase(gas_phase);
-          
-  micm::Process r3 =
-      micm::Process::create()
-          .reactants({ quz })
-          .products({ })
-          .phase(gas_phase);
+      micm::Process::create().reactants({ foo, baz }).products({ yields(bar, 1), yields(quuz, 2.4) }).phase(gas_phase);
 
-  micm::ProcessSet set{ std::vector<micm::Process>{ r1, r2, r3 }, state};
+  micm::Process r2 =
+      micm::Process::create().reactants({ bar }).products({ yields(foo, 1), yields(quz, 1.4) }).phase(gas_phase);
+
+  micm::Process r3 = micm::Process::create().reactants({ quz }).products({}).phase(gas_phase);
+
+  micm::ProcessSet set{ std::vector<micm::Process>{ r1, r2, r3 }, state };
 
   EXPECT_EQ(state.variables_.size(), 2);
   EXPECT_EQ(state.variables_[0].size(), 5);
@@ -53,14 +50,37 @@ TEST(ProcessSet, Constructor)
 
   set.AddForcingTerms(rate_constants, state.variables_, forcing);
 
-  EXPECT_EQ(forcing[0][0], 1000.0 -  10.0 * 0.1 * 0.3 +  20.0 * 0.2);
+  EXPECT_EQ(forcing[0][0], 1000.0 - 10.0 * 0.1 * 0.3 + 20.0 * 0.2);
   EXPECT_EQ(forcing[1][0], 1000.0 - 110.0 * 1.1 * 1.3 + 120.0 * 1.2);
-  EXPECT_EQ(forcing[0][1], 1000.0 +  10.0 * 0.1 * 0.3 -  20.0 * 0.2);
+  EXPECT_EQ(forcing[0][1], 1000.0 + 10.0 * 0.1 * 0.3 - 20.0 * 0.2);
   EXPECT_EQ(forcing[1][1], 1000.0 + 110.0 * 1.1 * 1.3 - 120.0 * 1.2);
-  EXPECT_EQ(forcing[0][2], 1000.0 -  10.0 * 0.1 * 0.3);
+  EXPECT_EQ(forcing[0][2], 1000.0 - 10.0 * 0.1 * 0.3);
   EXPECT_EQ(forcing[1][2], 1000.0 - 110.0 * 1.1 * 1.3);
-  EXPECT_EQ(forcing[0][3], 1000.0 +  20.0 * 0.2 * 1.4 -  30.0 * 0.4);
+  EXPECT_EQ(forcing[0][3], 1000.0 + 20.0 * 0.2 * 1.4 - 30.0 * 0.4);
   EXPECT_EQ(forcing[1][3], 1000.0 + 120.0 * 1.2 * 1.4 - 130.0 * 1.4);
-  EXPECT_EQ(forcing[0][4], 1000.0 +  10.0 * 0.1 * 0.3 * 2.4);
+  EXPECT_EQ(forcing[0][4], 1000.0 + 10.0 * 0.1 * 0.3 * 2.4);
   EXPECT_EQ(forcing[1][4], 1000.0 + 110.0 * 1.1 * 1.3 * 2.4);
+
+  auto non_zero_elements = set.NonZeroJacobianElements();
+
+  // ---- foo  bar  baz  quz  quuz
+  // foo   X    X    X    0    0
+  // bar   X    X    X    0    0
+  // baz   X    0    X    0    0
+  // quz   0    X    0    X    0
+  // quuz  X    0    X    0    0
+
+  auto elem = non_zero_elements.begin();
+  compare_pair(*elem, index_pair(0, 0));
+  compare_pair(*(++elem), index_pair(0, 1));
+  compare_pair(*(++elem), index_pair(0, 2));
+  compare_pair(*(++elem), index_pair(1, 0));
+  compare_pair(*(++elem), index_pair(1, 1));
+  compare_pair(*(++elem), index_pair(1, 2));
+  compare_pair(*(++elem), index_pair(2, 0));
+  compare_pair(*(++elem), index_pair(2, 2));
+  compare_pair(*(++elem), index_pair(3, 1));
+  compare_pair(*(++elem), index_pair(3, 3));
+  compare_pair(*(++elem), index_pair(4, 0));
+  compare_pair(*(++elem), index_pair(4, 2));
 }

--- a/test/unit/util/test_sparse_matrix.cpp
+++ b/test/unit/util/test_sparse_matrix.cpp
@@ -18,6 +18,8 @@ TEST(SparseMatrix, ZeroMatrix)
 
   micm::SparseMatrix<double> matrix{ builder };
 
+  EXPECT_EQ(matrix.FlatBlockSize(), 0);
+
   EXPECT_THROW(
       try { std::size_t elem = matrix.VectorIndex(0, 0); } catch (const std::invalid_argument& e) {
         EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
@@ -98,6 +100,7 @@ TEST(SparseMatrix, SingleBlockMatrix)
 
   micm::SparseMatrix<int> matrix{ builder };
 
+  EXPECT_EQ(matrix.FlatBlockSize(), 4);
   {
     std::size_t elem = matrix.VectorIndex(3, 2);
     EXPECT_EQ(elem, 3);
@@ -111,6 +114,7 @@ TEST(SparseMatrix, SingleBlockMatrix)
     EXPECT_EQ(matrix.AsVector()[2], 21);
   }
 
+  EXPECT_EQ(matrix[0][2][1], 0);
   matrix[0][2][1] = 45;
   EXPECT_EQ(matrix[0][2][1], 45);
 
@@ -178,6 +182,7 @@ TEST(SparseMatrix, MultiBlockMatrix)
                      .with_element(0, 1)
                      .with_element(2, 3)
                      .with_element(2, 1)
+                     .initial_value(24)
                      .number_of_blocks(3);
   // 0 X 0 0
   // 0 0 0 0
@@ -201,6 +206,7 @@ TEST(SparseMatrix, MultiBlockMatrix)
 
   micm::SparseMatrix<int> matrix{ builder };
 
+  EXPECT_EQ(matrix.FlatBlockSize(), 4);
   {
     std::size_t elem = matrix.VectorIndex(0, 2, 3);
     EXPECT_EQ(elem, 2);
@@ -214,6 +220,7 @@ TEST(SparseMatrix, MultiBlockMatrix)
     EXPECT_EQ(matrix.AsVector()[9], 31);
   }
 
+  EXPECT_EQ(matrix[0][2][1], 24);
   matrix[0][2][1] = 45;
   EXPECT_EQ(matrix[0][2][1], 45);
 


### PR DESCRIPTION
Adds the `dforce_dy()` function to the Rosenbrock solver.

The tests include a unit test for the `ProcessSet::AddJacobianTerms()` function, which does the actual calculations, but the regression test against the hard-coded Chapman solver is incomplete because the ordering of the sparse matrix Jacobian data appears to be different in the hard-coded array (maybe due to pivoting?).

As we go through the preprocessor logic to generalize the linear solver functions we should be able to extract the logic to translate the hard-coded sparse matrix data and finish the `dforce_dy` regression test.