### PR TITLE
Develop 245 terminator

### DIFF
--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -50,9 +50,11 @@ namespace micm
     double rejection_factor_decrease_{ 0.1 };                     // used to decrease the step after 2 successive rejections
     double safety_factor_{ 0.9 };                                 // safety factor in new step size computation
 
-    double h_min_{ 0 };        // step size min
-    double h_max_{ 0.5 };      // step size max
-    double h_start_{ 0.005 };  // step size start
+    double h_min_{ 0.0 };  // step size min [s]
+    double h_max_{
+      0.0
+    };  // step size max [s] (if zero or greater than the solver time-step, the time-step passed to the solver will be used)
+    double h_start_{ 0.0 };  // step size start [s] (if zero, 1.0e-6 will be used, if greater than h_max, h_max will be used)
 
     // Does the stage i require a new function evaluation (ros_NewF(i)=TRUE)
     // or does it re-use the function evaluation from stage i-1 (ros_NewF(i)=FALSE)
@@ -173,7 +175,8 @@ namespace micm
       uint64_t decompositions{};
       /// @brief The number of linear solvers
       uint64_t solves{};
-      /// @brief The number of times a singular matrix is detected. For now, this will always be zero as we assume the matrix is never singular
+      /// @brief The number of times a singular matrix is detected. For now, this will always be zero as we assume the matrix
+      /// is never singular
       uint64_t singular{};
       /// @brief The cumulative amount of time spent calculating the forcing function
       std::chrono::duration<double, std::nano> total_forcing_time{};

--- a/include/micm/system/phase.hpp
+++ b/include/micm/system/phase.hpp
@@ -49,5 +49,21 @@ namespace micm
       species_ = other.species_;
       return *this;
     }
+
+    /// @brief Returns the number of non-parameterized species
+    std::size_t StateSize() const
+    {
+      return std::count_if(species_.begin(), species_.end(), [](const Species& s) { return !s.IsParameterized(); });
+    }
+
+    /// @brief Returns a set of unique names for each non-parameterized species
+    std::vector<std::string> UniqueNames() const
+    {
+      std::vector<std::string> names{};
+      for (const auto& species : species_)
+        if (!species.IsParameterized())
+          names.push_back(species.name_);
+      return names;
+    }
   };
 }  // namespace micm

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -47,6 +47,9 @@ namespace micm
 
     /// @brief Returns whether a species is parameterized
     bool IsParameterized() const;
+
+    /// @brief Return a Species instance parameterized on air density
+    static Species ThirdBody();
   };
 
   inline Species& Species::operator=(const Species& other)
@@ -80,4 +83,10 @@ namespace micm
     return parameterize_ != nullptr;
   }
 
+  inline Species Species::ThirdBody()
+  {
+    Species third_body{ "M" };
+    third_body.parameterize_ = [](const Conditions& c) { return c.air_density_; };
+    return third_body;
+  }
 }  // namespace micm

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -3,8 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <functional>
 #include <string>
 #include <vector>
+
+#include "conditions.hpp"
 
 namespace micm
 {
@@ -18,6 +21,12 @@ namespace micm
 
     /// @brief A list of properties of this species
     std::map<std::string, double> properties_;
+
+    /// @brief A function that if provided will be used to parameterize
+    ///        the concentration of this species during solving.
+    ///        Species with this function defined will be excluded from
+    ///        the solver state.
+    std::function<double(const Conditions)> parameterize_{ nullptr };
 
     /// @brief Copy assignment
     /// @param other species to copy
@@ -35,6 +44,9 @@ namespace micm
     /// @param name The name of the species
     /// @param properties The properties of the species
     Species(const std::string& name, const std::map<std::string, double>& properties);
+
+    /// @brief Returns whether a species is parameterized
+    bool IsParameterized() const;
   };
 
   inline Species& Species::operator=(const Species& other)
@@ -46,13 +58,15 @@ namespace micm
 
     name_ = other.name_;
     properties_ = other.properties_;  // This performs a shallow copy
+    parameterize_ = other.parameterize_;
 
     return *this;
   }
 
   inline Species::Species(const Species& other)
       : name_(other.name_),
-        properties_(other.properties_){};
+        properties_(other.properties_),
+        parameterize_(other.parameterize_){};
 
   inline Species::Species(const std::string& name)
       : name_(name){};
