### PR TITLE
LU decomposition

### DIFF
--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 National Center for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <micm/solver/lu_decomposition.hpp>
+#include <micm/util/sparse_matrix.hpp>
+
+namespace micm
+{
+
+  /// @brief A general-use sparse-matrix linear solver
+  class LinearSolver
+  {
+    public:
+    /// @brief default constructor
+    LinearSolver();
+
+    /// @brief Constructs a linear solver for the sparsity structure of the given matrix
+    /// @param matrix Sparse matrix
+    LinearSolver(const SparseMatrix& matrix);
+
+
+  };
+} // namespace micm

--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -12,14 +12,21 @@ namespace micm
   /// @brief A general-use sparse-matrix linear solver
   class LinearSolver
   {
+    LuDecomposition lu_decomp_;
+
     public:
     /// @brief default constructor
-    LinearSolver();
+    LinearSolver() = default;
 
     /// @brief Constructs a linear solver for the sparsity structure of the given matrix
     /// @param matrix Sparse matrix
-    LinearSolver(const SparseMatrix& matrix);
-
+    template<class T>
+    LinearSolver(const SparseMatrix<T>& matrix);
 
   };
+
+  template<class T>
+  inline LinearSolver::LinearSolver(const SparseMatrix<T>& matrix)
+    : lu_decomp_(matrix) {};
+
 } // namespace micm

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -41,10 +41,10 @@ namespace micm
     /// triangular matrix; False otherwise
     std::vector<bool> do_aik_;
     /// Index in A.data_ for A[i][k] for each iteration of the middle (k) loop for the upper
-    /// triangular matrix, when A[i][k] is non-zero
+    /// triangular matrix when A[i][k] is non-zero
     std::vector<std::size_t> aik_;
     /// Index in U.data_ for U[i][k] for each iteration of the middle (k) loop for the upper
-    /// triangular matrix, when U[i][k] is non-zero, and the corresponding number of elements
+    /// triangular matrix when U[i][k] is non-zero, and the corresponding number of elements
     /// in the inner (j) loop
     std::vector<std::pair<std::size_t, std::size_t>> uik_nkj_;
     /// Index in L.data_ for L[i][j], and in U.data_ for U[j][k] in the upper inner (j) loop
@@ -54,13 +54,13 @@ namespace micm
     /// triangular matrix; False otherwise
     std::vector<bool> do_aki_;
     /// Index in A.data_ for A[k][i] for each iteration of the middle (k) loop for the lower
-    /// triangular matrix, when A[k][i] is non-zero
+    /// triangular matrix when A[k][i] is non-zero
     std::vector<std::size_t> aki_;
     /// Index in L.data_ for L[k][i] for each iteration of the middle (k) loop for the lower
-    /// triangular matrix, when L[k][i] is non-zero, and the corresponding number of elements
+    /// triangular matrix when L[k][i] is non-zero, and the corresponding number of elements
     /// in the inner (j) loop
     std::vector<std::pair<std::size_t, std::size_t>> lki_nkj_;
