### PR TITLE
Vectorizable Sparse Matrix

### DIFF
--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -3,11 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cassert>
 #include <micm/process/process.hpp>
 #include <micm/solver/state.hpp>
-#include <micm/util/matrix.hpp>
 #include <micm/util/sparse_matrix.hpp>
-#include <micm/util/vector_matrix.hpp>
 #include <vector>
 
 namespace micm
@@ -17,8 +16,14 @@ namespace micm
   template<typename T>
   concept VectorizableDense = requires(T t) {
     t.GroupSize();
+    t.GroupVectorSize();
     t.NumberOfGroups();
-    t.VectorSize();
+  };
+  template<typename T>
+  concept VectorizableSparse = requires(T t) {
+    t.GroupSize(0);
+    t.GroupVectorSize();
+    t.NumberOfGroups(0);
   };
 
   /// @brief Solver function calculators for a collection of processes
@@ -47,7 +52,8 @@ namespace micm
 
     /// @brief Sets the indicies for each non-zero Jacobian element in the underlying vector
     /// @param matrix The sparse matrix used for the Jacobian
-    void SetJacobianFlatIds(const SparseMatrix<double>& matrix);
+    template<typename OrderingPolicy>
+    void SetJacobianFlatIds(const SparseMatrix<double, OrderingPolicy>& matrix);
 
     /// @brief Add forcing terms for the set of processes for the current conditions
     /// @param rate_constants Current values for the process rate constants (grid cell, process)
@@ -55,19 +61,33 @@ namespace micm
     /// @param forcing Forcing terms for each state variable (grid cell, state variable)
     template<template<class> typename MatrixPolicy>
       requires(!VectorizableDense<MatrixPolicy<double>>)
-    void AddForcingTerms(const MatrixPolicy<double>& rate_constants, const MatrixPolicy<double>& state_variables, MatrixPolicy<double>& forcing) const;
+    void AddForcingTerms(
+        const MatrixPolicy<double>& rate_constants,
+        const MatrixPolicy<double>& state_variables,
+        MatrixPolicy<double>& forcing) const;
     template<template<class> typename MatrixPolicy>
       requires VectorizableDense<MatrixPolicy<double>>
-    void AddForcingTerms(const MatrixPolicy<double>& rate_constants, const MatrixPolicy<double>& state_variables, MatrixPolicy<double>& forcing)
-        const;
+    void AddForcingTerms(
+        const MatrixPolicy<double>& rate_constants,
+        const MatrixPolicy<double>& state_variables,
+        MatrixPolicy<double>& forcing) const;
 
     /// @brief Add Jacobian terms for the set of processes for the current conditions
     /// @param rate_constants Current values for the process rate constants (grid cell, process)
     /// @param state_variables Current state variable values (grid cell, state variable)
     /// @param jacobian Jacobian matrix for the system (grid cell, dependent variable, independent variable)
-    template<template<class> class MatrixPolicy>
-    void AddJacobianTerms(const MatrixPolicy<double>& rate_constants, const MatrixPolicy<double>& state_variables, SparseMatrix<double>& jacobian)
-        const;
+    template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+      requires(!VectorizableDense<MatrixPolicy<double>> || !VectorizableSparse<SparseMatrixPolicy<double>>)
+    void AddJacobianTerms(
+        const MatrixPolicy<double>& rate_constants,
+        const MatrixPolicy<double>& state_variables,
+        SparseMatrixPolicy<double>& jacobian) const;
+    template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+      requires(VectorizableDense<MatrixPolicy<double>> && VectorizableSparse<SparseMatrixPolicy<double>>)
+    void AddJacobianTerms(
+        const MatrixPolicy<double>& rate_constants,
+        const MatrixPolicy<double>& state_variables,
+        SparseMatrixPolicy<double>& jacobian) const;
   };
 
   template<template<class> class MatrixPolicy>
@@ -118,7 +138,8 @@ namespace micm
     return ids;
   }
 
-  void ProcessSet::SetJacobianFlatIds(const SparseMatrix<double>& matrix)
+  template<typename OrderingPolicy>
+  void ProcessSet::SetJacobianFlatIds(const SparseMatrix<double, OrderingPolicy>& matrix)
   {
     jacobian_flat_ids_.clear();
     auto react_id = reactant_ids_.begin();
@@ -143,8 +164,10 @@ namespace micm
 
   template<template<class> typename MatrixPolicy>
     requires(!VectorizableDense<MatrixPolicy<double>>)
-  inline void
-  ProcessSet::AddForcingTerms(const MatrixPolicy<double>& rate_constants, const MatrixPolicy<double>& state_variables, MatrixPolicy<double>& forcing) const
+  inline void ProcessSet::AddForcingTerms(
+      const MatrixPolicy<double>& rate_constants,
+      const MatrixPolicy<double>& state_variables,
+      MatrixPolicy<double>& forcing) const
   {
     // loop over grid cells
     for (std::size_t i_cell = 0; i_cell < state_variables.size(); ++i_cell)
@@ -173,22 +196,24 @@ namespace micm
 
   template<template<class> typename MatrixPolicy>
     requires VectorizableDense<MatrixPolicy<double>>
-  inline void
-  ProcessSet::AddForcingTerms(const MatrixPolicy<double>& rate_constants, const MatrixPolicy<double>& state_variables, MatrixPolicy<double>& forcing) const
+  inline void ProcessSet::AddForcingTerms(
+      const MatrixPolicy<double>& rate_constants,
+      const MatrixPolicy<double>& state_variables,
+      MatrixPolicy<double>& forcing) const
   {
     const auto& v_rate_constants = rate_constants.AsVector();
     const auto& v_state_variables = state_variables.AsVector();
     auto& v_forcing = forcing.AsVector();
+    const std::size_t L = rate_constants.GroupVectorSize();
     // loop over all rows
-    for (std::size_t i_block = 0; i_block < state_variables.NumberOfGroups(); ++i_block)
+    for (std::size_t i_group = 0; i_group < state_variables.NumberOfGroups(); ++i_group)
     {
-      std::size_t L = rate_constants.VectorSize();
       auto react_id = reactant_ids_.begin();
       auto prod_id = product_ids_.begin();
       auto yield = yields_.begin();
-      std::size_t offset_rc = i_block * rate_constants.GroupSize();
-      std::size_t offset_state = i_block * state_variables.GroupSize();
-      std::size_t offset_forcing = i_block * forcing.GroupSize();
+      std::size_t offset_rc = i_group * rate_constants.GroupSize();
+      std::size_t offset_state = i_group * state_variables.GroupSize();
+      std::size_t offset_forcing = i_group * forcing.GroupSize();
       for (std::size_t i_rxn = 0; i_rxn < number_of_reactants_.size(); ++i_rxn)
       {
         double rate[L];
@@ -210,11 +235,12 @@ namespace micm
     }
   }
 
-  template<template<class> class MatrixPolicy>
+  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+    requires(!VectorizableDense<MatrixPolicy<double>> || !VectorizableSparse<SparseMatrixPolicy<double>>)
   inline void ProcessSet::AddJacobianTerms(
       const MatrixPolicy<double>& rate_constants,
       const MatrixPolicy<double>& state_variables,
-      SparseMatrix<double>& jacobian) const
+      SparseMatrixPolicy<double>& jacobian) const
   {
     auto cell_jacobian = jacobian.AsVector().begin();
     // loop over grid cells
@@ -245,6 +271,60 @@ namespace micm
         yield += number_of_products_[i_rxn];
       }
       cell_jacobian += jacobian.FlatBlockSize();
+    }
+  }
+
+  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+    requires(VectorizableDense<MatrixPolicy<double>> && VectorizableSparse<SparseMatrixPolicy<double>>)
+  inline void ProcessSet::AddJacobianTerms(
+      const MatrixPolicy<double>& rate_constants,
+      const MatrixPolicy<double>& state_variables,
+      SparseMatrixPolicy<double>& jacobian) const
+  {
+    const auto& v_rate_constants = rate_constants.AsVector();
+    const auto& v_state_variables = state_variables.AsVector();
+    auto& v_jacobian = jacobian.AsVector();
+    assert(rate_constants.GroupVectorSize() == jacobian.GroupVectorSize());
+    const std::size_t L = rate_constants.GroupVectorSize();
+    // loop over all rows
+    for (std::size_t i_group = 0; i_group < state_variables.NumberOfGroups(); ++i_group)
+    {
+      auto react_id = reactant_ids_.begin();
+      auto yield = yields_.begin();
+      std::size_t offset_rc = i_group * rate_constants.GroupSize();
+      std::size_t offset_state = i_group * state_variables.GroupSize();
+      std::size_t offset_jacobian = i_group * jacobian.GroupSize(jacobian.FlatBlockSize());
+      auto flat_id = jacobian_flat_ids_.begin();
+      for (std::size_t i_rxn = 0; i_rxn < number_of_reactants_.size(); ++i_rxn)
+      {
+        for (std::size_t i_ind = 0; i_ind < number_of_reactants_[i_rxn]; ++i_ind)
+        {
+          double d_rate_d_ind[L];
+          for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+            d_rate_d_ind[i_cell] = v_rate_constants[offset_rc + i_rxn * L + i_cell];
+          for (std::size_t i_react = 0; i_react < number_of_reactants_[i_rxn]; ++i_react)
+          {
+            if (i_react == i_ind)
+              continue;
+            for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+              d_rate_d_ind[i_cell] *= v_state_variables[offset_state + react_id[i_react] * L + i_cell];
+          }
+          for (std::size_t i_dep = 0; i_dep < number_of_reactants_[i_rxn]; ++i_dep)
+          {
+            for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+              v_jacobian[offset_jacobian + *flat_id + i_cell] -= d_rate_d_ind[i_cell];
+            ++flat_id;
+          }
+          for (std::size_t i_dep = 0; i_dep < number_of_products_[i_rxn]; ++i_dep)
+          {
+            for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+              v_jacobian[offset_jacobian + *flat_id + i_cell] += yield[i_dep] * d_rate_d_ind[i_cell];
+            ++flat_id;
+          }
+        }
+        react_id += number_of_reactants_[i_rxn];
+        yield += number_of_products_[i_rxn];
+      }
     }
   }
 

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -12,20 +12,6 @@
 namespace micm
 {
 
-  /// Concepts for vectorizable matrices
-  template<typename T>
-  concept VectorizableDense = requires(T t) {
-    t.GroupSize();
-    t.GroupVectorSize();
-    t.NumberOfGroups();
-  };
-  template<typename T>
-  concept VectorizableSparse = requires(T t) {
-    t.GroupSize(0);
-    t.GroupVectorSize();
-    t.NumberOfGroups(0);
-  };
-
   /// @brief Solver function calculators for a collection of processes
   class ProcessSet
   {

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -34,6 +34,7 @@ namespace micm
   /// calls to Decompose to do the actual decomposition.
   class LuDecomposition
   {
+
     /// number of elements in the middle (k) loops for lower and upper triangular matrices, respectively,
     /// for each iteration of the outer (i) loop
     std::vector<std::pair<std::size_t, std::size_t>> niLU_;
@@ -73,31 +74,34 @@ namespace micm
 
     /// @brief Construct an LU decomposition algorithm for a given sparse matrix
     /// @param matrix Sparse matrix
-    template<class T>
-    LuDecomposition(const SparseMatrix<T>& matrix);
+    template<typename T, typename OrderingPolicy>
+    LuDecomposition(const SparseMatrix<T, OrderingPolicy>& matrix);
 
     /// @brief Create sparse L and U matrices for a given A matrix
     /// @param A Sparse matrix the will be decomposed
     /// @return L and U Sparse matrices
-    template<class T>
-    static std::pair<SparseMatrix<T>, SparseMatrix<T>> GetLUMatrices(const SparseMatrix<T>& A);
+    template<typename T, typename OrderingPolicy>
+    static std::pair<SparseMatrix<T, OrderingPolicy>, SparseMatrix<T, OrderingPolicy>> GetLUMatrices(
+        const SparseMatrix<T, OrderingPolicy>& A);
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose
     /// @param LU the lower and upper triangular matrices returned as a square matrix
     ///           The diagonal of LU belongs to the upper triangular matrix and the
     ///           diagonal of the lower triangular matrix shoud be assumed to be 1
-    template<class T>
-    void Decompose(const SparseMatrix<T>& A, SparseMatrix<T>& L, SparseMatrix<T>& U) const;
-
+    template<typename T, typename OrderingPolicy>
+    void Decompose(
+        const SparseMatrix<T, OrderingPolicy>& A,
+        SparseMatrix<T, OrderingPolicy>& L,
+        SparseMatrix<T, OrderingPolicy>& U) const;
   };
 
   inline LuDecomposition::LuDecomposition()
   {
   }
 
-  template<class T>
-  inline LuDecomposition::LuDecomposition(const SparseMatrix<T>& matrix)
+  template<typename T, typename OrderingPolicy>
+  inline LuDecomposition::LuDecomposition(const SparseMatrix<T, OrderingPolicy>& matrix)
   {
     std::size_t n = matrix[0].size();
     auto LU = GetLUMatrices(matrix);
@@ -170,8 +174,9 @@ namespace micm
     }
   }
 
-  template<class T>
-  inline std::pair<SparseMatrix<T>, SparseMatrix<T>> LuDecomposition::GetLUMatrices(const SparseMatrix<T>& A)
+  template<typename T, typename OrderingPolicy>
+  inline std::pair<SparseMatrix<T, OrderingPolicy>, SparseMatrix<T, OrderingPolicy>> LuDecomposition::GetLUMatrices(
+      const SparseMatrix<T, OrderingPolicy>& A)
   {
     std::size_t n = A[0].size();
     std::set<std::pair<std::size_t, std::size_t>> L_ids, U_ids;
@@ -214,22 +219,25 @@ namespace micm
         }
       }
     }
