### PR TITLE
Remove RosenbrockSolver inheritence from ChapmanODESolver

### DIFF
--- a/include/micm/solver/chapman_ode_solver.hpp
+++ b/include/micm/solver/chapman_ode_solver.hpp
@@ -11,24 +11,64 @@
 #include <iostream>
 #include <limits>
 #include <micm/process/arrhenius_rate_constant.hpp>
-#include <micm/solver/rosenbrock.hpp>
+#include <micm/solver/solver.hpp>
 #include <string>
 #include <vector>
 
 namespace micm
 {
 
-  /**
-   * @brief An implementation of the Chapman mechnanism solver
-   *
-   */
-  class ChapmanODESolver : public RosenbrockSolver<micm::Matrix>
+  /// @brief Chapman solver parameters
+  struct ChapmanParameters
   {
-    std::size_t number_sparse_factor_elements_ = 23;
+    std::size_t N_{};
+    size_t stages_{};
+    size_t upper_limit_tolerance_{};
+    size_t max_number_of_steps_{ 100 };
+
+    double round_off_{ std::numeric_limits<double>::epsilon() };  // Unit roundoff (1+round_off)>1
+    double factor_min_{ 0.2 };                                    // solver step size minimum boundary
+    double factor_max_{ 6 };                                      // solver step size maximum boundary
+    double rejection_factor_decrease_{ 0.1 };                     // used to decrease the step after 2 successive rejections
+    double safety_factor_{ 0.9 };                                 // safety factor in new step size computation
+
+    double h_min_{ 0 };        // step size min
+    double h_max_{ 0.5 };      // step size max
+    double h_start_{ 0.005 };  // step size start
+
+    std::array<bool, 6>
+        new_function_evaluation_{};  // which steps reuse the previous iterations evaluation or do a new evaluation
+
+    double estimator_of_local_order_{};  // the minumum between the main and the embedded scheme orders plus one
+    std::array<double, 15> a_{};         // coefficient matrix a
+    std::array<double, 15> c_{};         // coefficient matrix c
+    std::array<double, 6> m_{};          // coefficients for new step evaluation
+    std::array<double, 6> e_{};          // error estimation coefficients
+    std::array<double, 6> alpha_{};
+    std::array<double, 6> gamma_{};
+
+    double absolute_tolerance_{ 1e-12 };
+    double relative_tolerance_{ 1e-4 };
+
+    size_t number_of_grid_cells_{ 1 };  // Number of grid cells to solve simultaneously
+  };
+
+  /// @brief An implementation of the Chapman mechnanism solver
+  class ChapmanODESolver
+  {
    public:
+    ChapmanParameters parameters_;
+    Solver::Rosenbrock_stats stats_;
+    std::size_t number_sparse_factor_elements_ = 23;
+
+    static constexpr double delta_min_ = 1.0e-5;
+
     /// @brief Default constructor
     ChapmanODESolver();
     ~ChapmanODESolver();
+
+    /// @brief Sets parameters for the solver
+    void three_stage_rosenbrock();
 
     /// Returns a state variable for the Chapman system
     /// @return State variable for Chapman
@@ -39,22 +79,19 @@ namespace micm
     /// @param time_end Time step to end at
     /// @param state The system state to solve for
     /// @return A struct containing results and a status code
-    Solver::SolverResult Solve(
-        double time_start,
-        double time_end,
-        State<>& state) noexcept;
+    Solver::SolverResult Solve(double time_start, double time_end, State<>& state) noexcept;
 
     /// @brief Returns a list of reaction names
     /// @return vector of strings
-    std::vector<std::string> reaction_names() override;
+    std::vector<std::string> reaction_names();
 
     /// @brief Returns a list of species that participate in photolysis
     /// @return vector of strings
-    std::vector<std::string> photolysis_names() override;
+    std::vector<std::string> photolysis_names();
 
     /// @brief Returns a list of species names
     /// @return vector of strings
-    std::vector<std::string> species_names() override;
+    std::vector<std::string> species_names();
 
     /// @brief Calculate a chemical forcing
     /// @param rate_constants List of rate constants for each needed species
@@ -70,14 +107,13 @@ namespace micm
     /// @param dforce_dy
     /// @param alpha
     /// @return An jacobian decomposition
-    std::vector<double> factored_alpha_minus_jac(const std::vector<double>& dforce_dy, const double& alpha) override;
+    std::vector<double> factored_alpha_minus_jac(const std::vector<double>& dforce_dy, const double& alpha);
 
     /// @brief Computes product of [dforce_dy * vector]
     /// @param dforce_dy  jacobian of forcing
     /// @param vector vector ordered as the order of number density in dy
     /// @return Product of jacobian with vector
-    std::vector<double> dforce_dy_times_vector(const std::vector<double>& dforce_dy, const std::vector<double>& vector)
-        override;
+    std::vector<double> dforce_dy_times_vector(const std::vector<double>& dforce_dy, const std::vector<double>& vector);
 
     /// @brief Update the rate constants for the environment state
     /// @param state The current state of the chemical system
@@ -87,7 +123,7 @@ namespace micm
     /// @param K idk, something
     /// @param ode_jacobian the jacobian
     /// @return the new state?
-    std::vector<double> lin_solve(const std::vector<double>& K, const std::vector<double>& ode_jacobian) override;
+    std::vector<double> lin_solve(const std::vector<double>& K, const std::vector<double>& ode_jacobian);
 
     /// @brief Compute the derivative of the forcing w.r.t. each chemical, the jacobian
     /// @param rate_constants List of rate constants for each needed species
@@ -114,22 +150,94 @@ namespace micm
 
     /// @brief Factor
     /// @param jacobian
-    void factor(std::vector<double>& jacobian) override;
+    void factor(std::vector<double>& jacobian);
 
-    std::vector<double> backsolve_L_y_eq_b(const std::vector<double>& jacobian, const std::vector<double>& b) override;
-    std::vector<double> backsolve_U_x_eq_b(const std::vector<double>& jacobian, const std::vector<double>& y) override;
+    std::vector<double> backsolve_L_y_eq_b(const std::vector<double>& jacobian, const std::vector<double>& b);
+    std::vector<double> backsolve_U_x_eq_b(const std::vector<double>& jacobian, const std::vector<double>& y);
+
+    /// @brief Computes the scaled norm of the vector errors
+    /// @param original_number_densities the original number densities
+    /// @param new_number_densities the new number densities
+    /// @param errors The computed errors
+    /// @return
+    double error_norm(
+        std::vector<double> original_number_densities,
+        std::vector<double> new_number_densities,
+        std::vector<double> errors);
   };
 
   inline ChapmanODESolver::ChapmanODESolver()
-      : RosenbrockSolver()
   {
     three_stage_rosenbrock();
-    // override state size for hard-coded Chapman mechanism
-    parameters_.N_ = 9;
   }
 
   inline ChapmanODESolver::~ChapmanODESolver()
   {
+  }
+
+  inline void ChapmanODESolver::three_stage_rosenbrock()
+  {
+    // an L-stable method, 3 stages, order 3, 2 function evaluations
+    //
+    // original formaulation for three stages:
+    // Sandu, A., Verwer, J.G., Blom, J.G., Spee, E.J., Carmichael, G.R., Potra, F.A., 1997.
+    // Benchmarking stiff ode solvers for atmospheric chemistry problems II: Rosenbrock solvers.
+    // Atmospheric Environment 31, 3459–3472. https://doi.org/10.1016/S1352-2310(97)83212-8
+
+    parameters_.stages_ = 3;
+    parameters_.N_ = 9;
+
+    //  The coefficient matrices A and C are strictly lower triangular.
+    //  The lower triangular (subdiagonal) elements are stored in row-wise order:
+    //  A(2,1) = ros_A(1), A(3,1)=ros_A(2), A(3,2)=ros_A(3), etc.
+    //  The general mapping formula is:
+    //      A(i,j) = ros_A( (i-1)*(i-2)/2 + j )
+    //      C(i,j) = ros_C( (i-1)*(i-2)/2 + j )
+
+    parameters_.a_.fill(0);
+    parameters_.a_[0] = 1;
+    parameters_.a_[1] = 1;
+    parameters_.a_[2] = 0;
+
+    parameters_.c_.fill(0);
+    parameters_.c_[0] = -0.10156171083877702091975600115545e+01;
+    parameters_.c_[1] = 0.40759956452537699824805835358067e+01;
+    parameters_.c_[2] = 0.92076794298330791242156818474003e+01;
+
+    // Does the stage i require a new function evaluation (ros_NewF(i)=TRUE)
+    // or does it re-use the function evaluation from stage i-1 (ros_NewF(i)=FALSE)
+    parameters_.new_function_evaluation_.fill(false);
+    parameters_.new_function_evaluation_[0] = true;
+    parameters_.new_function_evaluation_[1] = true;
+    parameters_.new_function_evaluation_[2] = false;
+
+    // Coefficients for new step solution
+    parameters_.m_.fill(0);
+    parameters_.m_[0] = 0.1e+01;
+    parameters_.m_[1] = 0.61697947043828245592553615689730e+01;
+    parameters_.m_[2] = -0.42772256543218573326238373806514;
+
+    // Coefficients for error estimator
+    parameters_.e_.fill(0);
+    parameters_.e_[0] = 0.5;
+    parameters_.e_[1] = -0.29079558716805469821718236208017e+01;
+    parameters_.e_[2] = 0.22354069897811569627360909276199;
+
+    // ros_ELO = estimator of local order - the minimum between the
+    // main and the embedded scheme orders plus 1
+    parameters_.estimator_of_local_order_ = 3;
+
+    // Y_stage_i ~ Y( T + H*Alpha_i )
+    parameters_.alpha_.fill(0);
+    parameters_.alpha_[0] = 0;
+    parameters_.alpha_[1] = 0.43586652150845899941601945119356;
+    parameters_.alpha_[2] = 0.43586652150845899941601945119356;
+
+    // Gamma_i = \sum_j  gamma_{i,j}
+    parameters_.gamma_.fill(0);
+    parameters_.gamma_[0] = 0.43586652150845899941601945119356;
+    parameters_.gamma_[1] = 0.24291996454816804366592249683314;
+    parameters_.gamma_[2] = 0.21851380027664058511513169485832e+01;
   }
 
   inline State<> ChapmanODESolver::GetState() const
@@ -137,10 +245,7 @@ namespace micm
     return State<Matrix>{ 9, 3, 7 };
   }
 
