### PR TITLE
Initial CudaVectorMatrix implementation.

### DIFF
--- a/include/micm/util/cuda_vector_matrix.cuh
+++ b/include/micm/util/cuda_vector_matrix.cuh
@@ -1,0 +1,15 @@
+#include <vector>
+
+namespace micm
+{
+  namespace cuda
+  {
+    int malloc_vector(double *d_data, std::size_t num_elements);
+
+    int free_vector(double *d_data);
+
+    int copy_to_device(double *d_data, const double *h_data, std::size_t num_elements);
+
+    int copy_to_host(double *d_data, double *h_data, std::size_t num_elements);
+  }
+}

--- a/include/micm/util/cuda_vector_matrix.hpp
+++ b/include/micm/util/cuda_vector_matrix.hpp
@@ -1,0 +1,65 @@
+#include <type_traits>
+#include <micm/util/vector_matrix.hpp>
+#include <micm/util/cuda_vector_matrix.cuh>
+
+namespace micm {
+
+    template<class T, std::size_t L = DEFAULT_VECTOR_SIZE>
+    class CudaVectorMatrix : public VectorMatrix<T, L> {
+    private:
+        double* d_data_;
+
+    public:
+        CudaVectorMatrix() requires(std::is_same_v<T, double>)
+         : VectorMatrix<T,L>()
+        {
+          micm::cuda::malloc_vector(d_data_, static_cast<unsigned int>(0));
+        }
+        CudaVectorMatrix()
+         : VectorMatrix<T,L>()
+        {}
+
+        CudaVectorMatrix(std::size_t x_dim, std::size_t y_dim) requires(std::is_same_v<T, double>)
+          : VectorMatrix<T,L>(x_dim, y_dim)
+        {
+          micm::cuda::malloc_vector(d_data_, this->data_.size());
+        }
+        CudaVectorMatrix(std::size_t x_dim, std::size_t y_dim)
+          : VectorMatrix<T,L>(x_dim, y_dim)
+        {}
+
+        CudaVectorMatrix(std::size_t x_dim, std::size_t y_dim, T initial_value) requires(std::is_same_v<T, double>)
+          : VectorMatrix<T,L>(x_dim, y_dim, initial_value)
+        {
+          micm::cuda::malloc_vector(d_data_, this->data_.size());
+        }
+        CudaVectorMatrix(std::size_t x_dim, std::size_t y_dim, T initial_value)
+          : VectorMatrix<T,L>(x_dim, y_dim, initial_value)
+        {}
+
+        CudaVectorMatrix(const std::vector<std::vector<T>> other) requires(std::is_same_v<T, double>)
+          : VectorMatrix<T,L>(other)
+        {
+          micm::cuda::malloc_vector(d_data_, this->data_.size());
+        }
+        CudaVectorMatrix(const std::vector<std::vector<T>> other)
+          : VectorMatrix<T,L>(other)
+        {}
+
+        ~CudaVectorMatrix()
+        {
+          micm::cuda::free_vector(d_data_);
+        }
+
+        int CopyToDevice()
+        {
+          static_assert(std::is_same_v<T, double>);
+          return micm::cuda::copy_to_device(d_data_, this->data_.data(), this->AsVector().size());
+        }
+        int GetFromDevice()
+        {
+          static_assert(std::is_same_v<T, double>);
+          return micm::cuda::copy_to_host(d_data_, this->data_.data(), this->AsVector().size());
+        }
+    };
+}

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -25,7 +25,9 @@ namespace micm
   template<class T, std::size_t L = DEFAULT_VECTOR_SIZE>
   class VectorMatrix
   {
+protected:
     std::vector<T> data_;
+private:
     std::size_t x_dim_;  // number of rows
     std::size_t y_dim_;  // number of columns
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,3 +88,4 @@ endif()
 
 add_subdirectory(process)
 add_subdirectory(solver)
+add_subdirectory(util)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,0 +1,6 @@
+if(ENABLE_CUDA)
+  target_sources(micm_cuda
+       PRIVATE
+       cuda_vector_matrix.cu
+  )
+endif()

--- a/src/util/cuda_vector_matrix.cu
+++ b/src/util/cuda_vector_matrix.cu
@@ -1,0 +1,25 @@
+#include <vector>
+//#include <micm/util/cuda_vector_matrix.cuh>
+
+namespace micm
+{
+  namespace cuda
+  {
+    int malloc_vector(double *d_data, std::size_t num_elements)
+    {
+      return cudaMalloc(&d_data, sizeof(double) * num_elements);
+    }
+    int free_vector(double *d_data)
+    {
+      return cudaFree(d_data);
+    }
+    int copy_to_device(double *d_data, const double *h_data, std::size_t num_elements)
+    {
+      return cudaMemcpy(d_data, h_data, sizeof(double) * num_elements, cudaMemcpyHostToDevice);
+    }
+    int copy_to_host(double* d_data, double *h_data, std::size_t num_elements)
+    {
+      return cudaMemcpy(h_data, d_data, sizeof(double) * num_elements, cudaMemcpyDeviceToHost);
+    }
+  }
+}

--- a/test/unit/util/CMakeLists.txt
+++ b/test/unit/util/CMakeLists.txt
@@ -10,3 +10,7 @@ create_standard_test(NAME matrix SOURCES test_matrix.cpp)
 create_standard_test(NAME sparse_matrix_standard_ordering SOURCES test_sparse_matrix_standard_ordering.cpp)
 create_standard_test(NAME sparse_matrix_vector_ordering SOURCES test_sparse_matrix_vector_ordering.cpp)
 create_standard_test(NAME vector_matrix SOURCES test_vector_matrix.cpp)
+
+if(ENABLE_CUDA)
+  create_standard_test(NAME cuda_vector_matrix SOURCES test_cuda_vector_matrix.cpp LIBRARIES musica::micm_cuda)
+endif()

--- a/test/unit/util/test_cuda_vector_matrix.cpp
+++ b/test/unit/util/test_cuda_vector_matrix.cpp
@@ -1,0 +1,187 @@
+#include <gtest/gtest.h>
+
+#include <micm/util/cuda_vector_matrix.hpp>
+
+#include "test_matrix_policy.hpp"
+
+template<class T>
+using Group1MatrixAlias = micm::CudaVectorMatrix<T,1>;
+template<class T>
+using Group2MatrixAlias = micm::CudaVectorMatrix<T,2>;
+template<class T>
+using Group3MatrixAlias = micm::CudaVectorMatrix<T,3>;
+template<class T>
+using Group4MatrixAlias = micm::CudaVectorMatrix<T,4>;
+
+
+
+TEST(VectorMatrix, SmallVectorMatrix)
+{
+  auto matrix = testSmallMatrix<Group2MatrixAlias>();
+
+  matrix.CopyToDevice();
+  matrix.GetFromDevice();
+
+  EXPECT_EQ(matrix[1][3], 64.7);
+  EXPECT_EQ(matrix[0][0], 41.2);
+  EXPECT_EQ(matrix[2][4], 102.3);
+
+  std::vector<double>& data = matrix.AsVector();
+
+  EXPECT_EQ(data.size(), 4 * 5);
+  EXPECT_EQ(matrix.GroupSize(), 2 * 5);
+  EXPECT_EQ(matrix.NumberOfGroups(), 2);
+  EXPECT_EQ(matrix.GroupVectorSize(), 2);
+  EXPECT_EQ(data[0], 41.2);
+  EXPECT_EQ(data[2 * 5 + 0 + 2 * 4], 102.3);
+  EXPECT_EQ(data[1 + 2 * 3], 64.7);
+}
+
+TEST(VectorMatrix, SmallConstVectorMatrix)
+{
+  auto matrix = testSmallConstMatrix<Group4MatrixAlias>();
+
+  const std::vector<double>& data = matrix.AsVector();
+
+  EXPECT_EQ(data.size(), 4 * 5);
+  EXPECT_EQ(matrix.GroupSize(), 4 * 5);
+  EXPECT_EQ(matrix.NumberOfGroups(), 1);
+  EXPECT_EQ(matrix.GroupVectorSize(), 4);
+  EXPECT_EQ(data[0], 41.2);
+  EXPECT_EQ(data[2 + 4 * 4], 102.3);
+  EXPECT_EQ(data[1 + 4 * 3], 64.7);
+}
+
+TEST(VectorMatrix, InitializeVectorMatrix)
+{
+  auto matrix = testInializeMatrix<Group1MatrixAlias>();
+  matrix.CopyToDevice();
+  matrix.GetFromDevice();
+
+  EXPECT_EQ(matrix[0][0], 12.4);
+  EXPECT_EQ(matrix[1][0], 12.4);
+  EXPECT_EQ(matrix[1][2], 12.4);
+}
+
+TEST(VectorMatrix, InitializeConstVectorMatrix)
+{
+  auto matrix = testInializeConstMatrix<Group2MatrixAlias>();
+  matrix.CopyToDevice();
+  matrix.GetFromDevice();
+
+  EXPECT_EQ(matrix[0][0], 12.4);
+  EXPECT_EQ(matrix[1][0], 12.4);
+  EXPECT_EQ(matrix[1][2], 12.4);
+}
+
+TEST(VectorMatrix, LoopOverVectorMatrix)
+{
+  Group2MatrixAlias<double> matrix(3, 4, 0);
+  for (std::size_t i{}; i < matrix.size(); ++i)
+  {
+    for (std::size_t j{}; j < matrix[i].size(); ++j)
+    {
+      matrix[i][j] = i * 100 + j;
+    }
+  }
+
+  EXPECT_EQ(matrix[0][0], 0);
+  EXPECT_EQ(matrix[1][2], 102);
+  EXPECT_EQ(matrix[2][3], 203);
+  EXPECT_EQ(matrix[0][3], 3);
+
+  matrix.CopyToDevice();
+  matrix.GetFromDevice();
+
+  EXPECT_EQ(matrix[0][0], 0);
+  EXPECT_EQ(matrix[1][2], 102);
+  EXPECT_EQ(matrix[2][3], 203);
+  EXPECT_EQ(matrix[0][3], 3);
+}
+
+TEST(VectorMatrix, LoopOverConstVectorMatrix)
+{
+  Group2MatrixAlias<double> matrix(3, 4, 0);
+  for (std::size_t i{}; i < matrix.size(); ++i)
+  {
+    for (std::size_t j{}; j < matrix[i].size(); ++j)
+    {
+      matrix[i][j] = i * 100 + j;
+    }
+  }
+
+  const Group2MatrixAlias<double> const_matrix = matrix;
+
+  EXPECT_EQ(const_matrix[0][0], 0);
+  EXPECT_EQ(const_matrix[1][2], 102);
+  EXPECT_EQ(const_matrix[2][3], 203);
+  EXPECT_EQ(const_matrix[0][3], 3);
+
+  matrix.CopyToDevice();
+  matrix.GetFromDevice();
+
+  EXPECT_EQ(matrix[0][0], 0);
+  EXPECT_EQ(matrix[1][2], 102);
+  EXPECT_EQ(matrix[2][3], 203);
+  EXPECT_EQ(matrix[0][3], 3);
+}
+
+TEST(VectorMatrix, ConversionToVector)
+{
+  auto matrix = testConversionToVector<Group3MatrixAlias>();
+  matrix.CopyToDevice();
+  matrix.GetFromDevice();
+
+  auto slice = matrix[1];
+
+  EXPECT_EQ(slice[0], 13.2);
+  EXPECT_EQ(slice[1], 31.2);
+  EXPECT_EQ(slice[2], 314.2);
+}
+
+TEST(VectorMatrix, ConstConversionToVector)
+{
+  auto matrix = testConstConversionToVector<Group1MatrixAlias>();
+  matrix.CopyToDevice();
+  matrix.GetFromDevice();
+
+  auto slice = matrix[1];
+
+  EXPECT_EQ(slice[0], 13.2);
+  EXPECT_EQ(slice[1], 31.2);
+  EXPECT_EQ(slice[2], 314.2);
+}
+
+TEST(VectorMatrix, ConversionFromVector)
+{
+  Group2MatrixAlias<double> zero_matrix = std::vector<std::vector<double>>{};
+
+  EXPECT_EQ(zero_matrix.size(), 0);
+
+  std::vector<std::vector<double>> vec = { { 412.3, 32.4, 41.3 }, { 5.33, -0.3, 31.2 } };
+
+  Group2MatrixAlias<double> matrix = vec;
+
+  EXPECT_EQ(matrix.size(), 2);
+  EXPECT_EQ(matrix[0].size(), 3);
+  EXPECT_EQ(matrix[0][0], 412.3);
+  EXPECT_EQ(matrix[0][1], 32.4);
+  EXPECT_EQ(matrix[0][2], 41.3);
+  EXPECT_EQ(matrix[1].size(), 3);
+  EXPECT_EQ(matrix[1][0], 5.33);
+  EXPECT_EQ(matrix[1][1], -0.3);
+  EXPECT_EQ(matrix[1][2], 31.2);
+}
+
+TEST(VectorMatrix, AssignmentFromVector)
+{
+  auto matrix = testAssignmentFromVector<Group2MatrixAlias>();
+  matrix.CopyToDevice();
+  matrix.GetFromDevice();
+
+  EXPECT_EQ(matrix[0][0], 0.0);
+  EXPECT_EQ(matrix[2][0], 14.3);
+  EXPECT_EQ(matrix[2][1], 52.3);
+  EXPECT_EQ(matrix[2][2], 65.7);
+  EXPECT_EQ(matrix[3][0], 0.0);
+}


### PR DESCRIPTION
Adds new `CudaVectorMatrix` class which extends the base `VectorMatrix` class.

A few caveats are:
1) The class can only be used with doubles when trying to move memory to the GPU and vice-versa and throws a build error if using non-`double`s.
2) Currently does no work on GPU for `ForEach`.  This will come in with #394.
3) Some of the tests from `VectorMatrix` had to be copied into the `test_cuda_vector_matrix` file due to the base tests using `int`s instead of `double`s.

Closes #392 