### PR TITLE
Develop 82 singular matrix

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Check for changes
         id: check-changes
         run: |
-          git diff --exit-code || exit 0
+          git diff --exit-code
         continue-on-error: true
 
       - name: Commit and push changes
         # a failue of this step means changes were detected
-        if: steps.check-changes.outcome == 'failure'
+        if: steps.check-changes.outcome != 'success'
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
@@ -42,13 +42,13 @@ jobs:
 
       - name: Push changes to main-formatting branch
         # a failue of this step means changes were detected
-        if: steps.check-changes.outcome == 'failure'
+        if: steps.check-changes.outcome != 'success'
         run: |
           git push origin HEAD:main-formatting
 
       - name: Create Pull Request
         # a failue of this step means changes were detected
-        if: steps.check-changes.outcome == 'failure'
+        if: steps.check-changes.outcome != 'success'
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/include/micm/solver/jit_linear_solver.hpp
+++ b/include/micm/solver/jit_linear_solver.hpp
@@ -44,6 +44,12 @@ namespace micm
     ~JitLinearSolver();
 
     /// @brief Decompose the matrix into upper and lower triangular matrices and general JIT functions
+    /// @param matrix Matrix that will be factored into lower and upper triangular matrices
+    /// @param is_singular Flag that will be set to true if matrix is singular; false otherwise
+    void Factor(SparseMatrix<double, SparseMatrixVectorOrdering<L>>& matrix, bool& is_singular);
+
+    /// @brief Decompose the matrix into upper and lower triangular matrices and general JIT functions
+    /// @param matrix Matrix that will be factored into lower and upper triangular matrices
     void Factor(SparseMatrix<double, SparseMatrixVectorOrdering<L>>& matrix);
 
     /// @brief Solve for x in Ax = b

