### PR TITLE
Fix set concentrations mapping error

### DIFF
--- a/include/micm/solver/state.hpp
+++ b/include/micm/solver/state.hpp
@@ -49,7 +49,6 @@ namespace micm
     /// @brief Set species' concentrations
     /// @param species_to_concentration
     void SetConcentrations(
-        const System& system,
         const std::unordered_map<std::string, std::vector<double>>& species_to_concentration);
 
     /// @brief Set a single species concentration

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -51,7 +51,6 @@ namespace micm
 
   template<template<class> class MatrixPolicy>
   inline void State<MatrixPolicy>::SetConcentrations(
-      const System& system,
       const std::unordered_map<std::string, std::vector<double>>& species_to_concentration)
   {
     const int num_grid_cells = conditions_.size();

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -54,64 +54,17 @@ namespace micm
       const System& system,
       const std::unordered_map<std::string, std::vector<double>>& species_to_concentration)
   {
-    int num_set_grid_cells = 0;
-    unsigned num_species = system.gas_phase_.species_.size();
-
-    std::vector<int> num_concentrations_per_species;
-    num_concentrations_per_species.reserve(num_species);
-
-    // Iterate map to store the number of concentration values corresponding to the number of set of grid cells
-    for (auto& species : system.gas_phase_.species_)
-    {
-      auto species_ptr = species_to_concentration.find(species.name_);
-      if (species_ptr == species_to_concentration.end())
-      {
-        throw std::runtime_error("Concentration value(s) for '" + species.name_ + "' must be given.");
-      }
-      num_concentrations_per_species.push_back(species_ptr->second.size());
-    }
-
-    // Check if number of concentraiton inputs are the same for all species
-    if (!std::all_of(
-            num_concentrations_per_species.begin(),
-            num_concentrations_per_species.end(),
-            [&](int& i) { return i == num_concentrations_per_species.front(); }))
-    {
-      throw std::runtime_error("Concentration value must be given to all sets of grid cells.");
-    }
-
-    num_set_grid_cells = num_concentrations_per_species[0];
-
-    // Find species and iterate through the keys to store concentrations for each set of grid cells
-    // 'concentrations' represents an N-D array in contiguous memory (N = num_set_grid_cells)
-    std::vector<double> concentrations;
-    concentrations.resize(num_species * num_set_grid_cells);
-
-    for (int i = 0; i < num_species; i++)
-    {
-      auto species_ptr = species_to_concentration.find(system.gas_phase_.species_[i].name_);
-
-      for (int j = 0; j < num_set_grid_cells; j++)
-      {
-        concentrations[i + num_species * j] = species_ptr->second[j];
-      }
-    }
-
-    // Extract sub vector to assign to the corresponding set of grid cells.
-    std::vector<double> sub_concentrations;
-    sub_concentrations.reserve(num_species);
-
-    for (int i = 0; i < num_set_grid_cells; i++)
-    {
-      sub_concentrations = { concentrations.begin() + (num_species * i),
-                             concentrations.begin() + (num_species * i) + num_species };
-      variables_[i] = sub_concentrations;
-    }
+    const int num_grid_cells = conditions_.size();
+    for (const auto& pair : species_to_concentration)
+      SetConcentration({ pair.first }, pair.second);
   }
 
   template<template<class> class MatrixPolicy>
   inline void State<MatrixPolicy>::SetConcentration(const Species& species, double concentration)
   {
+    auto var = variable_map_.find(species.name_);
+    if (var == variable_map_.end())
+      throw std::invalid_argument("Unknown variable '" + species.name_ + "'");
     if (variables_.size() != 1)
       throw std::invalid_argument("Incorrect number of concentration values passed to multi-gridcell State");
     variables_[0][variable_map_[species.name_]] = concentration;
@@ -120,6 +73,9 @@ namespace micm
   template<template<class> class MatrixPolicy>
   inline void State<MatrixPolicy>::SetConcentration(const Species& species, const std::vector<double>& concentration)
   {
+    auto var = variable_map_.find(species.name_);
+    if (var == variable_map_.end())
+      throw std::invalid_argument("Unknown variable '" + species.name_ + "'");
     if (variables_.size() != concentration.size())
       throw std::invalid_argument("Incorrect number of concentration values passed to multi-gridcell State");
     std::size_t i_species = variable_map_[species.name_];

--- a/test/integration/chapman.cpp
+++ b/test/integration/chapman.cpp
@@ -46,7 +46,7 @@ TEST(ChapmanIntegration, CanBuildChapmanSystemUsingConfig)
     { "Ar", { 0.2 } }, { "N2", { 0.3 } },  { "H2O", { 0.3 } }, { "CO2", { 0.3 } }
   };
 
-  state.SetConcentrations(solver_params.system_, concentrations);
+  state.SetConcentrations(concentrations);
 
   // User gives an input of photolysis rate constants
   std::unordered_map<std::string, std::vector<double>> photo_rates = { { "PHOTO.O2_1", { 0.1 } },

--- a/test/tutorial/test_rate_constants_no_user_defined_with_config.cpp
+++ b/test/tutorial/test_rate_constants_no_user_defined_with_config.cpp
@@ -79,7 +79,7 @@ int main(const int argc, const char* argv[])
     { "G", { 0.0 } },  // mol m-3
   };
 
-  state.SetConcentrations(solver_params.system_, intial_concentration);
+  state.SetConcentrations(intial_concentration);
 
   state.SetCustomRateParameter("SURF.C surface.effective radius [m]", 1e-7);
   state.SetCustomRateParameter("SURF.C surface.particle number concentration [# m-3]", 2.5e6);

--- a/test/tutorial/test_rate_constants_user_defined_with_config.cpp
+++ b/test/tutorial/test_rate_constants_user_defined_with_config.cpp
@@ -87,7 +87,7 @@ int main(const int argc, const char* argv[])
     { "G", { 0.0 } },  // mol m-3
   };
 