-    auto L_builder = micm::SparseMatrix<T>::create(n).number_of_blocks(A.size());
+    auto L_builder = micm::SparseMatrix<T, OrderingPolicy>::create(n).number_of_blocks(A.size());
     for (auto& pair : L_ids)
     {
       L_builder = L_builder.with_element(pair.first, pair.second);
     }
-    auto U_builder = micm::SparseMatrix<T>::create(n).number_of_blocks(A.size());
+    auto U_builder = micm::SparseMatrix<T, OrderingPolicy>::create(n).number_of_blocks(A.size());
     for (auto& pair : U_ids)
     {
       U_builder = U_builder.with_element(pair.first, pair.second);
     }
-    std::pair<SparseMatrix<T>, SparseMatrix<T>> LU(L_builder, U_builder);
+    std::pair<SparseMatrix<T, OrderingPolicy>, SparseMatrix<T, OrderingPolicy>> LU(L_builder, U_builder);
     return LU;
   }
 
-  template<class T>
-  inline void LuDecomposition::Decompose(const SparseMatrix<T>& A, SparseMatrix<T>& L, SparseMatrix<T>& U) const
+  template<typename T, typename OrderingPolicy>
+  inline void LuDecomposition::Decompose(
+      const SparseMatrix<T, OrderingPolicy>& A,
+      SparseMatrix<T, OrderingPolicy>& L,
+      SparseMatrix<T, OrderingPolicy>& U) const
   {
     // Loop over blocks
     for (std::size_t i_block = 0; i_block < A.size(); ++i_block)

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -81,7 +81,7 @@ namespace micm
     /// @return L and U Sparse matrices
     template<typename T, typename OrderingPolicy>
     static std::pair<SparseMatrix<T, OrderingPolicy>, SparseMatrix<T, OrderingPolicy>> GetLUMatrices(
-        const SparseMatrix<T, OrderingPolicy>& A);
+        const SparseMatrix<T, OrderingPolicy>& A, T initial_value);
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose
@@ -104,7 +104,7 @@ namespace micm
   inline LuDecomposition::LuDecomposition(const SparseMatrix<T, OrderingPolicy>& matrix)
   {
     std::size_t n = matrix[0].size();
-    auto LU = GetLUMatrices(matrix);
+    auto LU = GetLUMatrices(matrix, T{});
     const auto& L_row_start = LU.first.RowStartVector();
     const auto& L_row_ids = LU.first.RowIdsVector();
     const auto& U_row_start = LU.second.RowStartVector();
@@ -176,7 +176,7 @@ namespace micm
 
   template<typename T, typename OrderingPolicy>
   inline std::pair<SparseMatrix<T, OrderingPolicy>, SparseMatrix<T, OrderingPolicy>> LuDecomposition::GetLUMatrices(
-      const SparseMatrix<T, OrderingPolicy>& A)
+      const SparseMatrix<T, OrderingPolicy>& A, T initial_value)
   {
     std::size_t n = A[0].size();
     std::set<std::pair<std::size_t, std::size_t>> L_ids, U_ids;
@@ -219,12 +219,12 @@ namespace micm
         }
       }
     }
-    auto L_builder = micm::SparseMatrix<T, OrderingPolicy>::create(n).number_of_blocks(A.size());
+    auto L_builder = micm::SparseMatrix<T, OrderingPolicy>::create(n).number_of_blocks(A.size()).initial_value(initial_value);
     for (auto& pair : L_ids)
     {
       L_builder = L_builder.with_element(pair.first, pair.second);
     }
