### PR TITLE
Parameter fixes

### DIFF
--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -588,7 +588,7 @@ namespace micm
    protected:
     /// @brief Computes the scaled norm of the vector errors
     /// @param Y the original vector
-    /// @param new_number_densities the new vector
+    /// @param Ynew the new vector
     /// @param errors The computed errors
     /// @return
     double NormalizedError(

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -76,7 +76,7 @@ namespace micm
     // Gamma_i = \sum_j  gamma_{i,j}
     std::array<double, 6> gamma_{};
 
-    double absolute_tolerance_{ 1e-12 };
+    double absolute_tolerance_{ 1e-3 };
     double relative_tolerance_{ 1e-4 };
 
     size_t number_of_grid_cells_{ 1 };  // Number of grid cells to solve simultaneously

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -794,7 +794,7 @@ namespace micm
             }
           }
           K[stage].AsVector().assign(forcing.AsVector().begin(), forcing.AsVector().end());
-          for (uint64_t j = 0; j < stage; ++j)
+          for (uint64_t j = 0; j <= stage; ++j)
           {
             auto HC = parameters_.c_[stage_combinations + j] / H;
             K[stage].ForEach([&](double& iKstage, double& iKj) { iKstage += HC * iKj; }, K[j]);

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -794,12 +794,13 @@ namespace micm
             }
           }
           K[stage].AsVector().assign(forcing.AsVector().begin(), forcing.AsVector().end());
-          for (uint64_t j = 0; j <= stage; ++j)
+          for (uint64_t j = 0; j < stage; ++j)
           {
             auto HC = parameters_.c_[stage_combinations + j] / H;
             K[stage].ForEach([&](double& iKstage, double& iKj) { iKstage += HC * iKj; }, K[j]);
           }
           temp.AsVector().assign(K[stage].AsVector().begin(), K[stage].AsVector().end());
+          // linear_solver_.template Solve<MatrixPolicy>(forcing, K[0]);
           linear_solver_.template Solve<MatrixPolicy>(temp, K[stage]);
           stats_.solves += 1;
         }

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -711,6 +711,7 @@ namespace micm
   RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::Solve(double time_step, State<MatrixPolicy>& state) noexcept
   {
     typename RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverResult result{};
+    result.state_ = SolverState::Converged;
     MatrixPolicy<double> Y(state.variables_);
     MatrixPolicy<double> Ynew(Y.size(), Y[0].size(), 0.0);
     MatrixPolicy<double> initial_forcing(Y.size(), Y[0].size(), 0.0);
@@ -864,7 +865,6 @@ namespace micm
     result.final_time_ = present_time;
     result.stats_ = stats_;
     result.result_ = std::move(Y);
-    result.state_ = SolverState::Converged;
     return result;
   }
 

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -713,7 +713,7 @@ namespace micm
     typename RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverResult result{};
     MatrixPolicy<double> Y(state.variables_);
     MatrixPolicy<double> Ynew(Y.size(), Y[0].size(), 0.0);
-    MatrixPolicy<double> intial_forcing(Y.size(), Y[0].size(), 0.0);
+    MatrixPolicy<double> initial_forcing(Y.size(), Y[0].size(), 0.0);
     MatrixPolicy<double> forcing(Y.size(), Y[0].size(), 0.0);
     MatrixPolicy<double> temp(Y.size(), Y[0].size(), 0.0);
     std::vector<MatrixPolicy<double>> K{};
@@ -754,7 +754,7 @@ namespace micm
       //  Limit H if necessary to avoid going beyond the specified chemistry time step
       H = std::min(H, std::abs(time_step - present_time));
 
-      CalculateForcing(state.rate_constants_, Y, intial_forcing);
+      CalculateForcing(state.rate_constants_, Y, initial_forcing);
 
       bool accepted = false;
       //  Repeat step calculation until current step accepted
