### PR TITLE
Parse scaling factors

### DIFF
--- a/include/micm/configure/solver_config.hpp
+++ b/include/micm/configure/solver_config.hpp
@@ -458,7 +458,7 @@ namespace micm
       const std::string REACTANTS = "reactants";
       const std::string PRODUCTS = "products";
       const std::string MUSICA_NAME = "MUSICA name";
-      const std::string SCALING_FACTOR = "scaling_factor";
+      const std::string SCALING_FACTOR = "scaling factor";
 
       auto status = ValidateSchema(object, { "type", REACTANTS, PRODUCTS, MUSICA_NAME }, { SCALING_FACTOR });
       if (status != ConfigParseStatus::Success)
@@ -479,17 +479,14 @@ namespace micm
         return products.first;
       }
 
-      if (object.contains(SCALING_FACTOR))
-      {
-        std::cerr << "Scaling factor supplied to photolysis rate. This is not yet implemented." << std::endl;
-      }
+      double scaling_factor = object.contains(SCALING_FACTOR) ? object[SCALING_FACTOR].get<double>() : 1.0;
 
       std::string name = "PHOTO." + object[MUSICA_NAME].get<std::string>();
 
-      user_defined_rate_arr_.push_back(UserDefinedRateConstant({ .label_ = name }));
+      user_defined_rate_arr_.push_back(UserDefinedRateConstant({ .label_ = name, .scaling_factor_ = scaling_factor }));
 
       std::unique_ptr<UserDefinedRateConstant> rate_ptr =
-          std::make_unique<UserDefinedRateConstant>(UserDefinedRateConstantParameters{ .label_ = name });
+          std::make_unique<UserDefinedRateConstant>(UserDefinedRateConstantParameters{ .label_ = name, .scaling_factor_ = scaling_factor });
       processes_.push_back(Process(reactants.second, products.second, std::move(rate_ptr), gas_phase_));
 
       return ConfigParseStatus::Success;
@@ -835,17 +832,14 @@ namespace micm
                   << std::endl;
       }
 
-      if (object.contains(SCALING_FACTOR))
-      {
-        std::cerr << "Scaling factor supplied to emission rate. This is not yet implemented." << std::endl;
-      }
+      double scaling_factor = object.contains(SCALING_FACTOR) ? object[SCALING_FACTOR].get<double>() : 1.0;
 
       std::string name = "EMIS." + object[MUSICA_NAME].get<std::string>();
 
-      user_defined_rate_arr_.push_back(UserDefinedRateConstant({ .label_ = name }));
+      user_defined_rate_arr_.push_back(UserDefinedRateConstant({ .label_ = name, .scaling_factor_ = scaling_factor }));
 
       std::unique_ptr<UserDefinedRateConstant> rate_ptr =
-          std::make_unique<UserDefinedRateConstant>(UserDefinedRateConstantParameters{ .label_ = name });
+          std::make_unique<UserDefinedRateConstant>(UserDefinedRateConstantParameters{ .label_ = name, .scaling_factor_ = scaling_factor });
       processes_.push_back(Process(reactants.second, products.second, std::move(rate_ptr), gas_phase_));
 
       return ConfigParseStatus::Success;