-    auto U_builder = micm::SparseMatrix<T, OrderingPolicy>::create(n).number_of_blocks(A.size());
+    auto U_builder = micm::SparseMatrix<T, OrderingPolicy>::create(n).number_of_blocks(A.size()).initial_value(initial_value);
     for (auto& pair : U_ids)
     {
       U_builder = U_builder.with_element(pair.first, pair.second);

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -11,6 +11,14 @@
 namespace micm
 {
 
+  /// Concept for vectorizable matrices
+  template<typename T>
+  concept VectorizableDense = requires(T t) {
+    t.GroupSize();
+    t.GroupVectorSize();
+    t.NumberOfGroups();
+  };
+
   /// @brief A 2D array class with contiguous memory
   template<class T>
   class Matrix

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -15,6 +15,14 @@
 namespace micm
 {
 
+  /// Concept for vectorizable matrices
+  template<typename T>
+  concept VectorizableSparse = requires(T t) {
+    t.GroupSize(0);
+    t.GroupVectorSize();
+    t.NumberOfGroups(0);
+  };
+
   template<class T, class OrderingPolicy>
   class SparseMatrixBuilder;
 

--- a/include/micm/util/sparse_matrix_standard_ordering.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering.hpp
@@ -10,7 +10,7 @@ namespace micm
   ///
   /// Data is stored with blocks in the block diagonal matrix as the highest
   /// level structure, then by row, then by non-zero columns in each row.
-  class StandardSparseMatrix
+  class SparseMatrixStandardOrdering
   {
    protected:
     static std::size_t VectorSize(

--- a/include/micm/util/sparse_matrix_vector_ordering.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering.hpp
@@ -45,5 +45,21 @@ namespace micm
         throw std::invalid_argument("SparseMatrix zero element access not allowed");
       return std::size_t{ (elem - row_ids.begin()) * L + block % L + (block / L) * L * row_ids.size() };
     };
+
+   public:
+    std::size_t GroupVectorSize() const
+    {
+      return L;
+    }
+
+    std::size_t GroupSize(std::size_t number_of_non_zero_elements) const
+    {
+      return L * number_of_non_zero_elements;
+    }
+
+    std::size_t NumberOfGroups(std::size_t number_of_blocks) const
+    {
+      return std::ceil((double)number_of_blocks / (double)L);
+    }
   };
 }  // namespace micm

--- a/include/micm/util/sparse_matrix_vector_ordering.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering.hpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2023 National Center for Atmospheric Research,
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cmath>
+
+namespace micm
+{
+
+  /// @brief Defines the ordering of SparseMatrix object data to encourage vectorization
+  ///
+  /// Data is stored with sets of blocks in the block diagonal matrix as the highest
+  /// level structure, then by row, then by non-zero columns in each row, then by
+  /// individual blocks in the set of blocks.
+  ///
+  /// The template argument is the number of blocks per set of blocks and should be
+  /// approximately the size of the vector register.
+  template<std::size_t L>
+  class SparseMatrixVectorOrdering
+  {
+   protected:
+    static std::size_t VectorSize(
+        std::size_t number_of_blocks,
+        const std::vector<std::size_t>& row_ids,
+        const std::vector<std::size_t>& row_start)
+    {
+      return std::ceil((double)number_of_blocks / (double)L) * row_ids.size();
+    };
+
+    std::size_t VectorIndex(
+        std::size_t number_of_blocks,
+        const std::vector<std::size_t>& row_ids,
+        const std::vector<std::size_t>& row_start,
+        std::size_t block,
+        std::size_t row,
+        std::size_t column) const
+    {
+      if (row >= row_start.size() - 1 || column >= row_start.size() - 1 || block >= number_of_blocks)
+        throw std::invalid_argument("SparseMatrix element out of range");
+      auto begin = std::next(row_ids.begin(), row_start[row]);
+      auto end = std::next(row_ids.begin(), row_start[row + 1]);
+      auto elem = std::find(begin, end, column);
+      if (elem == end)
+        throw std::invalid_argument("SparseMatrix zero element access not allowed");
+      return std::size_t{ (elem - row_ids.begin()) * L + block % L + (block / L) * row_ids.size() };
+    };
+  };
+}  // namespace micm

--- a/include/micm/util/sparse_matrix_vector_ordering.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering.hpp
@@ -25,7 +25,7 @@ namespace micm
         const std::vector<std::size_t>& row_ids,
         const std::vector<std::size_t>& row_start)
     {
-      return std::ceil((double)number_of_blocks / (double)L) * row_ids.size();
+      return std::ceil((double)number_of_blocks / (double)L) * L * row_ids.size();
     };
 
     std::size_t VectorIndex(
@@ -43,7 +43,7 @@ namespace micm
       auto elem = std::find(begin, end, column);
       if (elem == end)
         throw std::invalid_argument("SparseMatrix zero element access not allowed");
-      return std::size_t{ (elem - row_ids.begin()) * L + block % L + (block / L) * row_ids.size() };
+      return std::size_t{ (elem - row_ids.begin()) * L + block % L + (block / L) * L * row_ids.size() };
     };
   };
 }  // namespace micm

--- a/include/micm/util/standard_sparse_matrix.hpp
+++ b/include/micm/util/standard_sparse_matrix.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 National Center for Atmospheric Research,
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+namespace micm
+{
+
+  /// @brief Defines the ordering of SparseMatrix object data
+  ///
+  /// Data is stored with blocks in the block diagonal matrix as the highest
+  /// level structure, then by row, then by non-zero columns in each row.
+  class StandardSparseMatrix
+  {
+   protected:
+    static std::size_t VectorSize(
+        std::size_t number_of_blocks,
+        const std::vector<std::size_t>& row_ids,
+        const std::vector<std::size_t>& row_start)
+    {
+      return number_of_blocks * row_ids.size();
+    };
+
+    static std::size_t VectorIndex(
+        std::size_t number_of_blocks,
+        const std::vector<std::size_t>& row_ids,
+        const std::vector<std::size_t>& row_start,
+        std::size_t block,
+        std::size_t row,
+        std::size_t column)
+    {
+      if (row >= row_start.size() - 1 || column >= row_start.size() - 1 || block >= number_of_blocks)
+        throw std::invalid_argument("SparseMatrix element out of range");
+      auto begin = std::next(row_ids.begin(), row_start[row]);
+      auto end = std::next(row_ids.begin(), row_start[row + 1]);
+      auto elem = std::find(begin, end, column);
+      if (elem == end)
+        throw std::invalid_argument("SparseMatrix zero element access not allowed");
+      return std::size_t{ (elem - row_ids.begin()) + block * row_ids.size() };
+    };
+  };
+}  // namespace micm

--- a/include/micm/util/standard_sparse_matrix.hpp
+++ b/include/micm/util/standard_sparse_matrix.hpp
@@ -21,13 +21,13 @@ namespace micm
       return number_of_blocks * row_ids.size();
     };
 
-    static std::size_t VectorIndex(
+    std::size_t VectorIndex(
         std::size_t number_of_blocks,
         const std::vector<std::size_t>& row_ids,
         const std::vector<std::size_t>& row_start,
         std::size_t block,
         std::size_t row,
-        std::size_t column)
+        std::size_t column) const
     {
       if (row >= row_start.size() - 1 || column >= row_start.size() - 1 || block >= number_of_blocks)
         throw std::invalid_argument("SparseMatrix element out of range");

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -186,7 +186,7 @@ namespace micm
       return L * y_dim_;
     }
 
-    constexpr std::size_t VectorSize() const
+    constexpr std::size_t GroupVectorSize() const
     {
       return L;
     }

--- a/test/unit/process/test_process_set.cpp
+++ b/test/unit/process/test_process_set.cpp
@@ -127,20 +127,20 @@ TEST(ProcessSet, Matrix)
 }
 
 template<class T>
-using Block1VectorMatrix = micm::VectorMatrix<T, 1>;
+using Group1VectorMatrix = micm::VectorMatrix<T, 1>;
 template<class T>
-using Block2VectorMatrix = micm::VectorMatrix<T, 2>;
+using Group2VectorMatrix = micm::VectorMatrix<T, 2>;
 template<class T>
-using Block3VectorMatrix = micm::VectorMatrix<T, 3>;
+using Group3VectorMatrix = micm::VectorMatrix<T, 3>;
 template<class T>
-using Block4VectorMatrix = micm::VectorMatrix<T, 4>;
+using Group4VectorMatrix = micm::VectorMatrix<T, 4>;
 
 TEST(ProcessSet, VectorMatrix)
 {
-  testProcessSet<Block1VectorMatrix>();
-  testProcessSet<Block2VectorMatrix>();
-  testProcessSet<Block3VectorMatrix>();
-  testProcessSet<Block4VectorMatrix>();
+  testProcessSet<Group1VectorMatrix>();
+  testProcessSet<Group2VectorMatrix>();
+  testProcessSet<Group3VectorMatrix>();
+  testProcessSet<Group4VectorMatrix>();
 }
 
 template<template<class> class MatrixPolicy>

--- a/test/unit/process/test_process_set.cpp
+++ b/test/unit/process/test_process_set.cpp
@@ -4,6 +4,7 @@
 #include <micm/process/process_set.hpp>
 #include <micm/util/matrix.hpp>
 #include <micm/util/vector_matrix.hpp>
+#include <random>
 
 using yields = std::pair<micm::Species, double>;
 using index_pair = std::pair<std::size_t, std::size_t>;
@@ -26,9 +27,9 @@ void testProcessSet()
   micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar, baz, quz, quuz } };
 
   micm::State<MatrixPolicy> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz", "quuz" },
-                                            .number_of_grid_cells_ = 2,
-                                            .number_of_custom_parameters_ = 0,
-                                            .number_of_rate_constants_ = 3 } };
+                                                          .number_of_grid_cells_ = 2,
+                                                          .number_of_custom_parameters_ = 0,
+                                                          .number_of_rate_constants_ = 3 } };
 
   micm::Process r1 =
       micm::Process::create().reactants({ foo, baz }).products({ yields(bar, 1), yields(quuz, 2.4) }).phase(gas_phase);
@@ -140,4 +141,64 @@ TEST(ProcessSet, VectorMatrix)
   testProcessSet<Block2VectorMatrix>();
   testProcessSet<Block3VectorMatrix>();
   testProcessSet<Block4VectorMatrix>();