@@ -60,5 +74,10 @@ namespace micm
   inline Species::Species(const std::string& name, const std::map<std::string, double>& properties)
       : name_(name),
         properties_(properties){};
+
+  inline bool Species::IsParameterized() const
+  {
+    return parameterize_ != nullptr;
+  }
 
 }  // namespace micm

--- a/include/micm/system/system.hpp
+++ b/include/micm/system/system.hpp
@@ -92,10 +92,10 @@ namespace micm
 
   inline size_t System::StateSize() const
   {
-    size_t state_size = gas_phase_.species_.size();
+    size_t state_size = gas_phase_.StateSize();
     for (const auto& phase : phases_)
     {
-      state_size += phase.second.species_.size();
+      state_size += phase.second.StateSize();
     }
     return state_size;
   }
@@ -108,17 +108,11 @@ namespace micm
   inline std::vector<std::string> System::UniqueNames(
       const std::function<std::string(const std::vector<std::string>& variables, const std::size_t i)> f) const
   {
-    std::vector<std::string> names{};
-    for (auto& species : gas_phase_.species_)
-    {
-      names.push_back(species.name_);
-    }
+    std::vector<std::string> names = gas_phase_.UniqueNames();
     for (auto& phase : phases_)
     {
-      for (auto& species : phase.second.species_)
-      {
-        names.push_back(phase.first + "." + species.name_);
-      }
+      for (auto& species_name : phase.second.UniqueNames())
+        names.push_back(phase.first + "." + species_name);
     }
     if (f)
     {

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -8,6 +8,7 @@ include(test_util)
 
 create_standard_test(NAME chapman_integration SOURCES chapman.cpp)
 create_standard_test(NAME analytical_rosenbrock_integration SOURCES analytical_rosenbrock.cpp)
+create_standard_test(NAME terminator_integration SOURCES terminator.cpp)
 
 if(ENABLE_LLVM)
   create_standard_test(NAME analytical_jit_rosenbrock_integration SOURCES analytical_jit_rosenbrock.cpp)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -12,4 +12,5 @@ create_standard_test(NAME terminator_integration SOURCES terminator.cpp)
 
 if(ENABLE_LLVM)
   create_standard_test(NAME analytical_jit_rosenbrock_integration SOURCES analytical_jit_rosenbrock.cpp)
+  create_standard_test(NAME jit_terminator_integration SOURCES jit_terminator.cpp)
 endif()

--- a/test/integration/jit_terminator.cpp
+++ b/test/integration/jit_terminator.cpp
@@ -1,0 +1,69 @@
+#include <gtest/gtest.h>
+
+#include <micm/process/process.hpp>
+#include <micm/solver/jit_rosenbrock.hpp>
+#include <micm/system/system.hpp>
+#include <micm/util/sparse_matrix.hpp>
+#include <micm/util/sparse_matrix_vector_ordering.hpp>
+#include <micm/util/vector_matrix.hpp>
+
+#include "terminator.hpp"
+
+template<std::size_t number_of_grid_cells, template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+void RunTerminatorTest()
+{
+  TestTerminator<
+      MatrixPolicy,
+      micm::JitRosenbrockSolver<
+          MatrixPolicy,
+          SparseMatrixPolicy,
+          micm::JitLinearSolver<number_of_grid_cells, SparseMatrixPolicy>>>(
+      [&](const micm::System& s, const std::vector<micm::Process>& p)
+          -> micm::JitRosenbrockSolver<
+              MatrixPolicy,
+              SparseMatrixPolicy,
+              micm::JitLinearSolver<number_of_grid_cells, SparseMatrixPolicy>>
+      {
+        auto jit{ micm::JitCompiler::create() };
+        if (auto err = jit.takeError())
+        {
+          llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
+          EXPECT_TRUE(false);
+        }
+        auto solver_params = micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells, true);
+        solver_params.absolute_tolerance_ = 1.0e-20;
+        solver_params.relative_tolerance_ = 1.0e-8;
+        solver_params.max_number_of_steps_ = 100000;
+        return micm::JitRosenbrockSolver<
+            MatrixPolicy,
+            SparseMatrixPolicy,
+            micm::JitLinearSolver<number_of_grid_cells, SparseMatrixPolicy>>{ jit.get(), s, p, solver_params };
+      },
+      number_of_grid_cells);
+}
+
+template<class T>
+using Group1VectorMatrix = micm::VectorMatrix<T, 1>;
+template<class T>
+using Group2VectorMatrix = micm::VectorMatrix<T, 2>;
+template<class T>
+using Group3VectorMatrix = micm::VectorMatrix<T, 3>;
+template<class T>
+using Group4VectorMatrix = micm::VectorMatrix<T, 4>;
+
+template<class T>
+using Group1SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
+template<class T>
+using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
+template<class T>
+using Group3SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
+template<class T>
+using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+
+TEST(JitRosenbrockSolver, Terminator)
+{
+  RunTerminatorTest<1, Group1VectorMatrix, Group1SparseVectorMatrix>();
+  RunTerminatorTest<2, Group2VectorMatrix, Group2SparseVectorMatrix>();
+  RunTerminatorTest<3, Group3VectorMatrix, Group3SparseVectorMatrix>();
+  RunTerminatorTest<4, Group4VectorMatrix, Group4SparseVectorMatrix>();
+}

--- a/test/integration/terminator.cpp
+++ b/test/integration/terminator.cpp
@@ -2,17 +2,36 @@
 
 #include <gtest/gtest.h>
 
+#include <micm/process/process.hpp>
+#include <micm/solver/rosenbrock.hpp>
+#include <micm/system/system.hpp>
 #include <micm/util/matrix.hpp>
 #include <micm/util/sparse_matrix.hpp>
 #include <micm/util/sparse_matrix_vector_ordering.hpp>
 #include <micm/util/vector_matrix.hpp>
 
+template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
+void RunTerminatorTest(std::size_t number_of_grid_cells)
+{
+  TestTerminator<MatrixPolicy, micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>>(
+      [&](const micm::System& s, const std::vector<micm::Process>& p)
+          -> micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>
+      {
+        auto solver_params = micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells, true);
+        solver_params.absolute_tolerance_ = 1.0e-20;
+        solver_params.relative_tolerance_ = 1.0e-8;
+        solver_params.max_number_of_steps_ = 100000;
+        return micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>{ s, p, solver_params };
+      },
+      number_of_grid_cells);
+}
+
 TEST(RosenbrockSolver, Terminator)
 {
-  TestTerminator<micm::Matrix, micm::SparseMatrix, micm::LinearSolver<double, micm::SparseMatrix>>(1);
-  TestTerminator<micm::Matrix, micm::SparseMatrix, micm::LinearSolver<double, micm::SparseMatrix>>(2);
-  TestTerminator<micm::Matrix, micm::SparseMatrix, micm::LinearSolver<double, micm::SparseMatrix>>(3);
-  TestTerminator<micm::Matrix, micm::SparseMatrix, micm::LinearSolver<double, micm::SparseMatrix>>(4);
+  RunTerminatorTest<micm::Matrix, micm::SparseMatrix, micm::LinearSolver<double, micm::SparseMatrix>>(2);
+  RunTerminatorTest<micm::Matrix, micm::SparseMatrix, micm::LinearSolver<double, micm::SparseMatrix>>(2);
+  RunTerminatorTest<micm::Matrix, micm::SparseMatrix, micm::LinearSolver<double, micm::SparseMatrix>>(3);
+  RunTerminatorTest<micm::Matrix, micm::SparseMatrix, micm::LinearSolver<double, micm::SparseMatrix>>(4);
 }
 
 template<class T>
