### PR TITLE
Address compiler warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DENABLE_REGRESSION_TESTS=OFF
+          cmake ..
           cmake --build .
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
           mkdir build
           cd build
           cmake .. -DENABLE_REGRESSION_TESTS=OFF
-          cmake --build . --verbose
+          cmake --build .
 
       - name: Run tests
         run: |

--- a/Dockerfile.intel
+++ b/Dockerfile.intel
@@ -28,6 +28,7 @@ RUN mkdir /build \
       && cd /build \ 
       && cmake \
         -D CMAKE_BUILD_TYPE=debug \
+        -D CMAKE_CXX_FLAGS_DEBUG="-g -Rno-debug-disables-optimization" \
         ../micm \
       && make -j 8 install
 

--- a/include/micm/configure/solver_config.hpp
+++ b/include/micm/configure/solver_config.hpp
@@ -39,7 +39,7 @@ namespace micm
       {
       }
 
-      virtual const char* what()
+      virtual const char* what() const noexcept override
       {
         return msg_;
       }

--- a/include/micm/configure/solver_config.hpp
+++ b/include/micm/configure/solver_config.hpp
@@ -39,7 +39,7 @@ namespace micm
       {
       }
 
-      virtual const char* what() const noexcept override
+      virtual const char* what() const noexcept
       {
         return msg_;
       }

--- a/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
+++ b/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
@@ -225,9 +225,8 @@ namespace micm
       case ChapmanODESolver::SolverState::ConvergenceExceededMaxSteps: return "Convergence Exceeded Max Steps";
       case ChapmanODESolver::SolverState::StepSizeTooSmall: return "Step Size Too Small";
       case ChapmanODESolver::SolverState::RepeatedlySingularMatrix: return "Repeatedly Singular Matrix";
-      default: return "Unknown";
     }
-    return "";
+    return "Unknown";
   }
 
   inline ChapmanODESolver::ChapmanODESolver()


### PR DESCRIPTION
I think there is only one remaining warning. It's with nvhpc, and I'm pretty sure it's incorrectly applied:
```
"/micm/test/regression/RosenbrockChapman/regression_test_solve.cpp", line 57: warning: ignoring return value type with "nodiscard" attribute [nodiscard_return_type]
      fixed_results[i] = fixed_solver.Solve(0.0, 500.0, fixed_state);
                       ^

Remark: individual warnings can be suppressed with "--diag_suppress <warning-name>"
```

I opted to leave our code unchanged, instead of trying to get rid of the warning.

closes #138