+}
+
+template<template<class> class MatrixPolicy>
+void testRandomSystem(std::size_t n_cells, std::size_t n_reactions, std::size_t n_species)
+{
+  auto get_n_react = std::bind(std::uniform_int_distribution<>(0, 3), std::default_random_engine());
+  auto get_n_product = std::bind(std::uniform_int_distribution<>(0, 10), std::default_random_engine());
+  auto get_species_id = std::bind(std::uniform_int_distribution<>(0, n_species - 1), std::default_random_engine());
+  auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
+
+  std::vector<micm::Species> species{};
+  std::vector<std::string> species_names{};
+  for (std::size_t i = 0; i < n_species; ++i)
+  {
+    species.push_back(micm::Species{ std::to_string(i) });
+    species_names.push_back(std::to_string(i));
+  }
+  micm::Phase gas_phase{ species };
+  micm::State<MatrixPolicy> state{ micm::StateParameters{ .state_variable_names_{ species_names },
+                                                          .number_of_grid_cells_ = n_cells,
+                                                          .number_of_custom_parameters_ = 0,
+                                                          .number_of_rate_constants_ = n_reactions } };
+
+  std::vector<micm::Process> processes{};
+  for (std::size_t i = 0; i < n_reactions; ++i)
+  {
+    auto n_react = get_n_react();
+    std::vector<micm::Species> reactants{};
+    for (std::size_t i_react = 0; i_react < n_react; ++i_react)
+    {
+      reactants.push_back({ std::to_string(get_species_id()) });
+    }
+    auto n_product = get_n_product();
+    std::vector<yields> products{};
+    for (std::size_t i_prod = 0; i_prod < n_product; ++i_prod)
+    {
+      products.push_back(yields(std::to_string(get_species_id()), 1.2));
+    }
+    processes.push_back(micm::Process::create().reactants(reactants).products(products).phase(gas_phase));
+  }
+
+  micm::ProcessSet set{ processes, state };
+
+  for (auto& elem : state.variables_.AsVector())
+    elem = get_double();
+
+  MatrixPolicy<double> rate_constants{ n_cells, n_reactions };
+  for (auto& elem : rate_constants.AsVector())
+    elem = get_double();
+
+  MatrixPolicy<double> forcing{ n_cells, n_species, 1000.0 };
+
+  set.AddForcingTerms<MatrixPolicy>(rate_constants, state.variables_, forcing);
+}
+
+TEST(RandomProcessSet, Matrix)
+{
+  testRandomSystem<micm::Matrix>(2000, 500, 400);
+  testRandomSystem<micm::Matrix>(3000, 300, 200);
+  testRandomSystem<micm::Matrix>(4000, 100, 80);
 }

--- a/test/unit/solver/test_lu_decomposition.cpp
+++ b/test/unit/solver/test_lu_decomposition.cpp
@@ -75,7 +75,7 @@ void print_matrix(const SparseMatrixPolicy<T>& matrix, std::size_t width)
 template<template<class> class SparseMatrixPolicy>
 void testDenseMatrix()
 {
-  SparseMatrixPolicy<int> A = SparseMatrixPolicy<int>::create(3)
+  SparseMatrixPolicy<int> A = SparseMatrixPolicy<int>::create(3).initial_value(1)
                                   .with_element(0, 0)
                                   .with_element(0, 1)
                                   .with_element(0, 2)
@@ -97,7 +97,7 @@ void testDenseMatrix()
   A[0][2][2] = 8;
 
   micm::LuDecomposition lud(A);
-  auto LU = micm::LuDecomposition::GetLUMatrices(A);
+  auto LU = micm::LuDecomposition::GetLUMatrices(A, 1);
   lud.Decompose<int, SparseMatrixPolicy>(A, LU.first, LU.second);
   check_results<int, SparseMatrixPolicy>(A, LU.first, LU.second, [&](const int a, const int b) -> void { EXPECT_EQ(a, b); });
 }
@@ -108,7 +108,7 @@ void testRandomMatrix()
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::create(10).number_of_blocks(5);
+  auto builder = SparseMatrixPolicy<double>::create(10).number_of_blocks(5).initial_value(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())
@@ -123,7 +123,7 @@ void testRandomMatrix()
           A[i_block][i][j] = get_double();
 
   micm::LuDecomposition lud(A);