-  state.SetConcentrations(solver_params.system_, intial_concentration);
+  state.SetConcentrations(intial_concentration);
 
   state.SetCustomRateParameter("SURF.C surface.effective radius [m]", 1e-7);
   state.SetCustomRateParameter("SURF.C surface.particle number concentration [# m-3]", 2.5e6);

--- a/test/unit/solver/test_state.cpp
+++ b/test/unit/solver/test_state.cpp
@@ -69,12 +69,7 @@ TEST(State, SettingConcentrationsWithInvalidArguementsThrowsException)
     { "FUU", { 0.1 } }, { "bar", { 0.2 } }, { "baz", { 0.3 } }, { "quz", { 0.4 } }
   };
 
-  // Build system
-  micm::Phase gas_phase(
-      std::vector<micm::Species>{ micm::Species("foo"), micm::Species("bar"), micm::Species("baz"), micm::Species("quz") });
-  micm::System system{ micm::SystemParameters{ gas_phase } };
-
-  EXPECT_ANY_THROW(state.SetConcentrations(system, concentrations));
+  EXPECT_ANY_THROW(state.SetConcentrations(concentrations));
 }
 
 TEST(State, SetConcentrations)
@@ -87,17 +82,12 @@ TEST(State, SetConcentrations)
                                                           .number_of_grid_cells_ = num_grid_cells,
                                                           .number_of_rate_constants_ = 10 } };
 
-  // Build system
-  micm::Phase gas_phase(
-      std::vector<micm::Species>{ micm::Species("foo"), micm::Species("bar"), micm::Species("baz"), micm::Species("quz") });
-  micm::System system{ micm::SystemParameters{ gas_phase } };
-
   std::unordered_map<std::string, std::vector<double>> concentrations = { { "bar", { 0.2, 0.22, 0.222 } },
                                                                           { "baz", { 0.3, 0.33, 0.333 } },
                                                                           { "foo", { 0.9, 0.99, 0.999 } },
                                                                           { "quz", { 0.4, 0.44, 0.444 } } };
 
-  state.SetConcentrations(system, concentrations);
+  state.SetConcentrations(concentrations);
 
   // Compare concentration values
   std::vector<double> concentrations_in_order{


### PR DESCRIPTION
closes #296 

Removing the `System` argument from `SetConcentrations()` means there is no easy way for this bug to pop up again, so I didn't see the need to add an additional test.