### PR TITLE
157 steal the tests from the json library to test xcode builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,9 +98,76 @@ jobs:
           mkdir build
           cd build
           cmake ..
-          cmake --build .
+          cmake --build . --parallel 10
 
       - name: Run tests
         run: |
           cd build
           ctest -C Debug --rerun-failed --output-on-failure . --verbose
+
+  xcode_1:
+    runs-on: macos-11
+    strategy:
+      matrix:
+        xcode: ['11.7', '12.4', '12.5.1', '13.0']
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure and build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build . --parallel 10
+
+      - name: Run tests
+        run: |
+          cd build
+          ctest --rerun-failed --output-on-failure . --verbose -j 10
+
+  xcode_2:
+    runs-on: macos-12
+    strategy:
+      matrix:
+        xcode: ['13.1', '13.2.1', '13.3.1', '13.4.1', '14.0', '14.0.1', '14.1']
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure and build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build . --parallel 10
+
+      - name: Run tests
+        run: |
+          cd build
+          ctest --rerun-failed --output-on-failure . --verbose -j 10
+
+  xcode_standards:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        standard: [11, 14, 17, 20, 23]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure and build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build . --parallel 10
+
+      - name: Run tests
+        run: |
+          cd build
+          ctest --rerun-failed --output-on-failure . --verbose -j 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,29 +106,6 @@ jobs:
           ctest -C Debug --rerun-failed --output-on-failure . --verbose
 
   xcode_1:
-    runs-on: macos-11
-    strategy:
-      matrix:
-        xcode: ['11.7', '12.4', '12.5.1', '13.0']
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Configure and build
-        run: |
-          mkdir build
-          cd build
-          cmake ..
-          cmake --build . --parallel 10
-
-      - name: Run tests
-        run: |
-          cd build
-          ctest --rerun-failed --output-on-failure . --verbose -j 10
-
-  xcode_2:
     runs-on: macos-12
     strategy:
       matrix:
@@ -151,11 +128,13 @@ jobs:
           cd build
           ctest --rerun-failed --output-on-failure . --verbose -j 10
 
-  xcode_standards:
-    runs-on: macos-latest
+  xcode_2:
+    runs-on: macos-13
     strategy:
       matrix:
-        standard: [11, 14, 17, 20, 23]
+        xcode: ['14.1', '14.2', '14.3.1', '15.0']
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           # - Dockerfile.mpi
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -77,7 +77,7 @@ jobs:
       CXX: ${{ matrix.compiler.cpp }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install CMake
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
This adds tests that build on macos 12 and 13 with different versions

This would close #157, though I don't actually know if we need these or not. Feel free to reject this if you think these are superfluous