-  auto LU = micm::LuDecomposition::GetLUMatrices(A);
+  auto LU = micm::LuDecomposition::GetLUMatrices(A, 1.0e-30);
   lud.Decompose<double, SparseMatrixPolicy>(A, LU.first, LU.second);
   check_results<double, SparseMatrixPolicy>(
       A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
@@ -134,7 +134,7 @@ void testDiagonalMatrix()
 {
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::create(6).number_of_blocks(5);
+  auto builder = SparseMatrixPolicy<double>::create(6).number_of_blocks(5).initial_value(1.0e-30);
   for (std::size_t i = 0; i < 6; ++i)
     builder = builder.with_element(i, i);
 
@@ -145,7 +145,7 @@ void testDiagonalMatrix()
       A[i_block][i][i] = get_double();
 
   micm::LuDecomposition lud(A);
-  auto LU = micm::LuDecomposition::GetLUMatrices(A);
+  auto LU = micm::LuDecomposition::GetLUMatrices(A, 1.0e-30);
   lud.Decompose<double, SparseMatrixPolicy>(A, LU.first, LU.second);
   check_results<double, SparseMatrixPolicy>(
       A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });

--- a/test/unit/solver/test_lu_decomposition.cpp
+++ b/test/unit/solver/test_lu_decomposition.cpp
@@ -75,7 +75,7 @@ void print_matrix(const SparseMatrixPolicy<T>& matrix, std::size_t width)
 template<template<class> class SparseMatrixPolicy>
 void testDenseMatrix()
 {
-  SparseMatrixPolicy<int> A = SparseMatrixPolicy<int>::create(3).initial_value(1)
+  SparseMatrixPolicy<double> A = SparseMatrixPolicy<double>::create(3).initial_value(1.0e-30)
                                   .with_element(0, 0)
                                   .with_element(0, 1)
                                   .with_element(0, 2)
@@ -97,9 +97,9 @@ void testDenseMatrix()
   A[0][2][2] = 8;
 
   micm::LuDecomposition lud(A);
-  auto LU = micm::LuDecomposition::GetLUMatrices(A, 1);
-  lud.Decompose<int, SparseMatrixPolicy>(A, LU.first, LU.second);
-  check_results<int, SparseMatrixPolicy>(A, LU.first, LU.second, [&](const int a, const int b) -> void { EXPECT_EQ(a, b); });
+  auto LU = micm::LuDecomposition::GetLUMatrices(A, 1.0e-30);
+  lud.Decompose<double, SparseMatrixPolicy>(A, LU.first, LU.second);
+  check_results<double, SparseMatrixPolicy>(A, LU.first, LU.second, [&](const int a, const int b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
 }
 
 template<template<class> class SparseMatrixPolicy>

--- a/test/unit/solver/test_lu_decomposition.cpp
+++ b/test/unit/solver/test_lu_decomposition.cpp
@@ -3,13 +3,14 @@
 #include <functional>
 #include <micm/solver/lu_decomposition.hpp>
 #include <micm/util/sparse_matrix.hpp>
+#include <micm/util/sparse_matrix_vector_ordering.hpp>
 #include <random>
 
-template<class T>
+template<typename T, template<class> class SparseMatrixPolicy>
 void check_results(
-    const micm::SparseMatrix<T>& A,
-    const micm::SparseMatrix<T>& L,
-    const micm::SparseMatrix<T>& U,
+    const SparseMatrixPolicy<T>& A,
+    const SparseMatrixPolicy<T>& L,
+    const SparseMatrixPolicy<T>& U,
     const std::function<void(const T, const T)> f)
 {
   EXPECT_EQ(A.size(), L.size());
@@ -44,8 +45,8 @@ void check_results(
   }
 }
 
-template<class T>
-void print_matrix(const micm::SparseMatrix<T>& matrix, std::size_t width)
+template<typename T, template<class> class SparseMatrixPolicy>
+void print_matrix(const SparseMatrixPolicy<T>& matrix, std::size_t width)
 {
   for (std::size_t i_block = 0; i_block < matrix.size(); ++i_block)
   {
@@ -71,9 +72,10 @@ void print_matrix(const micm::SparseMatrix<T>& matrix, std::size_t width)
 }
 
 // tests example from https://www.geeksforgeeks.org/doolittle-algorithm-lu-decomposition/
-TEST(LuDecomposition, DenseMatrix)
+template<template<class> class SparseMatrixPolicy>
+void testDenseMatrix()
 {
-  micm::SparseMatrix<int> A = micm::SparseMatrix<int>::create(3)
+  SparseMatrixPolicy<int> A = SparseMatrixPolicy<int>::create(3)
                                   .with_element(0, 0)
                                   .with_element(0, 1)
                                   .with_element(0, 2)
@@ -96,22 +98,23 @@ TEST(LuDecomposition, DenseMatrix)
 
   micm::LuDecomposition lud(A);
   auto LU = micm::LuDecomposition::GetLUMatrices(A);
-  lud.Decompose(A, LU.first, LU.second);
-  check_results<int>(A, LU.first, LU.second, [&](const int a, const int b) -> void { EXPECT_EQ(a, b); });
+  lud.Decompose<int, SparseMatrixPolicy>(A, LU.first, LU.second);
+  check_results<int, SparseMatrixPolicy>(A, LU.first, LU.second, [&](const int a, const int b) -> void { EXPECT_EQ(a, b); });
 }
 
-TEST(LuDecomposition, RandomSparseMatrix)
+template<template<class> class SparseMatrixPolicy>
+void testRandomMatrix()
 {
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
-  auto builder = micm::SparseMatrix<double>::create(10).number_of_blocks(5);
+  auto builder = SparseMatrixPolicy<double>::create(10).number_of_blocks(5);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())
         builder = builder.with_element(i, j);
 
-  micm::SparseMatrix<double> A(builder);
+  SparseMatrixPolicy<double> A(builder);
 
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
@@ -121,19 +124,21 @@ TEST(LuDecomposition, RandomSparseMatrix)
 
   micm::LuDecomposition lud(A);
   auto LU = micm::LuDecomposition::GetLUMatrices(A);
-  lud.Decompose(A, LU.first, LU.second);
-  check_results<double>(A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
+  lud.Decompose<double, SparseMatrixPolicy>(A, LU.first, LU.second);
+  check_results<double, SparseMatrixPolicy>(
+      A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
 }
 
-TEST(LuDecomposition, DiagonalOnly)
+template<template<class> class SparseMatrixPolicy>
+void testDiagonalMatrix()
 {
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
-  auto builder = micm::SparseMatrix<double>::create(6).number_of_blocks(5);
+  auto builder = SparseMatrixPolicy<double>::create(6).number_of_blocks(5);
   for (std::size_t i = 0; i < 6; ++i)
     builder = builder.with_element(i, i);
 
-  micm::SparseMatrix<double> A(builder);
+  SparseMatrixPolicy<double> A(builder);
 
   for (std::size_t i = 0; i < 6; ++i)
     for (std::size_t i_block = 0; i_block < 5; ++i_block)
@@ -141,6 +146,55 @@ TEST(LuDecomposition, DiagonalOnly)
 
   micm::LuDecomposition lud(A);
   auto LU = micm::LuDecomposition::GetLUMatrices(A);
-  lud.Decompose(A, LU.first, LU.second);
-  check_results<double>(A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
+  lud.Decompose<double, SparseMatrixPolicy>(A, LU.first, LU.second);
+  check_results<double, SparseMatrixPolicy>(
+      A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
+}
+
+TEST(LuDecomposition, DenseMatrixStandardOrdering)
+{
+  testDenseMatrix<micm::SparseMatrix>();
+}
+
+TEST(LuDecomposition, RandomMatrixStandardOrdering)
+{
+  testRandomMatrix<micm::SparseMatrix>();
+}
+
+TEST(LuDecomposition, DiagonalMatrixStandardOrdering)
+{
+  testDiagonalMatrix<micm::SparseMatrix>();
+}
+
+template<class T>
+using Group1SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
+template<class T>
+using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
+template<class T>
+using Group3SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
+template<class T>
+using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+
+TEST(LuDecomposition, DenseMatrixVectorOrdering)
+{
+  testDenseMatrix<Group1SparseVectorMatrix>();
+  testDenseMatrix<Group2SparseVectorMatrix>();
+  testDenseMatrix<Group3SparseVectorMatrix>();
+  testDenseMatrix<Group4SparseVectorMatrix>();
+}
+
+TEST(LuDecomposition, RandomMatrixVectorOrdering)
+{
+  testRandomMatrix<Group1SparseVectorMatrix>();
+  testRandomMatrix<Group2SparseVectorMatrix>();
+  testRandomMatrix<Group3SparseVectorMatrix>();
+  testRandomMatrix<Group4SparseVectorMatrix>();
+}
+
+TEST(LuDecomposition, DiagonalMatrixVectorOrdering)
+{
+  testDiagonalMatrix<Group1SparseVectorMatrix>();
+  testDiagonalMatrix<Group2SparseVectorMatrix>();
+  testDiagonalMatrix<Group3SparseVectorMatrix>();
+  testDiagonalMatrix<Group4SparseVectorMatrix>();
 }

--- a/test/unit/util/CMakeLists.txt
+++ b/test/unit/util/CMakeLists.txt
@@ -7,5 +7,6 @@ include(test_util)
 # Tests
 
 create_standard_test(NAME matrix SOURCES test_matrix.cpp)
-create_standard_test(NAME sparse_matrix SOURCES test_sparse_matrix.cpp)
+create_standard_test(NAME sparse_matrix_standard_ordering SOURCES test_sparse_matrix_standard_ordering.cpp)
+create_standard_test(NAME sparse_matrix_vector_ordering SOURCES test_sparse_matrix_vector_ordering.cpp)
 create_standard_test(NAME vector_matrix SOURCES test_vector_matrix.cpp)

--- a/test/unit/util/test_sparse_matrix_policy.hpp
+++ b/test/unit/util/test_sparse_matrix_policy.hpp
@@ -89,3 +89,370 @@ micm::SparseMatrix<double, OrderingPolicy> testZeroMatrix()
       std::invalid_argument);
   return matrix;
 }
+
+template<class OrderingPolicy>
+micm::SparseMatrix<double, OrderingPolicy> testConstZeroMatrix()
+{
+  auto builder = micm::SparseMatrix<double, OrderingPolicy>::create(3);
+  auto row_ids = builder.RowIdsVector();
+  auto row_starts = builder.RowStartVector();
+
+  EXPECT_EQ(builder.NumberOfElements(), 0);
+  EXPECT_EQ(row_ids.size(), 0);
+  EXPECT_EQ(row_starts.size(), 4);
+  EXPECT_EQ(row_starts[0], 0);
+  EXPECT_EQ(row_starts[1], 0);
+  EXPECT_EQ(row_starts[2], 0);
+  EXPECT_EQ(row_starts[3], 0);
+
+  const micm::SparseMatrix<double, OrderingPolicy> matrix{ builder };
+
+  EXPECT_EQ(matrix.FlatBlockSize(), 0);
+
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(0, 0); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(6, 0); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(6, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { bool isZero = matrix.IsZero(6, 0); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { bool isZero = matrix.IsZero(1, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { bool isZero = matrix.IsZero(6, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument); 
+  return matrix;
+}
+
+template<class OrderingPolicy>
+micm::SparseMatrix<int, OrderingPolicy> testSingleBlockMatrix()
+{
+  auto builder = micm::SparseMatrix<int, OrderingPolicy>::create(4)
+                     .with_element(0, 1)
+                     .with_element(3, 2)
+                     .with_element(0, 1)
+                     .with_element(2, 3)
+                     .with_element(2, 1);
+  // 0 X 0 0
+  // 0 0 0 0
+  // 0 X 0 X
+  // 0 0 X 0
+  {
+    auto row_ids = builder.RowIdsVector();
+    auto row_starts = builder.RowStartVector();
+
+    EXPECT_EQ(builder.NumberOfElements(), 4);
+    EXPECT_EQ(row_ids.size(), 4);
+    EXPECT_EQ(row_ids[0], 1);
+    EXPECT_EQ(row_ids[1], 1);
+    EXPECT_EQ(row_ids[2], 3);
+    EXPECT_EQ(row_ids[3], 2);
+    EXPECT_EQ(row_starts.size(), 5);
+    EXPECT_EQ(row_starts[0], 0);
+    EXPECT_EQ(row_starts[1], 1);
+    EXPECT_EQ(row_starts[2], 1);
+    EXPECT_EQ(row_starts[3], 3);
+    EXPECT_EQ(row_starts[4], 4);
+  }
+
+  micm::SparseMatrix<int, OrderingPolicy> matrix{ builder };
+
+  {
+    auto& row_ids = matrix.RowIdsVector();
+    auto& row_starts = matrix.RowStartVector();
+    EXPECT_EQ(row_ids.size(), 4);
+    EXPECT_EQ(row_ids[0], 1);
+    EXPECT_EQ(row_ids[1], 1);
+    EXPECT_EQ(row_ids[2], 3);
+    EXPECT_EQ(row_ids[3], 2);
+    EXPECT_EQ(row_starts.size(), 5);
+    EXPECT_EQ(row_starts[0], 0);
+    EXPECT_EQ(row_starts[1], 1);
+    EXPECT_EQ(row_starts[2], 1);
+    EXPECT_EQ(row_starts[3], 3);
+    EXPECT_EQ(row_starts[4], 4);
+  }
+
+  EXPECT_EQ(matrix.FlatBlockSize(), 4);
+
+  EXPECT_EQ(matrix.IsZero(0, 1), false);
+  EXPECT_EQ(matrix.IsZero(3, 2), false);
+  EXPECT_EQ(matrix.IsZero(2, 1), false);
+  EXPECT_EQ(matrix.IsZero(2, 2), true);
+  EXPECT_EQ(matrix.IsZero(0, 0), true);
+  EXPECT_EQ(matrix.IsZero(3, 3), true);
+
+  EXPECT_EQ(matrix[0][2][1], 0);
+  matrix[0][2][1] = 45;
+  EXPECT_EQ(matrix[0][2][1], 45);
+
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(4, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 5); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 0, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 1); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(0, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][0][4] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[1][0][0] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][5][0] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][1][1] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  return matrix;
+}
+
+template<class OrderingPolicy>
+micm::SparseMatrix<int, OrderingPolicy> testConstSingleBlockMatrix()
+{
+  auto builder = micm::SparseMatrix<int, OrderingPolicy>::create(4)
+                     .with_element(0, 1)
+                     .with_element(3, 2)
+                     .with_element(0, 1)
+                     .with_element(2, 3)
+                     .with_element(2, 1);
+  // 0 X 0 0
+  // 0 0 0 0
+  // 0 X 0 X
+  // 0 0 X 0
+  micm::SparseMatrix<int, OrderingPolicy> orig_matrix{ builder };
+  orig_matrix[0][2][1] = 45;
+  orig_matrix[0][3][2] = 42;
+  orig_matrix[0][2][3] = 21;
+  const micm::SparseMatrix<int, OrderingPolicy> matrix = orig_matrix;
+
+  {
+    auto& row_ids = matrix.RowIdsVector();
+    auto& row_starts = matrix.RowStartVector();
+    EXPECT_EQ(row_ids.size(), 4);
+    EXPECT_EQ(row_ids[0], 1);
+    EXPECT_EQ(row_ids[1], 1);
+    EXPECT_EQ(row_ids[2], 3);
+    EXPECT_EQ(row_ids[3], 2);
+    EXPECT_EQ(row_starts.size(), 5);
+    EXPECT_EQ(row_starts[0], 0);
+    EXPECT_EQ(row_starts[1], 1);
+    EXPECT_EQ(row_starts[2], 1);
+    EXPECT_EQ(row_starts[3], 3);
+    EXPECT_EQ(row_starts[4], 4);
+  }
+
+  EXPECT_EQ(matrix.FlatBlockSize(), 4);
+
+  EXPECT_EQ(matrix.IsZero(0, 1), false);
+  EXPECT_EQ(matrix.IsZero(3, 2), false);
+  EXPECT_EQ(matrix.IsZero(2, 1), false);
+  EXPECT_EQ(matrix.IsZero(2, 2), true);
+  EXPECT_EQ(matrix.IsZero(0, 0), true);
+  EXPECT_EQ(matrix.IsZero(3, 3), true);
+
+  EXPECT_EQ(matrix[0][2][1], 45);
+
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(4, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 5); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 0, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 1); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(0, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  return matrix;
+}
+
+template<class OrderingPolicy>
+micm::SparseMatrix<int, OrderingPolicy> testMultiBlockMatrix()
+{
+  auto builder = micm::SparseMatrix<int, OrderingPolicy>::create(4)
+                     .with_element(0, 1)
+                     .with_element(3, 2)
+                     .with_element(0, 1)
+                     .with_element(2, 3)
+                     .with_element(2, 1)
+                     .initial_value(24)
+                     .number_of_blocks(3);
+  // 0 X 0 0
+  // 0 0 0 0
+  // 0 X 0 X
+  // 0 0 X 0
+  auto row_ids = builder.RowIdsVector();
+  auto row_starts = builder.RowStartVector();
+
+  EXPECT_EQ(builder.NumberOfElements(), 4 * 3);
+  EXPECT_EQ(row_ids.size(), 4);
+  EXPECT_EQ(row_ids[0], 1);
+  EXPECT_EQ(row_ids[1], 1);
+  EXPECT_EQ(row_ids[2], 3);
+  EXPECT_EQ(row_ids[3], 2);
+  EXPECT_EQ(row_starts.size(), 5);
+  EXPECT_EQ(row_starts[0], 0);
+  EXPECT_EQ(row_starts[1], 1);
+  EXPECT_EQ(row_starts[2], 1);
+  EXPECT_EQ(row_starts[3], 3);
+  EXPECT_EQ(row_starts[4], 4);
+
+  micm::SparseMatrix<int, OrderingPolicy> matrix{ builder };
+
+  EXPECT_EQ(matrix.FlatBlockSize(), 4);
+
+  EXPECT_EQ(matrix[0][2][1], 24);
+  matrix[0][2][1] = 45;
+  EXPECT_EQ(matrix[0][2][1], 45);
+
+  matrix[2][2][3] = 64;
+  EXPECT_EQ(matrix[2][2][3], 64);
+
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(0, 4, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(2, 1, 5); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(4, 0, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 1, 1); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(2, 0, 2); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(0, 1); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "Multi-block SparseMatrix access must specify block index");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][0][4] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[3][0][0] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][5][0] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][1][1] = 2; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  return matrix;
+}

--- a/test/unit/util/test_sparse_matrix_policy.hpp
+++ b/test/unit/util/test_sparse_matrix_policy.hpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+
+#include <micm/util/sparse_matrix.hpp>
+
+template<class OrderingPolicy>
+micm::SparseMatrix<double, OrderingPolicy> testZeroMatrix()
+{
+  auto builder = micm::SparseMatrix<double, OrderingPolicy>::create(3);
+  auto row_ids = builder.RowIdsVector();
+  auto row_starts = builder.RowStartVector();
+
+  EXPECT_EQ(builder.NumberOfElements(), 0);
+  EXPECT_EQ(row_ids.size(), 0);
+  EXPECT_EQ(row_starts.size(), 4);
+  EXPECT_EQ(row_starts[0], 0);
+  EXPECT_EQ(row_starts[1], 0);
+  EXPECT_EQ(row_starts[2], 0);
+  EXPECT_EQ(row_starts[3], 0);
+
+  micm::SparseMatrix<double, OrderingPolicy> matrix{ builder };
+
+  EXPECT_EQ(matrix.FlatBlockSize(), 0);
+
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(0, 0); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(6, 0); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(1, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { std::size_t elem = matrix.VectorIndex(6, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { bool isZero = matrix.IsZero(6, 0); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { bool isZero = matrix.IsZero(1, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { bool isZero = matrix.IsZero(6, 3); } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][0][4] = 2.0; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[1][0][0] = 2.0; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][3][0] = 2.0; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
+        throw;
+      },
+      std::invalid_argument);
+  EXPECT_THROW(
+      try { matrix[0][1][1] = 2.0; } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
+        throw;
+      },
+      std::invalid_argument);
+  return matrix;
+}

--- a/test/unit/util/test_sparse_matrix_standard_ordering.cpp
+++ b/test/unit/util/test_sparse_matrix_standard_ordering.cpp
@@ -2,6 +2,7 @@
 
 #include <micm/util/sparse_matrix.hpp>
 #include <micm/util/sparse_matrix_standard_ordering.hpp>
+
 #include "test_sparse_matrix_policy.hpp"
 
 TEST(SparseMatrix, ZeroMatrix)
@@ -11,115 +12,13 @@ TEST(SparseMatrix, ZeroMatrix)
 
 TEST(SparseMatrix, ConstZeroMatrix)
 {
-  auto builder = micm::SparseMatrix<double>::create(3);
-  auto row_ids = builder.RowIdsVector();
-  auto row_starts = builder.RowStartVector();
-
-  EXPECT_EQ(builder.NumberOfElements(), 0);
-  EXPECT_EQ(row_ids.size(), 0);
-  EXPECT_EQ(row_starts.size(), 4);
-  EXPECT_EQ(row_starts[0], 0);
-  EXPECT_EQ(row_starts[1], 0);
-  EXPECT_EQ(row_starts[2], 0);
-  EXPECT_EQ(row_starts[3], 0);
-
-  const micm::SparseMatrix<double> matrix{ builder };
-
-  EXPECT_EQ(matrix.FlatBlockSize(), 0);
-
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(0, 0); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(6, 0); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(1, 3); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(6, 3); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { bool isZero = matrix.IsZero(6, 0); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { bool isZero = matrix.IsZero(1, 3); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { bool isZero = matrix.IsZero(6, 3); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
+  testConstZeroMatrix<micm::SparseMatrixStandardOrdering>();
 }
 
 TEST(SparseMatrix, SingleBlockMatrix)
 {
-  auto builder = micm::SparseMatrix<int>::create(4)
-                     .with_element(0, 1)
-                     .with_element(3, 2)
-                     .with_element(0, 1)
-                     .with_element(2, 3)
-                     .with_element(2, 1);
-  // 0 X 0 0
-  // 0 0 0 0
-  // 0 X 0 X
-  // 0 0 X 0
-  {
-    auto row_ids = builder.RowIdsVector();
-    auto row_starts = builder.RowStartVector();
+  auto matrix = testSingleBlockMatrix<micm::SparseMatrixStandardOrdering>();
 
-    EXPECT_EQ(builder.NumberOfElements(), 4);
-    EXPECT_EQ(row_ids.size(), 4);
-    EXPECT_EQ(row_ids[0], 1);
-    EXPECT_EQ(row_ids[1], 1);
-    EXPECT_EQ(row_ids[2], 3);
-    EXPECT_EQ(row_ids[3], 2);
-    EXPECT_EQ(row_starts.size(), 5);
-    EXPECT_EQ(row_starts[0], 0);
-    EXPECT_EQ(row_starts[1], 1);
-    EXPECT_EQ(row_starts[2], 1);
-    EXPECT_EQ(row_starts[3], 3);
-    EXPECT_EQ(row_starts[4], 4);
-  }
-
-  micm::SparseMatrix<int> matrix{ builder };
-
-  {
-    auto& row_ids = matrix.RowIdsVector();
-    auto& row_starts = matrix.RowStartVector();
-    EXPECT_EQ(row_ids.size(), 4);
-    EXPECT_EQ(row_ids[0], 1);
-    EXPECT_EQ(row_ids[1], 1);
-    EXPECT_EQ(row_ids[2], 3);
-    EXPECT_EQ(row_ids[3], 2);
-    EXPECT_EQ(row_starts.size(), 5);
-    EXPECT_EQ(row_starts[0], 0);
-    EXPECT_EQ(row_starts[1], 1);
-    EXPECT_EQ(row_starts[2], 1);
-    EXPECT_EQ(row_starts[3], 3);
-    EXPECT_EQ(row_starts[4], 4);
-  }
-
-  EXPECT_EQ(matrix.FlatBlockSize(), 4);
   {
     std::size_t elem = matrix.VectorIndex(3, 2);
     EXPECT_EQ(elem, 3);
@@ -132,109 +31,11 @@ TEST(SparseMatrix, SingleBlockMatrix)
     matrix.AsVector()[elem] = 21;
     EXPECT_EQ(matrix.AsVector()[2], 21);
   }
-
-  EXPECT_EQ(matrix.IsZero(0, 1), false);
-  EXPECT_EQ(matrix.IsZero(3, 2), false);
-  EXPECT_EQ(matrix.IsZero(2, 1), false);
-  EXPECT_EQ(matrix.IsZero(2, 2), true);
-  EXPECT_EQ(matrix.IsZero(0, 0), true);
-  EXPECT_EQ(matrix.IsZero(3, 3), true);
-
-  EXPECT_EQ(matrix[0][2][1], 0);
-  matrix[0][2][1] = 45;
-  EXPECT_EQ(matrix[0][2][1], 45);
-
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(4, 2); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(1, 5); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(1, 0, 2); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(1, 1); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(0, 2); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { matrix[0][0][4] = 2; } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { matrix[1][0][0] = 2; } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { matrix[0][5][0] = 2; } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { matrix[0][1][1] = 2; } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
-        throw;
-      },
-      std::invalid_argument);
 }
 
 TEST(SparseMatrix, ConstSingleBlockMatrix)
 {
-  auto builder = micm::SparseMatrix<int>::create(4)
-                     .with_element(0, 1)
-                     .with_element(3, 2)
-                     .with_element(0, 1)
-                     .with_element(2, 3)
-                     .with_element(2, 1);
-  // 0 X 0 0
-  // 0 0 0 0
-  // 0 X 0 X
-  // 0 0 X 0
-  micm::SparseMatrix<int> orig_matrix{ builder };
-  orig_matrix[0][2][1] = 45;
-  orig_matrix[0][3][2] = 42;
-  orig_matrix[0][2][3] = 21;
-  const micm::SparseMatrix<int> matrix = orig_matrix;
-
-  {
-    auto& row_ids = matrix.RowIdsVector();
-    auto& row_starts = matrix.RowStartVector();
-    EXPECT_EQ(row_ids.size(), 4);
-    EXPECT_EQ(row_ids[0], 1);
-    EXPECT_EQ(row_ids[1], 1);
-    EXPECT_EQ(row_ids[2], 3);
-    EXPECT_EQ(row_ids[3], 2);
-    EXPECT_EQ(row_starts.size(), 5);
-    EXPECT_EQ(row_starts[0], 0);
-    EXPECT_EQ(row_starts[1], 1);
-    EXPECT_EQ(row_starts[2], 1);
-    EXPECT_EQ(row_starts[3], 3);
-    EXPECT_EQ(row_starts[4], 4);
-  }
-
-  EXPECT_EQ(matrix.FlatBlockSize(), 4);
+  auto matrix = testConstSingleBlockMatrix<micm::SparseMatrixStandardOrdering>();
   {
     std::size_t elem = matrix.VectorIndex(3, 2);
     EXPECT_EQ(elem, 3);
@@ -245,81 +46,12 @@ TEST(SparseMatrix, ConstSingleBlockMatrix)
     EXPECT_EQ(elem, 2);
     EXPECT_EQ(matrix.AsVector()[2], 21);
   }
-
-  EXPECT_EQ(matrix.IsZero(0, 1), false);
-  EXPECT_EQ(matrix.IsZero(3, 2), false);
-  EXPECT_EQ(matrix.IsZero(2, 1), false);
-  EXPECT_EQ(matrix.IsZero(2, 2), true);
-  EXPECT_EQ(matrix.IsZero(0, 0), true);
-  EXPECT_EQ(matrix.IsZero(3, 3), true);
-
-  EXPECT_EQ(matrix[0][2][1], 45);
-
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(4, 2); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(1, 5); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(1, 0, 2); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(1, 1); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(0, 2); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
-        throw;
-      },
-      std::invalid_argument);
 }
 
 TEST(SparseMatrix, MultiBlockMatrix)
 {
-  auto builder = micm::SparseMatrix<int>::create(4)
-                     .with_element(0, 1)
-                     .with_element(3, 2)
-                     .with_element(0, 1)
-                     .with_element(2, 3)
-                     .with_element(2, 1)
-                     .initial_value(24)
-                     .number_of_blocks(3);
-  // 0 X 0 0
-  // 0 0 0 0
-  // 0 X 0 X
-  // 0 0 X 0
-  auto row_ids = builder.RowIdsVector();
-  auto row_starts = builder.RowStartVector();
+  auto matrix = testMultiBlockMatrix<micm::SparseMatrixStandardOrdering>();
 
-  EXPECT_EQ(builder.NumberOfElements(), 4 * 3);
-  EXPECT_EQ(row_ids.size(), 4);
-  EXPECT_EQ(row_ids[0], 1);
-  EXPECT_EQ(row_ids[1], 1);
-  EXPECT_EQ(row_ids[2], 3);
-  EXPECT_EQ(row_ids[3], 2);
-  EXPECT_EQ(row_starts.size(), 5);
-  EXPECT_EQ(row_starts[0], 0);
-  EXPECT_EQ(row_starts[1], 1);
-  EXPECT_EQ(row_starts[2], 1);
-  EXPECT_EQ(row_starts[3], 3);
-  EXPECT_EQ(row_starts[4], 4);
-
-  micm::SparseMatrix<int> matrix{ builder };
-
-  EXPECT_EQ(matrix.FlatBlockSize(), 4);
   {
     std::size_t elem = matrix.VectorIndex(0, 2, 3);
     EXPECT_EQ(elem, 2);
@@ -332,74 +64,6 @@ TEST(SparseMatrix, MultiBlockMatrix)
     matrix.AsVector()[elem] = 31;
     EXPECT_EQ(matrix.AsVector()[9], 31);
   }
-
-  EXPECT_EQ(matrix[0][2][1], 24);
-  matrix[0][2][1] = 45;
-  EXPECT_EQ(matrix[0][2][1], 45);
-
-  matrix[2][2][3] = 64;
-  EXPECT_EQ(matrix[2][2][3], 64);
-
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(0, 4, 2); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(2, 1, 5); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(4, 0, 2); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(1, 1, 1); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(2, 0, 2); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(0, 1); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "Multi-block SparseMatrix access must specify block index");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { matrix[0][0][4] = 2; } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { matrix[3][0][0] = 2; } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { matrix[0][5][0] = 2; } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { matrix[0][1][1] = 2; } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
-        throw;
-      },
-      std::invalid_argument);
 }
 
 TEST(SparseMatrixBuilder, BadConfiguration)

--- a/test/unit/util/test_sparse_matrix_standard_ordering.cpp
+++ b/test/unit/util/test_sparse_matrix_standard_ordering.cpp
@@ -1,91 +1,12 @@
 #include <gtest/gtest.h>
 
 #include <micm/util/sparse_matrix.hpp>
+#include <micm/util/sparse_matrix_standard_ordering.hpp>
+#include "test_sparse_matrix_policy.hpp"
 
 TEST(SparseMatrix, ZeroMatrix)
 {
-  auto builder = micm::SparseMatrix<double>::create(3);
-  auto row_ids = builder.RowIdsVector();
-  auto row_starts = builder.RowStartVector();
-
-  EXPECT_EQ(builder.NumberOfElements(), 0);
-  EXPECT_EQ(row_ids.size(), 0);
-  EXPECT_EQ(row_starts.size(), 4);
-  EXPECT_EQ(row_starts[0], 0);
-  EXPECT_EQ(row_starts[1], 0);
-  EXPECT_EQ(row_starts[2], 0);
-  EXPECT_EQ(row_starts[3], 0);
-
-  micm::SparseMatrix<double> matrix{ builder };
-
-  EXPECT_EQ(matrix.FlatBlockSize(), 0);
-
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(0, 0); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(6, 0); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(1, 3); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { std::size_t elem = matrix.VectorIndex(6, 3); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { bool isZero = matrix.IsZero(6, 0); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { bool isZero = matrix.IsZero(1, 3); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { bool isZero = matrix.IsZero(6, 3); } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { matrix[0][0][4] = 2.0; } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { matrix[1][0][0] = 2.0; } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { matrix[0][3][0] = 2.0; } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix element out of range");
-        throw;
-      },
-      std::invalid_argument);
-  EXPECT_THROW(
-      try { matrix[0][1][1] = 2.0; } catch (const std::invalid_argument& e) {
-        EXPECT_STREQ(e.what(), "SparseMatrix zero element access not allowed");
-        throw;
-      },
-      std::invalid_argument);
+  testZeroMatrix<micm::SparseMatrixStandardOrdering>();
 }
 
 TEST(SparseMatrix, ConstZeroMatrix)

--- a/test/unit/util/test_sparse_matrix_vector_ordering.cpp
+++ b/test/unit/util/test_sparse_matrix_vector_ordering.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+
+#include <micm/util/sparse_matrix.hpp>
+#include <micm/util/sparse_matrix_vector_ordering.hpp>
+#include "test_sparse_matrix_policy.hpp"
+
+TEST(SparseMatrix, ZeroMatrix)
+{
+  testZeroMatrix<micm::SparseMatrixVectorOrdering<2>>();
+}

--- a/test/unit/util/test_sparse_matrix_vector_ordering.cpp
+++ b/test/unit/util/test_sparse_matrix_vector_ordering.cpp
@@ -2,9 +2,67 @@
 
 #include <micm/util/sparse_matrix.hpp>
 #include <micm/util/sparse_matrix_vector_ordering.hpp>
+
 #include "test_sparse_matrix_policy.hpp"
 
-TEST(SparseMatrix, ZeroMatrix)
+TEST(SparseVectorMatrix, ZeroMatrix)
 {
   testZeroMatrix<micm::SparseMatrixVectorOrdering<2>>();
+}
+
+TEST(SparseVectorMatrix, ConstZeroMatrix)
+{
+  testConstZeroMatrix<micm::SparseMatrixVectorOrdering<3>>();
+}
+
+TEST(SparseVectorMatrix, SingleBlockMatrix)
+{
+  auto matrix = testSingleBlockMatrix<micm::SparseMatrixVectorOrdering<4>>();
+
+  {
+    std::size_t elem = matrix.VectorIndex(3, 2);
+    EXPECT_EQ(elem, 12);
+    matrix.AsVector()[elem] = 42;
+    EXPECT_EQ(matrix.AsVector()[12], 42);
+  }
+  {
+    std::size_t elem = matrix.VectorIndex(2, 3);
+    EXPECT_EQ(elem, 8);
+    matrix.AsVector()[elem] = 21;
+    EXPECT_EQ(matrix.AsVector()[8], 21);
+  }
+}
+
+TEST(SparseVectorMatrix, ConstSingleBlockMatrix)
+{
+  auto matrix = testConstSingleBlockMatrix<micm::SparseMatrixVectorOrdering<2>>();
+
+  {
+    std::size_t elem = matrix.VectorIndex(3, 2);
+    EXPECT_EQ(elem, 6);
+    EXPECT_EQ(matrix.AsVector()[6], 42);
+  }
+  {
+    std::size_t elem = matrix.VectorIndex(2, 3);
+    EXPECT_EQ(elem, 4);
+    EXPECT_EQ(matrix.AsVector()[4], 21);
+  }
+}
+
+TEST(SparseVectorMatrix, MultiBlockMatrix)
+{
+  auto matrix = testMultiBlockMatrix<micm::SparseMatrixVectorOrdering<2>>();
+
+  {
+    std::size_t elem = matrix.VectorIndex(0, 2, 3);
+    EXPECT_EQ(elem, 4);
+    matrix.AsVector()[elem] = 21;
+    EXPECT_EQ(matrix.AsVector()[4], 21);
+  }
+  {
+    std::size_t elem = matrix.VectorIndex(2, 2, 1);
+    EXPECT_EQ(elem, 10);
+    matrix.AsVector()[elem] = 31;
+    EXPECT_EQ(matrix.AsVector()[10], 31);
+  }
 }

--- a/test/unit/util/test_sparse_matrix_vector_ordering.cpp
+++ b/test/unit/util/test_sparse_matrix_vector_ordering.cpp
@@ -31,6 +31,9 @@ TEST(SparseVectorMatrix, SingleBlockMatrix)
     matrix.AsVector()[elem] = 21;
     EXPECT_EQ(matrix.AsVector()[8], 21);
   }
+  EXPECT_EQ(matrix.GroupVectorSize(), 4);
+  EXPECT_EQ(matrix.GroupSize(matrix.FlatBlockSize()), 4*4);
+  EXPECT_EQ(matrix.NumberOfGroups(1), 1);
 }
 
 TEST(SparseVectorMatrix, ConstSingleBlockMatrix)
