### PR TITLE
State reordering

### DIFF
--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -15,7 +15,7 @@ namespace micm
   /// @param matrix Original matrix non-zero elements
   /// @result Reordered mapping vector (reordered[i] = original[map[i]])
   template<template<class> class MatrixPolicy>
-  std::vector<std::size_t> DiagonalMarkowitzReorder(const MatrixPolicy<bool>& matrix);
+  std::vector<std::size_t> DiagonalMarkowitzReorder(const MatrixPolicy<int>& matrix);
 
   /// @brief A general-use sparse-matrix linear solver
   template<typename T, template<class> class SparseMatrixPolicy>
@@ -72,7 +72,7 @@ namespace micm
   std::vector<std::size_t> DiagonalMarkowitzReorder(const MatrixPolicy<int>& matrix)
   {
     const std::size_t order = matrix.size();
-    std::vector<std::size_t> perm( order );
+    std::vector<std::size_t> perm(order);
     for (std::size_t i = 0; i < order; ++i)
       perm[i] = i;
     MatrixPolicy<int> pattern = matrix;

--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -3,12 +3,19 @@
 
 #pragma once
 
+#include <cmath>
 #include <micm/solver/lu_decomposition.hpp>
 #include <micm/util/matrix.hpp>
 #include <micm/util/sparse_matrix.hpp>
 
 namespace micm
 {
+
+  /// @brief Reorders a set of state variables using Diagonal Markowitz algorithm
+  /// @param matrix Original matrix non-zero elements
+  /// @result Reordered mapping vector (reordered[i] = original[map[i]])
+  template<template<class> class MatrixPolicy>
+  std::vector<std::size_t> DiagonalMarkowitzReorder(const MatrixPolicy<bool>& matrix);
 
   /// @brief A general-use sparse-matrix linear solver
   template<typename T, template<class> class SparseMatrixPolicy>
@@ -60,6 +67,51 @@ namespace micm
       requires(VectorizableDense<MatrixPolicy<T>> && VectorizableSparse<SparseMatrixPolicy<T>>)
     void Solve(const MatrixPolicy<T>& b, MatrixPolicy<T>& x);
   };
+
+  template<template<class> class MatrixPolicy>
+  std::vector<std::size_t> DiagonalMarkowitzReorder(const MatrixPolicy<int>& matrix)
+  {
+    const std::size_t order = matrix.size();
+    std::vector<std::size_t> perm( order );
+    for (std::size_t i = 0; i < order; ++i)
+      perm[i] = i;
+    MatrixPolicy<int> pattern = matrix;
+    for (std::size_t row = 0; row < (order - 1); ++row)
+    {
+      std::size_t beta = std::pow((order - 1), 2);
+      std::size_t max_row = row;
+      for (std::size_t col = row; col < order; ++col)
+      {
+        std::size_t count_a = 0;
+        std::size_t count_b = 0;
+        for (std::size_t i = row; i < order; ++i)
+        {
+          count_a += (pattern[col][i] == 0 ? 0 : 1);
+          count_b += (pattern[i][col] == 0 ? 0 : 1);
+        }
+        std::size_t count = (count_a - 1) * (count_b - 1);
+        if (count < beta)
+        {
+          beta = count;
+          max_row = col;
+        }
+      }
+      // Swap row and max_row
+      if (max_row != row)
+      {
+        for (std::size_t i = row; i < order; ++i)
+          std::swap(pattern[row][i], pattern[max_row][i]);
+        for (std::size_t i = row; i < order; ++i)
+          std::swap(pattern[i][row], pattern[i][max_row]);
+        std::swap(perm[row], perm[max_row]);
+      }
+      for (std::size_t col = row + 1; col < order; ++col)
+        if (pattern[row][col])
+          for (std::size_t i = row + 1; i < order; ++i)
+            pattern[i][col] = pattern[i][row] || pattern[i][col];
+    }
+    return perm;
+  }
 
   template<typename T, template<class> class SparseMatrixPolicy>
   inline LinearSolver<T, SparseMatrixPolicy>::LinearSolver(const SparseMatrixPolicy<T>& matrix, T initial_value)

--- a/include/micm/system/system.hpp
+++ b/include/micm/system/system.hpp
@@ -72,7 +72,14 @@ namespace micm
     size_t StateSize() const;
 
     /// @brief Returns a set of unique species names
+    /// @return vector of unique state variable names
     std::vector<std::string> UniqueNames() const;
+
+    /// @brief Returns a set of unique species names
+    /// @param reordering Function used to apply specific order to unique names
+    /// @return vector of unique state variable names
+    std::vector<std::string> UniqueNames(
+        const std::function<std::string(const std::vector<std::string>& variables, const std::size_t i)> f) const;
   };
 
   inline size_t System::StateSize() const