@@ -35,8 +54,8 @@ using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorO
 
 TEST(RosenbrockSolver, VectorTerminator)
 {
-  TestTerminator<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<double, Group1SparseVectorMatrix>>(1);
-  TestTerminator<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<double, Group2SparseVectorMatrix>>(4);
-  TestTerminator<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<double, Group3SparseVectorMatrix>>(3);
-  TestTerminator<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<double, Group4SparseVectorMatrix>>(2);
+  RunTerminatorTest<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<double, Group1SparseVectorMatrix>>(1);
+  RunTerminatorTest<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<double, Group2SparseVectorMatrix>>(4);
+  RunTerminatorTest<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<double, Group3SparseVectorMatrix>>(3);
+  RunTerminatorTest<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<double, Group4SparseVectorMatrix>>(2);
 }

--- a/test/integration/terminator.cpp
+++ b/test/integration/terminator.cpp
@@ -1,0 +1,42 @@
+#include "terminator.hpp"
+
+#include <gtest/gtest.h>
+
+#include <micm/util/matrix.hpp>
+#include <micm/util/sparse_matrix.hpp>
+#include <micm/util/sparse_matrix_vector_ordering.hpp>
+#include <micm/util/vector_matrix.hpp>
+
+TEST(RosenbrockSolver, Terminator)
+{
+  TestTerminator<micm::Matrix, micm::SparseMatrix, micm::LinearSolver<double, micm::SparseMatrix>>(1);
+  TestTerminator<micm::Matrix, micm::SparseMatrix, micm::LinearSolver<double, micm::SparseMatrix>>(2);
+  TestTerminator<micm::Matrix, micm::SparseMatrix, micm::LinearSolver<double, micm::SparseMatrix>>(3);
+  TestTerminator<micm::Matrix, micm::SparseMatrix, micm::LinearSolver<double, micm::SparseMatrix>>(4);
+}
+
+template<class T>
+using Group1VectorMatrix = micm::VectorMatrix<T, 1>;
+template<class T>
+using Group2VectorMatrix = micm::VectorMatrix<T, 2>;
+template<class T>
+using Group3VectorMatrix = micm::VectorMatrix<T, 3>;
+template<class T>
+using Group4VectorMatrix = micm::VectorMatrix<T, 4>;
+
+template<class T>
+using Group1SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
+template<class T>
+using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
+template<class T>
+using Group3SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
+template<class T>
+using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+
+TEST(RosenbrockSolver, VectorTerminator)
+{
+  TestTerminator<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<double, Group1SparseVectorMatrix>>(1);
+  TestTerminator<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<double, Group2SparseVectorMatrix>>(4);
+  TestTerminator<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<double, Group3SparseVectorMatrix>>(3);
+  TestTerminator<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<double, Group4SparseVectorMatrix>>(2);
+}

