### PR TITLE
Emission, loss rate constants

### DIFF
--- a/include/micm/configure/solver_config.hpp
+++ b/include/micm/configure/solver_config.hpp
@@ -12,7 +12,7 @@
 #include <iostream>
 #include <micm/process/arrhenius_rate_constant.hpp>
 #include <micm/process/branched_rate_constant.hpp>
-#include <micm/process/photolysis_rate_constant.hpp>
+#include <micm/process/user_defined_rate_constant.hpp>
 #include <micm/process/process.hpp>
 #include <micm/process/ternary_chemical_activation_rate_constant.hpp>
 #include <micm/process/troe_rate_constant.hpp>
@@ -90,7 +90,7 @@ namespace micm
     std::vector<Species> species_arr_;
 
     // Read from reaction configure
-    std::vector<PhotolysisRateConstant> photolysis_rate_arr_;
+    std::vector<UserDefinedRateConstant> user_defined_rate_arr_;
     std::vector<ArrheniusRateConstant> arrhenius_rate_arr_;
     std::vector<BranchedRateConstant> branched_rate_arr_;
     std::vector<TroeRateConstant> troe_rate_arr_;
@@ -404,11 +404,11 @@ namespace micm
       auto reactants = ParseReactants(object[REACTANTS]);
       auto products = ParseProducts(object[PRODUCTS]);
 
-      std::string name = object[MUSICA_NAME].get<std::string>();
+      std::string name = "PHOTO." + object[MUSICA_NAME].get<std::string>();
 
-      photolysis_rate_arr_.push_back(PhotolysisRateConstant(name));
+      user_defined_rate_arr_.push_back(UserDefinedRateConstant(name));
 
-      std::unique_ptr<PhotolysisRateConstant> rate_ptr = std::make_unique<PhotolysisRateConstant>(name);
+      std::unique_ptr<UserDefinedRateConstant> rate_ptr = std::make_unique<UserDefinedRateConstant>(name);
       processes_.push_back(Process(reactants, products, std::move(rate_ptr), gas_phase_));
 
       return ConfigParseStatus::Success;
@@ -729,19 +729,6 @@ namespace micm
           std::move(System(std::move(this->gas_phase_), std::move(this->phases_))), std::move(this->processes_));
     }
 
-    /// @brief Get a collection of 'PhotolysisRateConstant'
-    /// @return a collection of 'PhotolysisRateConstant'
-    std::vector<PhotolysisRateConstant>& GetPhotolysisRateConstants()
-    {
-      if (last_parse_status_ != ConfigParseStatus::Success)
-      {
-        std::string msg = "Parsing configuration files failed. The parsing failed with error: " +
-                          configParseStatusToString(last_parse_status_);
-        throw std::runtime_error(msg);
-      }
-
-      return this->photolysis_rate_arr_;
-    }
   };
 
 }  // namespace micm

--- a/include/micm/configure/solver_config.hpp
+++ b/include/micm/configure/solver_config.hpp
@@ -664,35 +664,55 @@ namespace micm
 
     ConfigParseStatus ParseEmission(const json& object)
     {
-      std::vector<std::string> required_keys = { "species" };
-      std::vector<std::string> optional_keys = { "MUSICA name" };
-      for (const auto& key : required_keys)
+      const std::string SPECIES = "species";
+      const std::string MUSICA_NAME = "MUSICA name";
+      for (const auto& key : { SPECIES, MUSICA_NAME })
       {
         if (!ValidateJsonWithKey(object, key))
           return ConfigParseStatus::RequiredKeyNotFound;
       }
 
-      std::string name = object["species"].get<std::string>();
+      std::string species = object["species"].get<std::string>();
+      json reactants_object{};
+      json products_object{};
+      products_object[species] = { { "YIELD", 1.0 } };
+      auto reactants = ParseReactants(reactants_object);
+      auto products = ParseProducts(products_object);
 
-      emission_arr_.push_back(Species(name));
+      std::string name = "EMIS." + object[MUSICA_NAME].get<std::string>();
+
+      user_defined_rate_arr_.push_back(UserDefinedRateConstant(name));
+
+      std::unique_ptr<UserDefinedRateConstant> rate_ptr = std::make_unique<UserDefinedRateConstant>(name);
+      processes_.push_back(Process(reactants, products, std::move(rate_ptr), gas_phase_));
 
       return ConfigParseStatus::Success;
     }
 
     ConfigParseStatus ParseFirstOrderLoss(const json& object)
     {
-      std::vector<std::string> required_keys = { "species" };
-      std::vector<std::string> optional_keys = { "MUSICA name" };
-      for (const auto& key : required_keys)
+      const std::string SPECIES = "species";
+      const std::string MUSICA_NAME = "MUSICA name";
+      for (const auto& key : { SPECIES, MUSICA_NAME })
       {
         if (!ValidateJsonWithKey(object, key))
           return ConfigParseStatus::RequiredKeyNotFound;
       }
 
-      std::string name = object["species"].get<std::string>();
+      std::string species = object["species"].get<std::string>();
+      json reactants_object{};
+      json products_object{};
+      reactants_object[species] = { { } };
+      auto reactants = ParseReactants(reactants_object);
+      auto products = ParseProducts(products_object);
 
-      first_order_loss_arr_.push_back(Species(name));
+      std::string name = "LOSS." + object[MUSICA_NAME].get<std::string>();
 
+      user_defined_rate_arr_.push_back(UserDefinedRateConstant(name));
+
+      std::unique_ptr<UserDefinedRateConstant> rate_ptr = std::make_unique<UserDefinedRateConstant>(name);
+      processes_.push_back(Process(reactants, products, std::move(rate_ptr), gas_phase_));
+      
       return ConfigParseStatus::Success;
     }
   };

--- a/include/micm/process/rate_constant.hpp
+++ b/include/micm/process/rate_constant.hpp
@@ -18,10 +18,19 @@ namespace micm
    public:
     /// @brief Virtual destructor
     virtual ~RateConstant(){};
+    
     /// @brief Deep copy
     virtual std::unique_ptr<RateConstant> clone() const = 0;