@@ -85,7 +92,12 @@ namespace micm
     return state_size;
   }
 
-  inline std::vector<std::string> System::UniqueNames() const
+  inline std::vector<std::string> System::UniqueNames() const{
+    return UniqueNames(nullptr);
+  }
+
+  inline std::vector<std::string> System::UniqueNames(
+      const std::function<std::string(const std::vector<std::string>& variables, const std::size_t i)> f) const
   {
     std::vector<std::string> names{};
     for (auto& species : gas_phase_.species_)
@@ -98,6 +110,12 @@ namespace micm
       {
         names.push_back(phase.first + "." + species.name_);
       }
+    }
+    if (f)
+    {
+      const auto orig_names = names;
+      for (std::size_t i = 0; i < orig_names.size(); ++i)
+        names[i] = f(orig_names, i);
     }
     return names;
   }

--- a/test/regression/RosenbrockChapman/regression_test_dforce_dy.cpp
+++ b/test/regression/RosenbrockChapman/regression_test_dforce_dy.cpp
@@ -34,7 +34,9 @@ void testJacobian()
   {
     double number_density_air = 1.0;
     std::vector<double> rate_constants = state.rate_constants_[i];
-    std::vector<double> variables = state.variables_[i];
+    std::vector<double> variables(state.variables_[i].size());
+    for (std::size_t j{}; j < state.variables_[i].size(); ++j)
+      variables[j] = state.variables_[i][state.variable_map_[fixed_solver.species_names()[j]]];
     std::vector<double> fixed_jacobian = fixed_solver.dforce_dy(rate_constants, variables, number_density_air);
 
     // TODO: The sparse matrix data ordering in the hard-coded solver is different (maybe because of pivoting?)

--- a/test/regression/RosenbrockChapman/regression_test_p_force.cpp
+++ b/test/regression/RosenbrockChapman/regression_test_p_force.cpp
@@ -70,13 +70,15 @@ void testForcing()
   {
     double number_density_air = 1.0;
     std::vector<double> rate_constants = state.rate_constants_[i];
-    std::vector<double> variables = state.variables_[i];
+    std::vector<double> variables(state.variables_[i].size());
+    for (std::size_t j{}; j < state.variables_[i].size(); ++j)
+      variables[j] = state.variables_[i][state.variable_map_[fixed_solver.species_names()[j]]];
     std::vector<double> fixed_forcing = fixed_solver.force(rate_constants, variables, number_density_air);
 
     EXPECT_EQ(forcing[i].size(), fixed_forcing.size());
     for (std::size_t j{}; j < fixed_forcing.size(); ++j)
     {
-      double a = forcing[i][j];
+      double a = forcing[i][state.variable_map_[fixed_solver.species_names()[j]]];
       double b = fixed_forcing[j];
       EXPECT_NEAR(a, b, (std::abs(a) + std::abs(b)) * 1.0e-8 + 1.0e-12);
     }

--- a/test/regression/RosenbrockChapman/regression_test_solve.cpp
+++ b/test/regression/RosenbrockChapman/regression_test_solve.cpp
@@ -52,7 +52,7 @@ void testSolve()
     fixed_state.conditions_[0].temperature_ = state.conditions_[i].temperature_;
     fixed_state.conditions_[0].pressure_ = state.conditions_[i].pressure_;
     for (int j = 0; j < fixed_state.variables_[0].size(); ++j)
-      fixed_state.variables_[0][j] = variables[i][j];
+      fixed_state.variables_[0][j] = variables[i][state.variable_map_[fixed_solver.species_names()[j]]];
     fixed_solver.UpdateState(fixed_state);
     fixed_results[i] = fixed_solver.Solve(0.0, 500.0, fixed_state);
   }
@@ -61,7 +61,7 @@ void testSolve()
   for (int i = 0; i < 3; ++i)
     for (int j = 0; j < fixed_results[i].result_.size(); ++j)
     {
-      double a = results.result_[i][j];
+      double a = results.result_[i][state.variable_map_[fixed_solver.species_names()[j]]];
       double b = fixed_results[i].result_[j];
       EXPECT_NEAR(a, b, (std::abs(a) + std::abs(b)) * 1.0e-8 + abs_tol);
     }

--- a/test/unit/solver/test_linear_solver.cpp
+++ b/test/unit/solver/test_linear_solver.cpp
@@ -152,8 +152,56 @@ void testDiagonalMatrix()
       A, b, x, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
 }
 