--- a/test/integration/terminator.hpp
+++ b/test/integration/terminator.hpp
@@ -1,0 +1,100 @@
+#include <gtest/gtest.h>
+#include <math.h>
+
+#include <micm/process/arrhenius_rate_constant.hpp>
+#include <micm/process/process.hpp>
+#include <micm/process/user_defined_rate_constant.hpp>
+#include <micm/solver/rosenbrock.hpp>
+#include <micm/solver/state.hpp>
+#include <micm/system/phase.hpp>
+#include <micm/system/system.hpp>
+#include <random>
+#include <utility>
+#include <vector>
+
+/// @brief A test of the "Terminator" mechanism:
+///
+/// Cl2 --hv--> 2 Cl
+/// Cl + Cl + M --> Cl2 + M
+///
+/// More details including analytical solution can be found here:
+/// https://github.com/ESCOMP/CAM/blob/8cd44c50fe107c0b93ccd48b61eaa3d10a5b4e2f/src/chemistry/pp_terminator/chemistry.F90#L1-L434
+template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
+void TestTerminator(std::size_t number_of_grid_cells)
+{
+  auto cl2 = micm::Species("Cl2");
+  auto cl = micm::Species("Cl");
+  auto m = micm::Species::ThirdBody();
+
+  micm::Phase gas_phase{ std::vector<micm::Species>{ cl2, cl, m } };
+
+  micm::Process toy_r1 = micm::Process::create()
+                             .reactants({ cl2 })
+                             .products({ micm::Yield(cl, 2.0) })
+                             .phase(gas_phase)
+                             .rate_constant(micm::UserDefinedRateConstant({ .label_ = "toy_k1" }));
+
+  constexpr double k2 = 1.0e-6;  // 1.0;
+  micm::Process toy_r2 = micm::Process::create()
+                             .reactants({ cl, cl, m })
+                             .products({ micm::Yield(cl2, 1.0) })
+                             .phase(gas_phase)
+                             .rate_constant(micm::ArrheniusRateConstant({ .A_ = k2 }));
+
+  micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> solver{
+    micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }),
+    std::vector<micm::Process>{ toy_r1, toy_r2 },
+    micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells, true)
+  };
+
+  micm::State<MatrixPolicy> state = solver.GetState();
+
+  auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
+  std::unordered_map<std::string, std::vector<double>> concentrations{ { "Cl2", {} }, { "Cl", {} } };
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    concentrations["Cl2"].push_back(get_double() * 1.0e-6);
+    concentrations["Cl"].push_back(get_double() * 1.0e-10);
+  }
+  state.SetConcentrations(concentrations);
+
+  std::unordered_map<std::string, std::vector<double>> custom_rate_constants{
+    { "toy_k1", std::vector<double>(number_of_grid_cells) }
+  };
+  for (double lon = 0.0; lon < 2.0 * M_PI; lon += 0.3)
+  {
+    for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+    {
+      constexpr double k1_lat_center = M_PI * 20.0 / 180.0;
+      constexpr double k1_lon_center = M_PI * 300.0 / 180.0;
+      double lat = M_PI / 180.0 * (i_cell * (90.0 / number_of_grid_cells));
+
+      double k1 = std::max(
+          0.0,
+          std::sin(lat) * std::sin(k1_lat_center) + std::cos(lat) * std::cos(k1_lat_center) * std::cos(lon - k1_lon_center));
+      custom_rate_constants["toy_k1"][i_cell] = 1.0e-6;  // k1;
+      state.conditions_[i_cell].temperature_ = 298.0;
+      state.conditions_[i_cell].pressure_ = 101300.0;
+    }
+    state.SetCustomRateParameters(custom_rate_constants);
+
+    double dt = 30.0;
+    auto result = solver.Solve(dt, state);
+    for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+    {
+      double r = custom_rate_constants["toy_k1"][i_cell] / (4.0 * k2);
+      double cl_i = concentrations["Cl"][i_cell];
+      double cl2_i = concentrations["Cl2"][i_cell];
+      double cly = cl_i + 2.0 * cl2_i;
+      double det = std::sqrt(r * r + 2.0 * r * cly);
+      double e = std::exp(-4.0 * k2 * det * dt);
+      double l = (det * k2 * dt) > 1.0e-16 ? (1.0 - e) / det / dt : 4.0 * k2;
+      double cl_f = -l * (cl_i - det + r) * (cl_i + det + r) / (1.0 + e + dt * l * (cl_i + r));
+      double cl2_f = -cl_f / 2.0;
+      EXPECT_NEAR(
+          result.result_[i_cell][state.variable_map_["Cl"]], cl_i + dt * cl_f, (cl_i + dt * cl_f) * 1.0e-8 + 1.0e-30);
+      EXPECT_NEAR(
+          result.result_[i_cell][state.variable_map_["Cl2"]], cl2_i + dt * cl2_f, (cl2_i + dt * cl2_f) * 1.0e-8 + 1.0e-30);
+    }
+  }
+}