-    /// @brief Returns the number of doubles needed to hold user-defined rate constant parameters
-    /// @return Number of user-defined rate constant parameters
+
+    /// @brief Returns a set of labels for user-defined rate constant parameters
+    /// @return Vector of custom parameter labels
+    virtual std::vector<std::string> CustomParameters() const
+    {
+      return std::vector<std::string>{};
+    }
+
+    /// @brief Returns the number of custom parameters
+    /// @return Number of custom parameters
     virtual std::size_t SizeCustomParameters() const
     {
       return 0;

--- a/include/micm/process/user_defined_rate_constant.hpp
+++ b/include/micm/process/user_defined_rate_constant.hpp
@@ -11,28 +11,27 @@ namespace micm
   class System;
 
   /// @brief A photolysis rate constant
-  class PhotolysisRateConstant : public RateConstant
+  class UserDefinedRateConstant : public RateConstant
   {
-   public:
     std::string name_;
 
    public:
     /// @brief Default constructor.
-    PhotolysisRateConstant();
+    UserDefinedRateConstant();
 
     /// @brief
     /// @param name A name for this reaction
-    PhotolysisRateConstant(const std::string& name);
+    UserDefinedRateConstant(const std::string& name);
 
     /// @brief Deep copy
     std::unique_ptr<RateConstant> clone() const override;
 
-    /// @brief Returns the number of parameters (1) that can be set at runtime
-    ///        for photolysis reactions
-    ///
-    ///        The single editable parameter is the unscaled rate constant for
-    ///        the photolysis reaction
-    /// @return Number of custom rate constant parameters
+    /// @brief Returns a label for the user-defined rate constant parameter
+    /// @return Rate constant label
+    std::vector<std::string> CustomParameters() const override;
+
+    /// @brief Returns the number of custom parameters
+    /// @return Number of custom parameters
     std::size_t SizeCustomParameters() const override;
 
     /// @brief Calculate the rate constant
@@ -43,29 +42,34 @@ namespace micm
         const override;
   };
 
-  inline PhotolysisRateConstant::PhotolysisRateConstant()
+  inline UserDefinedRateConstant::UserDefinedRateConstant()
       : name_()
   {
   }
 
-  inline PhotolysisRateConstant::PhotolysisRateConstant(const std::string& name)
+  inline UserDefinedRateConstant::UserDefinedRateConstant(const std::string& name)
       : name_(name)
   {
   }
 
-  inline std::unique_ptr<RateConstant> PhotolysisRateConstant::clone() const
+  inline std::unique_ptr<RateConstant> UserDefinedRateConstant::clone() const
   {
-    return std::unique_ptr<RateConstant>{ new PhotolysisRateConstant{ *this } };
+    return std::unique_ptr<RateConstant>{ new UserDefinedRateConstant{ *this } };
   }
 
-  inline double PhotolysisRateConstant::calculate(
+  inline double UserDefinedRateConstant::calculate(
       const Conditions& conditions,
       const std::vector<double>::const_iterator& custom_parameters) const
   {
     return (double)*custom_parameters;
   }
 
-  inline std::size_t PhotolysisRateConstant::SizeCustomParameters() const
+  inline std::vector<std::string> UserDefinedRateConstant::CustomParameters() const
+  {
+    return std::vector<std::string>{ name_ };
+  }
+
+  inline std::size_t UserDefinedRateConstant::SizeCustomParameters() const
   {
     return 1;
   }

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -695,15 +695,14 @@ namespace micm
   template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
   inline State<MatrixPolicy> RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::GetState() const
   {
-    std::size_t n_params = 0;
+    std::vector<std::string> param_labels{};
     for (const auto& process : processes_)
-    {
       if (process.rate_constant_)
-        n_params += process.rate_constant_->SizeCustomParameters();
-    }
+        for (auto& label : process.rate_constant_->CustomParameters())
+          param_labels.push_back(label);
     return State<MatrixPolicy>{ micm::StateParameters{ .state_variable_names_ = system_.UniqueNames(state_reordering_),
+                                                       .custom_rate_parameter_labels_ = param_labels,
                                                        .number_of_grid_cells_ = parameters_.number_of_grid_cells_,
-                                                       .number_of_custom_parameters_ = n_params,
                                                        .number_of_rate_constants_ = processes_.size() } };
   }
 

--- a/include/micm/solver/state.hpp
+++ b/include/micm/solver/state.hpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <map>
-#include <micm/process/photolysis_rate_constant.hpp>
 #include <micm/system/conditions.hpp>
 #include <micm/system/system.hpp>
 #include <micm/util/matrix.hpp>
@@ -18,8 +17,8 @@ namespace micm
   struct StateParameters
   {
     std::vector<std::string> state_variable_names_{};
+    std::vector<std::string> custom_rate_parameter_labels_{};
     std::size_t number_of_grid_cells_{ 1 };
-    std::size_t number_of_custom_parameters_{ 0 };
     std::size_t number_of_rate_constants_{ 0 };
   };
 
@@ -28,6 +27,7 @@ namespace micm
   {
     std::vector<Conditions> conditions_;
     std::map<std::string, std::size_t> variable_map_;
+    std::map<std::string, std::size_t> custom_rate_parameter_map_;
     MatrixPolicy<double> variables_;
     MatrixPolicy<double> custom_rate_parameters_;
     MatrixPolicy<double> rate_constants_;
@@ -57,17 +57,22 @@ namespace micm
     void SetConcentration(const Species& species, double concentration);
     void SetConcentration(const Species& species, const std::vector<double>& concentration);
 
-    /// @brief Set photolysis rate constants
-    /// @param photolysis rate
-    void SetPhotolysisRate(
-        const std::vector<PhotolysisRateConstant>& photolysis_rate_arr,
-        const std::unordered_map<std::string, std::vector<double>>& photolysis_rate);
+    /// @brief Set custom parameters for rate constant calculations by label
+    /// @param parameters map of custom rate parameters
+    void SetCustomRateParameters(const std::unordered_map<std::string, std::vector<double>>& parameters);
+
+    /// @brief Set a single custom rate constant parameter
+    /// @param label parameter label
+    /// @param value new parameter value
+    void SetCustomRateParameter(const std::string& label, double value);
+    void SetCustomRateParameter(const std::string& label, const std::vector<double>& values);
   };
 
   template<template<class> class MatrixPolicy>
   inline State<MatrixPolicy>::State()
       : conditions_(),
         variable_map_(),
+        custom_rate_parameter_map_(),
         variables_(),
         custom_rate_parameters_(),
         rate_constants_()
@@ -80,6 +85,7 @@ namespace micm
       const std::size_t process_size)
       : conditions_(1),
         variable_map_(),
+        custom_rate_parameter_map_(),
         variables_(1, state_size, 0.0),
         custom_rate_parameters_(1, custom_parameters_size, 0.0),
         rate_constants_(1, process_size, 0.0)
@@ -90,13 +96,17 @@ namespace micm
   inline State<MatrixPolicy>::State(const StateParameters parameters)
       : conditions_(parameters.number_of_grid_cells_),
         variable_map_(),
+        custom_rate_parameter_map_(),
         variables_(parameters.number_of_grid_cells_, parameters.state_variable_names_.size(), 0.0),
-        custom_rate_parameters_(parameters.number_of_grid_cells_, parameters.number_of_custom_parameters_, 0.0),
+        custom_rate_parameters_(parameters.number_of_grid_cells_, parameters.custom_rate_parameter_labels_.size(), 0.0),
         rate_constants_(parameters.number_of_grid_cells_, parameters.number_of_rate_constants_, 0.0)
   {
     std::size_t index = 0;
     for (auto& name : parameters.state_variable_names_)
       variable_map_[name] = index++;
+    index = 0;
+    for (auto& label : parameters.custom_rate_parameter_labels_)
+      custom_rate_parameter_map_[label] = index++;
   }
 
   template<template<class> class MatrixPolicy>
@@ -179,60 +189,33 @@ namespace micm
   }
 
   template<template<class> class MatrixPolicy>
-  inline void State<MatrixPolicy>::SetPhotolysisRate(
-      const std::vector<PhotolysisRateConstant>& photolysis_rate_arr,
-      const std::unordered_map<std::string, std::vector<double>>& photolysis_rate)
+  inline void State<MatrixPolicy>::SetCustomRateParameters(
+      const std::unordered_map<std::string, std::vector<double>>& parameters)
   {
-    int num_set_grid_cells = 0;
-    unsigned num_photo_values = photolysis_rate_arr.size();
+    for (auto& pair : parameters)
+      SetCustomRateParameter(pair.first, pair.second);
+  }
 
-    std::vector<int> num_values_per_key;
-    num_values_per_key.reserve(num_photo_values);
+  template<template<class> class MatrixPolicy>
+  inline void State<MatrixPolicy>::SetCustomRateParameter(const std::string& label, double value)
+  {
+    auto param = custom_rate_parameter_map_.find(label);
+    if (param == custom_rate_parameter_map_.end())
+      throw std::invalid_argument("Unkonwn rate constant parameter '" + label + "'");
+    if (custom_rate_parameters_.size() != 1)
+      throw std::invalid_argument("Incorrect number of custom rate parameter values passed to multi-gridcell State");
+    custom_rate_parameters_[0][param->second] = value;
+  }
 