@@ -47,6 +50,9 @@ TEST(SparseVectorMatrix, ConstSingleBlockMatrix)
     EXPECT_EQ(elem, 4);
     EXPECT_EQ(matrix.AsVector()[4], 21);
   }
+  EXPECT_EQ(matrix.GroupVectorSize(), 2);
+  EXPECT_EQ(matrix.GroupSize(matrix.FlatBlockSize()), 2*4);
+  EXPECT_EQ(matrix.NumberOfGroups(1), 1);
 }
 
 TEST(SparseVectorMatrix, MultiBlockMatrix)
@@ -65,4 +71,7 @@ TEST(SparseVectorMatrix, MultiBlockMatrix)
     matrix.AsVector()[elem] = 31;
     EXPECT_EQ(matrix.AsVector()[10], 31);
   }
+  EXPECT_EQ(matrix.GroupVectorSize(), 2);
+  EXPECT_EQ(matrix.GroupSize(matrix.FlatBlockSize()), 2*4);
+  EXPECT_EQ(matrix.NumberOfGroups(4), 2);
 }

--- a/test/unit/util/test_vector_matrix.cpp
+++ b/test/unit/util/test_vector_matrix.cpp
@@ -4,23 +4,23 @@
 #include "test_matrix_policy.hpp"
 
 template<class T>
