### PR TITLE
put the solver state out of the rosenbrock class to remove need to sp…

### DIFF
--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -106,6 +106,18 @@ namespace micm
     RosenbrockSolverParameters() = default;
   };
 
+  /// @brief The final state the solver was in after the Solve function finishes
+  enum class SolverState
+  {
+    NotYetCalled,
+    Running,
+    Converged,
+    ConvergenceExceededMaxSteps,
+    StepSizeTooSmall,
+    RepeatedlySingularMatrix,
+    NaNDetected
+  };
+
   /// @brief An implementation of the Chapman mechnanism solver
   ///
   /// The template parameter is the type of matrix to use
@@ -113,17 +125,6 @@ namespace micm
   class RosenbrockSolver
   {
    public:
-    enum class SolverState
-    {
-      NotYetCalled,
-      Running,
-      Converged,
-      ConvergenceExceededMaxSteps,
-      StepSizeTooSmall,
-      RepeatedlySingularMatrix,
-      NaNDetected
-    };
-
     struct SolverStats
     {
       uint64_t function_calls{};    // Nfun
@@ -137,7 +138,7 @@ namespace micm
       uint64_t total_steps{};       // Ntotstp
 
       void Reset();
-      std::string State(const RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverState& state) const;
+      std::string State(const SolverState& state) const;
     };
 
     struct [[nodiscard]] SolverResult
@@ -200,9 +201,9 @@ namespace micm
     /// @param jacobian Jacobian matrix (dforce_dy)
     /// @param alpha
     void AlphaMinusJacobian(SparseMatrixPolicy<double>& jacobian, const double& alpha) const
-        requires(!VectorizableSparse<SparseMatrixPolicy<double>>);
+      requires(!VectorizableSparse<SparseMatrixPolicy<double>>);
     void AlphaMinusJacobian(SparseMatrixPolicy<double>& jacobian, const double& alpha) const
-        requires(VectorizableSparse<SparseMatrixPolicy<double>>);
+      requires(VectorizableSparse<SparseMatrixPolicy<double>>);
 
     /// @brief Update the rate constants for the environment state
     /// @param state The current state of the chemical system

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -378,20 +378,17 @@ namespace micm
   }
 
   template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
-  inline std::string RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverStats::State(
-      const RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverState& state) const
+  inline std::string RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverStats::State(const SolverState& state) const
   {
     switch (state)
     {
-      case RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverState::NotYetCalled: return "Not Yet Called";
-      case RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverState::Running: return "Running";
-      case RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverState::Converged: return "Converged";
-      case RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverState::ConvergenceExceededMaxSteps:
-        return "Convergence Exceeded Max Steps";
-      case RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverState::StepSizeTooSmall: return "Step Size Too Small";
-      case RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverState::RepeatedlySingularMatrix:
-        return "Repeatedly Singular Matrix";
-      case RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy>::SolverState::NaNDetected: return "NaNDetected";
+      case SolverState::NotYetCalled: return "Not Yet Called";
+      case SolverState::Running: return "Running";
+      case SolverState::Converged: return "Converged";
+      case SolverState::ConvergenceExceededMaxSteps: return "Convergence Exceeded Max Steps";
+      case SolverState::StepSizeTooSmall: return "Step Size Too Small";
+      case SolverState::RepeatedlySingularMatrix: return "Repeatedly Singular Matrix";
+      case SolverState::NaNDetected: return "NaNDetected";
       default: return "Unknown";
     }
     return "";
@@ -764,5 +761,5 @@ namespace micm
     double error_min_ = 1.0e-10;
     return std::max(std::sqrt(error / N_), error_min_);
   }
-  
+
 }  // namespace micm

