### PR TITLE
using c++ compiler...

### DIFF
--- a/Dockerfile.intel
+++ b/Dockerfile.intel
@@ -17,7 +17,7 @@ RUN apt update \
 
 # set compilers
 ENV CC=icx
-ENV CXX=icx
+ENV CXX=icpx
 ENV FC=ifort
 
 # Micm

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,11 +8,6 @@ add_library(micm INTERFACE)
 add_library(musica::micm ALIAS micm)
 target_compile_features(micm INTERFACE cxx_std_20)
 
-# for some reason intel doesn't link a standard library
-if (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
-  target_link_libraries(micm INTERFACE stdc++)
-endif()
-
 target_include_directories(micm
   INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>


### PR DESCRIPTION
`icpx` is the c++ compiler for intel. The reason I had to manually link a std library is because I was using `icx` before, which is a c compiler that somehow compiles c++. This removes the need to link a specific c++ standard libary