### PR TITLE
Enable openacc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,16 @@ option(BUILD_DOCS "Build the documentation" OFF)
 option(ENABLE_CUDA "Build with Cuda support" OFF)
 option(ENABLE_OPENACC "Build with OpenACC Support" OFF)
 
+include(CMakeDependentOption)
+# Option to collect custom OpenACC flags
+cmake_dependent_option(ENABLE_GPU_TYPE "Enable custom OpenACC flags" OFF
+  "ENABLE_OPENACC" ON)
+
+if(ENABLE_GPU_TYPE)
+  set(GPU_TYPE "" CACHE STRING "Custom OpenACC flags")
+endif()
+
+
 ################################################################################
 # Dependencies
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ option(ENABLE_OPENACC "Build with OpenACC Support" OFF)
 include(CMakeDependentOption)
 # Option to collect custom OpenACC flags
 cmake_dependent_option(ENABLE_GPU_TYPE "Enable custom OpenACC flags" OFF
-  "ENABLE_OPENACC" ON)
+  "ENABLE_OPENACC OR ENABLE_CUDA" ON)
 
 if(ENABLE_GPU_TYPE)
   set(GPU_TYPE "" CACHE STRING "Custom OpenACC flags")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,8 @@ option(ENABLE_MEMCHECK "Enable memory checking in tests" OFF)
 option(ENABLE_JSON "Enable json configureation file reading" OFF)
 option(ENABLE_REGESSION_TESTS "Enable regression tests against the old pre-processed version of micm" ON)
 option(BUILD_DOCS "Build the documentation" OFF)
-option(ENABLE_GPU "Build the GPU library" OFF)
+option(ENABLE_CUDA "Build with Cuda support" OFF)
+option(ENABLE_OPENACC "Build with OpenACC Support" OFF)
 
 ################################################################################
 # Dependencies

--- a/Dockerfile.nvhpc
+++ b/Dockerfile.nvhpc
@@ -62,7 +62,7 @@ RUN mkdir /build \
         -D ENABLE_REGESSION_TESTS:BOOL=FALSE \
         -D ENABLE_CUDA=OFF \
         -D ENABLE_OPENACC=ON \
-        -D GPU_TYPE="cc80" \
+        -D GPU_TYPE="a100" \
         ../micm 
       # && make -j 8 install
 

--- a/Dockerfile.nvhpc
+++ b/Dockerfile.nvhpc
@@ -62,6 +62,7 @@ RUN mkdir /build \
         -D ENABLE_REGESSION_TESTS:BOOL=FALSE \
         -D ENABLE_CUDA=OFF \
         -D ENABLE_OPENACC=ON \
+        -D GPU_TYPE="cc80" \
         ../micm 
       # && make -j 8 install
 

--- a/Dockerfile.nvhpc
+++ b/Dockerfile.nvhpc
@@ -60,7 +60,8 @@ RUN mkdir /build \
       && cmake \
         -D CMAKE_BUILD_TYPE=debug \
         -D ENABLE_REGESSION_TESTS:BOOL=FALSE \
-        -D ENABLE_GPU=ON \
+        -D ENABLE_CUDA=OFF \
+        -D ENABLE_OPENACC=ON \
         ../micm 
       # && make -j 8 install
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make
 qinteractive -A<ACCOUNT_NUMBER> --ngpus=1
 module load cmake/3.25.2 nvhpc/23.1 cuda/11.7.1
 mkdir build && cd build
-cmake -DENABLE_GPU=ON -DENABLE_REGESSION_TESTS=OFF ..
+cmake -DENABLE_OPENACC=ON -DENABLE_CUDA=ON -DENABLE_REGESSION_TESTS=OFF ..
 make
 make test
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make
 qinteractive -A<ACCOUNT_NUMBER> --ngpus=1
 module load cmake/3.25.2 nvhpc/23.1 cuda/11.7.1
 mkdir build && cd build
-cmake -DENABLE_OPENACC=ON -DENABLE_CUDA=ON -DENABLE_REGESSION_TESTS=OFF -D GPU_TYPE="cc80" ..
+cmake -DENABLE_OPENACC=ON -DENABLE_CUDA=ON -DENABLE_REGESSION_TESTS=OFF -D GPU_TYPE="a100" ..
 make
 make test
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make
 qinteractive -A<ACCOUNT_NUMBER> --ngpus=1
 module load cmake/3.25.2 nvhpc/23.1 cuda/11.7.1
 mkdir build && cd build
