### PR TITLE
update line numbers in JIT tutorial

### DIFF
--- a/docs/source/user_guide/jit.rst
+++ b/docs/source/user_guide/jit.rst
@@ -9,12 +9,12 @@ acheive a numerically stable solution, and cache misses, among others.
 
 This tutorial focuses on alleviating the cache misses. A popular method for handling cache misses is to pre-compute the indices. 
 This method, which may be referred to as ahead-of-time (AOT) compilation, is used in applications such as KPP :cite:`Damian2002`.
-Pre-computed methods require code preprocessors and preclude runtime configurable software, which is a goal of micm.
+Pre-computed methods require code preprocessors and preclude runtime configurable software, which is a goal of MICM.
 
 MICM uses just-in-time (JIT) compiled functions built with `LLVM JIT <https://llvm.org/docs/tutorial/BuildingAJIT1.html>`_ libraries
 to supply runtime-configurable chemistry to avoid cache misses in important chemistry functions.
 
-Up until now, a :cpp:class:`micm::RosenbrockSolver` has been used. This is a special class in micm which builds all
+Up until now, a :cpp:class:`micm::RosenbrockSolver` has been used. This is a special class in MICM which builds all
 of the componenets needed to solve chemistry in memory, including the forcing function and the jacobian. MICM
 also provides a :cpp:class:`micm::JitRosenbrockSolver` which builds and compiles several important chemistry functions at runtime.
 
@@ -32,8 +32,9 @@ So what does this gain me?
 --------------------------
 
 Runtime configuraiton of chemical mechanisms that are *fast*. Let's compare the speed of :cpp:class:`micm::RosenbrockSolver` 
-and the :cpp:class:`micm::JitRosenbrockSolver` classes applied to the same problem. This time we'll use the carbon-bond 5
-mechanism :cite:`Yarwood2005`, which is an update to the carbon bond mechanism from :cite:`Gery1989`.
+and the :cpp:class:`micm::JitRosenbrockSolver` classes applied to the same problem. We will use the simple
+fictitous chemical system from previous examples for simplicity, but feel free to try out more complex
+mechanisms to see the effects of JIT compiling on compute time in more realistic cases.
 
 If you're looking for a copy and paste, choose
 the appropriate tab below and be on your way! Otherwise, stick around for a line by line explanation.
@@ -57,12 +58,11 @@ paste the example code into a file named ``foo_jit_chem.cpp`` and run:
 Line-by-line explanation
 ------------------------
 
-Starting with the header files, we need headers for timing, outpu, reading the configuration,
-and of course for both types of solvers.
+Starting with the header files, we need headers for timing, output, and of course for both types of solvers.
 
 .. literalinclude:: ../../../test/tutorial/test_jit_tutorial.cpp
   :language: cpp
-  :lines: 1-7
+  :lines: 1-5
 
 Next, we use our namespace, define our number of gridcells (1 for now), and some
 partial template specializations. We are using our custom vectorized matrix, which
@@ -71,24 +71,23 @@ grid cells to be solved simultaneously.
 
 .. literalinclude:: ../../../test/tutorial/test_jit_tutorial.cpp
   :language: cpp
-  :lines: 14-18
+  :lines: 7-16
 
 Now, all at once, is the function which runs either type of solver. We set all species
-concentrations to 1 :math:`\mathrm{mol\ m^-3}` and set the rate paramters for all of the
-photolysis and emissions reactions. Additionally, we are collecting all of the solver
-stats across all solving timesteps
+concentrations to 1 :math:`\mathrm{mol\ m^-3}`.
+Additionally, we are collecting all of the solver stats across all solving timesteps
 
 .. literalinclude:: ../../../test/tutorial/test_jit_tutorial.cpp
   :language: cpp
-  :lines: 20-96
+  :lines: 18-71
 
 Finally, the main function which reads the configuration and initializes the jit solver.
 
 .. literalinclude:: ../../../test/tutorial/test_jit_tutorial.cpp
   :language: cpp
-  :lines: 101-117
+  :lines: 73-113
 
-The only additionall step here is to make an instance of the :cpp:class:`micm::JitCompiler`
+The only additional step here is to make an instance of the :cpp:class:`micm::JitCompiler`
 and pass it as a shared pointer to the :cpp:class:`micm::JitRosenbrockSolver`. We also are
 using our vectorized matrix for both solvers. The :cpp:class:`micm::JitRosenbrockSolver` only works
 with the vectorized matrix whereas the :cpp:class:`micm::RosenbrockSolver` works with a regular matrix.
@@ -97,14 +96,14 @@ time here.
 
 .. literalinclude:: ../../../test/tutorial/test_jit_tutorial.cpp
   :language: cpp
-  :lines: 119-140
+  :lines: 103-113
 
 Finally, we run both solvers, output their cumulative stats, and compare their results.
 
 
 .. literalinclude:: ../../../test/tutorial/test_jit_tutorial.cpp
   :language: cpp
-  :lines: 142-198
+  :lines: 115-181
 
 
 The output will be similar to this:


### PR DESCRIPTION
One more update to the JIT tutorial to update the line numbers used to find code blocks in the example code.