--- a/include/micm/solver/jit_linear_solver.inl
+++ b/include/micm/solver/jit_linear_solver.inl
@@ -58,6 +58,13 @@ namespace micm
 
   template<std::size_t L, template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
   inline void JitLinearSolver<L, SparseMatrixPolicy, LuDecompositionPolicy>::Factor(
+      SparseMatrix<double, SparseMatrixVectorOrdering<L>> &matrix, bool& is_singular)
+  {
+    LinearSolver<double, SparseMatrixPolicy, LuDecompositionPolicy>::Factor(matrix, is_singular);
+  }
+
+  template<std::size_t L, template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
+  inline void JitLinearSolver<L, SparseMatrixPolicy, LuDecompositionPolicy>::Factor(
       SparseMatrix<double, SparseMatrixVectorOrdering<L>> &matrix)
   {
     LinearSolver<double, SparseMatrixPolicy, LuDecompositionPolicy>::Factor(matrix);

--- a/include/micm/solver/jit_lu_decomposition.hpp
+++ b/include/micm/solver/jit_lu_decomposition.hpp
@@ -43,6 +43,14 @@ namespace micm
     /// @param A Sparse matrix that will be decomposed
     /// @param lower The lower triangular matrix created by decomposition
     /// @param upper The upper triangular matrix created by decomposition
+    /// @param is_singular Flag that will be set to true if A is singular; false otherwise
+    template<typename T, template<class> class SparseMatrixPolicy>
+    void Decompose(const SparseMatrixPolicy<T> &A, SparseMatrixPolicy<T> &lower, SparseMatrixPolicy<T> &upper, bool& is_singular) const;
+
+    /// @brief Create sparse L and U matrices for a given A matrix
+    /// @param A Sparse matrix that will be decomposed
+    /// @param lower The lower triangular matrix created by decomposition
+    /// @param upper The upper triangular matrix created by decomposition
     template<typename T, template<class> class SparseMatrixPolicy>
     void Decompose(const SparseMatrixPolicy<T> &A, SparseMatrixPolicy<T> &lower, SparseMatrixPolicy<T> &upper) const;
 

--- a/include/micm/solver/jit_lu_decomposition.inl
+++ b/include/micm/solver/jit_lu_decomposition.inl
@@ -188,6 +188,17 @@ namespace micm
   void JitLuDecomposition<L>::Decompose(
       const SparseMatrixPolicy<T> &A,
       SparseMatrixPolicy<T> &lower,
+      SparseMatrixPolicy<T> &upper,
+      bool& is_singular) const
+  {
+    LuDecomposition::Decompose<T, SparseMatrixPolicy>(A, lower, upper, is_singular);
+  }
+
+  template<std::size_t L>
+  template<typename T, template<class> class SparseMatrixPolicy>
+  void JitLuDecomposition<L>::Decompose(
+      const SparseMatrixPolicy<T> &A,
+      SparseMatrixPolicy<T> &lower,
       SparseMatrixPolicy<T> &upper) const
   {
     decompose_function_(A.AsVector().data(), lower.AsVector().data(), upper.AsVector().data());

--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -71,7 +71,14 @@ namespace micm
         const std::function<LuDecompositionPolicy(const SparseMatrixPolicy<T>&)> create_lu_decomp);
 
     /// @brief Decompose the matrix into upper and lower triangular matrices
+    /// @param matrix Matrix to decompose into lower and upper triangular matrices
+    /// @param is_singular Flag that is set to true if matrix is singular; false otherwise
     void Factor(const SparseMatrixPolicy<T>& matrix);
+    
+    /// @brief Decompose the matrix into upper and lower triangular matrices
+    /// @param matrix Matrix to decompose into lower and upper triangular matrices
+    /// @param is_singular Flag that is set to true if matrix is singular; false otherwise
+    void Factor(const SparseMatrixPolicy<T>& matrix, bool& is_singular);
 
     /// @brief Solve for x in Ax = b
     template<template<class> class MatrixPolicy>

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -138,17 +138,11 @@ namespace micm
         }
       }
       {
-        auto y_elem = std::next(y_cell.end(), -1);
         auto x_elem = std::next(x_cell.end(), -1);
         auto Uij_xj = Uij_xj_.begin();
         for (auto& nUij_Uii : nUij_Uii_)
         {
-          // don't iterate before the beginning of the vector
-          if (y_elem != y_cell.begin())
-          {
-            --y_elem;
-          }
-
+          // x_elem starts out as y_elem from the previous loop
           for (std::size_t i = 0; i < nUij_Uii.first; ++i)
           {
             *x_elem -= upper_matrix_.AsVector()[upper_grid_offset + (*Uij_xj).first] * x_cell[(*Uij_xj).second];
@@ -203,15 +197,11 @@ namespace micm
         }
       }
       {
-        auto y_elem = std::next(y_group, x.GroupSize() - n_cells);
         auto x_elem = std::next(x_group, x.GroupSize() - n_cells);
         auto Uij_xj = Uij_xj_.begin();
         for (auto& nUij_Uii : nUij_Uii_)
         {
-          // don't iterate before the beginning of the vector
-          std::size_t y_elem_distance = std::distance(x.AsVector().begin(), y_elem);
-          y_elem -= std::min(n_cells, y_elem_distance);
-
+          // x_elem starts out as y_elem from the previous loop
           for (std::size_t i = 0; i < nUij_Uii.first; ++i)
           {
             for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -111,6 +111,12 @@ namespace micm
   }
 
   template<typename T, template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
+  inline void LinearSolver<T, SparseMatrixPolicy, LuDecompositionPolicy>::Factor(const SparseMatrixPolicy<T>& matrix, bool& is_singular)
+  {
+    lu_decomp_.template Decompose<T, SparseMatrixPolicy>(matrix, lower_matrix_, upper_matrix_, is_singular);
+  }
+
+  template<typename T, template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
   template<template<class> class MatrixPolicy>
     requires(!VectorizableDense<MatrixPolicy<T>> || !VectorizableSparse<SparseMatrixPolicy<T>>)
   inline void LinearSolver<T, SparseMatrixPolicy, LuDecompositionPolicy>::Solve(const MatrixPolicy<T>& b, MatrixPolicy<T>& x)

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -91,15 +91,28 @@ namespace micm
     /// @param L The lower triangular matrix created by decomposition
     /// @param U The upper triangular matrix created by decomposition
     template<typename T, template<class> class SparseMatrixPolicy>
-    requires(!VectorizableSparse<SparseMatrixPolicy<T>>) void Decompose(
+    void Decompose(
         const SparseMatrixPolicy<T>& A,
         SparseMatrixPolicy<T>& L,
         SparseMatrixPolicy<T>& U) const;
+
+    /// @brief Perform an LU decomposition on a given A matrix
+    /// @param A Sparse matrix to decompose
+    /// @param L The lower triangular matrix created by decomposition
+    /// @param U The upper triangular matrix created by decomposition
+    /// @param is_singular Flag that is set to true if A is singular; false otherwise
+    template<typename T, template<class> class SparseMatrixPolicy>
+    requires(!VectorizableSparse<SparseMatrixPolicy<T>>) void Decompose(
+        const SparseMatrixPolicy<T>& A,
+        SparseMatrixPolicy<T>& L,
+        SparseMatrixPolicy<T>& U,
+        bool& is_singular) const;
     template<typename T, template<class> class SparseMatrixPolicy>
     requires(VectorizableSparse<SparseMatrixPolicy<T>>) void Decompose(
         const SparseMatrixPolicy<T>& A,
         SparseMatrixPolicy<T>& L,
-        SparseMatrixPolicy<T>& U) const;
+        SparseMatrixPolicy<T>& U,
+        bool& is_singular) const;
   };
 
 }  // namespace micm

--- a/include/micm/solver/lu_decomposition.inl
+++ b/include/micm/solver/lu_decomposition.inl
@@ -145,8 +145,16 @@ namespace micm
   }
 
   template<typename T, template<class> class SparseMatrixPolicy>