-    // Iterate map to store the number of rate constant values corresponding to the number of set of grid cells
-    for (auto& elem : photolysis_rate_arr)
-    {
-      auto rate_ptr = photolysis_rate.find(elem.name_);
-      if (rate_ptr == photolysis_rate.end())
-      {
-        throw std::runtime_error("Photolysis rate constant(s) for '" + elem.name_ + "' must be given.");
-      }
-      num_values_per_key.push_back(rate_ptr->second.size());
-    }
-
-    // Check if number of rate constants inputs are the same for all photolysis rate constant objects.
-    if (!std::all_of(
-            num_values_per_key.begin(), num_values_per_key.end(), [&](int& i) { return i == num_values_per_key.front(); }))
-    {
-      throw std::runtime_error("Photolysis rate constant value must be given to all sets of grid cells.");
-    }
-
-    num_set_grid_cells = num_values_per_key[0];
-
-    // Find rate constants and iterate through the keys to store the rate constants for each set of grid cells
-    // 'photo_rates' represents an N-D array in contiguous memory (N = num_set_grid_cells)
-    std::vector<double> photo_rates;
-    photo_rates.resize(num_photo_values * num_set_grid_cells);
-
-    for (int i = 0; i < num_photo_values; i++)
-    {
-      auto rate_ptr = photolysis_rate.find(photolysis_rate_arr[i].name_);
-      for (int j = 0; j < num_set_grid_cells; j++)
-      {
-        photo_rates[i + num_photo_values * j] = rate_ptr->second[j];
-      }
-    }
-
-    // Extract sub vector to assign to the corresponding set of grid cells.
-    // TODO: jiwon 7/12 - I think we want to reduce copy operations here
-    std::vector<double> sub_photo_rates;
-    sub_photo_rates.reserve(num_photo_values);
-
-    for (int i = 0; i < num_set_grid_cells; i++)
-    {
-      sub_photo_rates = { photo_rates.begin() + (num_photo_values * i),
-                          photo_rates.begin() + (num_photo_values * i) + num_photo_values };
-      custom_rate_parameters_[i] = sub_photo_rates;
-    }
+  template<template<class> class MatrixPolicy>
+  inline void State<MatrixPolicy>::SetCustomRateParameter(const std::string& label, const std::vector<double>& values)
+  {
+    auto param = custom_rate_parameter_map_.find(label);
+    if (param == custom_rate_parameter_map_.end())
+      throw std::invalid_argument("Unkonwn rate constant parameter '" + label + "'");
+    if (custom_rate_parameters_.size() != values.size())
+      throw std::invalid_argument("Incorrect number of custom rate parameter values passed to multi-gridcell State");
+    for (std::size_t i = 0; i < custom_rate_parameters_.size(); ++i)
+      custom_rate_parameters_[i][param->second] = values[i];
   }
 }  // namespace micm

--- a/test/integration/chapman.cpp
+++ b/test/integration/chapman.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <micm/process/arrhenius_rate_constant.hpp>
+#include <micm/process/user_defined_rate_constant.hpp>
 #include <micm/process/process.hpp>
 #include <micm/solver/rosenbrock.hpp>
 #include <micm/solver/state.hpp>

--- a/test/regression/RosenbrockChapman/util.hpp
+++ b/test/regression/RosenbrockChapman/util.hpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <micm/process/arrhenius_rate_constant.hpp>
-#include <micm/process/photolysis_rate_constant.hpp>
+#include <micm/process/user_defined_rate_constant.hpp>
 #include <micm/process/process.hpp>
 #include <micm/solver/state.hpp>
 #include <micm/system/phase.hpp>
@@ -61,19 +61,19 @@ std::vector<micm::Process> createProcesses(const micm::Phase& gas_phase)
   micm::Process photo_1 = micm::Process::create()
                               .reactants({ micm::Species("O2") })
                               .products({ yields(micm::Species("O"), 2) })
-                              .rate_constant(micm::PhotolysisRateConstant())
+                              .rate_constant(micm::UserDefinedRateConstant("jO2"))
                               .phase(gas_phase);
 
   micm::Process photo_2 = micm::Process::create()
                               .reactants({ micm::Species("O3") })
                               .products({ yields(micm::Species("O1D"), 1), yields(micm::Species("O2"), 1) })
-                              .rate_constant(micm::PhotolysisRateConstant())
+                              .rate_constant(micm::UserDefinedRateConstant("jO3a"))
                               .phase(gas_phase);
 
   micm::Process photo_3 = micm::Process::create()
                               .reactants({ micm::Species("O3") })
                               .products({ yields(micm::Species("O"), 1), yields(micm::Species("O2"), 1) })
-                              .rate_constant(micm::PhotolysisRateConstant())
+                              .rate_constant(micm::UserDefinedRateConstant("jO3b"))
                               .phase(gas_phase);
 
   return { photo_1, photo_2, photo_3, r1, r2, r3, r4 };

--- a/test/unit/configure/process/CMakeLists.txt
+++ b/test/unit/configure/process/CMakeLists.txt
@@ -7,6 +7,8 @@ include(test_util)
 # Tests
 
 create_standard_test(NAME branched_config SOURCES test_branched_config.cpp)
+create_standard_test(NAME emission_config SOURCES test_emission_config.cpp)
+create_standard_test(NAME first_order_loss_config SOURCES test_first_order_loss_config.cpp)
 create_standard_test(NAME photolysis_config SOURCES test_photolysis_config.cpp)
 create_standard_test(NAME ternary_chemical_activation_config SOURCES test_ternary_chemical_activation_config.cpp)
 create_standard_test(NAME tunneling_config SOURCES test_tunneling_config.cpp)

--- a/test/unit/configure/process/CMakeLists.txt
+++ b/test/unit/configure/process/CMakeLists.txt
@@ -7,5 +7,6 @@ include(test_util)
 # Tests
 
 create_standard_test(NAME branched_config SOURCES test_branched_config.cpp)
+create_standard_test(NAME photolysis_config SOURCES test_photolysis_config.cpp)
 create_standard_test(NAME ternary_chemical_activation_config SOURCES test_ternary_chemical_activation_config.cpp)
 create_standard_test(NAME tunneling_config SOURCES test_tunneling_config.cpp)