--- a/test/integration/terminator.hpp
+++ b/test/integration/terminator.hpp
@@ -15,7 +15,7 @@
 /// @brief A test of the "Terminator" mechanism:
 ///
 /// Cl2 --hv--> 2 Cl
-/// Cl + Cl + M --> Cl2 + M
+/// Cl + Cl --> Cl2
 ///
 /// More details including analytical solution can be found here:
 /// https://github.com/ESCOMP/CAM/blob/8cd44c50fe107c0b93ccd48b61eaa3d10a5b4e2f/src/chemistry/pp_terminator/chemistry.F90#L1-L434
@@ -26,9 +26,8 @@ void TestTerminator(
 {
   auto cl2 = micm::Species("Cl2");
   auto cl = micm::Species("Cl");
-  auto m = micm::Species::ThirdBody();
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ cl2, cl, m } };
+  micm::Phase gas_phase{ std::vector<micm::Species>{ cl2, cl } };
 
   micm::Process toy_r1 = micm::Process::create()
                              .reactants({ cl2 })
@@ -38,7 +37,7 @@ void TestTerminator(
 
   constexpr double k2 = 1.0;
   micm::Process toy_r2 = micm::Process::create()
-                             .reactants({ cl, cl, m })
+                             .reactants({ cl, cl })
                              .products({ micm::Yield(cl2, 1.0) })
                              .phase(gas_phase)
                              .rate_constant(micm::ArrheniusRateConstant({ .A_ = k2 }));
@@ -71,9 +70,9 @@ void TestTerminator(
           0.0,
           std::sin(lat) * std::sin(k1_lat_center) + std::cos(lat) * std::cos(k1_lat_center) * std::cos(lon - k1_lon_center));
       custom_rate_constants["toy_k1"][i_cell] = k1;
-      state.conditions_[i_cell].temperature_ = 298.0;
-      state.conditions_[i_cell].pressure_ = 101300.0;
-      state.conditions_[i_cell].air_density_ = 1.0;
+      state.conditions_[i_cell].temperature_ = 298.0;  // K
+      state.conditions_[i_cell].pressure_ = 101300.0;  // Pa
+      state.conditions_[i_cell].air_density_ = 42.0;   // mol m-3
     }
     state.SetCustomRateParameters(custom_rate_constants);
 

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -14,11 +14,14 @@ template<template<class> class MatrixPolicy>
 void testProcessUpdateState(const std::size_t number_of_grid_cells)
 {
   micm::Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }, { "diffusion coefficient [m2 s-1]", 2.3e2 } });
