### PR TITLE
Allow custom rate parameters to be directly set

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # all available versions of xcode: https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
         xcode: ['13.1', '14.1']
-        build_type: [Debug, Release]
+        build_type: [Release]
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 
@@ -39,7 +39,7 @@ jobs:
       matrix:
         # all available versions of xcode: https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode
         xcode: ['14.1', '15.0']
-        build_type: [Debug, Release]
+        build_type: [Release]
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 
@@ -66,7 +66,7 @@ jobs:
           - { cpp: g++-11, c: gcc-11}
           - { cpp: g++-12, c: gcc-12}
           - { cpp: clang++, c: clang}
-        build_type: [Debug, Release]
+        build_type: [Release]
     env:
       CC: ${{ matrix.compiler.c }}
       CXX: ${{ matrix.compiler.cpp }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Release]
     env:
       CC: gcc
       CXX: g++
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Release]
     env:
       CC: clang
       CXX: clang++

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Release]
         architecture: [Win32, x64]
 
     steps:
@@ -53,25 +53,12 @@ jobs:
     - name: Test
       run: cd build ; ctest -j 10 -C ${{ matrix.build_type }} --output-on-failure
 
-  msvc2019_latest:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: windows-2019
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Run CMake
-      run: cmake -S . -B build -G "Visual Studio 16 2019" 
-    - name: Build
-      run: cmake --build build --config Release --parallel 10
-    - name: Test
-      run: cd build ; ctest -j 10 -C Release --output-on-failure
-
   msvc2022:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: windows-2022
     strategy:
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Release]
         architecture: [Win32, x64]
 
     steps:
@@ -82,19 +69,6 @@ jobs:
       run: cmake --build build --config ${{ matrix.build_type }} --parallel 10
     - name: Test
       run: cd build ; ctest -j 10 -C ${{ matrix.build_type }} --output-on-failure
-
-  msvc2022_latest:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: windows-2022
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Run CMake
-      run: cmake -S . -B build -G "Visual Studio 17 2022"
-    - name: Build
-      run: cmake --build build --config Release --parallel 10
-    - name: Test
-      run: cd build ; ctest -j 10 -C Release --output-on-failure
 
   clang:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name

--- a/include/micm/solver/state.hpp
+++ b/include/micm/solver/state.hpp
@@ -67,6 +67,10 @@ namespace micm
     void SetConcentration(const Species& species, double concentration);
     void SetConcentration(const Species& species, const std::vector<double>& concentration);
 
+    /// @brief Set custom parameters assuming the values are properly ordered
+    /// @param parameters map of custom rate parameters
+    void UnsafelySetCustomRateParameters(const std::vector<std::vector<double>>& parameters);
+
     /// @brief Set custom parameters for rate constant calculations by label
     /// @param parameters map of custom rate parameters
     void SetCustomRateParameters(const std::unordered_map<std::string, std::vector<double>>& parameters);

--- a/include/micm/solver/state.hpp
+++ b/include/micm/solver/state.hpp
@@ -49,6 +49,7 @@ namespace micm
     SparseMatrixPolicy<double> lower_matrix_;
     SparseMatrixPolicy<double> upper_matrix_;
     size_t state_size_;
+    std::size_t number_of_grid_cells_;
 
     /// @brief
     State();

--- a/include/micm/solver/state.hpp
+++ b/include/micm/solver/state.hpp
@@ -48,7 +48,7 @@ namespace micm
     std::vector<std::string> variable_names_{};
     SparseMatrixPolicy<double> lower_matrix_;
     SparseMatrixPolicy<double> upper_matrix_;