--- a/test/unit/configure/process/test_emission_config.cpp
+++ b/test/unit/configure/process/test_emission_config.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+
+#include <micm/configure/solver_config.hpp>
+
+TEST(EmissionConfig, DetectsInvalidConfig)\
+{
+  micm::SolverConfig solver_config;
+
+  // Read and parse the configure files
+  micm::ConfigParseStatus status = solver_config.ReadAndParse("./unit_configs/process/emission/missing_products");
+  EXPECT_EQ(micm::ConfigParseStatus::RequiredKeyNotFound, status);
+  status = solver_config.ReadAndParse("./unit_configs/process/emission/missing_MUSICA_name");
+  EXPECT_EQ(micm::ConfigParseStatus::RequiredKeyNotFound, status);
+}
+
+TEST(EmissionConfig, ParseConfig)
+{
+  micm::SolverConfig solver_config;
+
+  micm::ConfigParseStatus status = solver_config.ReadAndParse("./unit_configs/process/emission/valid");
+  EXPECT_EQ(micm::ConfigParseStatus::Success, status);
+
+  micm::SolverParameters solver_params = solver_config.GetSolverParams();
+
+  auto& process_vector = solver_params.processes_;
+
+  // first reaction
+  {
+    EXPECT_EQ(process_vector[0].reactants_.size(), 0);
+    EXPECT_EQ(process_vector[0].products_.size(), 1);
+    EXPECT_EQ(process_vector[0].products_[0].first.name_, "foo");
+    EXPECT_EQ(process_vector[0].products_[0].second, 1.0);
+    micm::UserDefinedRateConstant* emission_rate_constant =
+        dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[0].rate_constant_.get());
+    EXPECT_EQ(emission_rate_constant->SizeCustomParameters(), 1);
+    EXPECT_EQ(emission_rate_constant->CustomParameters()[0], "EMIS.foo");
+  }
+
+  // second reaction
+  {
+    EXPECT_EQ(process_vector[1].reactants_.size(), 0);
+    EXPECT_EQ(process_vector[1].products_.size(), 1);
+    EXPECT_EQ(process_vector[1].products_[0].first.name_, "bar");
+    EXPECT_EQ(process_vector[1].products_[0].second, 1.0);
+    micm::UserDefinedRateConstant* emission_rate_constant =
+        dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[1].rate_constant_.get());
+    EXPECT_EQ(emission_rate_constant->SizeCustomParameters(), 1);
+    EXPECT_EQ(emission_rate_constant->CustomParameters()[0], "EMIS.bar");
+  }
+
+}

--- a/test/unit/configure/process/test_first_order_loss_config.cpp
+++ b/test/unit/configure/process/test_first_order_loss_config.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include <micm/configure/solver_config.hpp>
+
+TEST(FirstOrderLossConfig, DetectsInvalidConfig)\
+{
+  micm::SolverConfig solver_config;
+
+  // Read and parse the configure files
+  micm::ConfigParseStatus status = solver_config.ReadAndParse("./unit_configs/process/first_order_loss/missing_reactants");
+  EXPECT_EQ(micm::ConfigParseStatus::RequiredKeyNotFound, status);
+  status = solver_config.ReadAndParse("./unit_configs/process/first_order_loss/missing_MUSICA_name");
+  EXPECT_EQ(micm::ConfigParseStatus::RequiredKeyNotFound, status);
+}
+
+TEST(FirstOrderLossConfig, ParseConfig)
+{
+  micm::SolverConfig solver_config;
+
+  micm::ConfigParseStatus status = solver_config.ReadAndParse("./unit_configs/process/first_order_loss/valid");
+  EXPECT_EQ(micm::ConfigParseStatus::Success, status);
+
+  micm::SolverParameters solver_params = solver_config.GetSolverParams();
+
+  auto& process_vector = solver_params.processes_;
+
+  // first reaction
+  {
+    EXPECT_EQ(process_vector[0].reactants_.size(), 1);
+    EXPECT_EQ(process_vector[0].reactants_[0].name_, "foo");
+    EXPECT_EQ(process_vector[0].products_.size(), 0);
+    micm::UserDefinedRateConstant* first_order_loss_rate_constant =
+        dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[0].rate_constant_.get());
+    EXPECT_EQ(first_order_loss_rate_constant->SizeCustomParameters(), 1);
+    EXPECT_EQ(first_order_loss_rate_constant->CustomParameters()[0], "LOSS.foo");
+  }
+
+  // second reaction
+  {
+    EXPECT_EQ(process_vector[1].reactants_.size(), 1);
+    EXPECT_EQ(process_vector[1].reactants_[0].name_, "bar");
+    EXPECT_EQ(process_vector[1].products_.size(), 0);
+    micm::UserDefinedRateConstant* first_order_loss_rate_constant =
+        dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[1].rate_constant_.get());
+    EXPECT_EQ(first_order_loss_rate_constant->SizeCustomParameters(), 1);
+    EXPECT_EQ(first_order_loss_rate_constant->CustomParameters()[0], "LOSS.bar");
+  }
+
+}

--- a/test/unit/configure/process/test_photolysis_config.cpp
+++ b/test/unit/configure/process/test_photolysis_config.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+
+#include <micm/configure/solver_config.hpp>
+
+TEST(PhotolysisConfig, DetectsInvalidConfig)\
+{
+  micm::SolverConfig solver_config;
+
+  // Read and parse the configure files
+  micm::ConfigParseStatus status = solver_config.ReadAndParse("./unit_configs/process/photolysis/missing_reactants");
+  EXPECT_EQ(micm::ConfigParseStatus::RequiredKeyNotFound, status);
+  status = solver_config.ReadAndParse("./unit_configs/process/photolysis/missing_products");
+  EXPECT_EQ(micm::ConfigParseStatus::RequiredKeyNotFound, status);
+  status = solver_config.ReadAndParse("./unit_configs/process/photolysis/missing_MUSICA_name");
+  EXPECT_EQ(micm::ConfigParseStatus::RequiredKeyNotFound, status);
+}
+
+TEST(PhotolysisConfig, ParseConfig)
+{
+  micm::SolverConfig solver_config;
+
+  micm::ConfigParseStatus status = solver_config.ReadAndParse("./unit_configs/process/photolysis/valid");
+  EXPECT_EQ(micm::ConfigParseStatus::Success, status);
+
+  micm::SolverParameters solver_params = solver_config.GetSolverParams();
+
+  auto& process_vector = solver_params.processes_;
+
+  // first reaction
+  {
+    EXPECT_EQ(process_vector[0].reactants_.size(), 1);
+    EXPECT_EQ(process_vector[0].reactants_[0].name_, "foo");
+    EXPECT_EQ(process_vector[0].products_.size(), 2);
+    EXPECT_EQ(process_vector[0].products_[0].first.name_, "bar");
+    EXPECT_EQ(process_vector[0].products_[0].second, 1.0);
+    EXPECT_EQ(process_vector[0].products_[1].first.name_, "baz");
+    EXPECT_EQ(process_vector[0].products_[1].second, 3.2);
+    micm::UserDefinedRateConstant* photo_rate_constant =
+        dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[0].rate_constant_.get());
+    EXPECT_EQ(photo_rate_constant->SizeCustomParameters(), 1);
+    EXPECT_EQ(photo_rate_constant->CustomParameters()[0], "PHOTO.jfoo");
+  }
+
+  // second reaction
+  {
+    EXPECT_EQ(process_vector[1].reactants_.size(), 1);
+    EXPECT_EQ(process_vector[1].reactants_[0].name_, "bar");
+    EXPECT_EQ(process_vector[1].products_.size(), 2);
+    EXPECT_EQ(process_vector[1].products_[0].first.name_, "bar");
+    EXPECT_EQ(process_vector[1].products_[0].second, 0.5);
+    EXPECT_EQ(process_vector[1].products_[1].first.name_, "foo");
+    EXPECT_EQ(process_vector[1].products_[1].second, 1.0);
+    micm::UserDefinedRateConstant* photo_rate_constant =
+        dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[1].rate_constant_.get());
+    EXPECT_EQ(photo_rate_constant->SizeCustomParameters(), 1);
+    EXPECT_EQ(photo_rate_constant->CustomParameters()[0], "PHOTO.jbar");
+  }
+
+}

--- a/test/unit/configure/test_solver_config.cpp
+++ b/test/unit/configure/test_solver_config.cpp
@@ -75,16 +75,16 @@ TEST(SolverConfig, ReadAndParseProcessObjects)
     idx++;
   }
 