+template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+void testMarkowitzReordering()
+{
+  const std::size_t order = 50;
+  auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
+  MatrixPolicy<int> orig(order, order, 0);
+
+  for (std::size_t i = 0; i < order; ++i)
+    for (std::size_t j = 0; j < order; ++j)
+      orig[i][j] = (i == j || gen_bool()) ? 1 : 0;
+
+  auto reorder_map = DiagonalMarkowitzReorder<MatrixPolicy>(orig);
+
+  auto builder = SparseMatrixPolicy<double>::create(50);
+  for (std::size_t i = 0; i < order; ++i)
+    for (std::size_t j = 0; j < order; ++j)
+      if (orig[i][j] != 0)
+        builder = builder.with_element(i, j);
+  SparseMatrixPolicy<double> orig_jac{ builder };
+
+  builder = SparseMatrixPolicy<double>::create(50);
+  for (std::size_t i = 0; i < order; ++i)
+    for (std::size_t j = 0; j < order; ++j)
+      if (orig[reorder_map[i]][reorder_map[j] != 0])
+        builder = builder.with_element(i, j);
+  SparseMatrixPolicy<double> reordered_jac{ builder };
+
+  auto orig_LU_calc = micm::LuDecomposition{ orig_jac };
+  auto reordered_LU_calc = micm::LuDecomposition{ reordered_jac };
+
+  auto orig_LU = orig_LU_calc.GetLUMatrices(orig_jac, 0.0);
+  auto reordered_LU = reordered_LU_calc.GetLUMatrices(reordered_jac, 0.0);
+
+  std::size_t sum_orig = 0;
+  std::size_t sum_reordered = 0;
+  for (std::size_t i = 0; i < reorder_map.size(); ++i)
+  {
+    sum_orig += i;
+    sum_reordered += reorder_map[i];
+  }
+
+  EXPECT_EQ(sum_orig, sum_reordered);
+  EXPECT_GT(
+      orig_LU.first.RowIdsVector().size() + orig_LU.second.RowIdsVector().size(),
+      reordered_LU.first.RowIdsVector().size() + reordered_LU.second.RowIdsVector().size());
+}
+
 template<class T>
 using SparseMatrix = micm::SparseMatrix<T>;