-    /// Index in L.data_ for L[k][j], and in U.data_ for U[j][i] in the upper inner (j) loop
+    /// Index in L.data_ for L[k][j], and in U.data_ for U[j][i] in the lower inner (j) loop
     /// when L[k][j] and U[j][i] are both non-zero.
     std::vector<std::pair<std::size_t, std::size_t>> lkj_uji_;
     /// Index in U.data_ for U[i][i] for each interation in the middle (k) loop for the lower

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -1,0 +1,278 @@
+// Copyright (C) 2023 National Center for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <micm/util/sparse_matrix.hpp>
+
+namespace micm
+{
+
+  class LuDecomposition
+  {
+    std::vector<std::pair<std::size_t, std::size_t>> niLU_;
+    std::vector<bool> do_aik_;
+    std::vector<std::size_t> aik_;
+    std::vector<std::pair<std::size_t, std::size_t>> uik_nkj_;
+    std::vector<std::pair<std::size_t, std::size_t>> lij_ujk_;
+    std::vector<bool> do_aki_;
+    std::vector<std::size_t> aki_;
+    std::vector<std::pair<std::size_t, std::size_t>> lki_nkj_;
+    std::vector<std::pair<std::size_t, std::size_t>> lkj_uji_;
+    std::vector<std::size_t> uii_;
+
+   public:
+    /// @brief default constructor
+    LuDecomposition();
+
+    /// @brief Construct an LU decomposition algorithm for a given sparse matrix
+    /// @param matrix Sparse matrix
+    template<class T>
+    LuDecomposition(const SparseMatrix<T>& matrix);
+
+    /// @brief Create sparse L and U matrices for a given A matrix
+    /// @param A Sparse matrix the will be decomposed
+    /// @return L and U Sparse matrices
+    template<class T>
+    static std::pair<SparseMatrix<T>, SparseMatrix<T>> GetLUMatrices(const SparseMatrix<T>& A);
+
+    /// @brief Perform an LU decomposition on a given A matrix
+    /// @param A Sparse matrix to decompose
+    /// @param LU the lower and upper triangular matrices returned as a square matrix
+    ///           The diagonal of LU belongs to the upper triangular matrix and the
+    ///           diagonal of the lower triangular matrix shoud be assumed to be 1
+    template<class T>
+    void Decompose(const SparseMatrix<T>& A, SparseMatrix<T>& L, SparseMatrix<T>& U) const;
+
+    void Print()
+    {
+      std::cout << "niLU ";
+      for (auto& elem : niLU_)
+        std::cout << "( " << elem.first << ", " << elem.second << ") ";
+      std::cout << std::endl;
+      std::cout << "do_aik ";
+      for (auto elem : do_aik_)
+        std::cout << elem << " ";
+      std::cout << std::endl;
+      std::cout << "aik ";
+      for (auto& elem : aik_)
+        std::cout << elem << " ";
+      std::cout << std::endl;
+      std::cout << "uik_nkj ";
+      for (auto& elem : uik_nkj_)
+        std::cout << "( " << elem.first << ", " << elem.second << ") ";
+      std::cout << std::endl;
+      std::cout << "lij_ujk ";
+      for (auto& elem : lij_ujk_)
+        std::cout << "( " << elem.first << ", " << elem.second << ") ";
+      std::cout << std::endl;
+      std::cout << "do_aki ";
+      for (auto elem : do_aki_)
+        std::cout << elem << " ";
+      std::cout << std::endl;
+      std::cout << "aki ";
+      for (auto& elem : aki_)
+        std::cout << elem << " ";
+      std::cout << std::endl;
+      std::cout << "lki_nkj ";
+      for (auto& elem : lki_nkj_)
+        std::cout << "( " << elem.first << ", " << elem.second << ") ";
+      std::cout << std::endl;
+      std::cout << "lkj_uji ";
+      for (auto& elem : lkj_uji_)
+        std::cout << "( " << elem.first << ", " << elem.second << ") ";
+      std::cout << std::endl;
+      std::cout << "uii ";
+      for (auto& elem : uii_)
+        std::cout << elem << " ";
+      std::cout << std::endl;
+    }
+  };
+
+  inline LuDecomposition::LuDecomposition()
+  {
+  }
+
+  template<class T>
+  inline LuDecomposition::LuDecomposition(const SparseMatrix<T>& matrix)
+  {
+    std::size_t n = matrix[0].size();
+    auto LU = GetLUMatrices(matrix);
+    const auto& L_row_start = LU.first.RowStartVector();
+    const auto& L_row_ids = LU.first.RowIdsVector();
+    const auto& U_row_start = LU.second.RowStartVector();
+    const auto& U_row_ids = LU.second.RowIdsVector();
+    for (std::size_t i = 0; i < matrix[0].size(); ++i)
+    {
+      std::pair<std::size_t, std::size_t> iLU(0, 0);
+      // Upper triangular matrix
+      for (std::size_t k = i; k < n; ++k)
+      {
+        std::size_t nkj = 0;
+        for (std::size_t j_id = L_row_start[i]; j_id < L_row_start[i + 1]; ++j_id)
+        {
+          std::size_t j = L_row_ids[j_id];
+          if (j >= i)
+            break;
+          if (LU.second.IsZero(j, k))
+            continue;
+          ++nkj;
+          lij_ujk_.push_back(std::make_pair(j_id, LU.second.VectorIndex(0, j, k)));
+        }
+        if (matrix.IsZero(i, k))
+        {
+          if (nkj == 0 && k != i)
+            continue;
+          do_aik_.push_back(false);
+        }
+        else
+        {
+          do_aik_.push_back(true);
+          aik_.push_back(matrix.VectorIndex(0, i, k));
+        }
+        uik_nkj_.push_back(std::make_pair(LU.second.VectorIndex(0, i, k), nkj));
+        ++(iLU.second);
+      }
+      // Lower triangular matrix
+      lki_nkj_.push_back(std::make_pair(LU.first.VectorIndex(0, i, i), 0));
+      for (std::size_t k = i + 1; k < n; ++k)
+      {
+        std::size_t nkj = 0;
+        for (std::size_t j_id = L_row_start[k]; j_id < L_row_start[k + 1]; ++j_id)
+        {
+          std::size_t j = L_row_ids[j_id];
+          if (j >= i)
+            break;
+          if (LU.second.IsZero(j, i))
+            continue;
+          ++nkj;
+          lkj_uji_.push_back(std::make_pair(j_id, LU.second.VectorIndex(0, j, i)));
+        }
+        if (matrix.IsZero(k, i))
+        {
+          if (nkj == 0)
+            continue;
+          do_aki_.push_back(false);
+        }
+        else
+        {
+          do_aki_.push_back(true);
+          aki_.push_back(matrix.VectorIndex(0, k, i));
+        }
+        uii_.push_back(LU.second.VectorIndex(0, i, i));
+        lki_nkj_.push_back(std::make_pair(LU.first.VectorIndex(0, k, i), nkj));
+        ++(iLU.first);
+      }
+      niLU_.push_back(iLU);
+    }
+  }
+
+  template<class T>
+  inline std::pair<SparseMatrix<T>, SparseMatrix<T>> LuDecomposition::GetLUMatrices(const SparseMatrix<T>& A)
+  {
+    std::size_t n = A[0].size();
+    std::set<std::pair<std::size_t, std::size_t>> L_ids, U_ids;
+    const auto& row_start = A.RowStartVector();
+    const auto& row_ids = A.RowIdsVector();
+    for (std::size_t i = 0; i < n; ++i)
+    {
+      // Upper triangular matrix
+      for (std::size_t k = i; k < n; ++k)
+      {
+        if (!A.IsZero(i, k) || k == i)
+        {
+          U_ids.insert(std::make_pair(i, k));
+          continue;
+        }
+        for (std::size_t j = 0; j < i; ++j)
+        {
+          if (L_ids.find(std::make_pair(i, j)) != L_ids.end() && U_ids.find(std::make_pair(j, k)) != U_ids.end())
+          {
+            U_ids.insert(std::make_pair(i, k));
+            break;
+          }
+        }
+      }
+      // Lower triangular matrix
+      for (std::size_t k = i; k < n; ++k)
+      {
+        if (!A.IsZero(k, i) || k == i)
+        {
+          L_ids.insert(std::make_pair(k, i));
+          continue;
+        }
+        for (std::size_t j = 0; j < i; ++j)
+        {
+          if (L_ids.find(std::make_pair(k, j)) != L_ids.end() && U_ids.find(std::make_pair(j, i)) != U_ids.end())
+          {
+            L_ids.insert(std::make_pair(k, i));
+            break;
+          }
+        }
+      }
+    }
+    auto L_builder = micm::SparseMatrix<T>::create(n).number_of_blocks(A.size());
+    for (auto& pair : L_ids)
+    {
+      L_builder = L_builder.with_element(pair.first, pair.second);
+    }
+    auto U_builder = micm::SparseMatrix<T>::create(n).number_of_blocks(A.size());
+    for (auto& pair : U_ids)
+    {
+      U_builder = U_builder.with_element(pair.first, pair.second);
+    }
+    std::pair<SparseMatrix<T>, SparseMatrix<T>> LU(L_builder, U_builder);
+    return LU;
+  }
+
+  template<class T>
+  inline void LuDecomposition::Decompose(const SparseMatrix<T>& A, SparseMatrix<T>& L, SparseMatrix<T>& U) const
+  {
+    // Loop over blocks
+    for (std::size_t i_block = 0; i_block < A.size(); ++i_block)
+    {
+      auto A_vector = std::next(A.AsVector().begin(), i_block * A.FlatBlockSize());
+      auto L_vector = std::next(L.AsVector().begin(), i_block * L.FlatBlockSize());
+      auto U_vector = std::next(U.AsVector().begin(), i_block * U.FlatBlockSize());
+      auto do_aik = do_aik_.begin();
+      auto aik = aik_.begin();
+      auto uik_nkj = uik_nkj_.begin();
+      auto lij_ujk = lij_ujk_.begin();
+      auto do_aki = do_aki_.begin();
+      auto aki = aki_.begin();
+      auto lki_nkj = lki_nkj_.begin();
+      auto lkj_uji = lkj_uji_.begin();
+      auto uii = uii_.begin();
+      for (auto& inLU : niLU_)
+      {
+        // Upper trianglur matrix
+        for (std::size_t iU = 0; iU < inLU.second; ++iU)
+        {
+          if (*(do_aik++))
+            U_vector[uik_nkj->first] = A_vector[*(aik++)];
+          for (std::size_t ikj = 0; ikj < uik_nkj->second; ++ikj)
+          {
+            U_vector[uik_nkj->first] -= L_vector[lij_ujk->first] * U_vector[lij_ujk->second];
+            ++lij_ujk;
+          }
+          ++uik_nkj;
+        }
+        // Lower triangular matrix
+        L_vector[(lki_nkj++)->first] = 1.0;
+        for (std::size_t iL = 0; iL < inLU.first; ++iL)
+        {
+          if (*(do_aki++))
+            L_vector[lki_nkj->first] = A_vector[*(aki++)];
+          for (std::size_t ikj = 0; ikj < lki_nkj->second; ++ikj)
+          {
+            L_vector[lki_nkj->first] -= L_vector[lkj_uji->first] * U_vector[lkj_uji->second];
+            ++lkj_uji;
+          }
+          L_vector[lki_nkj->first] /= U_vector[*uii];
+          ++lki_nkj;
+          ++uii;
+        }
+      }
+    }
+  }
+}  // namespace micm

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -25,6 +25,7 @@
 #include <limits>
 #include <micm/process/process.hpp>
 #include <micm/process/process_set.hpp>