-  // Check the name for 'PhotolysisRateConstant'
-  micm::PhotolysisRateConstant* photolysis_rate_const = nullptr;
-  std::string photolysis_name[] = { "O2_1", "O3_1", "O3_2" };
+  // Check the name for photolysis rate constants
+  micm::UserDefinedRateConstant* photolysis_rate_const = nullptr;
+  std::string photolysis_name[] = { "PHOTO.O2_1", "PHOTO.O3_1", "PHOTO.O3_2" };
 
   for (short i = 0; i < 3; i++)
   {
-    photolysis_rate_const = dynamic_cast<micm::PhotolysisRateConstant*>(process_vector[i].rate_constant_.get());
+    photolysis_rate_const = dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[i].rate_constant_.get());
 
     EXPECT_TRUE(photolysis_rate_const != nullptr);
-    EXPECT_EQ(photolysis_rate_const->name_, photolysis_name[i]);
+    EXPECT_EQ(photolysis_rate_const->CustomParameters()[0], photolysis_name[i]);
   }
 
   // Check the parameters for 'ArrheniusRateConstant'
@@ -124,34 +124,6 @@ TEST(SolverConfig, GettingSolverParamsThrowsExceptionWithFailedParsing)
   micm::ConfigParseStatus status = solverConfig.ReadAndParse("not_a_config_file_directory");
   EXPECT_NE(micm::ConfigParseStatus::Success, status);
   EXPECT_ANY_THROW(solverConfig.GetSolverParams());
-}
-
-TEST(SolverConfig, GettingPhotolysisRateConstantThrowsExceptionWithFailedParsing)
-{
-  micm::SolverConfig solverConfig;
-  micm::ConfigParseStatus status = solverConfig.ReadAndParse("not_a_config_file_directory");
-  EXPECT_NE(micm::ConfigParseStatus::Success, status);
-  EXPECT_ANY_THROW(solverConfig.GetPhotolysisRateConstants());
-}
-
-TEST(SolverConfig, GetPhotolysisRateConstants)
-{
-  // Read and parse the configure files
-  micm::SolverConfig solverConfig;
-  micm::ConfigParseStatus status = solverConfig.ReadAndParse("./unit_configs/chapman");
-  EXPECT_EQ(micm::ConfigParseStatus::Success, status);
-
-  std::vector<micm::PhotolysisRateConstant>& photolysis_rate_arr_ = solverConfig.GetPhotolysisRateConstants();
-
-  // Check the name of photolsis rate constants
-  std::array<std::string, 3> photo_names{ "O2_1", "O3_1", "O3_2" };
-
-  short idx = 0;
-  for (auto& rate : photolysis_rate_arr_)
-  {
-    EXPECT_EQ(rate.name_, photo_names[idx]);
-    idx++;
-  }
 }
 
 //
@@ -245,16 +217,16 @@ TEST(SolverConfig, ReadAndParseProcessObjectsfromMZ326)
     idx++;
   }
 
-  // Check the name for 'PhotolysisRateConstant'
-  micm::PhotolysisRateConstant* photolysis_rate_const = nullptr;
-  std::string photolysis_name = "jterpnit";
+  // Check the name for 'UserDefinedRateConstant'
+  micm::UserDefinedRateConstant* photolysis_rate_const = nullptr;
+  std::string photolysis_name = "PHOTO.jterpnit";
 
   for (short i : { 3 })
   {
-    photolysis_rate_const = dynamic_cast<micm::PhotolysisRateConstant*>(process_vector[i].rate_constant_.get());
+    photolysis_rate_const = dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[i].rate_constant_.get());
 
     EXPECT_TRUE(photolysis_rate_const != nullptr);
-    EXPECT_EQ(photolysis_rate_const->name_, photolysis_name);
+    EXPECT_EQ(photolysis_rate_const->CustomParameters()[0], photolysis_name);
   }
 
   // Check the parameters for 'ArrheniusRateConstant'

--- a/test/unit/process/CMakeLists.txt
+++ b/test/unit/process/CMakeLists.txt
@@ -8,7 +8,7 @@ include(test_util)
 
 create_standard_test(NAME arrhenius_rate_constant SOURCES test_arrhenius_rate_constant.cpp)
 create_standard_test(NAME branched_rate_constant SOURCES test_branched_rate_constant.cpp)
-create_standard_test(NAME photolysis_rate_constant SOURCES test_photolysis_rate_constant.cpp)
+create_standard_test(NAME user_defined_rate_constant SOURCES test_user_defined_rate_constant.cpp)
 create_standard_test(NAME ternary_chemical_activation_rate_constant SOURCES test_ternary_chemical_activation_rate_constant.cpp)
 create_standard_test(NAME troe_rate_constant SOURCES test_troe_rate_constant.cpp)
 create_standard_test(NAME tunneling_rate_constant SOURCES test_tunneling_rate_constant.cpp)

--- a/test/unit/process/test_cuda_process_set.cpp
+++ b/test/unit/process/test_cuda_process_set.cpp
@@ -36,8 +36,8 @@ void testRandomSystem(std::size_t n_cells, std::size_t n_reactions, std::size_t 
   }
   micm::Phase gas_phase{ species };
   micm::State<MatrixPolicy> state{ micm::StateParameters{ .state_variable_names_{ species_names },
+                                                          .custom_rate_parameter_labels_{ },
                                                           .number_of_grid_cells_ = n_cells,
-                                                          .number_of_custom_parameters_ = 0,
                                                           .number_of_rate_constants_ = n_reactions } };
 
   std::vector<micm::Process> processes{};

--- a/test/unit/process/test_process_set.cpp
+++ b/test/unit/process/test_process_set.cpp
@@ -31,7 +31,6 @@ void testProcessSet()
 
   micm::State<MatrixPolicy> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz", "quuz" },
                                                           .number_of_grid_cells_ = 2,
-                                                          .number_of_custom_parameters_ = 0,
                                                           .number_of_rate_constants_ = 3 } };
 
   micm::Process r1 =
