### PR TITLE
adding code of conduct and contributors guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+musica-support@ucar.edu.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ cutting edge science.
   - Anyone interested in scientific collaboration
 which would add new software functionality should read the [MUSICA software development plan](https://github.com/NCAR/musica/blob/main/docs/Software%20Development%20Plan.pdf).
 
-- [Code of conduct]
+- [Code of conduct](CODE_OF_CONDUCT.md)
   - Please read this through to you understand the expectations with how to interact with this project.
 
-- [Contributor's guide]
+- [Contributor's guide](https://ncar.github.io/micm/contributing/index.html)
   - Before submiitting a PR, please thouroughly read this to you understand our expectations. We reserve the right to reject any PR not meeting our guidelines.
 
 

--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -53,7 +53,7 @@ Building the documentation
 --------------------------
 
 All of our docs are stored in the ``docs`` directory. There are several python dependencies that need to install. To make 
-this easy, we provide a ``reuirements.txt`` file that you can use to install. 
+this easy, we provide a ``requirements.txt`` file that you can use to install. 
 
 Virtualenv
 ^^^^^^^^^^

--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -3,11 +3,99 @@ Contributing
 ============
 
 For all proposed changes (bug fixes, new feature, documentation upates, etc.) please file
-and [issue](https://github.com/NCAR/micm/issues/new/choose) detailing what your ask is or what you intend to do.
+an `issue <https://github.com/NCAR/micm/issues/new/choose>`_ detailing what your ask is or what you intend to do.
 
 The NCAR software developers will work with you on that issue to help recommend implementations, work through questions,
 or provide other background knowledge.
 
+Testing
+-------
+
 Any code that you contribute must include associated unit tests or an integration test of some kind. Our tests run across
 various platforms and with different configurations automatically. By including tests that exercise your code, you help to
-minimize the amount of time debugging platform portability issues.
+minimize the amount of time debugging platform portability issues. Further, new features must include at least an example
+in our documentation.
+
+MICM collects code coverage statistics which is displayed on our homepage in a little badge
+
+.. image:: https://codecov.io/gh/NCAR/micm/branch/main/graph/badge.svg?token=ATGO4DKTMY
+    :target: https://codecov.io/gh/NCAR/micm
+    :alt: codecov badge
+
+This coverage is also reported from the code cov bot in most PRs, like `this one <https://github.com/NCAR/micm/pull/105>`_.
+The coverage amount from any PR must not drop because of code that you add. This means that added code is required to be tested.
+We don't require your code to have 100% test coverage since some edge cases (like poor configurations) or platforms (like GPUs)
+may not be testable in the github runners, but at minimum you must not remove test coverage where it exists.
+
+Style guide
+-----------
+We (mostly) follow the `Google C++ style guide <https://google.github.io/styleguide/cppguide.html>`_. Please attempt to do 
+the same to minimize comments on PRs. However, we are not dogmatic and reasonable exceptions are allowed, especially where they
+help to simplify code or API intefaces.
+
+After each PR is pulled, we have an automated github action that runs ``clang-format`` over our codebase, so don't worry too much
+about formatting your code. Some of that format may be removed anyway. No format configuration is liked by everyone, but the use
+of ``clang-format`` enforces some consistency which means moving from file to file shouldn't have a large congitive load on the developer.
+
+Setting up developer environments
+---------------------------------
+
+macOS
+^^^^^
+
+Linux
+^^^^^
+
+Windows
+^^^^^^^
+
+Building the documentation
+--------------------------
+
+All of our docs are stored in the ``docs`` directory. There are several python dependencies that need to install. To make 
+this easy, we provide a ``reuirements.txt`` file that you can use to install. 
+
+Virtualenv
+^^^^^^^^^^
+
+From the root directory of micm:
+
+.. code-block:: bash
+
+  pip install virtualenv 
+  virtualenv micm_env
+  source micm_env/bin/activate
+  cd docs 
+  pip install -r requirements.txt
+  cd .. && mkdir build && cd build
+  cmake -DBUILD_DOCS=ON ..
+  make docs
+  open docs/sphinx/index.html 
+
+Venv
+^^^^
+
+.. code-block:: bash
+
+  python -m venv micm_env
+  source micm_env/bin/activate
+  cd docs 
+  pip install -r requirements.txt
+  cd .. && mkdir build && cd build
+  cmake -DBUILD_DOCS=ON ..
+  make docs
+  open docs/sphinx/index.html 
+
+Conda
+^^^^^
+
+.. code-block:: bash
+
+  conda create --name micm_env python=3.8 -y
+  conda activate micm_env
+  cd docs 
+  pip install -r requirements.txt
+  cd .. && mkdir build && cd build
+  cmake -DBUILD_DOCS=ON ..
+  make docs
+  open docs/sphinx/index.html 

--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -11,7 +11,7 @@ or provide other background knowledge.
 Testing
 -------
 
-Any code that you contribute must include associated unit tests or an integration test of some kind. Our tests run across
+Any code that you contribute must include associated unit tests and an integration test of some kind. Our tests run across
 various platforms and with different configurations automatically. By including tests that exercise your code, you help to
 minimize the amount of time debugging platform portability issues. Further, new features must include at least an example
 in our documentation.

--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -1,3 +1,13 @@
 
 Contributing
 ============
+
+For all proposed changes (bug fixes, new feature, documentation upates, etc.) please file
+and [issue](https://github.com/NCAR/micm/issues/new/choose) detailing what your ask is or what you intend to do.
+
+The NCAR software developers will work with you on that issue to help recommend implementations, work through questions,
+or provide other background knowledge.
+
+Any code that you contribute must include associated unit tests or an integration test of some kind. Our tests run across
+various platforms and with different configurations automatically. By including tests that exercise your code, you help to
+minimize the amount of time debugging platform portability issues.

--- a/docs/source/user_guide/rate_constant_tutorial.rst
+++ b/docs/source/user_guide/rate_constant_tutorial.rst
@@ -152,7 +152,7 @@ Finally, we are ready to pick a timestep and solve the system.
 
   .. literalinclude:: ../../../test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
     :language: cpp
-    :lines: 157-183
+    :lines: 149-173
 
 
 This is the output:


### PR DESCRIPTION
Closes #276

Docs can be viewed here: https://ncar.github.io/micm/branch/276-add-code-of-conduct-and-contributor-guide/contributing/index.html