-  inline Solver::SolverResult ChapmanODESolver::Solve(
-      double time_start,
-      double time_end,
-      State<>& state) noexcept
+  inline Solver::SolverResult ChapmanODESolver::Solve(double time_start, double time_end, State<>& state) noexcept
   {
     std::vector<std::vector<double>> K(parameters_.stages_, std::vector<double>(parameters_.N_, 0));
     std::vector<double> Y(state.variables_[0]);
@@ -786,5 +891,32 @@ namespace micm
     jacobian[22] = jacobian[22] - rate_constants[5] * number_densities[6];
 
     return jacobian;
+  }
+
+  inline double ChapmanODESolver::error_norm(std::vector<double> Y, std::vector<double> Ynew, std::vector<double> errors)
+  {
+    // Solving Ordinary Differential Equations II, page 123
+    // https://link-springer-com.cuucar.idm.oclc.org/book/10.1007/978-3-642-05221-7
+    std::vector<double> maxs(Y.size());
+    std::vector<double> scale(Y.size());
+
+    for (uint64_t idx = 0; idx < Y.size(); ++idx)
+    {
+      maxs[idx] = std::max(std::abs(Y[idx]), std::abs(Ynew[idx]));
+    }
+
+    for (uint64_t idx = 0; idx < Y.size(); ++idx)
+    {
+      scale[idx] = parameters_.absolute_tolerance_ + parameters_.relative_tolerance_ * maxs[idx];
+    }
+
+    double sum = 0;
+    for (uint64_t idx = 0; idx < Y.size(); ++idx)
+    {
+      sum += std::pow(errors[idx] / scale[idx], 2);
+    }
+
+    double error_min_ = 1.0e-10;
+    return std::max(std::sqrt(sum / parameters_.N_), error_min_);
   }
 }  // namespace micm


### PR DESCRIPTION
In preparation for moving the `ChapmanODESolver` to the tests, this PR removes its dependence on `RosenbrockSolver`