### PR TITLE
Update parser

### DIFF
--- a/include/micm/configure/solver_config.hpp
+++ b/include/micm/configure/solver_config.hpp
@@ -108,11 +108,13 @@ namespace micm
     bool is_parse_success_ = false;
 
     // Constants
+    // Configure files 
     static const inline std::string SPECIES_CONFIG = "species.json";
     static const inline std::string MECHANISM_CONFIG = "mechanism.json";
     static const inline std::string REACTIONS_CONFIG = "reactions.json";
     static const inline std::string TOLERANCE_CONFIG = "tolerance.json";
 
+    // Common JSON 
     static const inline std::string CAMP_DATA = "camp-data";
     static const inline std::string TYPE = "type";
 
@@ -285,12 +287,12 @@ namespace micm
     bool ParseChemicalSpecies(const json& object)
     {
       // required keys
-      static const std::string NAME = "name";
+      const std::string NAME = "name";
 
       // optional keys
-      static const std::string ABS_TOL = "absolute tolerance";
-      static const std::string MOL_WEIGHT = "molecular weight [kg mol-1]";
-      static const std::string MOL_WEIGHT_UNIT = "kg mol-1";
+      const std::string ABS_TOL = "absolute tolerance";
+      const std::string MOL_WEIGHT = "molecular weight [kg mol-1]";
+      const std::string MOL_WEIGHT_UNIT = "kg mol-1";
 
       std::array<std::string, 1> required_keys = { NAME };
 
@@ -347,12 +349,12 @@ namespace micm
 
     bool ParsePhotolysis(const json& object)
     {
-      static const std::string REACTANTS = "reactants";
-      static const std::string PRODUCTS = "products";
-      static const std::string MUSICA_NAME = "MUSICA name";
-      static const std::string YIELD = "yield";
+      const std::string REACTANTS = "reactants";
+      const std::string PRODUCTS = "products";
+      const std::string MUSICA_NAME = "MUSICA name";
+      const std::string YIELD = "yield";
 
-      const static double DEFAULT_YEILD = 1.0;
+      constexpr double DEFAULT_YEILD = 1.0;
 
       for (const auto& key : { REACTANTS, PRODUCTS, MUSICA_NAME })
       {
@@ -391,11 +393,11 @@ namespace micm
 
     bool ParseArrhenius(const json& object)
     {
-      static const std::string REACTANTS = "reactants";
-      static const std::string PRODUCTS = "products";
-      static const std::string YIELD = "yield";
+      const std::string REACTANTS = "reactants";
+      const std::string PRODUCTS = "products";
+      const std::string YIELD = "yield";
 
-      const double DEFAULT_YEILD = 1.0;
+      constexpr double DEFAULT_YEILD = 1.0;
 
       // Check required json objects exist
       for (const auto& key : { REACTANTS, PRODUCTS })
@@ -462,11 +464,11 @@ namespace micm
 
     bool ParseTroe(const json& object)
     {
-      static const std::string REACTANTS = "reactants";
-      static const std::string PRODUCTS = "products";
-      static const std::string YIELD = "yield";
+      const std::string REACTANTS = "reactants";
+      const std::string PRODUCTS = "products";
+      const std::string YIELD = "yield";
 
-      const double DEFAULT_YEILD = 1.0;
+      constexpr double DEFAULT_YEILD = 1.0;
 
       // Check required json objects exist
       for (const auto& key : { REACTANTS, PRODUCTS })

--- a/include/micm/configure/solver_config.hpp
+++ b/include/micm/configure/solver_config.hpp
@@ -6,16 +6,19 @@
 
 #pragma once
 
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <micm/process/arrhenius_rate_constant.hpp>
 #include <micm/process/photolysis_rate_constant.hpp>
 #include <micm/process/process.hpp>
+#include <micm/process/troe_rate_constant.hpp>
 #include <micm/system/phase.hpp>
 #include <micm/system/property.hpp>
 #include <micm/system/species.hpp>
 #include <micm/system/system.hpp>
+#include <micm/util/constants.hpp>
 #include <nlohmann/json.hpp>
 #include <variant>
 
@@ -92,6 +95,7 @@ namespace micm
     // Read from reaction configure
     std::vector<PhotolysisRateConstant> photolysis_rate_arr_;
     std::vector<ArrheniusRateConstant> arrhenius_rate_arr_;
+    std::vector<TroeRateConstant> troe_rate_arr_;
     std::vector<Species> emission_arr_;
     std::vector<Species> first_order_loss_arr_;
 
@@ -105,7 +109,9 @@ namespace micm
 
     // Constants
     static const inline std::string SPECIES_CONFIG = "species.json";
-    static const inline std::string REACTIONS_CONFIG = "mechanism.json";
+    static const inline std::string MECHANISM_CONFIG = "mechanism.json";
+    static const inline std::string REACTIONS_CONFIG = "reactions.json";
+    static const inline std::string TOLERANCE_CONFIG = "tolerance.json";
 
     static const inline std::string CAMP_DATA = "camp-data";
     static const inline std::string TYPE = "type";
@@ -116,19 +122,41 @@ namespace micm
     /// @return True for successful parsing
     bool Parse(const std::filesystem::path& config_dir)
     {
+      // Create configure paths
       std::filesystem::path species_config(config_dir / SPECIES_CONFIG);
+      std::filesystem::path mechanism_config(config_dir / MECHANISM_CONFIG);
       std::filesystem::path reactions_config(config_dir / REACTIONS_CONFIG);
+      std::filesystem::path tolerance_config(
+          config_dir / TOLERANCE_CONFIG);  // TODO: jiwon 7/13 - we don't need to worry about this now
 
-      // Check all the configure files exist
-      for (const auto& config : { species_config, reactions_config })
+      // Current reaction configs should be either mechanism_config or reactions config
+      std::filesystem::path cur_reactions_config;
+
+      // Check if species config exists
+      if (!std::filesystem::exists(species_config))
       {
-        if (!std::filesystem::exists(config))
-        {
-          std::string err_msg = "Configuration file at path " + config.string() + " does not exist\n";
-          this->OnError(err_msg);
+        std::string err_msg = "Species configuration file at path " + species_config.string() + " does not exist\n";
+        this->OnError(err_msg);
 
-          return false;
-        }
+        return false;
+      }
+
+      // Check if a reaction configure exists and decide which one
+      if (std::filesystem::exists(mechanism_config))
+      {
+        cur_reactions_config = mechanism_config;
+      }
+      else if (std::filesystem::exists(reactions_config))
+      {
+        cur_reactions_config = reactions_config;
+      }
+      else
+      {
+        std::string err_msg = "Reaction configuration file at path " + mechanism_config.string() + " or " +
+                              reactions_config.string() + " does not exist\n";
+        this->OnError(err_msg);
+
+        return false;
       }
 
       // Read species file to create Species and Phase that needs to be known to System and Process
@@ -139,7 +167,7 @@ namespace micm
       gas_phase_ = Phase(species_arr_);
 
       // Read reactions file
-      json reaction_data = json::parse(std::ifstream(reactions_config));
+      json reaction_data = json::parse(std::ifstream(cur_reactions_config));
 
       if (!ValidateJsonWithKey(reaction_data, CAMP_DATA))
         return false;
@@ -230,6 +258,11 @@ namespace micm
           if (!ParseArrhenius(object))
             return false;
         }
+        else if (type == "TROE")
+        {
+          if (!ParseTroe(object))
+            return false;
+        }
         else if (type == "EMISSION")
         {
           if (!ParseEmission(object))
@@ -251,23 +284,34 @@ namespace micm
 
     bool ParseChemicalSpecies(const json& object)
     {
-      std::vector<std::string> required_keys = { "name" };
-      std::vector<std::string> optional_keys = { "absolute tolerance" };
+      // required keys
+      static const std::string NAME = "name";
 
+      // optional keys
+      static const std::string ABS_TOL = "absolute tolerance";
+      static const std::string MOL_WEIGHT = "molecular weight [kg mol-1]";
+      static const std::string MOL_WEIGHT_UNIT = "kg mol-1";
+
+      std::array<std::string, 1> required_keys = { NAME };
+
+      // Check if it contains the required key(s)
       for (const auto& key : required_keys)
       {
         if (!ValidateJsonWithKey(object, key))
           return false;
       }
 
-      std::string name = object["name"].get<std::string>();
+      // Check if it contains optional key(s)
+      std::string name = object[NAME].get<std::string>();
 
-      std::string key = "absolute tolerance";
-
-      if (object.contains(key))
+      if (object.contains(ABS_TOL))
       {
-        double abs_tol = object[key].get<double>();
-        auto species = Species(name, Property(key, "", abs_tol));
+        auto species = Species(name, Property(ABS_TOL, "", object[ABS_TOL].get<double>()));
+        species_arr_.push_back(species);
+      }
+      else if (object.contains(MOL_WEIGHT))
+      {
+        auto species = Species(name, Property(MOL_WEIGHT, MOL_WEIGHT_UNIT, object[MOL_WEIGHT].get<double>()));
         species_arr_.push_back(species);
       }
       else
@@ -303,10 +347,10 @@ namespace micm
 
     bool ParsePhotolysis(const json& object)
     {
-      const std::string REACTANTS = "reactants";
-      const std::string PRODUCTS = "products";
-      const std::string MUSICA_NAME = "MUSICA name";
-      const std::string YIELD = "yield";
+      static const std::string REACTANTS = "reactants";
+      static const std::string PRODUCTS = "products";
+      static const std::string MUSICA_NAME = "MUSICA name";
+      static const std::string YIELD = "yield";
 
       const static double DEFAULT_YEILD = 1.0;
 
@@ -337,7 +381,7 @@ namespace micm
 
       std::string name = object[MUSICA_NAME].get<std::string>();
 
-      photolysis_rate_arr_.push_back(name);
+      photolysis_rate_arr_.push_back(PhotolysisRateConstant(name));
 
       std::unique_ptr<PhotolysisRateConstant> rate_ptr = std::make_unique<PhotolysisRateConstant>(name);
       processes_.push_back(Process(reactants, products, std::move(rate_ptr), gas_phase_));
@@ -347,9 +391,9 @@ namespace micm
 
     bool ParseArrhenius(const json& object)
     {
-      const std::string REACTANTS = "reactants";
-      const std::string PRODUCTS = "products";
-      const std::string YIELD = "yield";
+      static const std::string REACTANTS = "reactants";
+      static const std::string PRODUCTS = "products";
+      static const std::string YIELD = "yield";
 
       const double DEFAULT_YEILD = 1.0;
 
@@ -401,11 +445,93 @@ namespace micm
       {
         parameters.E_ = object["E"].get<double>();
       }
+      if (object.contains("Ea"))
+      {
+        // Calculate 'C' using 'Ea'
+        parameters.C_ = -1 * object["Ea"].get<double>() / BOLTZMANN_CONSTANT;
+      }
 
-      arrhenius_rate_arr_.push_back(parameters);
+      arrhenius_rate_arr_.push_back(ArrheniusRateConstant(parameters));
 
-      std::unique_ptr<ArrheniusRateConstant> rate_ptr =
-          std::make_unique<ArrheniusRateConstant>(ArrheniusRateConstantParameters(parameters));
+      std::unique_ptr<ArrheniusRateConstant> rate_ptr = std::make_unique<ArrheniusRateConstant>(parameters);
+
+      processes_.push_back(Process(reactants, products, std::move(rate_ptr), gas_phase_));
+
+      return true;
+    }
+
+    bool ParseTroe(const json& object)
+    {
+      static const std::string REACTANTS = "reactants";
+      static const std::string PRODUCTS = "products";
+      static const std::string YIELD = "yield";
+
+      const double DEFAULT_YEILD = 1.0;
+
+      // Check required json objects exist
+      for (const auto& key : { REACTANTS, PRODUCTS })
+      {
+        if (!ValidateJsonWithKey(object, key))
+          return false;
+      }
+
+      // Create process
+      std::vector<Species> reactants;
+      for (auto& [key, value] : object[REACTANTS].items())
+      {
+        reactants.push_back(Species(key));
+      }
+
+      std::vector<std::pair<Species, double>> products;
+      for (auto& [key, value] : object[PRODUCTS].items())
+      {
+        if (value.contains(YIELD))
+        {
+          products.push_back(std::make_pair(Species(key), value[YIELD]));
+        }
+        else
+        {
+          products.push_back(std::make_pair(Species(key), DEFAULT_YEILD));
+        }
+      }
+
+      TroeRateConstantParameters parameters;
+      if (object.contains("k0_A"))
+      {
+        parameters.k0_A_ = object["k0_A"].get<double>();
+      }
+      if (object.contains("k0_B"))
+      {
+        parameters.k0_B_ = object["k0_B"].get<double>();
+      }
+      if (object.contains("k0_C"))
+      {
+        parameters.k0_C_ = object["k0_C"].get<double>();
+      }
+      if (object.contains("kinf_A"))
+      {
+        parameters.kinf_A_ = object["kinf_A"].get<double>();
+      }
+      if (object.contains("kinf_B"))
+      {
+        parameters.kinf_B_ = object["kinf_B"].get<double>();
+      }
+      if (object.contains("kinf_C"))
+      {
+        parameters.kinf_C_ = object["kinf_C"].get<double>();
+      }
+      if (object.contains("Fc"))
+      {
+        parameters.Fc_ = object["Fc"].get<double>();
+      }
+      if (object.contains("N"))
+      {
+        parameters.N_ = object["N"].get<double>();
+      }
+
+      troe_rate_arr_.push_back(TroeRateConstant(parameters));
+
+      std::unique_ptr<TroeRateConstant> rate_ptr = std::make_unique<TroeRateConstant>(parameters);
 
       processes_.push_back(Process(reactants, products, std::move(rate_ptr), gas_phase_));
 

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -201,9 +201,7 @@ namespace micm
       std::size_t offset_state = i_group * state_variables.GroupSize();
       std::size_t offset_forcing = i_group * forcing.GroupSize();
 
-      std::vector<double> rate;
-      rate.reserve(L);
-
+      std::vector<double> rate(L, 0.0);
       for (std::size_t i_rxn = 0; i_rxn < number_of_reactants_.size(); ++i_rxn)
       {
         for (std::size_t i_cell = 0; i_cell < L; ++i_cell)

--- a/include/micm/util/constants.hpp
+++ b/include/micm/util/constants.hpp
@@ -1,0 +1,1 @@
+static constexpr double BOLTZMANN_CONSTANT = 1.3806505e-23;   // J K^{-1}

--- a/test/unit/configure/test_solver_config.cpp
+++ b/test/unit/configure/test_solver_config.cpp
@@ -160,4 +160,135 @@ TEST(SolverConfig, GetPhotolysisRateConstants)
     idx++;
   }
 }
+
+//
+// Tests for MZ326 configure files
+//
+TEST(SolverConfig, ReadAndParseSystemObjectfromMZ326)
+{
+  micm::SolverConfig<micm::JsonReaderPolicy, micm::ThrowPolicy> solverConfig;  // Set to throw-exception policy
+
+  // Read and parse the configure files
+  bool is_parse_success = solverConfig.ReadAndParse("./unit_configs/MZ326");
+  EXPECT_TRUE(is_parse_success);
+
+  // Get solver parameters ('System', the collection of 'Process')
+  micm::SolverParameters solver_params = solverConfig.GetSolverParams();
+
+  // Check 'gas_phase' in 'System'
+  EXPECT_EQ(solver_params.system_.gas_phase_.species_.size(), 6);
+
+  // Check 'phases' in 'System'
+  EXPECT_EQ(solver_params.system_.phases_.size(), 0);
+
+  // Check 'name' and molecular_weight from 'properties' in 'Species'
+  std::vector<std::pair<std::string, double>> species_name_and_molecular_weight = {
+    std::make_pair("ALKNIT", 0.133141), std::make_pair("BZOOH", 0.124135), std::make_pair("C6H5OOH", 0.110109),
+    std::make_pair("COF2", 0.0),        std::make_pair("O2", 0.0),         std::make_pair("FUR2O2", 0.0)
+  };
+
+  short idx = 0;
+  for (const auto& s : solver_params.system_.gas_phase_.species_)
+  {
+    EXPECT_EQ(s.name_, species_name_and_molecular_weight[idx].first);
+    EXPECT_EQ(s.properties_[0].value_, species_name_and_molecular_weight[idx].second);
+    idx++;
+  }
+}
+
+TEST(SolverConfig, ReadAndParseProcessObjectsfromMZ326)
+{
+  micm::SolverConfig<micm::JsonReaderPolicy, micm::ThrowPolicy> solverConfig;  // Set to throw-exception policy
+
+  // Read and parse the configure files
+  bool is_parse_success = solverConfig.ReadAndParse("./unit_configs/MZ326");
+  EXPECT_TRUE(is_parse_success);
+
+  // Get solver parameters ('System', the collection of 'Process')
+  micm::SolverParameters solver_params = solverConfig.GetSolverParams();
+
+  auto& process_vector = solver_params.processes_;
+
+  // Check the number of 'Process' created
+  EXPECT_EQ(process_vector.size(), 5);
+
+  // Check the number of 'reactants' and 'products' in each 'Process'
+  // Check 'yield' value for the first product and the number of 'spieces in 'phase' in each 'Process'
+  int num_reactants_in_each_process[] = { 2, 2, 2, 1, 1 };
+  int num_products_in_each_process[] = { 5, 5, 2, 3, 2 };
+  int num_phase_in_each_process = 6;
+
+  short idx = 0;
+  for (const auto& p : process_vector)
+  {
+    EXPECT_EQ(p.reactants_.size(), num_reactants_in_each_process[idx]);
+    EXPECT_EQ(p.products_.size(), num_products_in_each_process[idx]);
+    EXPECT_EQ(p.phase_.species_.size(), num_phase_in_each_process);
+    idx++;
+  }
+
+  // Check the parameters for 'TroeRateConstant'
+  micm::TroeRateConstant* troe_rate_const = nullptr;
+  double k0_A_param[] = { 5.5e-30, 1.07767 };
+  double k0_B_param[] = { 0.0, -5.6 };
+  double k0_C_param[] = { 0.0, -14000 };
+  double kinf_A_param[] = { 8.3e-13, 1.03323e+17 };
+  double kinf_B_param[] = { 0.0, 0.0 };
+  double kinf_C_param[] = { 0.0, -14000 };
+  double Fc_param[] = { 0.6, 0.6 };
+  double N_param[] = { -2, 1.5 };
+
+  idx = 0;
+  for (short i : { 0, 4 })
+  {
+    troe_rate_const = dynamic_cast<micm::TroeRateConstant*>(process_vector[i].rate_constant_.get());
+
+    EXPECT_TRUE(troe_rate_const != nullptr);
+    EXPECT_EQ(troe_rate_const->parameters_.k0_A_, k0_A_param[idx]);
+    EXPECT_EQ(troe_rate_const->parameters_.k0_B_, k0_B_param[idx]);
+    EXPECT_EQ(troe_rate_const->parameters_.k0_C_, k0_C_param[idx]);
+    EXPECT_EQ(troe_rate_const->parameters_.kinf_A_, kinf_A_param[idx]);
+    EXPECT_EQ(troe_rate_const->parameters_.kinf_B_, kinf_B_param[idx]);
+    EXPECT_EQ(troe_rate_const->parameters_.kinf_C_, kinf_C_param[idx]);
+    EXPECT_EQ(troe_rate_const->parameters_.Fc_, Fc_param[idx]);
+    EXPECT_EQ(troe_rate_const->parameters_.N_, N_param[idx]);
+
+    idx++;
+  }
+
+  // Check the name for 'PhotolysisRateConstant'
+  micm::PhotolysisRateConstant* photolysis_rate_const = nullptr;
+  std::string photolysis_name = "jterpnit";
+
+  for (short i : { 3 })
+  {
+    photolysis_rate_const = dynamic_cast<micm::PhotolysisRateConstant*>(process_vector[i].rate_constant_.get());
+
+    EXPECT_TRUE(photolysis_rate_const != nullptr);
+    EXPECT_EQ(photolysis_rate_const->name_, photolysis_name);
+  }
+
+  // Check the parameters for 'ArrheniusRateConstant'
+  micm::ArrheniusRateConstant* arrhenius_rate_const = nullptr;
+  double A_param[] = { 2.0e-12, 3.8e-12 };
+  double B_param[] = { 0.0, 0.0 };
+  double C_param[] = { 500.0, 200.0 };
+  double D_param[] = { 300.0, 300.0 };
+  double E_param[] = { 0.0, 0.0 };
+  
+  idx = 0;
+  for (short i : { 1, 2 })
+  {
+    arrhenius_rate_const = dynamic_cast<micm::ArrheniusRateConstant*>(process_vector[i].rate_constant_.get());
+
+    EXPECT_TRUE(arrhenius_rate_const != nullptr);
+    EXPECT_EQ(arrhenius_rate_const->parameters_.A_, A_param[idx]);
+    EXPECT_EQ(arrhenius_rate_const->parameters_.B_, B_param[idx]);
+    EXPECT_EQ(arrhenius_rate_const->parameters_.C_, C_param[idx]);
+    EXPECT_EQ(arrhenius_rate_const->parameters_.D_, D_param[idx]);
+    EXPECT_EQ(arrhenius_rate_const->parameters_.E_, E_param[idx]);
+
+    idx++;
+  }
+}
 #endif

--- a/test/unit/configure/test_solver_config.cpp
+++ b/test/unit/configure/test_solver_config.cpp
@@ -272,7 +272,7 @@ TEST(SolverConfig, ReadAndParseProcessObjectsfromMZ326)
   micm::ArrheniusRateConstant* arrhenius_rate_const = nullptr;
   double A_param[] = { 2.0e-12, 3.8e-12 };
   double B_param[] = { 0.0, 0.0 };
-  double C_param[] = { 500.0, 200.0 };
+  double C_param[] = { -1 * -6.90325e-21 / 1.3806505e-23, -1 * -2.7613e-21 / 1.3806505e-23 };
   double D_param[] = { 300.0, 300.0 };
   double E_param[] = { 0.0, 0.0 };
   
@@ -282,11 +282,11 @@ TEST(SolverConfig, ReadAndParseProcessObjectsfromMZ326)
     arrhenius_rate_const = dynamic_cast<micm::ArrheniusRateConstant*>(process_vector[i].rate_constant_.get());
 
     EXPECT_TRUE(arrhenius_rate_const != nullptr);
-    EXPECT_EQ(arrhenius_rate_const->parameters_.A_, A_param[idx]);
-    EXPECT_EQ(arrhenius_rate_const->parameters_.B_, B_param[idx]);
-    EXPECT_EQ(arrhenius_rate_const->parameters_.C_, C_param[idx]);
-    EXPECT_EQ(arrhenius_rate_const->parameters_.D_, D_param[idx]);
-    EXPECT_EQ(arrhenius_rate_const->parameters_.E_, E_param[idx]);
+    EXPECT_DOUBLE_EQ(arrhenius_rate_const->parameters_.A_, A_param[idx]);
+    EXPECT_DOUBLE_EQ(arrhenius_rate_const->parameters_.B_, B_param[idx]);
+    EXPECT_DOUBLE_EQ(arrhenius_rate_const->parameters_.C_, C_param[idx]);
+    EXPECT_DOUBLE_EQ(arrhenius_rate_const->parameters_.D_, D_param[idx]);
+    EXPECT_DOUBLE_EQ(arrhenius_rate_const->parameters_.E_, E_param[idx]);
 
     idx++;
   }

--- a/test/unit/unit_configs/MZ326/reactions.json
+++ b/test/unit/unit_configs/MZ326/reactions.json
@@ -1,0 +1,87 @@
+{
+    "comments": [ "This mechanism may contain refactored reactions based on custom",
+                  "...." 
+                ],
+    "camp-data": [
+      {
+        "name": "MZ326_TS1.3_20230106",
+        "type": "MECHANISM",
+        "reactions": [
+          {
+            "type": "TROE",
+            "k0_A": 5.5e-30,
+            "kinf_A": 8.3e-13,
+            "N": -2,
+            "reactants": {
+              "C2H2": { },
+              "OH": { }
+            },
+            "products": {
+              "GLYOXAL": { "yield": 0.65 },
+              "OH": { "yield": 0.65 },
+              "HCOOH": { "yield": 0.35 },
+              "HO2": { "yield": 0.35 },
+              "CO": { "yield": 0.35 }
+            }
+          },
+          {
+            "type": "ARRHENIUS",
+            "A": 2.0e-12,
+            "Ea": -6.90325e-21,
+            "reactants": {
+              "CH3O2": { },
+              "TERPO2": { }
+            },
+            "products": {
+              "TERPROD1": { },
+              "CH2O": { "yield": 0.95 },
+              "CH3OH": { "yield": 0.25 },
+              "HO2": { },
+              "CH3COCH3": { "yield": 0.025 }
+            }
+          },
+          {
+            "type": "ARRHENIUS",
+            "A": 3.8e-12,
+            "Ea": -2.7613e-21,
+            "reactants": {
+              "C3H7OOH": { },
+              "OH": { }
+            },
+            "products": {
+              "H2O": { },
+              "C3H7O2": { }
+            }
+          },
+          {
+            "type": "PHOTOLYSIS",
+            "MUSICA name": "jterpnit",
+            "reactants": {
+              "TERPNIT": { }
+            },
+            "products": {
+              "TERPROD1": { },
+              "NO2": { },
+              "HO2": { }
+            }
+          },
+          {
+            "type": "TROE",
+            "k0_A": 1.07767,
+            "k0_B": -5.6,
+            "k0_C": -14000,
+            "kinf_A": 1.03323e+17,
+            "kinf_C": -14000,
+            "N": 1.5,
+            "reactants": {
+              "PAN": { }
+            },
+            "products": {
+              "CH3CO3": { },
+              "NO2": { }
+            }
+          }
+        ]
+    }]
+}
+

--- a/test/unit/unit_configs/MZ326/species.json
+++ b/test/unit/unit_configs/MZ326/species.json
@@ -1,0 +1,40 @@
+{
+    "camp-data": [
+      {
+        "name": "ALKNIT",
+        "type": "CHEM_SPEC",
+        "description": "standard alkyl nitrate from BIGALK+OH chemistry",
+        "molecular weight [kg mol-1]": 0.133141
+      },
+      {
+        "name": "BZOOH",
+        "type": "CHEM_SPEC",
+        "description": "hydroperoxide from toluene oxidation",
+        "molecular weight [kg mol-1]": 0.124135
+      },
+      {
+        "name": "C6H5OOH",
+        "type": "CHEM_SPEC",
+        "description": "phenyl hydroperoxide",
+        "molecular weight [kg mol-1]": 0.110109
+      },
+      {
+        "name": "COF2",
+        "type": "CHEM_SPEC",
+        "description": "",
+        "molecular weight [kg mol-1]": 0
+      },
+      {
+        "name": "O2",
+        "type": "CHEM_SPEC",
+        "description": "",
+        "molecular weight [kg mol-1]": 0
+      },
+      {
+        "name": "FUR2O2",
+        "type": "CHEM_SPEC",
+        "description": "peroxy radical from furanone",
+        "molecular weight [kg mol-1]": 0
+      }
+    ]
+}

--- a/test/unit/unit_configs/MZ326/tolerance.json
+++ b/test/unit/unit_configs/MZ326/tolerance.json
@@ -1,0 +1,8 @@
+{
+  "camp-data": [
+    {
+      "type": "RELATIVE_TOLERANCE",
+      "value": 1.0e-4
+    }
+  ]
+}


### PR DESCRIPTION
Completed

- Added a function to parse `TroeRateConstants`
- Updated the function to configure species to store additional key-value from `molecular weight [kg mol-1]`  
- Added unit tests to parse a subset of MZ326 data that includes troe reactions and species that have `molecular weight [kg mol-1]`  
- Added `constants.hpp` to store scientific constants

Comments: Because`map_params` branch is still under review, I think it is hard to tell the changes made specific with the new data. I will leave this as a draft until the previous branch is merged into `main`. 
