### PR TITLE
Validation checks

### DIFF
--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -67,20 +67,10 @@ namespace micm
           rate_constant_(std::move(rate_constant)),
           phase_(phase)
     {
-      if (dynamic_cast<ArrheniusRateConstant*>(rate_constant_.get())) {
-      }
-      else if (dynamic_cast<BranchedRateConstant*>(rate_constant_.get())) {
-      }
-      else if (dynamic_cast<SurfaceRateConstant*>(rate_constant_.get())) {
+      if (dynamic_cast<SurfaceRateConstant*>(rate_constant_.get())) {
         if (reactants_.size() > 1) {
           throw std::runtime_error("A surface rate constant can only have one reactant");
         }
-      }
-      else if (dynamic_cast<TernaryChemicalActivationRateConstant*>(rate_constant_.get())) {
-      }
-      else if (dynamic_cast<TroeRateConstant*>(rate_constant_.get())) {
-      }
-      else if (dynamic_cast<TunnelingRateConstant*>(rate_constant_.get())) {
       }
     }
 

--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -6,6 +6,14 @@
 
 #include <memory>
 #include <micm/process/rate_constant.hpp>
+#include <micm/process/arrhenius_rate_constant.hpp>
+#include <micm/process/branched_rate_constant.hpp>
+#include <micm/process/rate_constant.hpp>
+#include <micm/process/surface_rate_constant.hpp>
+#include <micm/process/ternary_chemical_activation_rate_constant.hpp>
+#include <micm/process/troe_rate_constant.hpp>
+#include <micm/process/tunneling_rate_constant.hpp>
+#include <micm/process/user_defined_rate_constant.hpp>
 #include <micm/solver/state.hpp>
 #include <micm/system/phase.hpp>
 #include <micm/system/species.hpp>
@@ -59,6 +67,21 @@ namespace micm
           rate_constant_(std::move(rate_constant)),
           phase_(phase)
     {
+      if (dynamic_cast<ArrheniusRateConstant*>(rate_constant_.get())) {
+      }
+      else if (dynamic_cast<BranchedRateConstant*>(rate_constant_.get())) {
+      }
+      else if (dynamic_cast<SurfaceRateConstant*>(rate_constant_.get())) {
+        if (reactants_.size() > 1) {
+          throw std::runtime_error("A surface rate constant can only have one reactant");
+        }
+      }
+      else if (dynamic_cast<TernaryChemicalActivationRateConstant*>(rate_constant_.get())) {
+      }
+      else if (dynamic_cast<TroeRateConstant*>(rate_constant_.get())) {
+      }
+      else if (dynamic_cast<TunnelingRateConstant*>(rate_constant_.get())) {
+      }
     }
 
     Process& operator=(const Process& other)
@@ -148,10 +171,7 @@ namespace micm
   };
 
   inline Process::Process(ProcessBuilder& builder)
-      : reactants_(builder.reactants_),
-        products_(builder.products_),
-        rate_constant_(std::move(builder.rate_constant_)),
-        phase_(builder.phase_)
+      : Process(builder.reactants_, builder.products_, std::move(builder.rate_constant_), builder.phase_)
   {
   }
 

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 
 namespace micm
 {

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -85,3 +85,18 @@ TEST(Process, VectorMatrix)
   testProcessUpdateState<Group3VectorMatrix>(5);
   testProcessUpdateState<Group4VectorMatrix>(5);
 }
+
+TEST(Process, SurfaceRateConstantOnlyHasOneReactant)
+{
+  micm::Species c("c", { { "molecular weight [kg mol-1]", 0.025 }, { "diffusion coefficient [m2 s-1]", 2.3e2 } });
+  micm::Species e("e");
+  
+  micm::Phase gas_phase({c, e});
+  EXPECT_ANY_THROW(
+    micm::Process r = micm::Process::create()
+                    .reactants({ c, c })
+                    .products({ yields(e, 1) })
+                    .rate_constant(micm::SurfaceRateConstant({ .label_ = "c", .species_ = c, .reaction_probability_ = 0.90 }))
+                    .phase(gas_phase);
+  ); 
+}


### PR DESCRIPTION
Closes #165

- Adds a test to ensure surface reaction rates aren't created with more than one reactant

#Issues
- First order loss and emissions reaction emissions also should only accept one reactant. However, both of these are represented as a `UserDefinedRateConstant` which can be first order loss, emission, or photolysis, and photolysis reactions can have more than one reactant. There is no clean way to ensure that first order loss reactions and emission reactions have exactly one reactant.
  - This actually isn't a problem. Our json parsing code has a check for these conditions implicitly. It's only in the construction of a process by hand that someone could make a rate constant process for loss or emission with more than one reactant. That's a bug, but it's a user error. Unless we remove the the user defined process and specialize for each case, or switch to using [tagged unions](https://en.wikipedia.org/wiki/Tagged_union) for our rate constants, we can't reasonably make a check for this.

I can't think of any more checks to make. Let me know if any of you can think of some.