+  micm::Species bar("bar");
+  bar.parameterize_ = [](const micm::Conditions& c) { return c.air_density_ * 0.82; };
+
   micm::ArrheniusRateConstant rc1({ .A_ = 12.2, .C_ = 300.0 });
   micm::SurfaceRateConstant rc2({ .label_ = "foo_surf", .species_ = foo });
   micm::UserDefinedRateConstant rc3({ .label_ = "bar_user" });
 
-  micm::Process r1 = micm::Process::create().rate_constant(rc1);
+  micm::Process r1 = micm::Process::create().rate_constant(rc1).reactants({ foo, bar });
   micm::Process r2 = micm::Process::create().rate_constant(rc2);
   micm::Process r3 = micm::Process::create().rate_constant(rc3);
   std::vector<micm::Process> processes = { r1, r2, r3 };
@@ -39,6 +42,7 @@ void testProcessUpdateState(const std::size_t number_of_grid_cells)
   {
     state.conditions_[i_cell].temperature_ = get_double() * 285.0;
     state.conditions_[i_cell].pressure_ = get_double() * 101100.0;
+    state.conditions_[i_cell].air_density_ = get_double() * 10.0;
     params[0] = get_double() * 1.0e-8;
     params[1] = get_double() * 1.0e5;
     params[2] = get_double() * 1.0e-2;
@@ -48,7 +52,8 @@ void testProcessUpdateState(const std::size_t number_of_grid_cells)
         params[1];
     state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["bar_user"]] = params[2];
     std::vector<double>::const_iterator param_iter = params.begin();
-    expected_rate_constants[i_cell][0] = rc1.calculate(state.conditions_[i_cell], param_iter);
+    expected_rate_constants[i_cell][0] =
+        rc1.calculate(state.conditions_[i_cell], param_iter) * (state.conditions_[i_cell].air_density_ * 0.82);
     param_iter += rc1.SizeCustomParameters();
     expected_rate_constants[i_cell][1] = rc2.calculate(state.conditions_[i_cell], param_iter);
     param_iter += rc2.SizeCustomParameters();

