### PR TITLE
Develop windows tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ int main(const int argc, const char *argv[])
 
   std::vector<Process> reactions{ r1, r2 };
 
-  RosenbrockSolver solver{ chemical_system, reactions, RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
+  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
 
   State state = solver.GetState();
 

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -143,7 +143,7 @@ namespace micm
   /// @brief An implementation of the Rosenbrock ODE solver
   ///
   /// The template parameter is the type of matrix to use
-  template<template<class> class MatrixPolicy = Matrix, template<class> class SparseMatrixPolicy = SparseMatrix>
+  template<template<class> class MatrixPolicy = Matrix, template<class> class SparseMatrixPolicy = StandardSparseMatrix>
   class RosenbrockSolver
   {
    public:

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -25,6 +25,12 @@ namespace micm
   template<class T, class OrderingPolicy>
   class SparseMatrixBuilder;
 
+  template<class T, class OrderingPolicy = SparseMatrixStandardOrdering>
+  class SparseMatrix;
+
+  template<class T>
+  using StandardSparseMatrix = SparseMatrix<T, SparseMatrixStandardOrdering>;
+
   /// @brief A sparse block-diagonal 2D matrix class with contiguous memory
   ///
   /// Each block sub-matrix is square and has the same structure of non-zero elements
@@ -33,7 +39,7 @@ namespace micm
   ///
   /// The template parameters are the type of the matrix elements and a class that
   /// defines the sizing and ordering of the data elements
-  template<class T, class OrderingPolicy = SparseMatrixStandardOrdering>
+  template<class T, class OrderingPolicy>
   class SparseMatrix : public OrderingPolicy
   {
     std::size_t number_of_blocks_;        // Number of block sub-matrices in the overall matrix

--- a/test/tutorial/test_README_example.cpp
+++ b/test/tutorial/test_README_example.cpp
@@ -5,9 +5,6 @@
 
 using namespace micm;
 
-template<class T>
-using SparseMatrixPolicy = SparseMatrix<T>;
-
 int main(const int argc, const char *argv[])
 {
   auto foo = Species{ "Foo" };
@@ -32,9 +29,7 @@ int main(const int argc, const char *argv[])
 
   std::vector<Process> reactions{ r1, r2 };
 
-  RosenbrockSolver<Matrix, SparseMatrixPolicy> solver{ chemical_system,
-                                                       reactions,
-                                                       RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
+  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
   solver.parameters_.print();
 
   State state = solver.GetState();

--- a/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
@@ -14,12 +14,6 @@
 // Use our namespace so that this example is easier to read
 using namespace micm;
 
-// The Rosenbrock solver can use many matrix ordering types
-// Here, we use the default ordering, but we still need to provide a templated
-// Arguent to the solver so it can use the proper ordering with any data type
-template<class T>
-using SparseMatrixPolicy = SparseMatrix<T>;
-
 void print_header()
 {
   std::cout << std::setw(5) << "time"
@@ -135,9 +129,9 @@ int main(const int argc, const char* argv[])
   auto chemical_system = System(micm::SystemParameters{ .gas_phase_ = gas_phase });
   auto reactions = std::vector<micm::Process>{ r1, r2, r3, r4, r5, r6, r7 };
 
-  RosenbrockSolver<Matrix, SparseMatrixPolicy> solver{ chemical_system,
-                                                       reactions,
-                                                       RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
+  RosenbrockSolver<> solver{ chemical_system,
+                             reactions,
+                             RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
   State state = solver.GetState();
 
   state.conditions_[0].temperature_ = 287.45;  // K

--- a/test/tutorial/test_rate_constants_no_user_defined_with_config.cpp
+++ b/test/tutorial/test_rate_constants_no_user_defined_with_config.cpp
@@ -15,12 +15,6 @@
 // Use our namespace so that this example is easier to read
 using namespace micm;
 
-// The Rosenbrock solver can use many matrix ordering types
-// Here, we use the default ordering, but we still need to provide a templated
-// Arguent to the solver so it can use the proper ordering with any data type
-template<class T>
-using SparseMatrixPolicy = SparseMatrix<T>;
-
 void print_header()
 {
   std::cout << std::setw(5) << "time"
@@ -68,9 +62,9 @@ int main(const int argc, const char* argv[])
   auto chemical_system = solver_params.system_;
   auto reactions = solver_params.processes_;
 
-  RosenbrockSolver<Matrix, SparseMatrixPolicy> solver{ chemical_system,
-                                                       reactions,
-                                                       RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
+  RosenbrockSolver<> solver{ chemical_system,
+                             reactions,
+                             RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
 
   State state = solver.GetState();
 


### PR DESCRIPTION
Adds a `StandardSparseMatrix` alias to the `micm` namespace to simplify tutorial examples.

The docs are available [here](https://ncar.github.io/micm/branch/develop-windows-tutorial/user_guide/index.html)