-    size_t state_size_;
+    std::size_t state_size_;
     std::size_t number_of_grid_cells_;
 
     /// @brief

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -85,6 +85,12 @@ namespace micm
   inline void State<MatrixPolicy, SparseMatrixPolicy>::UnsafelySetCustomRateParameters(
       const std::vector<std::vector<double>>& parameters)
   {
+    if (parameters.size() != variables_.size())
+      throw std::invalid_argument("The number of grid cells configured for micm does not match the number of custom rate parameter values passed to multi-gridcell State");
+
+    if (parameters[0].size() != custom_rate_parameters_[0].size())
+      throw std::invalid_argument("The number of custom rate parameters configured for micm does not match the provided number of custom rate parameter values");
+
     for(size_t i = 0; i < variables_.size(); ++i) {
       custom_rate_parameters_[i] = parameters[i];
     }

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -26,7 +26,8 @@ namespace micm
         jacobian_(),
         lower_matrix_(),
         upper_matrix_(),
-        state_size_(parameters.variable_names_.size())
+        state_size_(parameters.variable_names_.size()),
+        number_of_grid_cells_(parameters.number_of_grid_cells_)
   {
     std::size_t index = 0;
     for (auto& name : variable_names_)
@@ -91,7 +92,7 @@ namespace micm
     if (parameters[0].size() != custom_rate_parameters_[0].size())
       throw std::invalid_argument("The number of custom rate parameters configured for micm does not match the provided number of custom rate parameter values");
 
-    for(size_t i = 0; i < variables_.size(); ++i) {
+    for(size_t i = 0; i < number_of_grid_cells_; ++i) {
       custom_rate_parameters_[i] = parameters[i];
     }
   }

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -82,6 +82,15 @@ namespace micm
   }
 
   template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  inline void State<MatrixPolicy, SparseMatrixPolicy>::UnsafelySetCustomRateParameters(
+      const std::vector<std::vector<double>>& parameters)
+  {
+    for(size_t i = 0; i < variables_.size(); ++i) {
+      custom_rate_parameters_[i] = parameters[i];
+    }
+  }
+
+  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameters(
       const std::unordered_map<std::string, std::vector<double>>& parameters)
   {

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -1108,7 +1108,6 @@ void test_analytical_arrhenius(
   times.push_back(0);
   for (size_t i_time = 1; i_time < nsteps; ++i_time)
   {
-    times.push_back(time_step);
     // Model results
     auto result = solver.Solve(time_step, state);
     EXPECT_EQ(result.state_, (micm::SolverState::Converged));
@@ -1119,6 +1118,7 @@ void test_analytical_arrhenius(
 
     // Analytical results
     double time = i_time * time_step;
+    times.push_back(time);
 
     double initial_A = analytical_concentrations[0][idx_A];
     analytical_concentrations[i_time][idx_A] = initial_A * std::exp(-(k1)*time);
@@ -1129,8 +1129,8 @@ void test_analytical_arrhenius(
   }
 
   std::vector<std::string> header = { "time", "A", "B", "C" };
-  writeCSV("analytical_concentrations.csv", header, analytical_concentrations, times);
-  writeCSV("model_concentrations.csv", header, model_concentrations, times);
+  writeCSV("analytical_concentrations-arrhenius.csv", header, analytical_concentrations, times);
+  writeCSV("model_concentrations-arrhenius.csv", header, model_concentrations, times);
 
   auto map = state.variable_map_;
 

--- a/test/unit/solver/test_state.cpp
+++ b/test/unit/solver/test_state.cpp
@@ -241,3 +241,31 @@ TEST(State, UnsafelySetCustomRateParameterMultiCell)
     EXPECT_EQ(state.custom_rate_parameters_[i][4], 0.5);
   }
 }
+
+TEST(State, UnsafelySetCustomRateParameterCatchesTooFewGridCells)
+{
+  micm::State state{ micm::StateParameters{
+      .number_of_grid_cells_ = 2,
+      .number_of_rate_constants_ = 10,
+      .variable_names_{ "foo", "bar", "baz", "quz" },
+      .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
+  } };
+
+  std::vector<std::vector<double>> parameters = {{0.1, 0.2, 0.3, 0.4, 0.5}};
+
+  EXPECT_ANY_THROW(state.UnsafelySetCustomRateParameters(parameters));
+}
+
+TEST(State, UnsafelySetCustomRateParameterCatchesTooParameters)
+{
+  micm::State state{ micm::StateParameters{
+      .number_of_grid_cells_ = 2,
+      .number_of_rate_constants_ = 10,
+      .variable_names_{ "foo", "bar", "baz", "quz" },
+      .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
+  } };
+
+  std::vector<std::vector<double>> parameters = {{0.1, 0.2, 0.3}};
+
+  EXPECT_ANY_THROW(state.UnsafelySetCustomRateParameters(parameters));
+}

--- a/test/unit/solver/test_state.cpp
+++ b/test/unit/solver/test_state.cpp
@@ -195,3 +195,49 @@ TEST(State, SetCustomRateParameters)
     }
   }
 }
+
+TEST(State, UnsafelySetCustomRateParameterOneCell)
+{
+  micm::State state{ micm::StateParameters{
+      .number_of_grid_cells_ = 1,
+      .number_of_rate_constants_ = 10,
+      .variable_names_{ "foo", "bar", "baz", "quz" },
+      .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
+  } };
+
+  std::vector<std::vector<double>> parameters = {{0.1, 0.2, 0.3, 0.4, 0.5}};
+
+  state.UnsafelySetCustomRateParameters(parameters);
+  EXPECT_EQ(state.custom_rate_parameters_[0][0], 0.1);
+  EXPECT_EQ(state.custom_rate_parameters_[0][1], 0.2);
+  EXPECT_EQ(state.custom_rate_parameters_[0][2], 0.3);
+  EXPECT_EQ(state.custom_rate_parameters_[0][3], 0.4);
+  EXPECT_EQ(state.custom_rate_parameters_[0][4], 0.5);
+}
+
+TEST(State, UnsafelySetCustomRateParameterMultiCell)
+{
+  uint32_t num_grid_cells = 3;
+
+  micm::State state{ micm::StateParameters{
+      .number_of_grid_cells_ = num_grid_cells,
+      .number_of_rate_constants_ = 10,
+      .variable_names_{ "foo", "bar", "baz", "quz" },
+      .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
+  } };
+
+  std::vector<std::vector<double>> parameters = {
+    {0.1, 0.2, 0.3, 0.4, 0.5},
+    {0.1, 0.2, 0.3, 0.4, 0.5},
+    {0.1, 0.2, 0.3, 0.4, 0.5}
+    };
+
+  state.UnsafelySetCustomRateParameters(parameters);
+  for(size_t i = 0; i < num_grid_cells; i++) {
+    EXPECT_EQ(state.custom_rate_parameters_[i][0], 0.1);
+    EXPECT_EQ(state.custom_rate_parameters_[i][1], 0.2);
+    EXPECT_EQ(state.custom_rate_parameters_[i][2], 0.3);
+    EXPECT_EQ(state.custom_rate_parameters_[i][3], 0.4);
+    EXPECT_EQ(state.custom_rate_parameters_[i][4], 0.5);
+  }
+}


### PR DESCRIPTION
To support https://github.com/NCAR/musica/issues/79, we will need to allow the interfaces with fortran and python to somehow set custom rate parameters. We only accept mappings as of now. This adds a new methods that takes a vector of vectors and assumes that the order of rate constants is already correct.