+
 TEST(LinearSolver, DenseMatrixStandardOrdering)
 {
   testDenseMatrix<micm::Matrix, SparseMatrix>();
@@ -167,6 +215,11 @@ TEST(LinearSolver, RandomMatrixStandardOrdering)
 TEST(LinearSolver, DiagonalMatrixStandardOrdering)
 {
   testDiagonalMatrix<micm::Matrix, SparseMatrix>();
+}
+
+TEST(LinearSolver, DiagonalMarkowitzReorder)
+{
+  testMarkowitzReordering<micm::Matrix, SparseMatrix>();
 }
 
 template<class T>
@@ -209,4 +262,12 @@ TEST(LinearSolver, DiagonalMatrixVectorOrdering)
   testDiagonalMatrix<Group2VectorMatrix, Group2SparseVectorMatrix>();
   testDiagonalMatrix<Group3VectorMatrix, Group3SparseVectorMatrix>();
   testDiagonalMatrix<Group4VectorMatrix, Group4SparseVectorMatrix>();
+}
+
+TEST(LinearSolver, VectorDiagonalMarkowitzReordering)
+{
+  testMarkowitzReordering<Group1VectorMatrix, Group1SparseVectorMatrix>();
+  testMarkowitzReordering<Group2VectorMatrix, Group2SparseVectorMatrix>();
+  testMarkowitzReordering<Group3VectorMatrix, Group3SparseVectorMatrix>();
+  testMarkowitzReordering<Group4VectorMatrix, Group4SparseVectorMatrix>();
 }

--- a/test/unit/solver/test_linear_solver.cpp
+++ b/test/unit/solver/test_linear_solver.cpp
@@ -175,7 +175,7 @@ void testMarkowitzReordering()
   builder = SparseMatrixPolicy<double>::create(50);
   for (std::size_t i = 0; i < order; ++i)
     for (std::size_t j = 0; j < order; ++j)
-      if (orig[reorder_map[i]][reorder_map[j] != 0])
+      if (orig[reorder_map[i]][reorder_map[j]] != 0)
         builder = builder.with_element(i, j);
   SparseMatrixPolicy<double> reordered_jac{ builder };
 

--- a/test/unit/solver/test_rosenbrock.cpp
+++ b/test/unit/solver/test_rosenbrock.cpp
@@ -36,7 +36,8 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy> getSolver(std::size_t n
   return micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>(
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }),
       std::vector<micm::Process>{ r1, r2, r3 },
-      micm::RosenbrockSolverParameters{ .number_of_grid_cells_ = number_of_grid_cells });
+      micm::RosenbrockSolverParameters{ .number_of_grid_cells_ = number_of_grid_cells,
+                                        .reorder_state_ = false });
 }
 
 // ---- foo  bar  baz  quz  quuz

--- a/test/unit/system/test_system.cpp
+++ b/test/unit/system/test_system.cpp
@@ -26,4 +26,16 @@ TEST(System, ConstructorWithAllParameters)
   EXPECT_NE(std::find(names.begin(), names.end(), "phase1.species2"), names.end());
   EXPECT_NE(std::find(names.begin(), names.end(), "phase2.species3"), names.end());
   EXPECT_NE(std::find(names.begin(), names.end(), "phase2.species4"), names.end());
+
+  std::vector<int> reorder{ 3, 2, 1, 0, 5, 4 };
+  auto reordered_names = system.UniqueNames([&](const std::vector<std::string> variables, const std::size_t i) {
+    return variables[reorder[i]];
+  });
+  EXPECT_EQ(reordered_names.size(), 6);
+  EXPECT_EQ(reordered_names[0], names[3]);
+  EXPECT_EQ(reordered_names[1], names[2]);
+  EXPECT_EQ(reordered_names[2], names[1]);
+  EXPECT_EQ(reordered_names[3], names[0]);
+  EXPECT_EQ(reordered_names[4], names[5]);
+  EXPECT_EQ(reordered_names[5], names[4]);
 }


### PR DESCRIPTION
Adds a function that performs Diagonal Markowitz reordering of the solver state variables to minimize fill-in during LU decomposition. Includes the reordering by default in the `RosenbrockSolver` but allows disabling the reordering with a solver parameter.

The algorithm is based on Stacy's write up (https://github.com/NCAR/micm-preprocessor/blob/2de3a3c6234d8629520debfc463f572ad5666d4c/documentation/pivot_algorithm.txt#L1-L65) and his original CAM-Chem preprocessor code (https://github.com/ESCOMP/CHEM_PREPROCESSOR/blob/944f506033d88a5dd1ee4556a932d2c90023cbfc/src/cam_chempp/sp_utils.f#L130-L194).

closes #116