--- a/test/unit/process/test_process_set_policy.hpp
+++ b/test/unit/process/test_process_set_policy.hpp
@@ -21,8 +21,10 @@ void testProcessSet(
   auto baz = micm::Species("baz");
   auto quz = micm::Species("quz");
   auto quuz = micm::Species("quuz");
+  auto qux = micm::Species("qux");
+  qux.parameterize_ = [](const micm::Conditions& c) { return c.air_density_ * 0.72; };
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar, baz, quz, quuz } };
+  micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar, qux, baz, quz, quuz } };
 
   micm::State<MatrixPolicy> state{ micm::StateParameters{ .state_variable_names_{ "foo", "bar", "baz", "quz", "quuz" },
                                                           .number_of_grid_cells_ = 2,
@@ -32,7 +34,7 @@ void testProcessSet(
       micm::Process::create().reactants({ foo, baz }).products({ yields(bar, 1), yields(quuz, 2.4) }).phase(gas_phase);
 
   micm::Process r2 =
-      micm::Process::create().reactants({ bar }).products({ yields(foo, 1), yields(quz, 1.4) }).phase(gas_phase);
+      micm::Process::create().reactants({ bar, qux }).products({ yields(foo, 1), yields(quz, 1.4) }).phase(gas_phase);
 
   micm::Process r3 = micm::Process::create().reactants({ quz }).products({}).phase(gas_phase);
 

--- a/test/unit/system/test_phase.cpp
+++ b/test/unit/system/test_phase.cpp
@@ -8,4 +8,26 @@ TEST(Phase, ConstructorWithVector)
   micm::Phase phase(std::vector<micm::Species>({ micm::Species("species1"), micm::Species("species2") }));
 
   EXPECT_EQ(phase.species_.size(), 2);
+  EXPECT_EQ(phase.StateSize(), 2);
+
+  auto names = phase.UniqueNames();
+  EXPECT_EQ(names[0], "species1");
+  EXPECT_EQ(names[1], "species2");
+}
+
+TEST(Phase, ConstructorWithParameterizedSpecies)
+{
+  auto foo = micm::Species("foo");
+  auto bar = micm::Species("bar");
+  auto baz = micm::Species("baz");
+
+  bar.parameterize_ = [](const micm::Conditions& c) { return 42.0; };
+  micm::Phase phase(std::vector<micm::Species>({ foo, bar, baz }));
+
+  EXPECT_EQ(phase.species_.size(), 3);
+  EXPECT_EQ(phase.StateSize(), 2);
+
+  auto names = phase.UniqueNames();
+  EXPECT_EQ(names[0], "foo");
+  EXPECT_EQ(names[1], "baz");
 }

--- a/test/unit/system/test_species.cpp
+++ b/test/unit/system/test_species.cpp
@@ -5,8 +5,11 @@
 TEST(Species, StringConstructor)
 {
   micm::Species species("thing");
-
   EXPECT_EQ(species.name_, "thing");
+  EXPECT_FALSE(species.IsParameterized());
+  species.parameterize_ = [](const micm::Conditions& c) { return c.temperature_ * 100.0; };
+  EXPECT_TRUE(species.IsParameterized());
+  EXPECT_EQ(species.parameterize_({ .temperature_ = 12.5 }), 12.5 * 100.0);
 }
 
 TEST(Species, StringAndVectorConstructor)
@@ -21,24 +24,56 @@ TEST(Species, StringAndVectorConstructor)
 
 TEST(Species, CopyConstructor)
 {
-  micm::Species species("thing", { { "name [units]", 1.0 }, { "name2 [units2]", 2.0 } });
+  {
+    micm::Species species("thing", { { "name [units]", 1.0 }, { "name2 [units2]", 2.0 } });
 
-  micm::Species species2(species);
+    micm::Species species2(species);
 
-  EXPECT_EQ(species2.name_, "thing");
-  EXPECT_EQ(species2.properties_.size(), 2);
-  EXPECT_EQ(species2.properties_["name [units]"], 1.0);
-  EXPECT_EQ(species2.properties_["name2 [units2]"], 2.0);
+    EXPECT_EQ(species2.name_, "thing");
+    EXPECT_EQ(species2.properties_.size(), 2);
+    EXPECT_EQ(species2.properties_["name [units]"], 1.0);
+    EXPECT_EQ(species2.properties_["name2 [units2]"], 2.0);
+    EXPECT_FALSE(species2.IsParameterized());
+  }
+  {
+    micm::Species species("thing", { { "name [units]", 1.0 }, { "name2 [units2]", 2.0 } });
+    species.parameterize_ = [](const micm::Conditions& c) { return 15.4; };
+
+    micm::Species species2(species);
+
+    EXPECT_EQ(species2.name_, "thing");
+    EXPECT_EQ(species2.properties_.size(), 2);
+    EXPECT_EQ(species2.properties_["name [units]"], 1.0);
+    EXPECT_EQ(species2.properties_["name2 [units2]"], 2.0);
+    EXPECT_TRUE(species2.IsParameterized());
+    EXPECT_EQ(species.parameterize_({}), 15.4);
+  }
 }
 
 TEST(Species, CopyAssignment)
 {
-  micm::Species species("thing", { { "name [units]", 1.0 }, { "name2 [units2]", 2.0 } });
+  {
+    micm::Species species("thing", { { "name [units]", 1.0 }, { "name2 [units2]", 2.0 } });
 
-  micm::Species species2 = species;
+    micm::Species species2 = species;
 
-  EXPECT_EQ(species2.name_, "thing");
-  EXPECT_EQ(species2.properties_.size(), 2);
-  EXPECT_EQ(species2.properties_["name [units]"], 1.0);
-  EXPECT_EQ(species2.properties_["name2 [units2]"], 2.0);
+    EXPECT_EQ(species2.name_, "thing");
+    EXPECT_EQ(species2.properties_.size(), 2);
+    EXPECT_EQ(species2.properties_["name [units]"], 1.0);
+    EXPECT_EQ(species2.properties_["name2 [units2]"], 2.0);
+    EXPECT_FALSE(species2.IsParameterized());
+  }
+  {
+    micm::Species species("thing", { { "name [units]", 1.0 }, { "name2 [units2]", 2.0 } });
+    species.parameterize_ = [](const micm::Conditions& c) { return 15.4; };
+
+    micm::Species species2 = species;
+
+    EXPECT_EQ(species2.name_, "thing");
+    EXPECT_EQ(species2.properties_.size(), 2);
+    EXPECT_EQ(species2.properties_["name [units]"], 1.0);
+    EXPECT_EQ(species2.properties_["name2 [units2]"], 2.0);
+    EXPECT_TRUE(species2.IsParameterized());
+    EXPECT_EQ(species.parameterize_({}), 15.4);
+  }
 }

--- a/test/unit/system/test_species.cpp
+++ b/test/unit/system/test_species.cpp
@@ -22,6 +22,14 @@ TEST(Species, StringAndVectorConstructor)
   EXPECT_EQ(species.properties_["name2 [units2]"], 2.0);
 }
 
+TEST(Species, ThirdBody)
+{
+  micm::Species species = micm::Species::ThirdBody();
+  EXPECT_EQ(species.name_, "M");
+  EXPECT_TRUE(species.IsParameterized());
+  EXPECT_EQ(species.parameterize_({ .air_density_ = 42.4 }), 42.4);
+}
+
 TEST(Species, CopyConstructor)
 {
   {

--- a/test/unit/system/test_system.cpp
+++ b/test/unit/system/test_system.cpp
@@ -38,3 +38,42 @@ TEST(System, ConstructorWithAllParameters)
   EXPECT_EQ(reordered_names[4], names[5]);
   EXPECT_EQ(reordered_names[5], names[4]);
 }
+
+TEST(System, ConstructorWithParameterizedSpecies)
+{
+  std::vector<micm::Species> speciesA = { micm::Species("species1"), micm::Species("species2") };
+  std::vector<micm::Species> speciesB = { micm::Species("species3"), micm::Species("species4") };
+  auto param_species = micm::Species("paramSpecies");
+  param_species.parameterize_ = [](const micm::Conditions& c) { return 64.2; };
+  speciesA.push_back(param_species);
+
+  micm::Phase phase = speciesA;
+  std::unordered_map<std::string, micm::Phase> phases = { { "phase1", speciesA }, { "phase2", speciesB } };
+
+  micm::System system = { micm::SystemParameters{ .gas_phase_ = phase, .phases_ = phases } };
+
+  EXPECT_EQ(system.gas_phase_.species_.size(), 3);
+  EXPECT_EQ(system.phases_.size(), 2);
+  EXPECT_EQ(system.StateSize(), 6);
+
+  auto names = system.UniqueNames();
+
+  EXPECT_EQ(names.size(), 6);
+  EXPECT_NE(std::find(names.begin(), names.end(), "species1"), names.end());
+  EXPECT_NE(std::find(names.begin(), names.end(), "species2"), names.end());
+  EXPECT_NE(std::find(names.begin(), names.end(), "phase1.species1"), names.end());
+  EXPECT_NE(std::find(names.begin(), names.end(), "phase1.species2"), names.end());
+  EXPECT_NE(std::find(names.begin(), names.end(), "phase2.species3"), names.end());
+  EXPECT_NE(std::find(names.begin(), names.end(), "phase2.species4"), names.end());
+
+  std::vector<int> reorder{ 3, 2, 1, 0, 5, 4 };
+  auto reordered_names = system.UniqueNames([&](const std::vector<std::string> variables, const std::size_t i)
+                                            { return variables[reorder[i]]; });
+  EXPECT_EQ(reordered_names.size(), 6);
+  EXPECT_EQ(reordered_names[0], names[3]);
+  EXPECT_EQ(reordered_names[1], names[2]);
+  EXPECT_EQ(reordered_names[2], names[1]);
+  EXPECT_EQ(reordered_names[3], names[0]);
+  EXPECT_EQ(reordered_names[4], names[5]);
+  EXPECT_EQ(reordered_names[5], names[4]);
+}


### PR DESCRIPTION
closes #245 

Includes the analytical solution from CAM-Chem in the test for the Terminator configuration.

Also, I updated slightly the logic around min/max/initial solver time steps to avoid changing solver parameters during the solve and to allow users to be able to specify these (which I did in the terminator test to get closer results to the analytical solution).

And, I added the ability to include species whose concentrations are not solved for, but are parameterized on environmental conditions. At first I did this because I mistakenly thought the third-body species "M" was included in the Terminator configuration. I left this option in the PR because it will be useful for other mechanisms that include "M" and for setting constant values for species like O2 and N2