@@ -855,8 +849,9 @@ namespace micm
     {
       const std::string SPECIES = "species";
       const std::string MUSICA_NAME = "MUSICA name";
+      const std::string SCALING_FACTOR = "scaling factor";
 
-      auto status = ValidateSchema(object, { "type", SPECIES, MUSICA_NAME }, {});
+      auto status = ValidateSchema(object, { "type", SPECIES, MUSICA_NAME }, { SCALING_FACTOR });
       if (status != ConfigParseStatus::Success)
       {
         return status;
@@ -877,12 +872,14 @@ namespace micm
         return products.first;
       }
 
+      double scaling_factor = object.contains(SCALING_FACTOR) ? object[SCALING_FACTOR].get<double>() : 1.0;
+      
       std::string name = "LOSS." + object[MUSICA_NAME].get<std::string>();
 
-      user_defined_rate_arr_.push_back(UserDefinedRateConstant({ .label_ = name }));
+      user_defined_rate_arr_.push_back(UserDefinedRateConstant({ .label_ = name, .scaling_factor_ = scaling_factor }));
 
       std::unique_ptr<UserDefinedRateConstant> rate_ptr =
-          std::make_unique<UserDefinedRateConstant>(UserDefinedRateConstantParameters{ .label_ = name });
+          std::make_unique<UserDefinedRateConstant>(UserDefinedRateConstantParameters{ .label_ = name, .scaling_factor_ = scaling_factor });
       processes_.push_back(Process(reactants.second, products.second, std::move(rate_ptr), gas_phase_));
 
       return ConfigParseStatus::Success;
@@ -893,8 +890,9 @@ namespace micm
       const std::string REACTANTS = "reactants";
       const std::string PRODUCTS = "products";
       const std::string MUSICA_NAME = "MUSICA name";
+      const std::string SCALING_FACTOR = "scaling factor";
 
-      auto status = ValidateSchema(object, { "type", REACTANTS, PRODUCTS, MUSICA_NAME }, {});
+      auto status = ValidateSchema(object, { "type", REACTANTS, PRODUCTS, MUSICA_NAME }, { SCALING_FACTOR });
       if (status != ConfigParseStatus::Success)
       {
         return status;
@@ -912,12 +910,14 @@ namespace micm
         return products.first;
       }
 
+      double scaling_factor = object.contains(SCALING_FACTOR) ? object[SCALING_FACTOR].get<double>() : 1.0;
+      
       std::string name = "USER." + object[MUSICA_NAME].get<std::string>();
 
-      user_defined_rate_arr_.push_back(UserDefinedRateConstant({ .label_ = name }));
+      user_defined_rate_arr_.push_back(UserDefinedRateConstant({ .label_ = name, .scaling_factor_ = scaling_factor }));
 
       std::unique_ptr<UserDefinedRateConstant> rate_ptr =
-          std::make_unique<UserDefinedRateConstant>(UserDefinedRateConstantParameters{ .label_ = name });
+          std::make_unique<UserDefinedRateConstant>(UserDefinedRateConstantParameters{ .label_ = name, .scaling_factor_ = scaling_factor });
       processes_.push_back(Process(reactants.second, products.second, std::move(rate_ptr), gas_phase_));
 
       return ConfigParseStatus::Success;

--- a/include/micm/process/arrhenius_rate_constant.hpp
+++ b/include/micm/process/arrhenius_rate_constant.hpp
@@ -29,7 +29,6 @@ namespace micm
    public:
     const ArrheniusRateConstantParameters parameters_;
 
-   public:
     /// @brief Default constructor
     ArrheniusRateConstant();
 

--- a/include/micm/process/branched_rate_constant.hpp
+++ b/include/micm/process/branched_rate_constant.hpp
@@ -37,7 +37,6 @@ namespace micm
     const double k0_;
     const double z_;
 
-   public:
     /// @brief Default constructor
     BranchedRateConstant();
 

--- a/include/micm/process/surface_rate_constant.hpp
+++ b/include/micm/process/surface_rate_constant.hpp
@@ -33,7 +33,6 @@ namespace micm
     double diffusion_coefficient_;   // [m2 s-1]
     double mean_free_speed_factor_;  // 8 * gas_constant / ( pi * molecular_weight )  [K-1]
 
-   public:
     /// @brief
     /// @param name A name for this reaction
     SurfaceRateConstant(const SurfaceRateConstantParameters& parameters);

--- a/include/micm/process/ternary_chemical_activation_rate_constant.hpp
+++ b/include/micm/process/ternary_chemical_activation_rate_constant.hpp
@@ -35,7 +35,6 @@ namespace micm
    public:
     const TernaryChemicalActivationRateConstantParameters parameters_;
 
-   public:
     /// @brief Default constructor
     TernaryChemicalActivationRateConstant();
 

--- a/include/micm/process/troe_rate_constant.hpp
+++ b/include/micm/process/troe_rate_constant.hpp
@@ -35,7 +35,6 @@ namespace micm
    public:
     const TroeRateConstantParameters parameters_;
 
-   public:
     /// @brief Default constructor
     TroeRateConstant();
 

--- a/include/micm/process/tunneling_rate_constant.hpp
+++ b/include/micm/process/tunneling_rate_constant.hpp
@@ -25,7 +25,6 @@ namespace micm
    public:
     const TunnelingRateConstantParameters parameters_;
 
-   public:
     /// @brief Default constructor
     TunnelingRateConstant();
 

--- a/include/micm/process/user_defined_rate_constant.hpp
+++ b/include/micm/process/user_defined_rate_constant.hpp
@@ -19,9 +19,9 @@ namespace micm
   /// @brief A photolysis rate constant
   class UserDefinedRateConstant : public RateConstant
   {
+   public:
     UserDefinedRateConstantParameters parameters_;
 
-   public:
     /// @brief Default constructor.
     UserDefinedRateConstant();
 

--- a/include/micm/process/user_defined_rate_constant.hpp
+++ b/include/micm/process/user_defined_rate_constant.hpp
@@ -12,6 +12,8 @@ namespace micm
   {
     /// @brief Label for the reaction used to identify user-defined parameters
     std::string label_;
+    /// @brief Scaling factor to apply to user-provided rate constants
+    double scaling_factor_{ 1.0 };
   };
 
   /// @brief A photolysis rate constant
@@ -75,7 +77,7 @@ namespace micm
       const Conditions& conditions,
       std::vector<double>::const_iterator custom_parameters) const
   {
-    return (double)*custom_parameters;
+    return (double)*custom_parameters * parameters_.scaling_factor_;
   }
 
   inline std::vector<std::string> UserDefinedRateConstant::CustomParameters() const

--- a/test/unit/configure/process/test_emission_config.cpp
+++ b/test/unit/configure/process/test_emission_config.cpp
@@ -34,6 +34,7 @@ TEST(EmissionConfig, ParseConfig)
         dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[0].rate_constant_.get());
     EXPECT_EQ(emission_rate_constant->SizeCustomParameters(), 1);
     EXPECT_EQ(emission_rate_constant->CustomParameters()[0], "EMIS.foo");
