### PR TITLE
416 add assignment overridescopy constructors to cudavectormatrix so new matrix has separate device memory

### DIFF
--- a/include/micm/util/cuda_vector_matrix.cuh
+++ b/include/micm/util/cuda_vector_matrix.cuh
@@ -27,5 +27,11 @@ namespace micm
     /// @param h_data Host data to copy data to
     /// @returns Error code from copying from the device to the host, if any
     int CopyToHost(CudaVectorMatrixParam& vectorMatrix, std::vector<double>& h_data);
+
+    /// @brief Copies data to the destination device memory block from the source device memory block
+    /// @param vectorMatrixDest Struct containing allocated destination device memory to copy to
+    /// @param vectorMatrixSrc Struct containing allocated source device memory to copy from
+    /// @returns Error code from copying to destination device memory from source device memory, if any
+    int CopyToDeviceFromDevice(CudaVectorMatrixParam& vectorMatrixDest, const CudaVectorMatrixParam& vectorMatrixSrc);
   }
 }

--- a/include/micm/util/cuda_vector_matrix.hpp
+++ b/include/micm/util/cuda_vector_matrix.hpp
@@ -69,12 +69,18 @@ namespace micm
         : VectorMatrix<T, L>(other)
     {}
 
-    CudaVectorMatrix(const CudaVectorMatrix& other)
+    CudaVectorMatrix(const CudaVectorMatrix& other) requires(std::is_same_v<T, double>)
         : VectorMatrix<T, L>(other.x_dim_, other.y_dim_)
     {
       this->data_ = other.data_;
       micm::cuda::MallocVector(vector_matrix_param_, this->data_.size());
-      this->CopyToDevice();
+      micm::cuda::CopyToDeviceFromDevice(vector_matrix_param_, other.vector_matrix_param_);
+    }
+
+    CudaVectorMatrix(const CudaVectorMatrix& other)
+        : VectorMatrix<T, L>(other.x_dim_, other.y_dim_)
+    {
+        this->data_ = other.data_;
     }
 
     CudaVectorMatrix(CudaVectorMatrix&& other) noexcept
@@ -113,9 +119,9 @@ namespace micm
       static_assert(std::is_same_v<T, double>);
       return micm::cuda::CopyToHost(vector_matrix_param_, this->data_);
     }
-    CudaVectorMatrixParam AsDeviceParam()
+    CudaVectorMatrixParam AsDeviceParam() const
     {
-      return CudaVectorMatrixParam{ vector_matrix_param_.d_data_, vector_matrix_param_.num_elements_ };
+      return CudaVectorMatrixParam { vector_matrix_param_.d_data_, vector_matrix_param_.num_elements_ };
     }
   };
 }  // namespace micm

--- a/include/micm/util/cuda_vector_matrix.hpp
+++ b/include/micm/util/cuda_vector_matrix.hpp
@@ -64,9 +64,39 @@ namespace micm
     {
       micm::cuda::MallocVector(vector_matrix_param_, this->data_.size());
     }
+
     CudaVectorMatrix(const std::vector<std::vector<T>> other)
         : VectorMatrix<T, L>(other)
     {
+        micm::cuda::MallocVector(vector_matrix_param_, this->data_.size());
+    }
+
+    CudaVectorMatrix(const CudaVectorMatrix& other)
+        : VectorMatrix<T, L>(other.x_dim_, other.y_dim_)
+    {
+      this->data_ = other.data_;
+      micm::cuda::MallocVector(vector_matrix_param_, this->data_.size());
+    }
+
+    CudaVectorMatrix(CudaVectorMatrix&& other) noexcept
+        : VectorMatrix<T, L>(other.x_dim_, other.y_dim_)
+    {
+      this->data_ = std::move(other.data_);
+      this->vector_matrix_param_ = std::move(other.vector_matrix_param_);
+    }
+
+    CudaVectorMatrix& operator=(const CudaVectorMatrix& other)
+    {
+      return *this = CudaVectorMatrix(other);
+    }
+
+    CudaVectorMatrix& operator=(CudaVectorMatrix&& other) noexcept
+    {
+      std::swap(this->data_, other.data_);
+      std::swap(this->vector_matrix_param_, other.vector_matrix_param_);
+      this->x_dim_ = other.x_dim_;
+      this->y_dim_ = other.y_dim_;
+      return *this;
     }
 
     ~CudaVectorMatrix() requires(std::is_same_v<T, double>)

