### PR TITLE
creating a separate cuda and openacc target

### DIFF
--- a/Dockerfile.nvhpc
+++ b/Dockerfile.nvhpc
@@ -61,7 +61,7 @@ RUN mkdir /build \
         -D CMAKE_BUILD_TYPE=debug \
         -D ENABLE_REGESSION_TESTS:BOOL=FALSE \
         -D ENABLE_CUDA=ON \
-        -D ENABLE_OPENACC=OFF \
+        -D ENABLE_OPENACC=ON \
         -D GPU_TYPE="a100" \
         ../micm 
       # && make -j 8 install

--- a/cmake/test_util.cmake
+++ b/cmake/test_util.cmake
@@ -11,7 +11,7 @@ endif()
 function(create_standard_test)
   set(prefix TEST)
   set(singleValues NAME WORKING_DIRECTORY)
-  set(multiValues SOURCES)
+  set(multiValues SOURCES LIBRARIES)
 
   include(CMakeParseArguments)
   cmake_parse_arguments(${prefix} " " "${singleValues}" "${multiValues}" ${ARGN})
@@ -20,9 +20,10 @@ function(create_standard_test)
 
   target_link_libraries(test_${TEST_NAME} PUBLIC musica::micm GTest::gtest_main)
 
-  if(ENABLE_CUDA OR ENABLE_OPENACC)
-    target_link_libraries(test_${TEST_NAME} PUBLIC musica::micm_gpu)
-  endif()
+  # link additional libraries
+  foreach(library ${TEST_LIBRARIES})
+    target_link_libraries(test_${TEST_NAME} PUBLIC ${library})
+  endforeach()
 
   if(ENABLE_JSON)
     target_link_libraries(test_${TEST_NAME} PRIVATE nlohmann_json::nlohmann_json)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,11 +57,9 @@ if(ENABLE_OPENACC)
     PRIVATE micm
   )
 
-  if(ENABLE_OPENACC)
-    target_link_libraries(micm_openacc 
-      PUBLIC OpenACC::OpenACC_CXX
-    )
-  endif()
+  target_link_libraries(micm_openacc 
+    PUBLIC OpenACC::OpenACC_CXX
+  )
 endif()
 
 if(ENABLE_CUDA)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,9 +28,9 @@ if(ENABLE_MPI)
   target_link_libraries(micm INTERFACE MPI::MPI_CXX)
 endif()
 
-if(ENABLE_CUDA OR ENABLE_OPENACC)
-  add_library(micm_gpu)
-  add_library(musica::micm_gpu ALIAS micm_gpu)
+if(ENABLE_OPENACC)
+  add_library(micm_openacc)
+  add_library(musica::micm_openacc ALIAS micm_openacc)
 
   if(NOT GPU_TYPE)
     message(FATAL_ERROR "GPU_TYPE is not set or is empty. Please provide a GPU type.")
@@ -51,23 +51,32 @@ if(ENABLE_CUDA OR ENABLE_OPENACC)
   set(GPU_FLAGS -gpu=${GPU_ARCH},lineinfo -Minfo=accel)
   message(STATUS "GPU Flags: ${OpenACC_CXX_FLAGS} ${GPU_FLAGS}")
 
-  # target_compile_options(micm_gpu PRIVATE ${OpenACC_CXX_FLAGS} ${GPU_FLAGS})
+  target_compile_options(micm_openacc PRIVATE ${OpenACC_CXX_FLAGS} ${GPU_FLAGS})
 
-  target_link_libraries(micm_gpu 
+  target_link_libraries(micm_openacc 
+    PRIVATE micm
+  )
+
+  if(ENABLE_OPENACC)
+    target_link_libraries(micm_openacc 
+      PUBLIC OpenACC::OpenACC_CXX
+    )
+  endif()
+endif()
+
+if(ENABLE_CUDA)
+  add_library(micm_cuda)
+  add_library(musica::micm_cuda ALIAS micm_cuda)
+
+  target_link_libraries(micm_cuda 
     PRIVATE micm
   )
 
   if(ENABLE_CUDA)
-    target_link_libraries(micm_gpu 
+    target_link_libraries(micm_cuda 
       PUBLIC cudart
     )
   endif()
-
-  if(ENABLE_OPENACC)
-    target_link_libraries(micm_gpu 
-      PUBLIC OpenACC::OpenACC_CXX
-    )
-  endif()
-
-  add_subdirectory(process)
 endif()
+
+add_subdirectory(process)

--- a/src/process/CMakeLists.txt
+++ b/src/process/CMakeLists.txt
@@ -1,11 +1,11 @@
 if(ENABLE_CUDA)
-  target_sources(micm_gpu
+  target_sources(micm_cuda
     PRIVATE
       process_set.cu
   )
 endif()
 if(ENABLE_OPENACC)
-  target_sources(micm_gpu
+  target_sources(micm_openacc
     PRIVATE
       process_set.cpp
   )

--- a/test/unit/process/CMakeLists.txt
+++ b/test/unit/process/CMakeLists.txt
@@ -13,9 +13,9 @@ create_standard_test(NAME process_set SOURCES test_process_set.cpp)
 
 # GPU tests
 if(ENABLE_CUDA)
-  create_standard_test(NAME cuda_process_set SOURCES test_cuda_process_set.cpp)
+  create_standard_test(NAME cuda_process_set SOURCES test_cuda_process_set.cpp LIBRARIES musica::micm_cuda)
 endif()
 
 if(ENABLE_OPENACC)
-  create_standard_test(NAME openacc_process_set SOURCES test_openacc_process_set.cpp)
+  create_standard_test(NAME openacc_process_set SOURCES test_openacc_process_set.cpp LIBRARIES musica::micm_openacc)
 endif()


### PR DESCRIPTION
Creates a separate target for cuda and openacc. This means that tests that need to use code for either must explicitly link to that library