+#include <micm/solver/linear_solver.hpp>
 #include <micm/solver/solver.hpp>
 #include <micm/solver/state.hpp>
 #include <micm/system/system.hpp>
@@ -83,6 +84,7 @@ namespace micm
     ProcessSet process_set_;
     Solver::Rosenbrock_stats stats_;
     SparseMatrix<double> jacobian_;
+    LinearSolver linear_solver_;
 
     static constexpr double delta_min_ = 1.0e-5;
 
@@ -201,7 +203,8 @@ namespace micm
         parameters_(),
         process_set_(),
         stats_(),
-        jacobian_()
+        jacobian_(),
+        linear_solver_()
   {
     three_stage_rosenbrock();
   }
@@ -215,13 +218,15 @@ namespace micm
         parameters_(parameters),
         process_set_(processes_, GetState()),
         stats_(),
-        jacobian_()
+        jacobian_(),
+        linear_solver_()
   {
     auto builder = SparseMatrix<double>::create(system_.StateSize()).number_of_blocks(parameters_.number_of_grid_cells_);
     auto jac_elements = process_set_.NonZeroJacobianElements();
     for (auto& elem : jac_elements)
       builder = builder.with_element(elem.first, elem.second);
     jacobian_ = builder;
+    linear_solver_ = LinearSolver(jacobian_);
     process_set_.SetJacobianFlatIds(jacobian_);
 
     // TODO: move three stage rosenbrock to parameter constructor

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -121,6 +121,18 @@ namespace micm
       return VectorIndex(0, row, column);
     }
 
