### PR TITLE
Develop 193 jit rate constants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ################################################################################
 # Preamble
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.21)
 
 project(
   micm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ################################################################################
 # Preamble
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.5)
 
 project(
   micm

--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -35,6 +35,10 @@ namespace micm
     /// @param processes The set of processes being solved
     /// @param state The solver state to update
     template<template<class> class MatrixPolicy>
+      requires(!VectorizableDense<MatrixPolicy<double>>)
+    static void UpdateState(const std::vector<Process>& processes, State<MatrixPolicy>& state);
+    template<template<class> class MatrixPolicy>
+      requires(VectorizableDense<MatrixPolicy<double>>)
     static void UpdateState(const std::vector<Process>& processes, State<MatrixPolicy>& state);
 
     friend class ProcessBuilder;
@@ -85,11 +89,12 @@ namespace micm
   };
 
   template<template<class> class MatrixPolicy>
+    requires(!VectorizableDense<MatrixPolicy<double>>)
   void Process::UpdateState(const std::vector<Process>& processes, State<MatrixPolicy>& state)
   {
     for (std::size_t i{}; i < state.custom_rate_parameters_.size(); ++i)
     {
-      std::vector<double> custom_parameters = state.custom_rate_parameters_[i];
+      const std::vector<double> custom_parameters = state.custom_rate_parameters_[i];
       std::vector<double>::const_iterator custom_parameters_iter = custom_parameters.begin();
       std::size_t i_rate_constant = 0;
       for (auto& process : processes)
@@ -97,6 +102,37 @@ namespace micm
         state.rate_constants_[i][(i_rate_constant++)] =
             process.rate_constant_->calculate(state.conditions_[i], custom_parameters_iter);
         custom_parameters_iter += process.rate_constant_->SizeCustomParameters();
+      }
+    }
+  }
+
+  template<template<class> class MatrixPolicy>
+    requires(VectorizableDense<MatrixPolicy<double>>)
+  void Process::UpdateState(const std::vector<Process>& processes, State<MatrixPolicy>& state)
+  {
+    const auto& v_custom_parameters = state.custom_rate_parameters_.AsVector();
+    auto& v_rate_constants = state.rate_constants_.AsVector();
+    const std::size_t L = state.rate_constants_.GroupVectorSize();
+    // loop over all rows
+    for (std::size_t i_group = 0; i_group < state.rate_constants_.NumberOfGroups(); ++i_group)
+    {
+      std::size_t offset_rc = i_group * state.rate_constants_.GroupSize();
+      std::size_t offset_params = i_group * state.custom_rate_parameters_.GroupSize();
+      for (auto& process : processes)
+      {
+        std::vector<double> params(process.rate_constant_->SizeCustomParameters());
+        for (std::size_t i_cell{}; i_cell < std::min(L, state.rate_constants_.size() - (i_group * L)); ++i_cell)
+        {
+          for (std::size_t i_param = 0; i_param < params.size(); ++i_param)
+          {
+            params[i_param] = v_custom_parameters[offset_params + i_param * L + i_cell];
+          }
+          std::vector<double>::const_iterator custom_parameters_iter = params.begin();
+          v_rate_constants[offset_rc + i_cell] =
+              process.rate_constant_->calculate(state.conditions_[i_group * L + i_cell], custom_parameters_iter);
+        }
+        offset_params += params.size() * L;
+        offset_rc += L;
       }
     }
   }

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -120,7 +120,7 @@ namespace micm
 
   std::string StateToString(const SolverState& state);
 
-  /// @brief An implementation of the Chapman mechnanism solver
+  /// @brief An implementation of the Rosenbrock ODE solver
   ///
   /// The template parameter is the type of matrix to use
   template<template<class> class MatrixPolicy = Matrix, template<class> class SparseMatrixPolicy = SparseMatrix>
@@ -202,9 +202,9 @@ namespace micm
     /// @param jacobian Jacobian matrix (dforce_dy)
     /// @param alpha
     void AlphaMinusJacobian(SparseMatrixPolicy<double>& jacobian, const double& alpha) const
-        requires(!VectorizableSparse<SparseMatrixPolicy<double>>);
+      requires(!VectorizableSparse<SparseMatrixPolicy<double>>);
     void AlphaMinusJacobian(SparseMatrixPolicy<double>& jacobian, const double& alpha) const
-        requires(VectorizableSparse<SparseMatrixPolicy<double>>);
+      requires(VectorizableSparse<SparseMatrixPolicy<double>>);
 
     /// @brief Update the rate constants for the environment state
     /// @param state The current state of the chemical system

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -520,10 +520,10 @@ namespace micm
       //  Limit H if necessary to avoid going beyond the specified chemistry time step
       H = std::min(H, std::abs(time_step - present_time));
 
-      // compute the concentrations at the current time
+      // compute the forcing at the beginning of the current time
       CalculateForcing(state.rate_constants_, Y, initial_forcing);
 
-      // compute the jacobian at the current time
+      // compute the jacobian at the beginning of the current time
       CalculateJacobian(state.rate_constants_, Y, jacobian_);
 
       bool accepted = false;

--- a/test/unit/process/CMakeLists.txt
+++ b/test/unit/process/CMakeLists.txt
@@ -6,6 +6,7 @@ include(test_util)
 ################################################################################
 # Tests
 