+    EXPECT_EQ(emission_rate_constant->parameters_.scaling_factor_, 1.0);
   }
 
   // second reaction
@@ -46,6 +47,7 @@ TEST(EmissionConfig, ParseConfig)
         dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[1].rate_constant_.get());
     EXPECT_EQ(emission_rate_constant->SizeCustomParameters(), 1);
     EXPECT_EQ(emission_rate_constant->CustomParameters()[0], "EMIS.bar");
+    EXPECT_EQ(emission_rate_constant->parameters_.scaling_factor_, 2.5);
   }
 }
 

--- a/test/unit/configure/process/test_first_order_loss_config.cpp
+++ b/test/unit/configure/process/test_first_order_loss_config.cpp
@@ -33,6 +33,7 @@ TEST(FirstOrderLossConfig, ParseConfig)
         dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[0].rate_constant_.get());
     EXPECT_EQ(first_order_loss_rate_constant->SizeCustomParameters(), 1);
     EXPECT_EQ(first_order_loss_rate_constant->CustomParameters()[0], "LOSS.foo");
+    EXPECT_EQ(first_order_loss_rate_constant->parameters_.scaling_factor_, 1.0);
   }
 
   // second reaction
@@ -44,6 +45,7 @@ TEST(FirstOrderLossConfig, ParseConfig)
         dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[1].rate_constant_.get());
     EXPECT_EQ(first_order_loss_rate_constant->SizeCustomParameters(), 1);
     EXPECT_EQ(first_order_loss_rate_constant->CustomParameters()[0], "LOSS.bar");
+    EXPECT_EQ(first_order_loss_rate_constant->parameters_.scaling_factor_, 2.5);
   }
 }
 

--- a/test/unit/configure/process/test_photolysis_config.cpp
+++ b/test/unit/configure/process/test_photolysis_config.cpp
@@ -39,6 +39,7 @@ TEST(PhotolysisConfig, ParseConfig)
         dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[0].rate_constant_.get());
     EXPECT_EQ(photo_rate_constant->SizeCustomParameters(), 1);
     EXPECT_EQ(photo_rate_constant->CustomParameters()[0], "PHOTO.jfoo");
+    EXPECT_EQ(photo_rate_constant->parameters_.scaling_factor_, 1.0);
   }
 
   // second reaction
@@ -54,6 +55,7 @@ TEST(PhotolysisConfig, ParseConfig)
         dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[1].rate_constant_.get());
     EXPECT_EQ(photo_rate_constant->SizeCustomParameters(), 1);
     EXPECT_EQ(photo_rate_constant->CustomParameters()[0], "PHOTO.jbar");