@@ -171,7 +170,6 @@ void testRandomSystem(std::size_t n_cells, std::size_t n_reactions, std::size_t 
   micm::Phase gas_phase{ species };
   micm::State<MatrixPolicy> state{ micm::StateParameters{ .state_variable_names_{ species_names },
                                                           .number_of_grid_cells_ = n_cells,
-                                                          .number_of_custom_parameters_ = 0,
                                                           .number_of_rate_constants_ = n_reactions } };
   std::vector<micm::Process> processes{};
   for (std::size_t i = 0; i < n_reactions; ++i)

--- a/test/unit/process/test_user_defined_rate_constant.cpp
+++ b/test/unit/process/test_user_defined_rate_constant.cpp
@@ -1,36 +1,36 @@
 #include <gtest/gtest.h>
 
-#include <micm/process/photolysis_rate_constant.hpp>
+#include <micm/process/user_defined_rate_constant.hpp>
 #include <micm/solver/state.hpp>
 #include <micm/system/system.hpp>
 
-TEST(PhotolysisRateConstant, CalculateWithSystem)
+TEST(UserDefinedRateConstant, CalculateWithSystem)
 {
   micm::State<micm::Matrix> state{ 0, 1, 1 };
   state.custom_rate_parameters_[0][0] = 0.5;
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
-  micm::PhotolysisRateConstant photo{};
+  micm::UserDefinedRateConstant photo{};
   auto k = photo.calculate(state.conditions_[0], params);
   EXPECT_EQ(k, 0.5);
 }
 
-TEST(PhotolysisRateConstant, ConstructorWithRate)
+TEST(UserDefinedRateConstant, ConstructorWithRate)
 {
   micm::State<micm::Matrix> state{ 0, 1, 1 };
   state.custom_rate_parameters_[0][0] = 1.1;
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
-  micm::PhotolysisRateConstant photo{};
+  micm::UserDefinedRateConstant photo{};
   auto k = photo.calculate(state.conditions_[0], params);
   EXPECT_EQ(k, 1.1);
 }
 
-TEST(PhotolysisRateConstant, ConstructorWithRateAndName)
+TEST(UserDefinedRateConstant, ConstructorWithRateAndName)
 {
   micm::State<micm::Matrix> state{ 0, 1, 1 };
   state.custom_rate_parameters_[0][0] = 1.1;
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
-  micm::PhotolysisRateConstant photo("a name");
+  micm::UserDefinedRateConstant photo("a name");
   auto k = photo.calculate(state.conditions_[0], params);
   EXPECT_EQ(k, 1.1);
-  EXPECT_EQ(photo.name_, "a name");
+  EXPECT_EQ(photo.CustomParameters()[0], "a name");
 }

--- a/test/unit/solver/test_state.cpp
+++ b/test/unit/solver/test_state.cpp
@@ -1,13 +1,12 @@
 #include <gtest/gtest.h>
 
-#include <micm/process/photolysis_rate_constant.hpp>
 #include <micm/solver/state.hpp>
 
 TEST(State, Constructor)
 {
   micm::State<micm::Matrix> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz" },
+                                                          .custom_rate_parameter_labels_{ "quux", "corge" },
                                                           .number_of_grid_cells_ = 3,
-                                                          .number_of_custom_parameters_ = 5,
                                                           .number_of_rate_constants_ = 10 } };
 
   EXPECT_EQ(state.conditions_.size(), 3);
@@ -17,8 +16,10 @@ TEST(State, Constructor)
   EXPECT_EQ(state.variable_map_["quz"], 3);
   EXPECT_EQ(state.variables_.size(), 3);
   EXPECT_EQ(state.variables_[0].size(), 4);
+  EXPECT_EQ(state.custom_rate_parameter_map_["quux"], 0);
+  EXPECT_EQ(state.custom_rate_parameter_map_["corge"], 1);
   EXPECT_EQ(state.custom_rate_parameters_.size(), 3);
-  EXPECT_EQ(state.custom_rate_parameters_[0].size(), 5);
+  EXPECT_EQ(state.custom_rate_parameters_[0].size(), 2);
   EXPECT_EQ(state.rate_constants_.size(), 3);
   EXPECT_EQ(state.rate_constants_[0].size(), 10);
 }
@@ -26,8 +27,8 @@ TEST(State, Constructor)
 TEST(State, SettingSingleConcentrationWithInvalidArgumentsThowsException)
 {
   micm::State<micm::Matrix> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz" },
+                                                          .custom_rate_parameter_labels_{ "quux", "corge" },
                                                           .number_of_grid_cells_ = 3,
-                                                          .number_of_custom_parameters_ = 5,
                                                           .number_of_rate_constants_ = 10 } };
   EXPECT_ANY_THROW(state.SetConcentration(micm::Species{ "foo" }, 1.0));
   EXPECT_ANY_THROW(state.SetConcentration(micm::Species{ "foo" }, std::vector<double>{ 1.0, 2.0 }));
@@ -39,8 +40,8 @@ TEST(State, SetSingleConcentration)
 {
   {
     micm::State<micm::Matrix> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz" },
+                                                          .custom_rate_parameter_labels_{ "quux", "corge" },
                                                             .number_of_grid_cells_ = 3,
-                                                            .number_of_custom_parameters_ = 5,
                                                             .number_of_rate_constants_ = 10 } };
     std::vector<double> concentrations{ 12.0, 42.0, 35.2 };
     state.SetConcentration(micm::Species{ "bar" }, concentrations);
@@ -49,8 +50,8 @@ TEST(State, SetSingleConcentration)
   }
   {
     micm::State<micm::Matrix> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz" },
+                                                            .custom_rate_parameter_labels_{ "quux", "corge" },
                                                             .number_of_grid_cells_ = 1,
-                                                            .number_of_custom_parameters_ = 5,
                                                             .number_of_rate_constants_ = 10 } };
     state.SetConcentration(micm::Species{ "bar" }, 324.2);
     EXPECT_EQ(state.variables_[0][state.variable_map_["bar"]], 324.2);
@@ -60,8 +61,8 @@ TEST(State, SetSingleConcentration)
 TEST(State, SettingConcentrationsWithInvalidArguementsThrowsException)
 {
   micm::State<micm::Matrix> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz" },
+                                                          .custom_rate_parameter_labels_{ "quux", "corge" },
                                                           .number_of_grid_cells_ = 3,
-                                                          .number_of_custom_parameters_ = 5,
                                                           .number_of_rate_constants_ = 10 } };
 
   std::unordered_map<std::string, std::vector<double>> concentrations = {
@@ -82,8 +83,8 @@ TEST(State, SetConcentrations)
   uint32_t num_species = 4;
 
   micm::State<micm::Matrix> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz" },
+                                                          .custom_rate_parameter_labels_{ "quux", "corge" },
                                                           .number_of_grid_cells_ = num_grid_cells,
-                                                          .number_of_custom_parameters_ = 5,
                                                           .number_of_rate_constants_ = 10 } };
 
   // Build system
@@ -113,71 +114,74 @@ TEST(State, SetConcentrations)
   }
 }
 
-TEST(State, SettingPhotolysisRateWithInvalidArguementsThrowsException)
+TEST(State, SettingCustomRateParameterWithInvalidVectorSizeThrowsException)
 {
   micm::State<micm::Matrix> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz" },
+                                                          .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
                                                           .number_of_grid_cells_ = 3,
-                                                          .number_of_custom_parameters_ = 5,
                                                           .number_of_rate_constants_ = 10 } };
 
-  // Build an array of photolysis rate constant
-  std::vector<micm::PhotolysisRateConstant> photolysis_rate_arr;
-  photolysis_rate_arr.reserve(5);
-  photolysis_rate_arr.emplace_back("O1");
-  photolysis_rate_arr.emplace_back("O2");
-  photolysis_rate_arr.emplace_back("O3");
-  photolysis_rate_arr.emplace_back("AAA");
-  photolysis_rate_arr.emplace_back("BBB");
+  // user input for custom rate parameters (unordered)
+  std::unordered_map<std::string, std::vector<double>> custom_params = {
+    { "O3", { 0.3 } }, { "O1", { 0.1 } }, { "O2", { 0.5 } }, { "BBB", { 0.7 } }, { "AAA", { 0.5 } }
+  };
 
-  // user input for photolysis rate constant (unordered)
-  std::unordered_map<std::string, std::vector<double>> photo_rates = {
+  EXPECT_ANY_THROW(state.SetCustomRateParameters(custom_params));
+}
+
+TEST(State, SettingCustomRateParameterWithInvalidLabelThrowsException)
+{
+  micm::State<micm::Matrix> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz" },
+                                                          .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
+                                                          .number_of_grid_cells_ = 1,
+                                                          .number_of_rate_constants_ = 10 } };
+
+  // user input for custom rate parameters (unordered)
+  std::unordered_map<std::string, std::vector<double>> custom_params = {
     { "O3", { 0.3 } }, { "O1", { 0.1 } }, { "O2", { 0.5 } }, { "CCC", { 0.7 } }, { "AAA", { 0.5 } }
   };
 