@@ -778,7 +778,7 @@ namespace micm
           double stage_combinations = ((stage + 1) - 1) * ((stage + 1) - 2) / 2;
           if (stage == 0)
           {
-            forcing = intial_forcing;
+            forcing = initial_forcing;
           }
           else
           {
@@ -817,11 +817,12 @@ namespace micm
         auto error = NormalizedError(Y, Ynew, Yerror);
 
         // New step size is bounded by FacMin <= Hnew/H <= FacMax
-        double Hnew = H * std::min(
+        double fac = std::min(
                               parameters_.factor_max_,
                               std::max(
                                   parameters_.factor_min_,
                                   parameters_.safety_factor_ / std::pow(error, 1 / parameters_.estimator_of_local_order_)));
+        double Hnew = H * fac;
 
         // Check the error magnitude and adjust step size
         stats_.number_of_steps += 1;

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -982,7 +982,7 @@ namespace micm
 
     double error = 0;
 
-    for(size_t i = 0; i < Y.size(); ++i) {
+    for(size_t i = 0; i < N_; ++i) {
       double ymax = std::max(std::abs(_y[i]), std::abs(_ynew[i]));
       double scale = parameters_.absolute_tolerance_ + parameters_.relative_tolerance_ * ymax;
       error += std::pow(_errors[i] / scale, 2);

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -766,7 +766,6 @@ namespace micm
         bool is_singular{ false };
         // Form and factor the rosenbrock ode jacobian
         LinearFactor(H, parameters_.gamma_[0], is_singular, Y, state.rate_constants_);
-        stats_.jacobian_updates += 1;
         if (is_singular)
         {
           result.state_ = SolverState::RepeatedlySingularMatrix;

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -755,7 +755,11 @@ namespace micm
       //  Limit H if necessary to avoid going beyond the specified chemistry time step
       H = std::min(H, std::abs(time_step - present_time));
 
+      // compute the concentrations at the current time
       CalculateForcing(state.rate_constants_, Y, initial_forcing);
+
+      // compute the jacobian at the current time
+      CalculateJacobian(state.rate_constants_, Y, jacobian_);
 
       bool accepted = false;
       //  Repeat step calculation until current step accepted
@@ -944,7 +948,6 @@ namespace micm
     while (true)
     {
       double alpha = 1 / (H * gamma);
-      CalculateJacobian(rate_constants, number_densities, jacobian_);
       AlphaMinusJacobian(jacobian_, alpha);
       linear_solver_.Factor(jacobian_);
       singular = false;  // TODO This should be evaluated in some way

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -41,7 +41,7 @@ namespace micm
   {
     size_t stages_{};
     size_t upper_limit_tolerance_{};
-    size_t max_number_of_steps_{ 100 };
+    size_t max_number_of_steps_{ 200000 };
 
     double round_off_{ std::numeric_limits<double>::epsilon() };  // Unit roundoff (1+round_off)>1
     double factor_min_{ 0.2 };                                    // solver step size minimum boundary

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -943,13 +943,14 @@ namespace micm
   {
     // TODO: invesitage this function. The fortran equivalent appears to have a bug.
     // From my understanding the fortran do loop would only ever do one iteration and is equivalent to what's below
+    SparseMatrixPolicy<double> jacobian = jacobian_;
     uint64_t n_consecutive = 0;
     singular = true;
     while (true)
     {
       double alpha = 1 / (H * gamma);
-      AlphaMinusJacobian(jacobian_, alpha);
-      linear_solver_.Factor(jacobian_);
+      AlphaMinusJacobian(jacobian, alpha);
+      linear_solver_.Factor(jacobian);
       singular = false;  // TODO This should be evaluated in some way
       stats_.decompositions += 1;
       if (!singular)

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -586,14 +586,14 @@ namespace micm
 
    protected:
     /// @brief Computes the scaled norm of the vector errors
-    /// @param original_number_densities the original number densities
-    /// @param new_number_densities the new number densities
+    /// @param Y the original vector
+    /// @param new_number_densities the new vector
     /// @param errors The computed errors
     /// @return
     double NormalizedError(
-        MatrixPolicy<double> original_number_densities,
-        MatrixPolicy<double> new_number_densities,
-        MatrixPolicy<double> errors);
+      const MatrixPolicy<double>& Y,
+      const MatrixPolicy<double>& Ynew,
+      const MatrixPolicy<double>& errors)
   };
 
   template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
@@ -969,9 +969,9 @@ namespace micm
 
   template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
   inline double RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::NormalizedError(
-      MatrixPolicy<double> Y,
-      MatrixPolicy<double> Ynew,
-      MatrixPolicy<double> errors)
+      const MatrixPolicy<double>& Y,
+      const MatrixPolicy<double>& Ynew,
+      const MatrixPolicy<double>& errors)
   {
     // Solving Ordinary Differential Equations II, page 123
     // https://link-springer-com.cuucar.idm.oclc.org/book/10.1007/978-3-642-05221-7

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -763,7 +763,7 @@ namespace micm
 
       bool accepted = false;
       //  Repeat step calculation until current step accepted
-      while (!accepted & (stats_.number_of_steps < parameters_.max_number_of_steps_))
+      while (!accepted)
       {
         bool is_singular{ false };
         // Form and factor the rosenbrock ode jacobian

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -41,7 +41,7 @@ namespace micm
   {
     size_t stages_{};
     size_t upper_limit_tolerance_{};
-    size_t max_number_of_steps_{ 200000 };
+    size_t max_number_of_steps_{ 1000 };
 
     double round_off_{ std::numeric_limits<double>::epsilon() };  // Unit roundoff (1+round_off)>1
     double factor_min_{ 0.2 };                                    // solver step size minimum boundary
@@ -763,10 +763,8 @@ namespace micm
 
       bool accepted = false;
       //  Repeat step calculation until current step accepted
-      while (!accepted)
+      while (!accepted & (stats_.number_of_steps > parameters_.max_number_of_steps_))
       {
-        if (stats_.number_of_steps > parameters_.max_number_of_steps_)
-          break;
         bool is_singular{ false };
         // Form and factor the rosenbrock ode jacobian
         LinearFactor(H, parameters_.gamma_[0], is_singular, Y, state.rate_constants_);

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -832,6 +832,7 @@ namespace micm
         stats_.total_steps += 1;
 
         if (std::isnan(error)) {
+          Y.AsVector().assign(Ynew.AsVector().begin(), Ynew.AsVector().end());
           result.state_ = SolverState::NaNDetected;
           break;
         }

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -592,8 +592,8 @@ namespace micm
     /// @param errors The computed errors
     /// @return
     double NormalizedError(
-      const MatrixPolicy<double>& Y,
-      const MatrixPolicy<double>& Ynew,
+      const MatrixPolicy<double>& y,
+      const MatrixPolicy<double>& y_new,
       const MatrixPolicy<double>& errors);
   };
 

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -800,7 +800,6 @@ namespace micm
             K[stage].ForEach([&](double& iKstage, double& iKj) { iKstage += HC * iKj; }, K[j]);
           }
           temp.AsVector().assign(K[stage].AsVector().begin(), K[stage].AsVector().end());
-          // linear_solver_.template Solve<MatrixPolicy>(forcing, K[0]);
           linear_solver_.template Solve<MatrixPolicy>(temp, K[stage]);
           stats_.solves += 1;
         }

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -713,6 +713,7 @@ namespace micm
     typename RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverResult result{};
     MatrixPolicy<double> Y(state.variables_);
     MatrixPolicy<double> Ynew(Y.size(), Y[0].size(), 0.0);
+    MatrixPolicy<double> intial_forcing(Y.size(), Y[0].size(), 0.0);
     MatrixPolicy<double> forcing(Y.size(), Y[0].size(), 0.0);
     MatrixPolicy<double> temp(Y.size(), Y[0].size(), 0.0);
     std::vector<MatrixPolicy<double>> K{};
@@ -753,7 +754,7 @@ namespace micm
       //  Limit H if necessary to avoid going beyond the specified chemistry time step
       H = std::min(H, std::abs(time_step - present_time));
 
-      CalculateForcing(state.rate_constants_, Y, forcing);
+      CalculateForcing(state.rate_constants_, Y, intial_forcing);
 
       bool accepted = false;
       //  Repeat step calculation until current step accepted
@@ -777,8 +778,7 @@ namespace micm
           double stage_combinations = ((stage + 1) - 1) * ((stage + 1) - 2) / 2;
           if (stage == 0)
           {
-            // the first stage simply uses the initial forcing
-            // nothing to do
+            forcing = intial_forcing;
           }
           else
           {

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -811,7 +811,7 @@ namespace micm
           Ynew.ForEach([&](double& iYnew, double& iKstage) { iYnew += parameters_.m_[stage] * iKstage; }, K[stage]);
 
         // Compute the error estimation
-        MatrixPolicy<double> Yerror(Y.AsVector().size(), 0);
+        MatrixPolicy<double> Yerror(Y.size(), Y[0].size(), 0);
         for (uint64_t stage = 0; stage < parameters_.stages_; ++stage)
           Yerror.ForEach([&](double& iYerror, double& iKstage) { iYerror += parameters_.e_[stage] * iKstage; }, K[stage]);
 

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -763,7 +763,7 @@ namespace micm
 
       bool accepted = false;
       //  Repeat step calculation until current step accepted
-      while (!accepted & (stats_.number_of_steps > parameters_.max_number_of_steps_))
+      while (!accepted & (stats_.number_of_steps < parameters_.max_number_of_steps_))
       {
         bool is_singular{ false };
         // Form and factor the rosenbrock ode jacobian

--- a/test/integration/analytical.cpp
+++ b/test/integration/analytical.cpp
@@ -1528,11 +1528,11 @@ TEST(AnalyticalExamples, BranchedSuperStiffButAnalytical)
 
   for (size_t i = 0; i < model_concentrations.size(); ++i)
   {
-    EXPECT_NEAR(model_concentrations[i][_a1] + model_concentrations[i][_a2], analytical_concentrations[i][0], 1e-4)
+    EXPECT_NEAR(model_concentrations[i][_a1] + model_concentrations[i][_a2], analytical_concentrations[i][0], 1e-3)
         << "Arrays differ at index (" << i << ", " << 0 << ")";
-    EXPECT_NEAR(model_concentrations[i][_b], analytical_concentrations[i][1], 1e-4)
+    EXPECT_NEAR(model_concentrations[i][_b], analytical_concentrations[i][1], 1e-3)
         << "Arrays differ at index (" << i << ", " << 1 << ")";
-    EXPECT_NEAR(model_concentrations[i][_c], analytical_concentrations[i][2], 1e-4)
+    EXPECT_NEAR(model_concentrations[i][_c], analytical_concentrations[i][2], 1e-3)
         << "Arrays differ at index (" << i << ", " << 2 << ")";
   }
 }

--- a/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
+++ b/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
@@ -47,7 +47,7 @@ namespace micm
     std::array<double, 6> alpha_{};
     std::array<double, 6> gamma_{};
 
-    double absolute_tolerance_{ 1e-12 };
+    double absolute_tolerance_{ 1e-3 };
     double relative_tolerance_{ 1e-4 };
 
     size_t number_of_grid_cells_{ 1 };  // Number of grid cells to solve simultaneously
@@ -316,8 +316,8 @@ namespace micm
     const double number_density_air = state.conditions_[0].air_density_;
     std::vector<double> forcing{};
 
-    // parameters_.h_max_ = time_end - time_start;
-    // parameters_.h_start_ = std::max(parameters_.h_min_, delta_min_);
+    parameters_.h_max_ = time_end - time_start;
+    parameters_.h_start_ = std::max(parameters_.h_min_, delta_min_);
 
     double present_time = time_start;
     double H =

--- a/test/regression/RosenbrockChapman/regression_test_solve.cpp
+++ b/test/regression/RosenbrockChapman/regression_test_solve.cpp
@@ -92,7 +92,7 @@ using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorO
 TEST(RegressionRosenbrock, TwoStageSolve)
 {
   auto solver = getTwoStageMultiCellChapmanSolver<DenseMatrix, SparseMatrix>(3);
-  testSolve(solver, 1.0e-4);
+  testSolve(solver, 1.0e-2);
 }
 
 TEST(RegressionRosenbrock, ThreeStageSolve)
@@ -104,7 +104,7 @@ TEST(RegressionRosenbrock, ThreeStageSolve)
 TEST(RegressionRosenbrock, FourStageSolve)
 {
   auto solver = getFourStageMultiCellChapmanSolver<DenseMatrix, SparseMatrix>(3);
-  testSolve(solver, 1.0e-5);
+  testSolve(solver, 1.0e-4);
 }
 
 TEST(RegressionRosenbrock, FourStageDASolve)


### PR DESCRIPTION
Fixed a few logic issues in the solver

- calculating the jacobian exactly once for each phase of the solver
- calculating an initial forcing which I had removed previously, not realizing that when rejecting an `H`, the initial forcing is used
- setting some of the same parameters as KPP
- setting the right size for `Yerror`
- added a `NaN` check