### PR TITLE
Optimize data movement for CudaRosenbrocksolver and compute minus Jacobian matrix on GPU

### DIFF
--- a/include/micm/solver/cuda_rosenbrock.cuh
+++ b/include/micm/solver/cuda_rosenbrock.cuh
@@ -19,14 +19,15 @@ namespace micm{
       void FreeConstData(CudaRosenbrockSolverParam& devstruct);
 
       /// @brief Compute alpha - J[i] for each element i at the diagnoal of matrix J
-      /// @param sparseMatrix struct of sparse matrix (will be replaced by the CudaSparseMatrix class)
-      /// @param jacobian_diagonal_elements location id of the diagonal elements 
+      /// @param h_jacobian sparse matrix on the host (will be replaced by the CudaSparseMatrix class)
+      /// @param num_elements number of elements in the h_jacobian (will be replaced by the CudaSparseMatrix class)
       /// @param alpha scalar variable
+      /// @param devstruct device struct including the locations of diagonal elements of the Jacobian matrix
       /// @return
-      std::chrono::nanoseconds AlphaMinusJacobianDriver(
-                               CudaSparseMatrixParam& sparseMatrix,
-                               const std::vector<size_t> jacobian_diagonal_elements,
-                               double alpha);
+      void AlphaMinusJacobianDriver(double* h_jacobian,
+                                    const size_t num_elements,
+                                    const double alpha,
+                                    const CudaRosenbrockSolverParam& devstruct);
 
       /// @brief Computes the scaled norm of the matrix errors on the GPU; assume all the data are GPU resident already
       /// @param y_old_param matrix on the device

--- a/include/micm/solver/cuda_rosenbrock.hpp
+++ b/include/micm/solver/cuda_rosenbrock.hpp
@@ -101,11 +101,8 @@ namespace micm
     void AlphaMinusJacobian(SparseMatrixPolicy<double>& jacobian, double alpha) const requires
         VectorizableSparse<SparseMatrixPolicy<double>>
     {
-      for (auto& element : jacobian.AsVector())
-        element = -element;
       double* h_jacobian = jacobian.AsVector().data();
       size_t num_elements = jacobian.AsVector().size();
-      size_t num_grid_cells = this->parameters_.number_of_grid_cells_;
       micm::cuda::AlphaMinusJacobianDriver(h_jacobian, num_elements,
                                            alpha, this->devstruct_);
     }

--- a/include/micm/util/cuda_param.hpp
+++ b/include/micm/util/cuda_param.hpp
@@ -122,12 +122,7 @@ struct CudaRosenbrockSolverParam
   double* errors_input_;
   double* errors_output_;
   size_t errors_size_;
-<<<<<<< HEAD
   // for AlphaMinusJacobian function
   size_t* jacobian_diagonal_elements_;
   size_t jacobian_diagonal_elements_size_;
-=======
-  //  size_t* jacobian_diagonal_elements_;
-  //  size_t jacobian_diagonal_elements_size_;
->>>>>>> main
 };

--- a/include/micm/util/cuda_param.hpp
+++ b/include/micm/util/cuda_param.hpp
@@ -117,9 +117,12 @@ struct CudaVectorMatrixParam
 /// This struct could be allocated on the host or device; 
 struct CudaRosenbrockSolverParam
 {
+  size_t num_grid_cells_;
+  // for NormalizedError function
   double* errors_input_;
   double* errors_output_;
   size_t errors_size_;
-//  size_t* jacobian_diagonal_elements_;
-//  size_t jacobian_diagonal_elements_size_;
+  // for AlphaMinusJacobian function
+  size_t* jacobian_diagonal_elements_;
+  size_t jacobian_diagonal_elements_size_;
 };

--- a/test/unit/process/test_cuda_process_set.cpp
+++ b/test/unit/process/test_cuda_process_set.cpp
@@ -167,7 +167,7 @@ void testRandomSystemAddJacobianTerms(std::size_t n_cells, std::size_t n_reactio
   {
     double a = cpu_jacobian_vector[i];
     double b = gpu_jacobian_vector[i];
-    ASSERT_EQ(a, b);
+    ASSERT_EQ(a, -b);
   }
 }
 

--- a/test/unit/solver/test_cuda_rosenbrock.cpp
+++ b/test/unit/solver/test_cuda_rosenbrock.cpp
@@ -152,6 +152,10 @@ void testAlphaMinusJacobian(std::size_t number_of_grid_cells)
   }
   auto cpu_jacobian = jacobian;
 
+  // Generate minus jacobian matrix (-J) here
+  for (auto& elem : jacobian.AsVector())
+    elem = -elem;
+
   gpu_solver.AlphaMinusJacobian(jacobian, 42.042);
   for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
   {


### PR DESCRIPTION
This PR moves the data movement of array of indices for the diagonal elements of Jacobian matrix to the constructor/destructor of `CudaRosenbrocksolver` class.

In addition:
- currently the operation of negating Jacobian matrix is done on the CPU (https://github.com/NCAR/micm/blob/main/include/micm/solver/cuda_rosenbrock.hpp#L94-L95) for the `AlphaMinusJacobian` function. This PR moves this operation to the `AddJacobianTermsKernel` function so the CUDA kernel now returns `-J` ranther than `J` matrix.
- the `AlphaMinusJacobianKernel` function is revised to achieve more parallelism on GPU. 

All the 40 tests passed on Derecho's A100 GPU with `nvhpc/23.7`.

Fix #391 