-  std::vector<double> photo_rates_in_order{ 0.1, 0.5, 0.3, 0.5, 0.7 };
-
-  // Compare photolysis rate constants
-  EXPECT_ANY_THROW(state.SetPhotolysisRate(photolysis_rate_arr, photo_rates));
+  EXPECT_ANY_THROW(state.SetCustomRateParameters(custom_params));
 }
 
-TEST(State, SetPhotolysisRate)
+TEST(State, SetCustomRateParameter)
 {
-  uint32_t num_grid_cells = 3;
-  uint32_t num_custom_params = 5;
-
   micm::State<micm::Matrix> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz" },
-                                                          .number_of_grid_cells_ = num_grid_cells,
-                                                          .number_of_custom_parameters_ = num_custom_params,
+                                                          .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
+                                                          .number_of_grid_cells_ = 1,
                                                           .number_of_rate_constants_ = 10 } };
 
-  // Build an array of photolysis rate constant
-  std::vector<micm::PhotolysisRateConstant> photolysis_rate_arr;
-  photolysis_rate_arr.reserve(num_custom_params);
-  photolysis_rate_arr.emplace_back("O1");
-  photolysis_rate_arr.emplace_back("O2");
-  photolysis_rate_arr.emplace_back("O3");
-  photolysis_rate_arr.emplace_back("AAA");
-  photolysis_rate_arr.emplace_back("BBB");
+  state.SetCustomRateParameter("O2", 42.3);
+  EXPECT_EQ(state.custom_rate_parameters_[0][1], 42.3);
+}
 
-  // user input for photolysis rate constant (unordered)
-  std::unordered_map<std::string, std::vector<double>> photo_rates = { { "O3", { 0.3, 0.33, 0.333 } },
+TEST(State, SetCustomRateParameters)
+{
+  uint32_t num_grid_cells = 3;
+
+  micm::State<micm::Matrix> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz" },
+                                                          .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
+                                                          .number_of_grid_cells_ = num_grid_cells,
+                                                          .number_of_rate_constants_ = 10 } };
+
+  // user input for custom rate parameters (unordered)
+  std::unordered_map<std::string, std::vector<double>> custom_params = { { "O3", { 0.3, 0.33, 0.333 } },
                                                                        { "O1", { 0.1, 0.11, 0.111 } },
                                                                        { "O2", { 0.5, 0.55, 0.555 } },
                                                                        { "BBB", { 0.7, 0.77, 0.777 } },
                                                                        { "AAA", { 0.5, 0.55, 0.555 } } };
 
-  std::vector<double> photo_rates_in_order{ 0.1,  0.5,  0.3,   0.5,   0.7,   0.11,  0.55, 0.33,
+  std::vector<double> custom_params_in_order{ 0.1,  0.5,  0.3,   0.5,   0.7,   0.11,  0.55, 0.33,
                                             0.55, 0.77, 0.111, 0.555, 0.333, 0.555, 0.777 };
 
-  // Compare photolysis rate constants
-  state.SetPhotolysisRate(photolysis_rate_arr, photo_rates);
+  state.SetCustomRateParameters(custom_params);
 
   short idx = 0;
   for (short i = 0; i < num_grid_cells; i++)
   {
-    for (short j = 0; j < num_custom_params; j++, idx++)
+    for (short j = 0; j < 5; j++, idx++)
     {
-      EXPECT_EQ(state.custom_rate_parameters_[i][j], photo_rates_in_order[idx]);
+      EXPECT_EQ(state.custom_rate_parameters_[i][j], custom_params_in_order[idx]);
     }
   }
 }

