### PR TITLE
fix missing namespace in linear solver test

### DIFF
--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -162,7 +162,7 @@ void testMarkowitzReordering()
     for (std::size_t j = 0; j < order; ++j)
       orig[i][j] = (i == j || gen_bool()) ? 1 : 0;
 
-  auto reorder_map = DiagonalMarkowitzReorder<MatrixPolicy>(orig);
+  auto reorder_map = micm::DiagonalMarkowitzReorder<MatrixPolicy>(orig);
 
   auto builder = SparseMatrixPolicy<double>::create(50);
   for (std::size_t i = 0; i < order; ++i)


### PR DESCRIPTION
Fixes a missing namespace in the linear solver tests