-    requires(!VectorizableSparse<SparseMatrixPolicy<T>>)
   inline void LuDecomposition::Decompose(const SparseMatrixPolicy<T>& A, SparseMatrixPolicy<T>& L, SparseMatrixPolicy<T>& U)
+      const
+  {
+    bool is_singular;
+    Decompose<T, SparseMatrixPolicy>(A, L, U, is_singular);
+  }
+
+  template<typename T, template<class> class SparseMatrixPolicy>
+    requires(!VectorizableSparse<SparseMatrixPolicy<T>>)
+  inline void LuDecomposition::Decompose(const SparseMatrixPolicy<T>& A, SparseMatrixPolicy<T>& L, SparseMatrixPolicy<T>& U, bool& is_singular)
       const
   {
     // Loop over blocks
@@ -164,6 +172,7 @@ namespace micm
       auto lki_nkj = lki_nkj_.begin();
       auto lkj_uji = lkj_uji_.begin();
       auto uii = uii_.begin();
+      is_singular = false;
       for (auto& inLU : niLU_)
       {
         // Upper trianglur matrix
@@ -189,6 +198,11 @@ namespace micm
             L_vector[lki_nkj->first] -= L_vector[lkj_uji->first] * U_vector[lkj_uji->second];
             ++lkj_uji;
           }
+          if( U_vector[*uii] == 0.0 )
+          {
+            is_singular = true;
+            return;
+          }
           L_vector[lki_nkj->first] /= U_vector[*uii];
           ++lki_nkj;
           ++uii;
@@ -199,10 +213,9 @@ namespace micm
 
   template<typename T, template<class> class SparseMatrixPolicy>
     requires(VectorizableSparse<SparseMatrixPolicy<T>>)
-  inline void LuDecomposition::Decompose(const SparseMatrixPolicy<T>& A, SparseMatrixPolicy<T>& L, SparseMatrixPolicy<T>& U)
+  inline void LuDecomposition::Decompose(const SparseMatrixPolicy<T>& A, SparseMatrixPolicy<T>& L, SparseMatrixPolicy<T>& U, bool& is_singular)
       const
   {
-    const std::size_t n_cells = A.GroupVectorSize();
     // Loop over groups of blocks
     for (std::size_t i_group = 0; i_group < A.NumberOfGroups(A.size()); ++i_group)
     {
@@ -218,6 +231,8 @@ namespace micm
       auto lki_nkj = lki_nkj_.begin();
       auto lkj_uji = lkj_uji_.begin();
       auto uii = uii_.begin();
+      is_singular = false;
+      const std::size_t n_cells = std::min(A.GroupVectorSize(), A.size() - i_group * A.GroupVectorSize());
       for (auto& inLU : niLU_)
       {
         // Upper trianglur matrix
@@ -256,7 +271,13 @@ namespace micm
             ++lkj_uji;
           }
           for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+          {
+            if (U_vector[*uii + i_cell] == 0.0) {
+              is_singular = true;
+              return;
+            }
             L_vector[lki_nkj->first + i_cell] /= U_vector[*uii + i_cell];
+          }
           ++lki_nkj;
           ++uii;
         }

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -84,6 +84,7 @@ namespace micm
 
     size_t number_of_grid_cells_{ 1 };  // Number of grid cells to solve simultaneously
     bool reorder_state_{ true };        // Reorder state during solver construction to minimize LU fill-in
+    bool check_singularity_{ false };   // Check for singular A matrix in linear solve of A x = b
 
     // Print RosenbrockSolverParameters to console
     void print() const;

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -757,12 +757,18 @@ namespace micm
     // From my understanding the fortran do loop would only ever do one iteration and is equivalent to what's below
     SparseMatrixPolicy<double> jacobian = jacobian_;
     uint64_t n_consecutive = 0;
-    singular = true;
+    singular = false;
     while (true)
     {
       double alpha = 1 / (H * gamma);
       AlphaMinusJacobian(jacobian, alpha);
-      linear_solver_.Factor(jacobian);
+      if (parameters_.check_singularity_)
+      {
+        linear_solver_.Factor(jacobian, singular);
+      } else {
+        singular = false;
+        linear_solver_.Factor(jacobian);
+      }
       singular = false;  // TODO This should be evaluated in some way
       stats_.decompositions += 1;
       if (!singular)

--- a/test/integration/terminator.cpp
+++ b/test/integration/terminator.cpp
@@ -27,6 +27,18 @@ void RunTerminatorTest(std::size_t number_of_grid_cells)
         return micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>{ s, p, solver_params };
       },
       number_of_grid_cells);
+  TestTerminator<MatrixPolicy, micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>>(
+      [&](const micm::System& s, const std::vector<micm::Process>& p)
+          -> micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>
+      {
+        auto solver_params = micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells, true);
+        solver_params.absolute_tolerance_ = 1.0e-20;
+        solver_params.relative_tolerance_ = 1.0e-8;
+        solver_params.max_number_of_steps_ = 100000;
+        solver_params.check_singularity_ = true;
+        return micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>{ s, p, solver_params };
+      },
+      number_of_grid_cells);
 }
 
 TEST(RosenbrockSolver, Terminator)