--- a/test/integration/analytical.cpp
+++ b/test/integration/analytical.cpp
@@ -142,7 +142,7 @@ TEST(AnalyticalExamples, Troe)
   {
     // Model results
     auto result = solver.Solve(time_step, state);
-    EXPECT_EQ(result.state_, (micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>::SolverState::Converged));
+    EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     EXPECT_NEAR(k1, state.rate_constants_.AsVector()[0], 1e-8);
     EXPECT_NEAR(k2, state.rate_constants_.AsVector()[1], 1e-8);
     model_concentrations[i_time] = result.result_.AsVector();
@@ -282,7 +282,7 @@ TEST(AnalyticalExamples, TroeSuperStiffButAnalytical)
   {
     // Model results
     auto result = solver.Solve(time_step, state);
-    EXPECT_EQ(result.state_, (micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>::SolverState::Converged));
+    EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     model_concentrations[i_time] = result.result_.AsVector();
     state.variables_[0] = result.result_.AsVector();
 
@@ -382,7 +382,7 @@ TEST(AnalyticalExamples, Photolysis)
   {
     // Model results
     auto result = solver.Solve(time_step, state);
-    EXPECT_EQ(result.state_, (micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>::SolverState::Converged));
+    EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     EXPECT_NEAR(k1, state.rate_constants_.AsVector()[0], 1e-8);
     EXPECT_NEAR(k2, state.rate_constants_.AsVector()[1], 1e-8);
     model_concentrations[i_time] = result.result_.AsVector();
@@ -514,7 +514,7 @@ TEST(AnalyticalExamples, PhotolysisSuperStiffButAnalytical)
   {
     // Model results
     auto result = solver.Solve(time_step, state);
-    EXPECT_EQ(result.state_, (micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>::SolverState::Converged));
+    EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     model_concentrations[i_time] = result.result_.AsVector();
     state.variables_[0] = result.result_.AsVector();
 
@@ -625,7 +625,7 @@ TEST(AnalyticalExamples, TernaryChemicalActivation)
   {
     // Model results
     auto result = solver.Solve(time_step, state);
-    EXPECT_EQ(result.state_, (micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>::SolverState::Converged));
+    EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     EXPECT_NEAR(k1, state.rate_constants_.AsVector()[0], 1e-8);
     EXPECT_NEAR(k2, state.rate_constants_.AsVector()[1], 1e-8);
     model_concentrations[i_time] = result.result_.AsVector();
@@ -765,7 +765,7 @@ TEST(AnalyticalExamples, TernaryChemicalActivationSuperStiffButAnalytical)
   {
     // Model results
     auto result = solver.Solve(time_step, state);
-    EXPECT_EQ(result.state_, (micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>::SolverState::Converged));
+    EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     model_concentrations[i_time] = result.result_.AsVector();
     state.variables_[0] = result.result_.AsVector();
 
@@ -863,7 +863,7 @@ TEST(AnalyticalExamples, Tunneling)
   {
     // Model results
     auto result = solver.Solve(time_step, state);
-    EXPECT_EQ(result.state_, (micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>::SolverState::Converged));
+    EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     EXPECT_NEAR(k1, state.rate_constants_.AsVector()[0], 1e-8);
     EXPECT_NEAR(k2, state.rate_constants_.AsVector()[1], 1e-8);
     model_concentrations[i_time] = result.result_.AsVector();
@@ -990,7 +990,7 @@ TEST(AnalyticalExamples, TunnelingSuperStiffButAnalytical)
   {
     // Model results
     auto result = solver.Solve(time_step, state);
-    EXPECT_EQ(result.state_, (micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>::SolverState::Converged));
+    EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     model_concentrations[i_time] = result.result_.AsVector();
     state.variables_[0] = result.result_.AsVector();
 
@@ -1090,7 +1090,7 @@ TEST(AnalyticalExamples, Arrhenius)
   {
     // Model results
     auto result = solver.Solve(time_step, state);
-    EXPECT_EQ(result.state_, (micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>::SolverState::Converged));
+    EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     EXPECT_NEAR(k1, state.rate_constants_.AsVector()[0], 1e-8);
     EXPECT_NEAR(k2, state.rate_constants_.AsVector()[1], 1e-8);
     model_concentrations[i_time] = result.result_.AsVector();
@@ -1218,7 +1218,7 @@ TEST(AnalyticalExamples, ArrheniusSuperStiffButAnalytical)
   {
     // Model results
     auto result = solver.Solve(time_step, state);
-    EXPECT_EQ(result.state_, (micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>::SolverState::Converged));
+    EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     model_concentrations[i_time] = result.result_.AsVector();
     state.variables_[0] = result.result_.AsVector();
 
@@ -1343,7 +1343,7 @@ TEST(AnalyticalExamples, Branched)
   {
     // Model results
     auto result = solver.Solve(time_step, state);
-    EXPECT_EQ(result.state_, (micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>::SolverState::Converged));
+    EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     EXPECT_NEAR(k1, state.rate_constants_.AsVector()[0], 1e-8);
     EXPECT_NEAR(k2, state.rate_constants_.AsVector()[1], 1e-8);
     model_concentrations[i_time] = result.result_.AsVector();
@@ -1500,7 +1500,7 @@ TEST(AnalyticalExamples, BranchedSuperStiffButAnalytical)
   {
     // Model results
     auto result = solver.Solve(time_step, state);
-    EXPECT_EQ(result.state_, (micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>::SolverState::Converged));
+    EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     model_concentrations[i_time] = result.result_.AsVector();
     state.variables_[0] = result.result_.AsVector();
 


### PR DESCRIPTION
Closes #185. When accessing the solver results you no longer need to type `RosenbroclSolver<Matrix, SparseMatrix>`, which was cumbersome.