-using Block1MatrixAlias = micm::VectorMatrix<T, 1>;
+using Group1MatrixAlias = micm::VectorMatrix<T, 1>;
 template<class T>
-using Block2MatrixAlias = micm::VectorMatrix<T, 2>;
+using Group2MatrixAlias = micm::VectorMatrix<T, 2>;
 template<class T>
-using Block3MatrixAlias = micm::VectorMatrix<T, 3>;
+using Group3MatrixAlias = micm::VectorMatrix<T, 3>;
 template<class T>
-using Block4MatrixAlias = micm::VectorMatrix<T, 4>;
+using Group4MatrixAlias = micm::VectorMatrix<T, 4>;
 
 TEST(VectorMatrix, SmallVectorMatrix)
 {
-  auto matrix = testSmallMatrix<Block2MatrixAlias>();
+  auto matrix = testSmallMatrix<Group2MatrixAlias>();
 
   std::vector<double>& data = matrix.AsVector();
 
   EXPECT_EQ(data.size(), 4 * 5);
-  EXPECT_EQ(matrix.BlockSize(), 2 * 5);
-  EXPECT_EQ(matrix.NumberOfBlocks(), 2);
+  EXPECT_EQ(matrix.GroupSize(), 2 * 5);
+  EXPECT_EQ(matrix.NumberOfGroups(), 2);
   EXPECT_EQ(matrix.VectorSize(), 2);
   EXPECT_EQ(data[0], 41.2);
   EXPECT_EQ(data[2 * 5 + 0 + 2 * 4], 102.3);
@@ -29,13 +29,13 @@ TEST(VectorMatrix, SmallVectorMatrix)
 
 TEST(VectorMatrix, SmallConstVectorMatrix)
 {
-  auto matrix = testSmallConstMatrix<Block4MatrixAlias>();
+  auto matrix = testSmallConstMatrix<Group4MatrixAlias>();
 
   const std::vector<double>& data = matrix.AsVector();
 
   EXPECT_EQ(data.size(), 4 * 5);
-  EXPECT_EQ(matrix.BlockSize(), 4 * 5);
-  EXPECT_EQ(matrix.NumberOfBlocks(), 1);
+  EXPECT_EQ(matrix.GroupSize(), 4 * 5);
+  EXPECT_EQ(matrix.NumberOfGroups(), 1);
   EXPECT_EQ(matrix.VectorSize(), 4);
   EXPECT_EQ(data[0], 41.2);
   EXPECT_EQ(data[2 + 4 * 4], 102.3);
@@ -44,40 +44,40 @@ TEST(VectorMatrix, SmallConstVectorMatrix)
 
 TEST(VectorMatrix, InitializeVectorMatrix)
 {
-  testInializeMatrix<Block1MatrixAlias>();
+  testInializeMatrix<Group1MatrixAlias>();
 }
 
 TEST(VectorMatrix, InitializeConstVectorMatrix)
 {
-  testInializeConstMatrix<Block2MatrixAlias>();
+  testInializeConstMatrix<Group2MatrixAlias>();
 }
 
 TEST(VectorMatrix, LoopOverVectorMatrix)
 {
-  testLoopOverMatrix<Block2MatrixAlias>();
+  testLoopOverMatrix<Group2MatrixAlias>();
 }
 
 TEST(VectorMatrix, LoopOverConstVectorMatrix)
 {
-  testLoopOverConstMatrix<Block1MatrixAlias>();
+  testLoopOverConstMatrix<Group1MatrixAlias>();
 }
 
 TEST(VectorMatrix, ConversionToVector)
 {
-  testConversionToVector<Block3MatrixAlias>();
+  testConversionToVector<Group3MatrixAlias>();
 }
 
 TEST(VectorMatrix, ConstConversionToVector)
 {
-  testConstConversionToVector<Block1MatrixAlias>();
+  testConstConversionToVector<Group1MatrixAlias>();
 }
 
 TEST(VectorMatrix, ConversionFromVector)
 {
-  testConversionFromVector<Block2MatrixAlias>();
+  testConversionFromVector<Group2MatrixAlias>();
 }
 
 TEST(VectorMatrix, AssignmentFromVector)
 {
-  testAssignmentFromVector<Block2MatrixAlias>();
+  testAssignmentFromVector<Group2MatrixAlias>();
 }

--- a/test/unit/util/test_vector_matrix.cpp
+++ b/test/unit/util/test_vector_matrix.cpp
@@ -21,7 +21,7 @@ TEST(VectorMatrix, SmallVectorMatrix)
   EXPECT_EQ(data.size(), 4 * 5);
   EXPECT_EQ(matrix.GroupSize(), 2 * 5);
   EXPECT_EQ(matrix.NumberOfGroups(), 2);
-  EXPECT_EQ(matrix.VectorSize(), 2);
+  EXPECT_EQ(matrix.GroupVectorSize(), 2);
   EXPECT_EQ(data[0], 41.2);
   EXPECT_EQ(data[2 * 5 + 0 + 2 * 4], 102.3);
   EXPECT_EQ(data[1 + 2 * 3], 64.7);
@@ -36,7 +36,7 @@ TEST(VectorMatrix, SmallConstVectorMatrix)
   EXPECT_EQ(data.size(), 4 * 5);
   EXPECT_EQ(matrix.GroupSize(), 4 * 5);
   EXPECT_EQ(matrix.NumberOfGroups(), 1);
-  EXPECT_EQ(matrix.VectorSize(), 4);
+  EXPECT_EQ(matrix.GroupVectorSize(), 4);
   EXPECT_EQ(data[0], 41.2);
   EXPECT_EQ(data[2 + 4 * 4], 102.3);
   EXPECT_EQ(data[1 + 4 * 3], 64.7);


### PR DESCRIPTION
Adds a sparse matrix that is structured to encourage vectorization. Updates the `ProcessSet::AddJacobianTerms()` and `LuDecomposition::Decompose()` functions to support the new sparse matrix.

Replaces the term "block" in the `VectorMatrix` class with "group" to avoid confusion with blocks in the block-diagonal sparse matrix. "Group" is now used in dense and sparse matrices to refer to the rows that are grouped together to encourage vectorization. The number of rows in a group is the template parameter in both `VectorMatrix` and `SparseMatrixVectorOrdering`

Closes #94 