+    EXPECT_EQ(photo_rate_constant->parameters_.scaling_factor_, 2.5);
   }
 }
 

--- a/test/unit/configure/process/test_user_defined_config.cpp
+++ b/test/unit/configure/process/test_user_defined_config.cpp
@@ -41,6 +41,7 @@ TEST(UserDefinedConfig, ParseConfig)
         dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[0].rate_constant_.get());
     EXPECT_EQ(photo_rate_constant->SizeCustomParameters(), 1);
     EXPECT_EQ(photo_rate_constant->CustomParameters()[0], "USER.foo");
+    EXPECT_EQ(photo_rate_constant->parameters_.scaling_factor_, 1.0);
   }
 
   // second reaction
@@ -55,6 +56,7 @@ TEST(UserDefinedConfig, ParseConfig)
         dynamic_cast<micm::UserDefinedRateConstant*>(process_vector[1].rate_constant_.get());
     EXPECT_EQ(photo_rate_constant->SizeCustomParameters(), 1);
     EXPECT_EQ(photo_rate_constant->CustomParameters()[0], "USER.bar");
+    EXPECT_EQ(photo_rate_constant->parameters_.scaling_factor_, 2.5);
   }
 }
 

--- a/test/unit/process/test_user_defined_rate_constant.cpp
+++ b/test/unit/process/test_user_defined_rate_constant.cpp
@@ -57,3 +57,21 @@ TEST(UserDefinedRateConstant, ConstructorWithRateAndName)
   EXPECT_EQ(k, 1.1);
   EXPECT_EQ(photo.CustomParameters()[0], "a name");
 }
+
+TEST(UserDefinedRateConstant, CustomScalingFactor)
+{
+  auto state_parameters = micm::StateParameters{
+    .number_of_grid_cells_ = 1,
+    .number_of_rate_constants_ = 1,
+    .variable_names_ = {"user"},
+    .custom_rate_parameter_labels_ = { "my rate", },
+  };
+
+  micm::State state{ state_parameters };
+  state.custom_rate_parameters_[0][0] = 1.2;
+  std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
+  micm::UserDefinedRateConstant photo({ .label_ = "a name", .scaling_factor_ = 2.0 });
+  auto k = photo.calculate(state.conditions_[0], params);
+  EXPECT_EQ(k, 1.2 * 2.0);
+  EXPECT_EQ(photo.CustomParameters()[0], "a name");
+}

--- a/test/unit/unit_configs/process/emission/valid/reactions.json
+++ b/test/unit/unit_configs/process/emission/valid/reactions.json
@@ -13,7 +13,8 @@
         {
           "type": "EMISSION",
           "species": "bar",
-          "MUSICA name": "bar"
+          "MUSICA name": "bar",
+          "scaling factor": 2.5
         }
       ]
     }

--- a/test/unit/unit_configs/process/first_order_loss/valid/reactions.json
+++ b/test/unit/unit_configs/process/first_order_loss/valid/reactions.json
@@ -13,7 +13,8 @@
         {
           "type": "FIRST_ORDER_LOSS",
           "species": "bar",
-          "MUSICA name": "bar"
+          "MUSICA name": "bar",
+          "scaling factor": 2.5
         }
       ]
     }

--- a/test/unit/unit_configs/process/photolysis/valid/reactions.json
+++ b/test/unit/unit_configs/process/photolysis/valid/reactions.json
@@ -24,7 +24,8 @@
             "bar": { "yield": 0.5 },
             "foo": { }
           },
-          "MUSICA name": "jbar"
+          "MUSICA name": "jbar",
+          "scaling factor": 2.5
         }
       ]
     }

--- a/test/unit/unit_configs/process/user_defined/valid/reactions.json
+++ b/test/unit/unit_configs/process/user_defined/valid/reactions.json
@@ -25,7 +25,8 @@
           },
           "products": {
             "bar" : { }
-          } 
+          }, 
+          "scaling factor": 2.5
         }
       ]
     }


### PR DESCRIPTION
closes #330 

Adds the ability to parse scaling factors for user-defined rate constants (e.g., emissions, photolysis, first-order loss)