--- a/include/micm/util/cuda_vector_matrix.hpp
+++ b/include/micm/util/cuda_vector_matrix.hpp
@@ -80,27 +80,23 @@ namespace micm
     CudaVectorMatrix(const CudaVectorMatrix& other)
         : VectorMatrix<T, L>(other.x_dim_, other.y_dim_)
     {
-        std::cout << "In copy constructor" << std::endl;
         this->data_ = other.data_;
     }
 
     CudaVectorMatrix(CudaVectorMatrix&& other) noexcept
         : VectorMatrix<T, L>(other.x_dim_, other.y_dim_)
     {
-      std::cout << "In move constructor" << std::endl;
       this->data_ = std::move(other.data_);
       this->vector_matrix_param_ = std::move(other.vector_matrix_param_);
     }
 
     CudaVectorMatrix& operator=(const CudaVectorMatrix& other)
     {
-      std::cout << "In copy assignment" << std::endl;
       return *this = CudaVectorMatrix(other);
     }
 
     CudaVectorMatrix& operator=(CudaVectorMatrix&& other) noexcept
     {
-      std::cout << "In move assignment" << std::endl;
       std::swap(this->data_, other.data_);
       std::swap(this->vector_matrix_param_, other.vector_matrix_param_);
       this->x_dim_ = other.x_dim_;

--- a/include/micm/util/cuda_vector_matrix.hpp
+++ b/include/micm/util/cuda_vector_matrix.hpp
@@ -80,23 +80,27 @@ namespace micm
     CudaVectorMatrix(const CudaVectorMatrix& other)
         : VectorMatrix<T, L>(other.x_dim_, other.y_dim_)
     {
+        std::cout << "In copy constructor" << std::endl;
         this->data_ = other.data_;
     }
 
     CudaVectorMatrix(CudaVectorMatrix&& other) noexcept
         : VectorMatrix<T, L>(other.x_dim_, other.y_dim_)
     {
+      std::cout << "In move constructor" << std::endl;
       this->data_ = std::move(other.data_);
       this->vector_matrix_param_ = std::move(other.vector_matrix_param_);
     }
 
     CudaVectorMatrix& operator=(const CudaVectorMatrix& other)
     {
+      std::cout << "In copy assignment" << std::endl;
       return *this = CudaVectorMatrix(other);
     }
 
     CudaVectorMatrix& operator=(CudaVectorMatrix&& other) noexcept
     {
+      std::cout << "In move assignment" << std::endl;
       std::swap(this->data_, other.data_);
       std::swap(this->vector_matrix_param_, other.vector_matrix_param_);
       this->x_dim_ = other.x_dim_;

--- a/include/micm/util/cuda_vector_matrix.hpp
+++ b/include/micm/util/cuda_vector_matrix.hpp
@@ -67,15 +67,14 @@ namespace micm
 
     CudaVectorMatrix(const std::vector<std::vector<T>> other)
         : VectorMatrix<T, L>(other)
-    {
-        micm::cuda::MallocVector(vector_matrix_param_, this->data_.size());
-    }
+    {}
 
     CudaVectorMatrix(const CudaVectorMatrix& other)
         : VectorMatrix<T, L>(other.x_dim_, other.y_dim_)
     {
       this->data_ = other.data_;
       micm::cuda::MallocVector(vector_matrix_param_, this->data_.size());
+      this->CopyToDevice();
     }
 
     CudaVectorMatrix(CudaVectorMatrix&& other) noexcept

--- a/include/micm/util/cuda_vector_matrix.hpp
+++ b/include/micm/util/cuda_vector_matrix.hpp
@@ -107,12 +107,12 @@ namespace micm
     int CopyToDevice()
     {
       static_assert(std::is_same_v<T, double>);
-      return micm::cuda::CopyToDevice(vector_matrix_param_, this->AsVector());
+      return micm::cuda::CopyToDevice(vector_matrix_param_, this->data_);
     }
     int CopyToHost()
     {
       static_assert(std::is_same_v<T, double>);
-      return micm::cuda::CopyToHost(vector_matrix_param_, this->AsVector());
+      return micm::cuda::CopyToHost(vector_matrix_param_, this->data_);
     }
     CudaVectorMatrixParam AsDeviceParam()
     {

--- a/include/micm/util/cuda_vector_matrix.hpp
+++ b/include/micm/util/cuda_vector_matrix.hpp
@@ -18,6 +18,10 @@ namespace micm
    * including initialization must be followed by CopyToDevice() otherwise
    * host and device data will be out of sync.
    *
+   * Copy/Move constructors/assignment operators are non-synchronizing
+   * operators/constructors so if device and host data is desynchronized,
+   * the copies and moved matrices will remain desynchronized.
+   *
    * CUDA functionality requires T to be of type double, otherwise this
    * behaves similarily to VectorMatrix.
    */

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -27,11 +27,10 @@ namespace micm
   {
    protected:
     std::vector<T> data_;
-
-   private:
     std::size_t x_dim_;  // number of rows
     std::size_t y_dim_;  // number of columns
 
+   private:
     friend class Proxy;
     friend class ConstProxy;
 

--- a/src/util/cuda_vector_matrix.cu
+++ b/src/util/cuda_vector_matrix.cu
@@ -22,5 +22,9 @@ namespace micm
     {
       return cudaMemcpy(h_data.data(), param.d_data_, sizeof(double) * param.num_elements_, cudaMemcpyDeviceToHost);
     }
+    int CopyToDeviceFromDevice(CudaVectorMatrixParam& vectorMatrixDest, const CudaVectorMatrixParam& vectorMatrixSrc)
+    {
+      return cudaMemcpy(vectorMatrixDest.d_data_, vectorMatrixSrc.d_data_, sizeof(double) * vectorMatrixSrc.num_elements_, cudaMemcpyDeviceToDevice);
+    }
   }  // namespace cuda
 }  // namespace micm

--- a/test/unit/util/test_cuda_vector_matrix.cpp
+++ b/test/unit/util/test_cuda_vector_matrix.cpp
@@ -34,7 +34,7 @@ TEST(CudaVectorMatrix, DeviceMemCopy)
 }
 
 template<class T, std::size_t L = DEFAULT_VECTOR_SIZE>
-static void ModifyAndSyncToHost(micm::CudaVectorMatrix<T, L> matrix)
+static void ModifyAndSyncToHost(micm::CudaVectorMatrix<T, L>& matrix)
 {
   matrix.CopyToDevice();
   auto matrixParam = matrix.AsDeviceParam();

--- a/test/unit/util/test_cuda_vector_matrix.cpp
+++ b/test/unit/util/test_cuda_vector_matrix.cpp
@@ -215,18 +215,31 @@ TEST(CudaVectorMatrix, MoveConstructor)
   std::vector<std::vector<double>> h_vector{ {1, 2}, {3, 4} };
   auto matrix = micm::CudaVectorMatrix<double, 2>(h_vector);
 
-  auto matrix2 = std::move(matrix);
+  EXPECT_EQ(matrix[0][0], 1);
+  EXPECT_EQ(matrix[0][1], 2);
+  EXPECT_EQ(matrix[1][0], 3);
+  EXPECT_EQ(matrix[1][1], 4);
 
-  matrix2[0][0] = 5;
+  matrix.CopyToDevice();
+  auto matrixParam = matrix.AsDeviceParam();
+  micm::cuda::SquareDriver(matrixParam);  
+  matrix[0][0] = 5;
+
+  EXPECT_EQ(matrix[0][0], 5);
+  EXPECT_EQ(matrix[0][1], 2);
+  EXPECT_EQ(matrix[1][0], 3);
+  EXPECT_EQ(matrix[1][1], 4);
+
+  auto matrix2 = std::move(matrix);
 
   EXPECT_EQ(matrix2[0][0], 5);
   EXPECT_EQ(matrix2[0][1], 2);
   EXPECT_EQ(matrix2[1][0], 3);
   EXPECT_EQ(matrix2[1][1], 4);
 
-  ModifyAndSyncToHost(matrix2);
+  matrix2.CopyToHost();
 
-  EXPECT_EQ(matrix2[0][0], 25);
+  EXPECT_EQ(matrix2[0][0], 1);
   EXPECT_EQ(matrix2[0][1], 4);
   EXPECT_EQ(matrix2[1][0], 9);
   EXPECT_EQ(matrix2[1][1], 16);


### PR DESCRIPTION
Adds assignment and move operators and constructors so a CudaVectorMatrix can be assigned to another  which generates new device data for the newly assigned vector or moves the other vector into the new vector while in that case taking ownership of the other matrix's device memory.