### PR TITLE
236 set up micm documentation builds and gh pages

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -10,9 +10,8 @@ jobs:
   build-and-deploy:
     name: Build and deploy to gh-pages
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           lfs: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project(
   micm
-  VERSION 3.1.0
+  VERSION 3.2.0
   LANGUAGES CXX
 )
 

--- a/README.md
+++ b/README.md
@@ -189,3 +189,7 @@ installation and usage instructions.
 - [Apache 2.0](/LICENSE)
 
 Copyright (C) 2018-2023 National Center for Atmospheric Research
+
+
+> **Note**
+> MICM 3.x.x is part of a refactor and may include breaking changes across minor revision numbers

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = f'2022-{datetime.datetime.now().year}, NCAR/UCAR'
 author = 'NCAR/UCAR'
 
 # The full version, including alpha/beta/rc tags
-release = '3.0.0'
+release = '3.2.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/switcher.json
+++ b/docs/switcher.json
@@ -1,6 +1,6 @@
 [
   {
-      "name": "v3.0.0 (stable)",
+      "name": "v3.2.0 (stable)",
       "version": "stable",
       "url": "https://ncar.github.io/micm/versions/stable"
   },

--- a/test/integration/analytical.cpp
+++ b/test/integration/analytical.cpp
@@ -1667,8 +1667,6 @@ TEST(AnalyticalExamples, Robertson)
   state.conditions_[0].pressure_ = pressure;
   state.conditions_[0].air_density_ = air_density;
 
-  size_t idx_A = 0, idx_B = 1, idx_C = 2;
-
   double time_step = 1.0;
   std::vector<double> times;
   times.push_back(0);


### PR DESCRIPTION
Closes #236, which really was already done. The main version of the docs **should** be released when we do the release