-cmake -DENABLE_OPENACC=ON -DENABLE_CUDA=ON -DENABLE_REGESSION_TESTS=OFF ..
+cmake -DENABLE_OPENACC=ON -DENABLE_CUDA=ON -DENABLE_REGESSION_TESTS=OFF -D GPU_TYPE="cc80" ..
 make
 make test
 ```

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -84,9 +84,13 @@ endif()
 ################################################################################
 # GPU Support
 
-if(ENABLE_GPU)
+if(ENABLE_CUDA)
   find_package(CUDA REQUIRED)
   enable_language(CUDA)
 
   set(CMAKE_CUDA_STANDARD 11.7.1)
+endif()
+
+if(ENABLE_OPENACC)
+  find_package(OpenACC REQUIRED)
 endif()

--- a/cmake/test_util.cmake
+++ b/cmake/test_util.cmake
@@ -20,7 +20,7 @@ function(create_standard_test)
 
   target_link_libraries(test_${TEST_NAME} PUBLIC musica::micm GTest::gtest_main)
 
-  if(ENABLE_GPU)
+  if(ENABLE_CUDA OR ENABLE_OPENACC)
     target_link_libraries(test_${TEST_NAME} PUBLIC musica::micm_gpu)
   endif()
 

--- a/include/micm/process/process_set_cuda.hpp
+++ b/include/micm/process/process_set_cuda.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 namespace micm {
+    namespace cuda {
 
     void AddForcingTerms_kernelSetup(
         const Matrix<double>& rate_constants,
@@ -35,4 +36,5 @@ namespace micm {
         std::vector<std::size_t> yields_
     );
 
+    } // namespace cuda
 } // namespace micm

--- a/include/micm/process/process_set_openacc.hpp
+++ b/include/micm/process/process_set_openacc.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <micm/process/process.hpp>
+#include <micm/solver/state.hpp>
+#include <micm/util/matrix.hpp>
+#include <micm/util/sparse_matrix.hpp>
+#include <vector>
+
+namespace micm {
+  namespace openacc {
+
+    void deriv();
+
+  } // namespace openacc
+} // namespace micm

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ if(ENABLE_CUDA OR ENABLE_OPENACC)
   endif()
   
   set(GPU_FLAGS -gpu=${GPU_ARCH},lineinfo,nofma -Minfo=accel)
-  message(STATUS "GPU Flags: ${OpenACC_CXX_FLAGS}  ${GPU_FLAGS}")
+  message(STATUS "GPU Flags: ${OpenACC_CXX_FLAGS} ${GPU_FLAGS}")
 
   target_compile_options(micm_gpu PRIVATE ${GPU_FLAGS})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,10 +48,10 @@ if(ENABLE_CUDA OR ENABLE_OPENACC)
     message(FATAL_ERROR "GPU_TYPE (${GPU_TYPE}) is not recognized. Available options are [a100, v100].")
   endif()
   
-  set(GPU_FLAGS -gpu=${GPU_ARCH},lineinfo,nofma -Minfo=accel)
+  set(GPU_FLAGS -gpu=${GPU_ARCH},lineinfo -Minfo=accel)
   message(STATUS "GPU Flags: ${OpenACC_CXX_FLAGS} ${GPU_FLAGS}")
 
-  target_compile_options(micm_gpu PRIVATE ${GPU_FLAGS})
+  target_compile_options(micm_gpu PRIVATE ${OpenACC_CXX_FLAGS} ${GPU_FLAGS})
 
   target_link_libraries(micm_gpu 
     PRIVATE micm

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,14 @@ if(ENABLE_CUDA OR ENABLE_OPENACC)
   add_library(micm_gpu)
   add_library(musica::micm_gpu ALIAS micm_gpu)
 
+  message(STATUS "GPU Flags: ${OpenACC_CXX_FLAGS} -gpu=${GPU_TYPE},lineinfo")
+
+  if(NOT GPU_TYPE)
+    message(FATAL_ERROR "GPU_TYPE is not set or is empty. Please provide a GPU type.")
+  endif()
+
+  target_compile_options(micm_gpu PRIVATE ${OpenACC_CXX_FLAGS} -gpu=${GPU_TYPE},lineinfo)
+
   target_link_libraries(micm_gpu 
     PRIVATE micm
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,13 +32,26 @@ if(ENABLE_CUDA OR ENABLE_OPENACC)
   add_library(micm_gpu)
   add_library(musica::micm_gpu ALIAS micm_gpu)
 
-  message(STATUS "GPU Flags: ${OpenACC_CXX_FLAGS} -gpu=${GPU_TYPE},lineinfo")
-
   if(NOT GPU_TYPE)
     message(FATAL_ERROR "GPU_TYPE is not set or is empty. Please provide a GPU type.")
   endif()
 
-  target_compile_options(micm_gpu PRIVATE ${OpenACC_CXX_FLAGS} -gpu=${GPU_TYPE},lineinfo)
+  set(GPU_ARCH "")
+  if (GPU_TYPE STREQUAL a100)
+    set(GPU_ARCH "cc80")
+  endif()
+  if (GPU_TYPE STREQUAL v100)
+    set(GPU_ARCH "cc70")
+  endif()
+
+  if(NOT GPU_ARCH)
+    message(FATAL_ERROR "GPU_TYPE (${GPU_TYPE}) is not recognized. Available options are [a100, v100].")
+  endif()
+  
+  set(GPU_FLAGS -gpu=${GPU_ARCH},lineinfo,nofma -Minfo=accel)
+  message(STATUS "GPU Flags: ${OpenACC_CXX_FLAGS}  ${GPU_FLAGS}")
+
+  target_compile_options(micm_gpu PRIVATE ${GPU_FLAGS})
 
   target_link_libraries(micm_gpu 
     PRIVATE micm

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,14 +28,25 @@ if(ENABLE_MPI)
   target_link_libraries(micm INTERFACE MPI::MPI_CXX)
 endif()
 
-if(ENABLE_GPU)
+if(ENABLE_CUDA OR ENABLE_OPENACC)
   add_library(micm_gpu)
   add_library(musica::micm_gpu ALIAS micm_gpu)
 
   target_link_libraries(micm_gpu 
-    PUBLIC cudart
     PRIVATE micm
   )
+
+  if(ENABLE_CUDA)
+    target_link_libraries(micm_gpu 
+      PUBLIC cudart
+    )
+  endif()
+
+  if(ENABLE_OPENACC)
+    target_link_libraries(micm_gpu 
+      PUBLIC OpenACC::OpenACC_CXX
+    )
+  endif()
 
   add_subdirectory(process)
 endif()

--- a/src/process/CMakeLists.txt
+++ b/src/process/CMakeLists.txt
@@ -1,4 +1,12 @@
-target_sources(micm_gpu
-  PRIVATE
-    process_set.cu
-)
+if(ENABLE_CUDA)
+  target_sources(micm_gpu
+    PRIVATE
+      process_set.cu
+  )
+endif()
+if(ENABLE_OPENACC)
+  target_sources(micm_gpu
+    PRIVATE
+      process_set.cpp
+  )
+endif()

--- a/src/process/process_set.cpp
+++ b/src/process/process_set.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 
+#include <micm/process/process_set_openacc.hpp>
+
 namespace micm
 {
   namespace openacc

--- a/src/process/process_set.cpp
+++ b/src/process/process_set.cpp
@@ -7,7 +7,7 @@ namespace micm
 
     void deriv()
     {
-      const int N = 1000000;
+      const int N = 100000000;
       int data[N];
 
       // Initialize data
@@ -22,13 +22,6 @@ namespace micm
       {
         data[i] *= 2;
       }
-
-      // Print the modified data
-      for (int i = 0; i < N; ++i)
-      {
-        std::cout << data[i] << " ";
-      }
-      std::cout << std::endl;
     }
 
   }  // namespace openacc

--- a/src/process/process_set.cpp
+++ b/src/process/process_set.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+
+namespace micm
+{
+  namespace openacc
+  {
+
+    void deriv()
+    {
+      const int N = 10;
+      int data[N];
+
+      // Initialize data
+      for (int i = 0; i < N; ++i)
+      {
+        data[i] = i;
+      }
+
+// Parallelize the loop using OpenACC
+#pragma acc parallel loop
+      for (int i = 0; i < N; ++i)
+      {
+        data[i] *= 2;
+      }
+
+      // Print the modified data
+      for (int i = 0; i < N; ++i)
+      {
+        std::cout << data[i] << " ";
+      }
+      std::cout << std::endl;
+    }
+
+  }  // namespace openacc
+} // namespace micm

--- a/src/process/process_set.cpp
+++ b/src/process/process_set.cpp
@@ -22,14 +22,12 @@ namespace micm
       {
         data[i] *= 2;
       }
-    }
 
 #pragma acc parallel loop
       for (int i = 0; i < N; ++i)
       {
         data[i] /= 3;
       }
-    }
 
 #pragma acc parallel loop
       for (int i = 0; i < N; ++i)

--- a/src/process/process_set.cpp
+++ b/src/process/process_set.cpp
@@ -7,7 +7,7 @@ namespace micm
 
     void deriv()
     {
-      const int N = 10;
+      const int N = 10000;
       int data[N];
 
       // Initialize data

--- a/src/process/process_set.cpp
+++ b/src/process/process_set.cpp
@@ -7,7 +7,7 @@ namespace micm
 
     void deriv()
     {
-      const int N = 10000;
+      const int N = 1000000;
       int data[N];
 
       // Initialize data

--- a/src/process/process_set.cpp
+++ b/src/process/process_set.cpp
@@ -7,7 +7,7 @@ namespace micm
 
     void deriv()
     {
-      const int N = 100000000;
+      const int N = 100'000'000;
       int data[N];
 
       // Initialize data
@@ -21,6 +21,20 @@ namespace micm
       for (int i = 0; i < N; ++i)
       {
         data[i] *= 2;
+      }
+    }
+
+#pragma acc parallel loop
+      for (int i = 0; i < N; ++i)
+      {
+        data[i] /= 3;
+      }
+    }
+
+#pragma acc parallel loop
+      for (int i = 0; i < N; ++i)
+      {
+        data[i] += 3;
       }
     }
 

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -5,6 +5,7 @@
 #include <vector>
 
 namespace micm {
+    namespace cuda {
 
     void AddForcingTerms_kernelSetup(
         const Matrix<double>& rate_constants,
@@ -135,6 +136,7 @@ namespace micm {
             int forcing_col_index = product_ids_[product_ids_index]; 
             forcing[row_index * state_forcing_columns + forcing_col_index] += yields_[yields_index] * rate; 
         }   
+        }
     }
-    }
+  }  // namespace cuda
 }

--- a/test/unit/process/CMakeLists.txt
+++ b/test/unit/process/CMakeLists.txt
@@ -12,6 +12,10 @@ create_standard_test(NAME troe_rate_constant SOURCES test_troe_rate_constant.cpp
 create_standard_test(NAME process_set SOURCES test_process_set.cpp)
 
 # GPU tests
-if(ENABLE_GPU)
-  create_standard_test(NAME gpu_process_set SOURCES test_gpu_process_set.cpp)
+if(ENABLE_CUDA)
+  create_standard_test(NAME cuda_process_set SOURCES test_cuda_process_set.cpp)
+endif()
+
+if(ENABLE_OPENACC)
+  create_standard_test(NAME openacc_process_set SOURCES test_openacc_process_set.cpp)
 endif()

--- a/test/unit/process/test_cuda_process_set.cpp
+++ b/test/unit/process/test_cuda_process_set.cpp
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 
 #include <micm/process/process.hpp>
-#include <micm/process/process_set_gpu.hpp>
+#include <micm/process/process_set_cuda.hpp>
 
 TEST(ProcessSet, Constructor)
 {
-  // AddForcingTerms_kernelSetup(...);
+  // micm::cuda::AddForcingTerms_kernelSetup(...);
 }

--- a/test/unit/process/test_openacc_process_set.cpp
+++ b/test/unit/process/test_openacc_process_set.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+#include <micm/process/process.hpp>
+#include <micm/process/process_set_openacc.hpp>
+
+TEST(ProcessSet, Deriv)
+{
+  micm::openacc::deriv();
+}


### PR DESCRIPTION
- Adds support for building openacc
- Wraps cuda and openacc code in their own namespaces so that function names can be the same if desired

1. Setup a localrc file
```
makelocalrc -d . -x -gcc /glade/u/apps/gust/23.04/spack/opt/spack/ncarcompilers/0.8.0/gcc/12.2.0/bin/gcc -gpp /glade/u/apps/gust/23.04/spack/opt/spack/ncarcompilers/0.8.0/gcc/12.2.0/bin/g++ -g77 /glade/u/apps/gust/23.04/spack/opt/spack/ncarcompilers/0.8.0/gcc/12.2.0/bin/gfortran
```
2. Start a session
```
qinteractive -A<AccountNumber> --ngpus=1
```
3. Tell nvidia to use this file. 
```
export NVLOCALRC=/glade/u/home/kshores/localrc
```
4. Load the modules
```
module load nvhpc/23.1 cmake/3.25
```
5. Build micm with open acc
```
cd micm/build
cmake -DENABLE_OPENACC=ON -DENABLE_REGESSION_TESTS=OFF -D GPU_TYPE="cc80"  ..
```
6. Run the tests
```
make test
```