--- a/test/unit/solver/test_jit_lu_decomposition.cpp
+++ b/test/unit/solver/test_jit_lu_decomposition.cpp
@@ -41,6 +41,32 @@ TEST(JitLuDecomposition, DenseMatrixVectorOrdering)
       });
 }
 
+TEST(JitLuDecomposition, SingularMatrixVectorOrdering)
+{
+  auto jit{ micm::JitCompiler::create() };
+  if (auto err = jit.takeError())
+  {
+    llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
+    EXPECT_TRUE(false);
+  }
+  testSingularMatrix<Group1SparseVectorMatrix, micm::JitLuDecomposition<1>>(
+      [&](const Group1SparseVectorMatrix<double>& matrix) -> micm::JitLuDecomposition<1> {
+        return micm::JitLuDecomposition<1>{ jit.get(), matrix };
+      });
+  testSingularMatrix<Group2SparseVectorMatrix, micm::JitLuDecomposition<2>>(
+      [&](const Group2SparseVectorMatrix<double>& matrix) -> micm::JitLuDecomposition<2> {
+        return micm::JitLuDecomposition<2>{ jit.get(), matrix };
+      });
+  testSingularMatrix<Group3SparseVectorMatrix, micm::JitLuDecomposition<3>>(
+      [&](const Group3SparseVectorMatrix<double>& matrix) -> micm::JitLuDecomposition<3> {
+        return micm::JitLuDecomposition<3>{ jit.get(), matrix };
+      });
+  testSingularMatrix<Group4SparseVectorMatrix, micm::JitLuDecomposition<4>>(
+      [&](const Group4SparseVectorMatrix<double>& matrix) -> micm::JitLuDecomposition<4> {
+        return micm::JitLuDecomposition<4>{ jit.get(), matrix };
+      });
+}
+
 TEST(JitLuDecomposition, RandomMatrixVectorOrdering)
 {
   auto jit{ micm::JitCompiler::create() };

--- a/test/unit/solver/test_lu_decomposition.cpp
+++ b/test/unit/solver/test_lu_decomposition.cpp
@@ -24,6 +24,12 @@ TEST(LuDecomposition, DenseMatrixStandardOrdering)
       [](const SparseMatrixTest<double>& matrix) -> micm::LuDecomposition { return micm::LuDecomposition{ matrix }; });
 }
 