+create_standard_test(NAME process SOURCES test_process.cpp)
 create_standard_test(NAME process_set SOURCES test_process_set.cpp)
 create_standard_test(NAME arrhenius_rate_constant SOURCES test_arrhenius_rate_constant.cpp)
 create_standard_test(NAME branched_rate_constant SOURCES test_branched_rate_constant.cpp)

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -1,0 +1,87 @@
+// Copyright (C) 2023 National Center for Atmospheric Research,
+// SPDX-License-Identifier: Apache-2.0
+#include <gtest/gtest.h>
+
+#include <micm/process/arrhenius_rate_constant.hpp>
+#include <micm/process/process.hpp>
+#include <micm/process/surface_rate_constant.hpp>
+#include <micm/process/user_defined_rate_constant.hpp>
+#include <micm/util/matrix.hpp>
+#include <micm/util/vector_matrix.hpp>
+#include <random>
+
+template<template<class> class MatrixPolicy>
+void testProcessUpdateState(const std::size_t number_of_grid_cells)
+{
+  micm::Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }, { "diffusion coefficient [m2 s-1]", 2.3e2 } });
+  micm::ArrheniusRateConstant rc1({ .A_ = 12.2, .C_ = 300.0 });
+  micm::SurfaceRateConstant rc2({ .label_ = "foo_surf", .species_ = foo });
+  micm::UserDefinedRateConstant rc3({ .label_ = "bar_user" });
+
+  micm::Process r1 = micm::Process::create().rate_constant(rc1);
+  micm::Process r2 = micm::Process::create().rate_constant(rc2);
+  micm::Process r3 = micm::Process::create().rate_constant(rc3);
+  std::vector<micm::Process> processes = { r1, r2, r3 };
+
+  std::vector<std::string> param_labels{};
+  for (const auto& process : processes)
+    for (auto& label : process.rate_constant_->CustomParameters())
+      param_labels.push_back(label);
+  micm::State<MatrixPolicy> state{ micm::StateParameters{ .custom_rate_parameter_labels_ = param_labels,
+                                                          .number_of_grid_cells_ = number_of_grid_cells,
+                                                          .number_of_rate_constants_ = processes.size() } };
+
+  MatrixPolicy<double> expected_rate_constants(number_of_grid_cells, 3, 0.0);
+  std::vector<double> params = { 0.0, 0.0, 0.0 };
+  auto get_double = std::bind(std::lognormal_distribution(0.0, -4.0), std::default_random_engine());
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    state.conditions_[i_cell].temperature_ = get_double() * 285.0;
+    state.conditions_[i_cell].pressure_ = get_double() * 101100.0;
+    params[0] = get_double() * 1.0e-8;
+    params[1] = get_double() * 1.0e5;
+    params[2] = get_double() * 1.0e-2;
+    state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["foo_surf.effective radius [m]"]] = params[0];
+    state.custom_rate_parameters_[i_cell]
+                                 [state.custom_rate_parameter_map_["foo_surf.particle number concentration [# m-3]"]] =
+        params[1];
+    state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["bar_user"]] = params[2];
+    std::vector<double>::const_iterator param_iter = params.begin();
+    expected_rate_constants[i_cell][0] = rc1.calculate(state.conditions_[i_cell], param_iter);
+    param_iter += rc1.SizeCustomParameters();
+    expected_rate_constants[i_cell][1] = rc2.calculate(state.conditions_[i_cell], param_iter);
+    param_iter += rc2.SizeCustomParameters();
+    expected_rate_constants[i_cell][2] = rc3.calculate(state.conditions_[i_cell], param_iter);
+    param_iter += rc3.SizeCustomParameters();
+  }
+
+  micm::Process::UpdateState(processes, state);
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+    for (std::size_t i_rxn = 0; i_rxn < processes.size(); ++i_rxn)
+      EXPECT_EQ(state.rate_constants_[i_cell][i_rxn], expected_rate_constants[i_cell][i_rxn])
+          << "grid cell " << i_cell << "; reaction " << i_rxn;
+}
+
+template<class T>
+using Group1VectorMatrix = micm::VectorMatrix<T, 1>;
+template<class T>
+using Group2VectorMatrix = micm::VectorMatrix<T, 2>;
+template<class T>
+using Group3VectorMatrix = micm::VectorMatrix<T, 3>;
+template<class T>
+using Group4VectorMatrix = micm::VectorMatrix<T, 4>;
+
+TEST(Process, Matrix)
+{
+  testProcessUpdateState<micm::Matrix>(5);
+}
+
+TEST(Process, VectorMatrix)
+{
+  testProcessUpdateState<Group1VectorMatrix>(5);
+  testProcessUpdateState<Group2VectorMatrix>(5);
+  testProcessUpdateState<Group3VectorMatrix>(5);
+  testProcessUpdateState<Group4VectorMatrix>(5);
+}

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -33,7 +33,7 @@ void testProcessUpdateState(const std::size_t number_of_grid_cells)
 
   MatrixPolicy<double> expected_rate_constants(number_of_grid_cells, 3, 0.0);
   std::vector<double> params = { 0.0, 0.0, 0.0 };
-  auto get_double = std::bind(std::lognormal_distribution(0.0, -4.0), std::default_random_engine());
+  auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
 
   for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
   {


### PR DESCRIPTION
Adds a rate constant calculation function for `VectorMatrix`. I didn't add a JITed version of this function because there is no indirect addressing and so it probably wouldn't benefit from JIT compiling.

closes #193