### PR TITLE
Changed rate constant expression to allow for N = 0.

### DIFF
--- a/include/micm/process/ternary_chemical_activation_rate_constant.hpp
+++ b/include/micm/process/ternary_chemical_activation_rate_constant.hpp
@@ -105,7 +105,7 @@ namespace micm
     return k0 / (1.0 + k0 * air_number_density / kinf) *
            std::pow(
                parameters_.Fc_,
-               1.0 / (1.0 + 1.0 / parameters_.N_ * std::pow(std::log10(k0 * air_number_density / kinf), 2)));
+               parameters_.N_ / (parameters_.N_ + std::pow(std::log10(k0 * air_number_density / kinf), 2)));
   }
 
 }  // namespace micm

--- a/include/micm/process/troe_rate_constant.hpp
+++ b/include/micm/process/troe_rate_constant.hpp
@@ -101,7 +101,7 @@ namespace micm
     return k0 * air_number_density / (1.0 + k0 * air_number_density / kinf) *
            std::pow(
                parameters_.Fc_,
-               1.0 / (1.0 + (1.0 / parameters_.N_) * std::pow(std::log10(k0 * air_number_density / kinf), 2)));
+               parameters_.N_ / (parameters_.N_ + std::pow(std::log10(k0 * air_number_density / kinf), 2)));
   }
 
 }  // namespace micm


### PR DESCRIPTION
In Troe and Ternary reactions, changed rate constant expressions to allow for N = 0.

closes #349 