+TEST(LuDecomposition, SingularMatrixStandardOrdering)
+{
+    testSingularMatrix<SparseMatrixTest, micm::LuDecomposition>(
+        [](const SparseMatrixTest<double>& matrix) -> micm::LuDecomposition { return micm::LuDecomposition{ matrix }; });
+}
+
 TEST(LuDecomposition, RandomMatrixStandardOrdering)
 {
   testRandomMatrix<SparseMatrixTest, micm::LuDecomposition>(
@@ -48,6 +54,22 @@ TEST(LuDecomposition, DenseMatrixVectorOrdering)
       [](const Group3SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
       { return micm::LuDecomposition{ matrix }; });
   testDenseMatrix<Group4SparseVectorMatrix, micm::LuDecomposition>(
+      [](const Group4SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
+      { return micm::LuDecomposition{ matrix }; });
+}
+
+TEST(LuDecomposition, SingluarMatrixVectorOrdering)
+{
+  testSingularMatrix<Group1SparseVectorMatrix, micm::LuDecomposition>(
+      [](const Group1SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
+      { return micm::LuDecomposition{ matrix }; });
+  testSingularMatrix<Group2SparseVectorMatrix, micm::LuDecomposition>(
+      [](const Group2SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
+      { return micm::LuDecomposition{ matrix }; });
+  testSingularMatrix<Group3SparseVectorMatrix, micm::LuDecomposition>(
+      [](const Group3SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
+      { return micm::LuDecomposition{ matrix }; });
+  testSingularMatrix<Group4SparseVectorMatrix, micm::LuDecomposition>(
       [](const Group4SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
       { return micm::LuDecomposition{ matrix }; });
 }

--- a/test/unit/solver/test_lu_decomposition_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_policy.hpp
@@ -105,6 +105,31 @@ void testDenseMatrix(const std::function<LuDecompositionPolicy(const SparseMatri
 }
 
 template<template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
+void testSingularMatrix(const std::function<LuDecompositionPolicy(const SparseMatrixPolicy<double>&)> create_lu_decomp)
+{
+  SparseMatrixPolicy<double> A = SparseMatrixPolicy<double>(SparseMatrixPolicy<double>::create(2)
+                                                                .initial_value(1.0e-30)
+                                                                .with_element(0, 0)
+                                                                .with_element(0, 1)
+                                                                .with_element(1, 0)
+                                                                .with_element(1, 1));
+
+  A[0][0][0] = 0;
+  A[0][0][1] = 1;
+  A[0][1][0] = 1;
+  A[0][1][1] = 1;
+
+  LuDecompositionPolicy lud = create_lu_decomp(A);
+  auto LU = micm::LuDecomposition::GetLUMatrices(A, 1.0E-30);
+  bool is_singular{ false };
+  lud.template Decompose<double, SparseMatrixPolicy>(A, LU.first, LU.second, is_singular);
+  EXPECT_TRUE(is_singular);
+  A[0][0][0] = 12;
+  lud.template Decompose<double, SparseMatrixPolicy>(A, LU.first, LU.second, is_singular);
+  EXPECT_FALSE(is_singular);
+}
+
+template<template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
 void testRandomMatrix(
     const std::function<LuDecompositionPolicy(const SparseMatrixPolicy<double>&)> create_lu_decomp,
     std::size_t number_of_blocks)


### PR DESCRIPTION
closes #82 

Adds an option to the `RosenbrockSolver` to perform a check for singularity. The `JitLuDecomposition::Factor` function calls the base class function when checking for singularity, until we decide it's worthwhile to have a JITed version of the LU factorization that does this check.