### PR TITLE
Develop 337 non si units

### DIFF
--- a/include/micm/configure/solver_config.hpp
+++ b/include/micm/configure/solver_config.hpp
@@ -42,6 +42,8 @@ namespace micm
     MutuallyExclusiveOption
   };
 
+  constexpr double MolesM3ToMoleculesCm3 = 1.0e-6 * 6.02214076e23;
+
   inline std::string configParseStatusToString(const ConfigParseStatus& status)
   {
     switch (status)
@@ -522,6 +524,7 @@ namespace micm
       {
         parameters.A_ = object["A"].get<double>();
       }
+      parameters.A_ *= std::pow(MolesM3ToMoleculesCm3, reactants.second.size()-1);
       if (object.contains("B"))
       {
         parameters.B_ = object["B"].get<double>();
@@ -588,6 +591,8 @@ namespace micm
       {
         parameters.k0_A_ = object["k0_A"].get<double>();
       }
+      // Account for the conversion of reactant concentrations (including M) to molecules cm-3
+      parameters.k0_A_ *= std::pow(MolesM3ToMoleculesCm3, reactants.second.size());
       if (object.contains("k0_B"))
       {
         parameters.k0_B_ = object["k0_B"].get<double>();
@@ -600,6 +605,8 @@ namespace micm
       {
         parameters.kinf_A_ = object["kinf_A"].get<double>();
       }
+      // Account for terms in denominator and exponent that include [M] but not other reactants
+      parameters.kinf_A_ *= std::pow(MolesM3ToMoleculesCm3, reactants.second.size()-1);
       if (object.contains("kinf_B"))
       {
         parameters.kinf_B_ = object["kinf_B"].get<double>();
@@ -656,6 +663,8 @@ namespace micm
       {
         parameters.k0_A_ = object["k0_A"].get<double>();
       }
+      // Account for the conversion of reactant concentrations (including M) to molecules cm-3
+      parameters.k0_A_ *= std::pow(MolesM3ToMoleculesCm3, reactants.second.size()-1);
       if (object.contains("k0_B"))
       {
         parameters.k0_B_ = object["k0_B"].get<double>();
@@ -668,6 +677,8 @@ namespace micm
       {
         parameters.kinf_A_ = object["kinf_A"].get<double>();
       }
+      // Account for terms in denominator and exponent that include [M] but not other reactants
+      parameters.kinf_A_ *= std::pow(MolesM3ToMoleculesCm3, reactants.second.size()-2);
       if (object.contains("kinf_B"))
       {
         parameters.kinf_B_ = object["kinf_B"].get<double>();
@@ -732,6 +743,8 @@ namespace micm
 
       BranchedRateConstantParameters parameters;
       parameters.X_ = object[X].get<double>();
+      // Account for the conversion of reactant concentrations to molecules cm-3
+      parameters.X_ *= std::pow(MolesM3ToMoleculesCm3, reactants.second.size()-1);
       parameters.Y_ = object[Y].get<double>();
       parameters.a0_ = object[A0].get<double>();
       parameters.n_ = object[N].get<int>();
@@ -780,6 +793,8 @@ namespace micm
       {
         parameters.A_ = object["A"].get<double>();
       }
+      // Account for the conversion of reactant concentrations to molecules cm-3
+      parameters.A_ *= std::pow(MolesM3ToMoleculesCm3, reactants.second.size()-1);
       if (object.contains("B"))
       {
         parameters.B_ = object["B"].get<double>();

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -52,7 +52,7 @@ namespace micm
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetConcentrations(
       const std::unordered_map<std::string, std::vector<double>>& species_to_concentration)
   {
-    const int num_grid_cells = conditions_.size();
+    const std::size_t num_grid_cells = conditions_.size();
     for (const auto& pair : species_to_concentration)
       SetConcentration({ pair.first }, pair.second);
   }

--- a/test/unit/configure/process/test_arrhenius_config.cpp
+++ b/test/unit/configure/process/test_arrhenius_config.cpp
@@ -26,6 +26,9 @@ TEST(ArrheniusConfig, ParseConfig)
 
   auto& process_vector = solver_params.processes_;
 
+  // Convert Arrhenius parameters from expecting molecules cm-3 to moles m-3
+  const double conv = 1.0e-6 * 6.02214076e23;
+
   // first reaction
   {
     EXPECT_EQ(process_vector[0].reactants_.size(), 3);
@@ -40,7 +43,7 @@ TEST(ArrheniusConfig, ParseConfig)
     micm::ArrheniusRateConstant* ternary_rate_constant =
         dynamic_cast<micm::ArrheniusRateConstant*>(process_vector[0].rate_constant_.get());
     auto& params = ternary_rate_constant->parameters_;
-    EXPECT_EQ(params.A_, 1.0);
+    EXPECT_EQ(params.A_, 1.0 * conv * conv);
     EXPECT_EQ(params.B_, 0.0);
     EXPECT_EQ(params.C_, 0.0);
     EXPECT_EQ(params.D_, 300);
@@ -60,7 +63,7 @@ TEST(ArrheniusConfig, ParseConfig)
     micm::ArrheniusRateConstant* ternary_rate_constant =
         dynamic_cast<micm::ArrheniusRateConstant*>(process_vector[1].rate_constant_.get());
     auto& params = ternary_rate_constant->parameters_;
-    EXPECT_EQ(params.A_, 32.1);
+    EXPECT_EQ(params.A_, 32.1 * conv);
     EXPECT_EQ(params.B_, -2.3);
     EXPECT_EQ(params.C_, 102.3);
     EXPECT_EQ(params.D_, 63.4);
@@ -80,7 +83,7 @@ TEST(ArrheniusConfig, ParseConfig)
     micm::ArrheniusRateConstant* ternary_rate_constant =
         dynamic_cast<micm::ArrheniusRateConstant*>(process_vector[2].rate_constant_.get());
     auto& params = ternary_rate_constant->parameters_;
-    EXPECT_EQ(params.A_, 32.1);
+    EXPECT_EQ(params.A_, 32.1 * conv);
     EXPECT_EQ(params.B_, -2.3);
     EXPECT_EQ(params.C_, -1 * 2e23 / BOLTZMANN_CONSTANT);
     EXPECT_EQ(params.D_, 63.4);

--- a/test/unit/configure/process/test_branched_config.cpp
+++ b/test/unit/configure/process/test_branched_config.cpp
@@ -27,6 +27,9 @@ TEST(BranchedConfig, ParseConfig)
   auto& process_vector = solver_params.processes_;
   EXPECT_EQ(process_vector.size(), 4);
 
+  // Convert Arrhenius parameters from expecting molecules cm-3 to moles m-3
+  const double conv = 1.0e-6 * 6.02214076e23;
+
   // first reaction
   {
     EXPECT_EQ(process_vector[0].reactants_.size(), 3);
@@ -41,7 +44,7 @@ TEST(BranchedConfig, ParseConfig)
     micm::BranchedRateConstant* branched_rate_constant =
         dynamic_cast<micm::BranchedRateConstant*>(process_vector[0].rate_constant_.get());
     auto& params = branched_rate_constant->parameters_;
-    EXPECT_EQ(params.X_, 12.3);
+    EXPECT_EQ(params.X_, 12.3 * std::pow(conv, 2));
     EXPECT_EQ(params.Y_, 42.3);
     EXPECT_EQ(params.a0_, 1.0e-5);
     EXPECT_EQ(params.n_, 3);
@@ -58,7 +61,7 @@ TEST(BranchedConfig, ParseConfig)
     micm::BranchedRateConstant* branched_rate_constant =
         dynamic_cast<micm::BranchedRateConstant*>(process_vector[1].rate_constant_.get());
     auto& params = branched_rate_constant->parameters_;
-    EXPECT_EQ(params.X_, 12.3);
+    EXPECT_EQ(params.X_, 12.3 * std::pow(conv, 2));
     EXPECT_EQ(params.Y_, 42.3);
     EXPECT_EQ(params.a0_, 1.0e-5);
     EXPECT_EQ(params.n_, 3);
@@ -76,7 +79,7 @@ TEST(BranchedConfig, ParseConfig)
     micm::BranchedRateConstant* branched_rate_constant =
         dynamic_cast<micm::BranchedRateConstant*>(process_vector[2].rate_constant_.get());
     auto& params = branched_rate_constant->parameters_;
-    EXPECT_EQ(params.X_, 0.32);
+    EXPECT_EQ(params.X_, 0.32 * conv);
     EXPECT_EQ(params.Y_, 2.3e8);
     EXPECT_EQ(params.a0_, 0.423);
     EXPECT_EQ(params.n_, 6);
@@ -94,7 +97,7 @@ TEST(BranchedConfig, ParseConfig)
     micm::BranchedRateConstant* branched_rate_constant =
         dynamic_cast<micm::BranchedRateConstant*>(process_vector[3].rate_constant_.get());
     auto& params = branched_rate_constant->parameters_;
-    EXPECT_EQ(params.X_, 0.32);
+    EXPECT_EQ(params.X_, 0.32 * conv);
     EXPECT_EQ(params.Y_, 2.3e8);
     EXPECT_EQ(params.a0_, 0.423);
     EXPECT_EQ(params.n_, 6);

--- a/test/unit/configure/process/test_ternary_chemical_activation_config.cpp
+++ b/test/unit/configure/process/test_ternary_chemical_activation_config.cpp
@@ -25,6 +25,9 @@ TEST(TernaryChemicalActivationConfig, ParseConfig)
 
   auto& process_vector = solver_params.processes_;
 
+  // Convert Arrhenius parameters from expecting molecules cm-3 to moles m-3
+  const double conv = 1.0e-6 * 6.02214076e23;
+
   // first reaction
   {
     EXPECT_EQ(process_vector[0].reactants_.size(), 3);
@@ -39,10 +42,10 @@ TEST(TernaryChemicalActivationConfig, ParseConfig)
     micm::TernaryChemicalActivationRateConstant* ternary_rate_constant =
         dynamic_cast<micm::TernaryChemicalActivationRateConstant*>(process_vector[0].rate_constant_.get());
     auto& params = ternary_rate_constant->parameters_;
-    EXPECT_EQ(params.k0_A_, 1.0);
+    EXPECT_EQ(params.k0_A_, 1.0 * conv * conv);
     EXPECT_EQ(params.k0_B_, 0.0);
     EXPECT_EQ(params.k0_C_, 0.0);
-    EXPECT_EQ(params.kinf_A_, 1.0);
+    EXPECT_EQ(params.kinf_A_, 1.0 * conv);
     EXPECT_EQ(params.kinf_B_, 0.0);
     EXPECT_EQ(params.kinf_C_, 0.0);
     EXPECT_EQ(params.Fc_, 0.6);
@@ -62,7 +65,7 @@ TEST(TernaryChemicalActivationConfig, ParseConfig)
     micm::TernaryChemicalActivationRateConstant* ternary_rate_constant =
         dynamic_cast<micm::TernaryChemicalActivationRateConstant*>(process_vector[1].rate_constant_.get());
     auto& params = ternary_rate_constant->parameters_;
-    EXPECT_EQ(params.k0_A_, 32.1);
+    EXPECT_EQ(params.k0_A_, 32.1 * conv);
     EXPECT_EQ(params.k0_B_, -2.3);
     EXPECT_EQ(params.k0_C_, 102.3);
     EXPECT_EQ(params.kinf_A_, 63.4);

--- a/test/unit/configure/process/test_troe_config.cpp
+++ b/test/unit/configure/process/test_troe_config.cpp
@@ -41,7 +41,8 @@ TEST(TroeConfig, ParseConfig)
     micm::TroeRateConstant* ternary_rate_constant =
         dynamic_cast<micm::TroeRateConstant*>(process_vector[0].rate_constant_.get());
     auto& params = ternary_rate_constant->parameters_;
-    EXPECT_EQ(params.k0_A_, 1.0 * std::pow(conv, 3));
+    // NVHPC compiler has some round-off error
+    EXPECT_NEAR(params.k0_A_, 1.0 * std::pow(conv, 3), std::pow(conv, 3) * 1e-12);
     EXPECT_EQ(params.k0_B_, 0.0);
     EXPECT_EQ(params.k0_C_, 0.0);
     EXPECT_EQ(params.kinf_A_, 1.0 * std::pow(conv, 2));

--- a/test/unit/configure/process/test_troe_config.cpp
+++ b/test/unit/configure/process/test_troe_config.cpp
@@ -24,6 +24,9 @@ TEST(TroeConfig, ParseConfig)
 
   auto& process_vector = solver_params.processes_;
 
+  // Convert Arrhenius parameters from expecting molecules cm-3 to moles m-3
+  const double conv = 1.0e-6 * 6.02214076e23;
+  
   // first reaction
   {
     EXPECT_EQ(process_vector[0].reactants_.size(), 3);
@@ -38,10 +41,10 @@ TEST(TroeConfig, ParseConfig)
     micm::TroeRateConstant* ternary_rate_constant =
         dynamic_cast<micm::TroeRateConstant*>(process_vector[0].rate_constant_.get());
     auto& params = ternary_rate_constant->parameters_;
-    EXPECT_EQ(params.k0_A_, 1.0);
+    EXPECT_EQ(params.k0_A_, 1.0 * std::pow(conv, 3));
     EXPECT_EQ(params.k0_B_, 0.0);
     EXPECT_EQ(params.k0_C_, 0.0);
-    EXPECT_EQ(params.kinf_A_, 1.0);
+    EXPECT_EQ(params.kinf_A_, 1.0 * std::pow(conv, 2));
     EXPECT_EQ(params.kinf_B_, 0.0);
     EXPECT_EQ(params.kinf_C_, 0.0);
     EXPECT_EQ(params.Fc_, 0.6);
@@ -61,10 +64,10 @@ TEST(TroeConfig, ParseConfig)
     micm::TroeRateConstant* ternary_rate_constant =
         dynamic_cast<micm::TroeRateConstant*>(process_vector[1].rate_constant_.get());
     auto& params = ternary_rate_constant->parameters_;
-    EXPECT_EQ(params.k0_A_, 32.1);
+    EXPECT_EQ(params.k0_A_, 32.1 * std::pow(conv, 2));
     EXPECT_EQ(params.k0_B_, -2.3);
     EXPECT_EQ(params.k0_C_, 102.3);
-    EXPECT_EQ(params.kinf_A_, 63.4);
+    EXPECT_EQ(params.kinf_A_, 63.4 * conv);
     EXPECT_EQ(params.kinf_B_, -1.3);
     EXPECT_EQ(params.kinf_C_, 908.5);
     EXPECT_EQ(params.Fc_, 1.3);

--- a/test/unit/configure/process/test_tunneling_config.cpp
+++ b/test/unit/configure/process/test_tunneling_config.cpp
@@ -24,6 +24,9 @@ TEST(TunnelingConfig, ParseConfig)
 
   auto& process_vector = solver_params.processes_;
 
+  // Convert Arrhenius parameters from expecting molecules cm-3 to moles m-3
+  const double conv = 1.0e-6 * 6.02214076e23;
+  
   // first reaction
   {
     EXPECT_EQ(process_vector[0].reactants_.size(), 3);
@@ -38,7 +41,7 @@ TEST(TunnelingConfig, ParseConfig)
     micm::TunnelingRateConstant* tunneling_rate_constant =
         dynamic_cast<micm::TunnelingRateConstant*>(process_vector[0].rate_constant_.get());
     auto& params = tunneling_rate_constant->parameters_;
-    EXPECT_EQ(params.A_, 1.0);
+    EXPECT_EQ(params.A_, 1.0 * conv * conv);
     EXPECT_EQ(params.B_, 0.0);
     EXPECT_EQ(params.C_, 0.0);
   }
@@ -56,7 +59,7 @@ TEST(TunnelingConfig, ParseConfig)
     micm::TunnelingRateConstant* tunneling_rate_constant =
         dynamic_cast<micm::TunnelingRateConstant*>(process_vector[1].rate_constant_.get());
     auto& params = tunneling_rate_constant->parameters_;
-    EXPECT_EQ(params.A_, 32.1);
+    EXPECT_EQ(params.A_, 32.1 * conv);
     EXPECT_EQ(params.B_, -2.3);
     EXPECT_EQ(params.C_, 102.3);
   }

--- a/test/unit/configure/test_solver_config.cpp
+++ b/test/unit/configure/test_solver_config.cpp
@@ -110,6 +110,13 @@ TEST(SolverConfig, ReadAndParseProcessObjects)
   double D_param[] = { 300.0, 300.0, 300.0, 300.0 };
   double E_param[] = { 0.0, 0.0, 0.0, 0.0 };
 
+  // Convert Arrhenius parameters from expecting molecules cm-3 to moles m-3
+  const double conv = 1.0e-6 * 6.02214076e23;
+  A_param[0] *= conv; // 2 reactants
+  A_param[1] *= conv; // 2 reactants
+  A_param[2] *= conv; // 2 reactants
+  A_param[3] *= conv * conv; // 3 reactants
+
   for (short i = 3; i < 7; i++)
   {
     arrhenius_rate_const = dynamic_cast<micm::ArrheniusRateConstant*>(process_vector[i].rate_constant_.get());


### PR DESCRIPTION
closes #337 

Introduces the conversion of parameters from the OpenAtmos configuration format to account for the use of SI units in MICM. A separate issue will be created on the https://github.com/NCAR/micm-kpp/ repo to account for this change.