--- a/test/unit/unit_configs/process/emission/missing_MUSICA_name/reactions.json
+++ b/test/unit/unit_configs/process/emission/missing_MUSICA_name/reactions.json
@@ -1,0 +1,14 @@
+{
+  "camp-data": [
+    {
+      "name": "Emission missing MUSICA name",
+      "type": "MECHANISM",
+      "reactions": [
+        {
+          "type": "EMISSION",
+          "species": "bar"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/emission/missing_MUSICA_name/species.json
+++ b/test/unit/unit_configs/process/emission/missing_MUSICA_name/species.json
@@ -1,0 +1,16 @@
+{
+  "camp-data": [
+    {
+      "name": "foo",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "bar",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "baz",
+      "type": "CHEM_SPEC"
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/emission/missing_MUSICA_name/tolerance.json
+++ b/test/unit/unit_configs/process/emission/missing_MUSICA_name/tolerance.json
@@ -1,0 +1,8 @@
+{
+  "camp-data": [
+    {
+      "type": "RELATIVE_TOLERANCE",
+      "value": 1.0e-4
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/emission/missing_products/reactions.json
+++ b/test/unit/unit_configs/process/emission/missing_products/reactions.json
@@ -1,0 +1,14 @@
+{
+  "camp-data": [
+    {
+      "name": "Emission missing products",
+      "type": "MECHANISM",
+      "reactions": [
+        {
+          "type": "EMISSION",
+          "MUSICA name" : "foo"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/emission/missing_products/species.json
+++ b/test/unit/unit_configs/process/emission/missing_products/species.json
@@ -1,0 +1,16 @@
+{
+  "camp-data": [
+    {
+      "name": "foo",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "bar",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "baz",
+      "type": "CHEM_SPEC"
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/emission/missing_products/tolerance.json
+++ b/test/unit/unit_configs/process/emission/missing_products/tolerance.json
@@ -1,0 +1,8 @@
+{
+  "camp-data": [
+    {
+      "type": "RELATIVE_TOLERANCE",
+      "value": 1.0e-4
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/emission/valid/reactions.json
+++ b/test/unit/unit_configs/process/emission/valid/reactions.json
@@ -1,0 +1,20 @@
+{
+  "camp-data": [
+    {
+      "name": "Valid emissions",
+      "type": "MECHANISM",
+      "reactions": [
+        {
+          "type": "EMISSION",
+          "species": "foo",
+          "MUSICA name": "foo"
+        },
+        {
+          "type": "EMISSION",
+          "species": "bar",
+          "MUSICA name": "bar"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/emission/valid/species.json
+++ b/test/unit/unit_configs/process/emission/valid/species.json
@@ -1,0 +1,20 @@
+{
+  "camp-data": [
+    {
+      "name": "foo",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "bar",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "baz",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "quz",
+      "type": "CHEM_SPEC"
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/emission/valid/tolerance.json
+++ b/test/unit/unit_configs/process/emission/valid/tolerance.json
@@ -1,0 +1,8 @@
+{
+  "camp-data": [
+    {
+      "type": "RELATIVE_TOLERANCE",
+      "value": 1.0e-4
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/first_order_loss/missing_MUSICA_name/reactions.json
+++ b/test/unit/unit_configs/process/first_order_loss/missing_MUSICA_name/reactions.json
@@ -1,0 +1,14 @@
+{
+  "camp-data": [
+    {
+      "name": "First-order loss missing MUSICA name",
+      "type": "MECHANISM",
+      "reactions": [
+        {
+          "type": "FIRST_ORDER_LOSS",
+          "species": "bar"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/first_order_loss/missing_MUSICA_name/species.json
+++ b/test/unit/unit_configs/process/first_order_loss/missing_MUSICA_name/species.json
@@ -1,0 +1,16 @@
+{
+  "camp-data": [
+    {
+      "name": "foo",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "bar",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "baz",
+      "type": "CHEM_SPEC"
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/first_order_loss/missing_MUSICA_name/tolerance.json
+++ b/test/unit/unit_configs/process/first_order_loss/missing_MUSICA_name/tolerance.json
@@ -1,0 +1,8 @@
+{
+  "camp-data": [
+    {
+      "type": "RELATIVE_TOLERANCE",
+      "value": 1.0e-4
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/first_order_loss/missing_reactants/reactions.json
+++ b/test/unit/unit_configs/process/first_order_loss/missing_reactants/reactions.json
@@ -1,0 +1,14 @@
+{
+  "camp-data": [
+    {
+      "name": "First-order loss missing reactants",
+      "type": "MECHANISM",
+      "reactions": [
+        {
+          "type": "FIRST_ORDER_LOSS",
+          "MUSICA name" : "foo"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/first_order_loss/missing_reactants/species.json
+++ b/test/unit/unit_configs/process/first_order_loss/missing_reactants/species.json
@@ -1,0 +1,16 @@
+{
+  "camp-data": [
+    {
+      "name": "foo",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "bar",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "baz",
+      "type": "CHEM_SPEC"
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/first_order_loss/missing_reactants/tolerance.json
+++ b/test/unit/unit_configs/process/first_order_loss/missing_reactants/tolerance.json
@@ -1,0 +1,8 @@
+{
+  "camp-data": [
+    {
+      "type": "RELATIVE_TOLERANCE",
+      "value": 1.0e-4
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/first_order_loss/valid/reactions.json
+++ b/test/unit/unit_configs/process/first_order_loss/valid/reactions.json
@@ -1,0 +1,20 @@
+{
+  "camp-data": [
+    {
+      "name": "Valid first-order-loss",
+      "type": "MECHANISM",
+      "reactions": [
+        {
+          "type": "FIRST_ORDER_LOSS",
+          "species": "foo",
+          "MUSICA name": "foo"
+        },
+        {
+          "type": "FIRST_ORDER_LOSS",
+          "species": "bar",
+          "MUSICA name": "bar"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/first_order_loss/valid/species.json
+++ b/test/unit/unit_configs/process/first_order_loss/valid/species.json
@@ -1,0 +1,20 @@
+{
+  "camp-data": [
+    {
+      "name": "foo",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "bar",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "baz",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "quz",
+      "type": "CHEM_SPEC"
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/first_order_loss/valid/tolerance.json
+++ b/test/unit/unit_configs/process/first_order_loss/valid/tolerance.json
@@ -1,0 +1,8 @@
+{
+  "camp-data": [
+    {
+      "type": "RELATIVE_TOLERANCE",
+      "value": 1.0e-4
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/photolysis/missing_MUSICA_name/reactions.json
+++ b/test/unit/unit_configs/process/photolysis/missing_MUSICA_name/reactions.json
@@ -1,0 +1,21 @@
+{
+  "camp-data": [
+    {
+      "name": "Photolysis missing MUSICA name",
+      "type": "MECHANISM",
+      "reactions": [
+        {
+          "type": "PHOTOLYSIS",
+          "reactants":
+          {
+            "foo": {}
+          },
+          "products": {
+            "bar": { "yield": 1.0 },
+            "baz": { "yield": 3.2 }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/photolysis/missing_MUSICA_name/species.json
+++ b/test/unit/unit_configs/process/photolysis/missing_MUSICA_name/species.json
@@ -1,0 +1,16 @@
+{
+  "camp-data": [
+    {
+      "name": "foo",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "bar",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "baz",
+      "type": "CHEM_SPEC"
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/photolysis/missing_MUSICA_name/tolerance.json
+++ b/test/unit/unit_configs/process/photolysis/missing_MUSICA_name/tolerance.json
@@ -1,0 +1,8 @@
+{
+  "camp-data": [
+    {
+      "type": "RELATIVE_TOLERANCE",
+      "value": 1.0e-4
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/photolysis/missing_products/reactions.json
+++ b/test/unit/unit_configs/process/photolysis/missing_products/reactions.json
@@ -1,0 +1,17 @@
+{
+  "camp-data": [
+    {
+      "name": "Photolysis missing products",
+      "type": "MECHANISM",
+      "reactions": [
+        {
+          "type": "PHOTOLYSIS",
+          "reactants": {
+            "foo": { }
+          },
+          "MUSICA name" : "jfoo"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/photolysis/missing_products/species.json
+++ b/test/unit/unit_configs/process/photolysis/missing_products/species.json
@@ -1,0 +1,16 @@
+{
+  "camp-data": [
+    {
+      "name": "foo",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "bar",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "baz",
+      "type": "CHEM_SPEC"
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/photolysis/missing_products/tolerance.json
+++ b/test/unit/unit_configs/process/photolysis/missing_products/tolerance.json
@@ -1,0 +1,8 @@
+{
+  "camp-data": [
+    {
+      "type": "RELATIVE_TOLERANCE",
+      "value": 1.0e-4
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/photolysis/missing_reactants/reactions.json
+++ b/test/unit/unit_configs/process/photolysis/missing_reactants/reactions.json
@@ -1,0 +1,18 @@
+{
+  "camp-data": [
+    {
+      "name": "Photolysis missing reactants",
+      "type": "MECHANISM",
+      "reactions": [
+        {
+          "type": "PHOTOLYSIS",
+          "products": {
+            "bar": { "yield": 1.0 },
+            "baz": { "yield": 3.2 }
+          },
+          "MUSICA name" : "jfoo"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/photolysis/missing_reactants/species.json
+++ b/test/unit/unit_configs/process/photolysis/missing_reactants/species.json
@@ -1,0 +1,16 @@
+{
+  "camp-data": [
+    {
+      "name": "foo",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "bar",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "baz",
+      "type": "CHEM_SPEC"
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/photolysis/missing_reactants/tolerance.json
+++ b/test/unit/unit_configs/process/photolysis/missing_reactants/tolerance.json
@@ -1,0 +1,8 @@
+{
+  "camp-data": [
+    {
+      "type": "RELATIVE_TOLERANCE",
+      "value": 1.0e-4
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/photolysis/valid/reactions.json
+++ b/test/unit/unit_configs/process/photolysis/valid/reactions.json
@@ -1,0 +1,32 @@
+{
+  "camp-data": [
+    {
+      "name": "Valid photolysis reactions",
+      "type": "MECHANISM",
+      "reactions": [
+        {
+          "type": "PHOTOLYSIS",
+          "reactants": {
+            "foo" : { }
+          },
+          "products": {
+            "bar": { "yield": 1.0 },
+            "baz": { "yield": 3.2 }
+          },
+          "MUSICA name": "jfoo"
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "reactants": {
+            "bar" : { }
+          },
+          "products": {
+            "bar": { "yield": 0.5 },
+            "foo": { }
+          },
+          "MUSICA name": "jbar"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/photolysis/valid/species.json
+++ b/test/unit/unit_configs/process/photolysis/valid/species.json
@@ -1,0 +1,20 @@
+{
+  "camp-data": [
+    {
+      "name": "foo",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "bar",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "baz",
+      "type": "CHEM_SPEC"
+    },
+    {
+      "name": "quz",
+      "type": "CHEM_SPEC"
+    }
+  ]
+}

--- a/test/unit/unit_configs/process/photolysis/valid/tolerance.json
+++ b/test/unit/unit_configs/process/photolysis/valid/tolerance.json
@@ -1,0 +1,8 @@
+{
+  "camp-data": [
+    {
+      "type": "RELATIVE_TOLERANCE",
+      "value": 1.0e-4
+    }
+  ]
+}


### PR DESCRIPTION
Adds ability to parse emission and first-order loss processes from configuration files.

I modified the `PhotolysisRateConstant` class to be a more general-use `UserDefinedRateConstant` class and applied it to photolysis, emission, and first-order loss processes.

closes #144