+    bool IsZero(std::size_t row, std::size_t column) const
+    {
+      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1)
+        throw std::invalid_argument("SparseMatrix element out of range");
+      auto begin = std::next(row_ids_.begin(), row_start_[row]);
+      auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
+      auto elem = std::find(begin, end, column);
+      if (elem == end)
+        return true;
+      return false;
+    }
+
     std::size_t size() const
     {
       return number_of_blocks_;

--- a/test/unit/solver/CMakeLists.txt
+++ b/test/unit/solver/CMakeLists.txt
@@ -7,5 +7,6 @@ include(test_util)
 # Tests
 
 create_standard_test(NAME chapman_ode_solver SOURCES test_chapman_ode_solver.cpp)
+create_standard_test(NAME lu_decomposition SOURCES test_lu_decomposition.cpp)
 create_standard_test(NAME rosenbrock SOURCES test_rosenbrock.cpp)
 create_standard_test(NAME state SOURCES test_state.cpp)

--- a/test/unit/solver/test_lu_decomposition.cpp
+++ b/test/unit/solver/test_lu_decomposition.cpp
@@ -121,3 +121,23 @@ TEST(LuDecomposition, RandomSparseMatrix)
   lud.Decompose(A, LU.first, LU.second);
   check_results<double>(A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
 }
+
+TEST(LuDecomposition, DiagonalOnly)
+{
+  auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
+
+  auto builder = micm::SparseMatrix<double>::create(6).number_of_blocks(5);
+  for (std::size_t i = 0; i < 6; ++i)
+    builder = builder.with_element(i, i);
+
+  micm::SparseMatrix<double> A(builder);
+
+  for (std::size_t i = 0; i < 6; ++i)
+    for (std::size_t i_block = 0; i_block < 5; ++i_block)
+      A[i_block][i][i] = get_double();
+
+  micm::LuDecomposition lud(A);
+  auto LU = micm::LuDecomposition::GetLUMatrices(A);
+  lud.Decompose(A, LU.first, LU.second);
+  check_results<double>(A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
+}

--- a/test/unit/solver/test_lu_decomposition.cpp
+++ b/test/unit/solver/test_lu_decomposition.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+
+#include <micm/solver/lu_decomposition.hpp>
+#include <micm/util/sparse_matrix.hpp>
+
+template<class T>
+void check_results(const micm::SparseMatrix<T>& A, const micm::SparseMatrix<T>& L, const micm::SparseMatrix<T>& U)
+{
+  EXPECT_EQ(A.size(), L.size());
+  EXPECT_EQ(A.size(), U.size());
+  for (std::size_t i_block = 0; i_block < A.size(); ++i_block)
+  {
+    for (std::size_t i = 0; i < A[i_block].size(); ++i)
+    {
+      for (std::size_t j = 0; j < A[i_block].size(); ++j)
+      {
+        T result{};
+        for (std::size_t k = 0; k < A[i_block].size(); ++k)
+        {
+          if (!(L.IsZero(i, k) || U.IsZero(k, j)))
+          {
+            result += L[i_block][i][k] * U[i_block][k][j];
+          }
+        }
+        if (A.IsZero(i, j))
+        {
+          EXPECT_EQ(result, 0);
+        }
+        else
+        {
+          EXPECT_EQ(A[i_block][i][j], result);
+        }
+      }
+    }
+  }
+}
+
+template<class T>
+void print_matrix(const micm::SparseMatrix<T>& matrix, std::size_t width)
+{
+  for (std::size_t i_block = 0; i_block < matrix.size(); ++i_block)
+  {
+    std::cout << "block: " << i_block << std::endl;
+    for (std::size_t i = 0; i < matrix[i_block].size(); ++i)
+    {
+      for (std::size_t j = 0; j < matrix[i_block][i].size(); ++j)
+      {
+        if (matrix.IsZero(i, j))
+        {
+          std::cout << " " << std::setfill('-') << std::setw(width) << "-"
+                    << " ";
+        }
+        else
+        {
+          std::cout << " " << std::setfill(' ') << std::setw(width) << matrix[i_block][i][j] << " ";
+        }
+      }
+      std::cout << std::endl;
+    }
+    std::cout << std::endl;
+  }
+}
+
+// tests example from https://www.geeksforgeeks.org/doolittle-algorithm-lu-decomposition/
+TEST(LuDecomposition, denseMatrix)
+{
+  micm::SparseMatrix<int> A = micm::SparseMatrix<int>::create(3)
+                                  .with_element(0, 0)
+                                  .with_element(0, 1)
+                                  .with_element(0, 2)
+                                  .with_element(1, 0)
+                                  .with_element(1, 1)
+                                  .with_element(1, 2)
+                                  .with_element(2, 0)
+                                  .with_element(2, 1)
+                                  .with_element(2, 2);
+
+  A[0][0][0] = 2;
+  A[0][0][1] = -1;
+  A[0][0][2] = -2;
+  A[0][1][0] = -4;
+  A[0][1][1] = 6;
+  A[0][1][2] = 3;
+  A[0][2][0] = -4;
+  A[0][2][1] = -2;
+  A[0][2][2] = 8;
+
+  micm::LuDecomposition lud(A);
+  lud.Print();
+
+  auto LU = micm::LuDecomposition::GetLUMatrices(A);
+  lud.Decompose(A, LU.first, LU.second);
+
+  std::cout << "A matrix" << std::endl;
+  print_matrix(A, 3);
+  std::cout << "L matrix" << std::endl;
+  print_matrix(LU.first, 3);
+  std::cout << "U matrix" << std::endl;
+  print_matrix(LU.second, 3);
+
+  check_results(A, LU.first, LU.second);
+}

--- a/test/unit/solver/test_lu_decomposition.cpp
+++ b/test/unit/solver/test_lu_decomposition.cpp
@@ -28,6 +28,9 @@ void check_results(
             result += L[i_block][i][k] * U[i_block][k][j];
           }
         }
+        // Make sure these are actually triangular matrices
+        EXPECT_TRUE(i >= j || L.IsZero(i, j));
+        EXPECT_TRUE(j >= i || U.IsZero(i, j));
         if (A.IsZero(i, j))
         {
           f(result, T{});

--- a/test/unit/util/test_sparse_matrix.cpp
+++ b/test/unit/util/test_sparse_matrix.cpp
@@ -45,6 +45,24 @@ TEST(SparseMatrix, ZeroMatrix)
       },
       std::invalid_argument);
   EXPECT_THROW(
+      try { bool isZero = matrix.IsZero(6, 0); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { bool isZero = matrix.IsZero(1, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { bool isZero = matrix.IsZero(6, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
       try { matrix[0][0][4] = 2.0; } catch (const std::invalid_argument& e) {
         EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
         throw;
@@ -113,6 +131,13 @@ TEST(SparseMatrix, SingleBlockMatrix)
     matrix.AsVector()[elem] = 21;
     EXPECT_EQ(matrix.AsVector()[2], 21);
   }
+
+  EXPECT_EQ(matrix.IsZero(0, 1), false);
+  EXPECT_EQ(matrix.IsZero(3, 2), false);
+  EXPECT_EQ(matrix.IsZero(2, 1), false);
+  EXPECT_EQ(matrix.IsZero(2, 2), true);
+  EXPECT_EQ(matrix.IsZero(0, 0), true);
+  EXPECT_EQ(matrix.IsZero(3, 3), true);
 
   EXPECT_EQ(matrix[0][2][1], 0);
   matrix[0][2][1] = 45;

--- a/test/unit/util/test_sparse_matrix.cpp
+++ b/test/unit/util/test_sparse_matrix.cpp
@@ -88,6 +88,68 @@ TEST(SparseMatrix, ZeroMatrix)
       std::invalid_argument);
 }
 
+TEST(SparseMatrix, ConstZeroMatrix)
+{
+  auto builder = micm::SparseMatrix<double>::create(3);
+  auto row_ids = builder.RowIdsVector();
+  auto row_starts = builder.RowStartVector();
+
+  EXPECT_EQ(builder.NumberOfElements(), 0);
+  EXPECT_EQ(row_ids.size(), 0);
+  EXPECT_EQ(row_starts.size(), 4);
+  EXPECT_EQ(row_starts[0], 0);
+  EXPECT_EQ(row_starts[1], 0);
+  EXPECT_EQ(row_starts[2], 0);
+  EXPECT_EQ(row_starts[3], 0);
+
+  const micm::SparseMatrix<double> matrix{ builder };
+
+  EXPECT_EQ(matrix.FlatBlockSize(), 0);
+
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(0, 0); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(6, 0); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(6, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { bool isZero = matrix.IsZero(6, 0); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { bool isZero = matrix.IsZero(1, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { bool isZero = matrix.IsZero(6, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+}
+
 TEST(SparseMatrix, SingleBlockMatrix)
 {
   auto builder = micm::SparseMatrix<int>::create(4)
@@ -100,23 +162,41 @@ TEST(SparseMatrix, SingleBlockMatrix)
   // 0 0 0 0
   // 0 X 0 X
   // 0 0 X 0
-  auto row_ids = builder.RowIdsVector();
-  auto row_starts = builder.RowStartVector();
+  {
+    auto row_ids = builder.RowIdsVector();
+    auto row_starts = builder.RowStartVector();
 
-  EXPECT_EQ(builder.NumberOfElements(), 4);
-  EXPECT_EQ(row_ids.size(), 4);
-  EXPECT_EQ(row_ids[0], 1);
-  EXPECT_EQ(row_ids[1], 1);
-  EXPECT_EQ(row_ids[2], 3);
-  EXPECT_EQ(row_ids[3], 2);
-  EXPECT_EQ(row_starts.size(), 5);
-  EXPECT_EQ(row_starts[0], 0);
-  EXPECT_EQ(row_starts[1], 1);
-  EXPECT_EQ(row_starts[2], 1);
-  EXPECT_EQ(row_starts[3], 3);
-  EXPECT_EQ(row_starts[4], 4);
+    EXPECT_EQ(builder.NumberOfElements(), 4);
+    EXPECT_EQ(row_ids.size(), 4);
+    EXPECT_EQ(row_ids[0], 1);
+    EXPECT_EQ(row_ids[1], 1);
+    EXPECT_EQ(row_ids[2], 3);
+    EXPECT_EQ(row_ids[3], 2);
+    EXPECT_EQ(row_starts.size(), 5);
+    EXPECT_EQ(row_starts[0], 0);
+    EXPECT_EQ(row_starts[1], 1);
+    EXPECT_EQ(row_starts[2], 1);
+    EXPECT_EQ(row_starts[3], 3);
+    EXPECT_EQ(row_starts[4], 4);
+  }
 
   micm::SparseMatrix<int> matrix{ builder };
+
+  {
+    auto& row_ids = matrix.RowIdsVector();
+    auto& row_starts = matrix.RowStartVector();
+    EXPECT_EQ(row_ids.size(), 4);
+    EXPECT_EQ(row_ids[0], 1);
+    EXPECT_EQ(row_ids[1], 1);
+    EXPECT_EQ(row_ids[2], 3);
+    EXPECT_EQ(row_ids[3], 2);
+    EXPECT_EQ(row_starts.size(), 5);
+    EXPECT_EQ(row_starts[0], 0);
+    EXPECT_EQ(row_starts[1], 1);
+    EXPECT_EQ(row_starts[2], 1);
+    EXPECT_EQ(row_starts[3], 3);
+    EXPECT_EQ(row_starts[4], 4);
+  }
 
   EXPECT_EQ(matrix.FlatBlockSize(), 4);
   {
@@ -193,6 +273,93 @@ TEST(SparseMatrix, SingleBlockMatrix)
       std::invalid_argument);
   EXPECT_THROW(
       try { matrix[0][1][1] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+}
+
+TEST(SparseMatrix, ConstSingleBlockMatrix)
+{
+  auto builder = micm::SparseMatrix<int>::create(4)
+                     .with_element(0, 1)
+                     .with_element(3, 2)
+                     .with_element(0, 1)
+                     .with_element(2, 3)
+                     .with_element(2, 1);
+  // 0 X 0 0
+  // 0 0 0 0
+  // 0 X 0 X
+  // 0 0 X 0
+  micm::SparseMatrix<int> orig_matrix{ builder };
+  orig_matrix[0][2][1] = 45;
+  orig_matrix[0][3][2] = 42;
+  orig_matrix[0][2][3] = 21;
+  const micm::SparseMatrix<int> matrix = orig_matrix;
+
+  {
+    auto& row_ids = matrix.RowIdsVector();
+    auto& row_starts = matrix.RowStartVector();
+    EXPECT_EQ(row_ids.size(), 4);
+    EXPECT_EQ(row_ids[0], 1);
+    EXPECT_EQ(row_ids[1], 1);
+    EXPECT_EQ(row_ids[2], 3);
+    EXPECT_EQ(row_ids[3], 2);
+    EXPECT_EQ(row_starts.size(), 5);
+    EXPECT_EQ(row_starts[0], 0);
+    EXPECT_EQ(row_starts[1], 1);
+    EXPECT_EQ(row_starts[2], 1);
+    EXPECT_EQ(row_starts[3], 3);
+    EXPECT_EQ(row_starts[4], 4);
+  }
+
+  EXPECT_EQ(matrix.FlatBlockSize(), 4);
+  {
+    std::size_t elem = matrix.VectorIndex(3, 2);
+    EXPECT_EQ(elem, 3);
+    EXPECT_EQ(matrix.AsVector()[3], 42);
+  }
+  {
+    std::size_t elem = matrix.VectorIndex(2, 3);
+    EXPECT_EQ(elem, 2);
+    EXPECT_EQ(matrix.AsVector()[2], 21);
+  }
+
+  EXPECT_EQ(matrix.IsZero(0, 1), false);
+  EXPECT_EQ(matrix.IsZero(3, 2), false);
+  EXPECT_EQ(matrix.IsZero(2, 1), false);
+  EXPECT_EQ(matrix.IsZero(2, 2), true);
+  EXPECT_EQ(matrix.IsZero(0, 0), true);
+  EXPECT_EQ(matrix.IsZero(3, 3), true);
+
+  EXPECT_EQ(matrix[0][2][1], 45);
+
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(4, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 5); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 0, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 1); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(0, 2); } catch (const std::invalid_argument& e) {
         EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
         throw;
       },


### PR DESCRIPTION
Adds an LU decomposer class to close #65 

The `factor()` function in the hard-coded solver was performing an LU decomposition. The `LuDecomposition::Decompose()` function is its replacement for the general Rosenbrock solver.

Also includes the draft of a `LinearSolver` class that will hold the remaining formerly preprocessed functions as they are generalized. Once this is finished, `LinearSolver` will be usable by the `Rosenbrock` solver and any other ODE solver that may be added in the future.

Also adds support for `const SparseMatrix`