### PR TITLE
hopefully copying the switcher

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -67,13 +67,13 @@ jobs:
           docker cp $id:/build/docs/sphinx tmpdocs
           docker rm -v $id
           mv tmpdocs _build/html/versions/stable
-          mv docs/switcher.json _build/html
           # Delete everything under _gh-pages/ that is from the
           # primary branch deployment.  Excludes the other branches
           # _gh-pages/branch-* paths, and not including
           # _gh-pages itself.
           find _gh-pages/ -mindepth 1 ! -path '_gh-pages/branch*' ! -path '_gh-pages/versions*' -delete
           rsync -a _build/html/versions/stable/* _gh-pages/
+          mv docs/switcher.json _gh-pages
 
       # If a push and not on default branch, then copy the build to
       # _gh-pages/branch/$brname (transforming '/' into '--')


### PR DESCRIPTION
The switcher on the [docs](https://ncar.github.io/micm/) doesn't work because the switcher.json file isn't copied correctly. Hopefully this fixes it.

You can see that the switcher [doesn't exist at the root of the branch where it needs to be](https://github.com/NCAR/micm/tree/gh-pages).