### PR TITLE
Rename CUDA matrix class to be Dense or Sparse

### DIFF
--- a/include/micm/process/cuda_process_set.cuh
+++ b/include/micm/process/cuda_process_set.cuh
@@ -21,15 +21,15 @@ namespace micm
     /// This is the host function that will call the CUDA kernel
     ///   to calculate the forcing terms
     void AddForcingTermsKernelDriver(
-        const CudaVectorMatrixParam& rate_constants_param,
-        const CudaVectorMatrixParam& state_variables_param,
-        CudaVectorMatrixParam& forcing_param,
+        const CudaMatrixParam& rate_constants_param,
+        const CudaMatrixParam& state_variables_param,
+        CudaMatrixParam& forcing_param,
         const ProcessSetParam& devstruct);
 
     /// This is the host function that will call the CUDA kernel
     ///   to form the negative Jacobian matrix (-J)
     std::chrono::nanoseconds SubtractJacobianTermsKernelDriver(
-        CudaMatrixParam& matrixParam, 
+        CudaMatrixParam_to_be_removed& matrixParam, 
         CudaSparseMatrixParam& sparseMatrix, 
         const ProcessSetParam& devstruct);
   }  // namespace cuda

--- a/include/micm/process/cuda_process_set.hpp
+++ b/include/micm/process/cuda_process_set.hpp
@@ -108,7 +108,7 @@ namespace micm
       const MatrixPolicy<double>& state_variables,
       SparseMatrixPolicy<double>& jacobian) const
   {
-    CudaMatrixParam matrix;
+    CudaMatrixParam_to_be_removed matrix;
     matrix.rate_constants_ = rate_constants.AsVector().data();
     matrix.state_variables_ = state_variables.AsVector().data();
     matrix.n_grids_ = rate_constants.size();

--- a/include/micm/solver/cuda_linear_solver.cuh
+++ b/include/micm/solver/cuda_linear_solver.cuh
@@ -13,7 +13,7 @@ namespace micm
     ///   to perform the "solve" function on the device
     std::chrono::nanoseconds SolveKernelDriver(
            CudaSparseMatrixParam& sparseMatrix, 
-           CudaMatrixParam& denseMatrix,
+           CudaMatrixParam_to_be_removed& denseMatrix,
            const LinearSolverParam& devstruct);
 
     /// This is the function that will copy the constant data

--- a/include/micm/solver/cuda_linear_solver.hpp
+++ b/include/micm/solver/cuda_linear_solver.hpp
@@ -73,7 +73,7 @@ namespace micm
         SparseMatrixPolicy<T>& upper_matrix)
     {
       CudaSparseMatrixParam sparseMatrix;
-      CudaMatrixParam denseMatrix;
+      CudaMatrixParam_to_be_removed denseMatrix;
 
       sparseMatrix.lower_matrix_ = lower_matrix.AsVector().data();
       sparseMatrix.lower_matrix_size_ = lower_matrix.AsVector().size();

--- a/include/micm/util/cuda_dense_matrix.hpp
+++ b/include/micm/util/cuda_dense_matrix.hpp
@@ -1,4 +1,4 @@
-#include <micm/util/cuda_vector_matrix.cuh>
+#include <micm/util/cuda_matrix.cuh>
 #include <micm/util/vector_matrix.hpp>
 #include <type_traits>
 
@@ -28,41 +28,41 @@ namespace micm
    * behaves similarily to VectorMatrix.
    */
   template<class T, std::size_t L = MICM_DEFAULT_VECTOR_SIZE>
-  class CudaVectorMatrix : public VectorMatrix<T, L>
+  class CudaDenseMatrix : public VectorMatrix<T, L>
   {
    private:
     /// @brief The device pointer (handle) to the allocated memory on the target device.
-    CudaVectorMatrixParam vector_matrix_param_;
+    CudaMatrixParam param_;
     /// @brief The handle to the CUBLAS library
     cublasHandle_t handle_ = NULL;
 
    public:
-    CudaVectorMatrix() requires(std::is_same_v<T, double>)
+    CudaDenseMatrix() requires(std::is_same_v<T, double>)
         : VectorMatrix<T, L>()
     {
-      micm::cuda::MallocVector(vector_matrix_param_, this->data_.size());
+      micm::cuda::MallocVector(param_, this->data_.size());
     }
-    CudaVectorMatrix()
+    CudaDenseMatrix()
         : VectorMatrix<T, L>()
     {
     }
 
-    CudaVectorMatrix(std::size_t x_dim, std::size_t y_dim) requires(std::is_same_v<T, double>)
+    CudaDenseMatrix(std::size_t x_dim, std::size_t y_dim) requires(std::is_same_v<T, double>)
         : VectorMatrix<T, L>(x_dim, y_dim)
     {
-      micm::cuda::MallocVector(vector_matrix_param_, this->data_.size());
-      this->vector_matrix_param_.number_of_grid_cells_ = x_dim;
+      micm::cuda::MallocVector(param_, this->data_.size());
+      this->param_.number_of_grid_cells_ = x_dim;
     }
-    CudaVectorMatrix(std::size_t x_dim, std::size_t y_dim)
+    CudaDenseMatrix(std::size_t x_dim, std::size_t y_dim)
         : VectorMatrix<T, L>(x_dim, y_dim)
     {
     }
 
-    CudaVectorMatrix(std::size_t x_dim, std::size_t y_dim, T initial_value) requires(std::is_same_v<T, double>)
+    CudaDenseMatrix(std::size_t x_dim, std::size_t y_dim, T initial_value) requires(std::is_same_v<T, double>)
         : VectorMatrix<T, L>(x_dim, y_dim, initial_value)
     {
-      micm::cuda::MallocVector(vector_matrix_param_, this->data_.size());
-      this->vector_matrix_param_.number_of_grid_cells_ = x_dim;
+      micm::cuda::MallocVector(param_, this->data_.size());
+      this->param_.number_of_grid_cells_ = x_dim;
       if (this->handle_ == NULL)
       {
         cublasStatus_t stat = cublasCreate(&(this->handle_));
@@ -73,64 +73,64 @@ namespace micm
         }
       }
     }
-    CudaVectorMatrix(std::size_t x_dim, std::size_t y_dim, T initial_value)
+    CudaDenseMatrix(std::size_t x_dim, std::size_t y_dim, T initial_value)
         : VectorMatrix<T, L>(x_dim, y_dim, initial_value)
     {
     }
 
-    CudaVectorMatrix(const std::vector<std::vector<T>> other) requires(std::is_same_v<T, double>)
+    CudaDenseMatrix(const std::vector<std::vector<T>> other) requires(std::is_same_v<T, double>)
         : VectorMatrix<T, L>(other)
     {
-      micm::cuda::MallocVector(vector_matrix_param_, this->data_.size());
+      micm::cuda::MallocVector(param_, this->data_.size());
     }
 
-    CudaVectorMatrix(const std::vector<std::vector<T>> other)
+    CudaDenseMatrix(const std::vector<std::vector<T>> other)
         : VectorMatrix<T, L>(other)
     {
     }
 
-    CudaVectorMatrix(const CudaVectorMatrix& other) requires(std::is_same_v<T, double>)
+    CudaDenseMatrix(const CudaDenseMatrix& other) requires(std::is_same_v<T, double>)
         : VectorMatrix<T, L>(other.x_dim_, other.y_dim_)
     {
       this->data_ = other.data_;
-      micm::cuda::MallocVector(vector_matrix_param_, this->data_.size());
-      micm::cuda::CopyToDeviceFromDevice(vector_matrix_param_, other.vector_matrix_param_);
+      micm::cuda::MallocVector(param_, this->data_.size());
+      micm::cuda::CopyToDeviceFromDevice(param_, other.param_);
     }
 
-    CudaVectorMatrix(const CudaVectorMatrix& other)
+    CudaDenseMatrix(const CudaDenseMatrix& other)
         : VectorMatrix<T, L>(other.x_dim_, other.y_dim_)
     {
       this->data_ = other.data_;
     }
 
-    CudaVectorMatrix(CudaVectorMatrix&& other) noexcept
+    CudaDenseMatrix(CudaDenseMatrix&& other) noexcept
         : VectorMatrix<T, L>(other.x_dim_, other.y_dim_)
     {
       this->data_ = std::move(other.data_);
-      this->vector_matrix_param_ = std::move(other.vector_matrix_param_);
+      this->param_ = std::move(other.param_);
     }
 
-    CudaVectorMatrix& operator=(const CudaVectorMatrix& other)
+    CudaDenseMatrix& operator=(const CudaDenseMatrix& other)
     {
-      return *this = CudaVectorMatrix(other);
+      return *this = CudaDenseMatrix(other);
     }
 
-    CudaVectorMatrix& operator=(CudaVectorMatrix&& other) noexcept
+    CudaDenseMatrix& operator=(CudaDenseMatrix&& other) noexcept
     {
       std::swap(this->data_, other.data_);
-      std::swap(this->vector_matrix_param_, other.vector_matrix_param_);
+      std::swap(this->param_, other.param_);
       this->x_dim_ = other.x_dim_;
       this->y_dim_ = other.y_dim_;
       return *this;
     }
 
-    ~CudaVectorMatrix()
+    ~CudaDenseMatrix()
     {
     }
 
-    ~CudaVectorMatrix() requires(std::is_same_v<T, double>)
+    ~CudaDenseMatrix() requires(std::is_same_v<T, double>)
     {
-      micm::cuda::FreeVector(this->vector_matrix_param_);
+      micm::cuda::FreeVector(this->param_);
       if (this->handle_ != NULL)
         cublasDestroy(this->handle_);
     }
@@ -138,16 +138,16 @@ namespace micm
     int CopyToDevice()
     {
       static_assert(std::is_same_v<T, double>);
-      return micm::cuda::CopyToDevice(vector_matrix_param_, this->data_);
+      return micm::cuda::CopyToDevice(param_, this->data_);
     }
     int CopyToHost()
     {
       static_assert(std::is_same_v<T, double>);
-      return micm::cuda::CopyToHost(vector_matrix_param_, this->data_);
+      return micm::cuda::CopyToHost(param_, this->data_);
     }
-    CudaVectorMatrixParam AsDeviceParam() const
+    CudaMatrixParam AsDeviceParam() const
     {
-      return this->vector_matrix_param_;
+      return this->param_;
     }
     cublasHandle_t AsCublasHandle() const
     {
@@ -160,16 +160,16 @@ namespace micm
     /// @param incx The increment for the elements of x
     /// @param incy The increment for the elements of y
     /// @return 0 if successful, otherwise an error code
-    void Axpy(const double alpha, const CudaVectorMatrix<T, L>& x, const int incx, const int incy)
+    void Axpy(const double alpha, const CudaDenseMatrix<T, L>& x, const int incx, const int incy)
     {
       static_assert(std::is_same_v<T, double>);
       cublasStatus_t stat = cublasDaxpy(
           this->handle_,
-          x.vector_matrix_param_.number_of_elements_,
+          x.param_.number_of_elements_,
           &alpha,
-          x.vector_matrix_param_.d_data_,
+          x.param_.d_data_,
           incx,
-          this->vector_matrix_param_.d_data_,
+          this->param_.d_data_,
           incy);
       if (stat != CUBLAS_STATUS_SUCCESS)
       {

--- a/include/micm/util/cuda_matrix.cuh
+++ b/include/micm/util/cuda_matrix.cuh
@@ -9,29 +9,29 @@ namespace micm
     /// @param vectorMatrix Reference to struct containing information about allocated memory
     /// @param num_elements Requested number of elements to allocate
     /// @returns Error code from allocating data on the device, if any
-    int MallocVector(CudaVectorMatrixParam& vectorMatrix, std::size_t num_elements);
+    int MallocVector(CudaMatrixParam& vectorMatrix, std::size_t num_elements);
 
     /// @brief Free memory allocated on device
     /// @param vectorMatrix Struct containing allocated device memory
     /// @returns Error code from free-ing data on device, if any
-    int FreeVector(CudaVectorMatrixParam& vectorMatrix);
+    int FreeVector(CudaMatrixParam& vectorMatrix);
 
     /// @brief Copies data from the host to the device
     /// @param vectorMatrix Struct containing allocated device memory
     /// @param h_data Host data to copy from
     /// @returns Error code from copying to device from the host, if any
-    int CopyToDevice(CudaVectorMatrixParam& vectorMatrix, std::vector<double>& h_data);
+    int CopyToDevice(CudaMatrixParam& vectorMatrix, std::vector<double>& h_data);
 
     /// @brief Copies data from the device to the host
     /// @param vectorMatrix Struct containing allocated device memory
     /// @param h_data Host data to copy data to
     /// @returns Error code from copying from the device to the host, if any
-    int CopyToHost(CudaVectorMatrixParam& vectorMatrix, std::vector<double>& h_data);
+    int CopyToHost(CudaMatrixParam& vectorMatrix, std::vector<double>& h_data);
 
     /// @brief Copies data to the destination device memory block from the source device memory block
     /// @param vectorMatrixDest Struct containing allocated destination device memory to copy to
     /// @param vectorMatrixSrc Struct containing allocated source device memory to copy from
     /// @returns Error code from copying to destination device memory from source device memory, if any
-    int CopyToDeviceFromDevice(CudaVectorMatrixParam& vectorMatrixDest, const CudaVectorMatrixParam& vectorMatrixSrc);
+    int CopyToDeviceFromDevice(CudaMatrixParam& vectorMatrixDest, const CudaMatrixParam& vectorMatrixSrc);
   }
 }

--- a/include/micm/util/cuda_param.hpp
+++ b/include/micm/util/cuda_param.hpp
@@ -9,7 +9,7 @@
 const size_t BLOCK_SIZE = 32;
 
 // different matrix data grouped in struct passing to kernel driver function
-struct CudaMatrixParam
+struct CudaMatrixParam_to_be_removed
 {
   const double* rate_constants_;
   const double* state_variables_;
@@ -106,7 +106,7 @@ struct LinearSolverParam
 
 /// This struct holds (1) pointer to, and (2) size of
 ///   data allocated on a device.
-struct CudaVectorMatrixParam
+struct CudaMatrixParam
 {
   double* d_data_;
   size_t number_of_elements_;

--- a/include/micm/util/cuda_sparse_matrix.hpp
+++ b/include/micm/util/cuda_sparse_matrix.hpp
@@ -1,5 +1,5 @@
 #include <micm/util/cuda_param.hpp>
-#include <micm/util/cuda_vector_matrix.cuh>
+#include <micm/util/cuda_matrix.cuh>
 #include <micm/util/sparse_matrix.hpp>
 #include <type_traits>
 
@@ -9,7 +9,7 @@ namespace micm
   class CudaSparseMatrix : public SparseMatrix<T, OrderingPolicy>
   {
    private:
-    CudaVectorMatrixParam param_;
+    CudaMatrixParam param_;
 
    public:
     CudaSparseMatrix() = default;
@@ -88,7 +88,7 @@ namespace micm
     {
       return micm::cuda::CopyToHost(param_, this->data_);
     }
-    CudaVectorMatrixParam AsDeviceParam()
+    CudaMatrixParam AsDeviceParam()
     {
       return this->param_;
     }

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -11,9 +11,9 @@ namespace micm
   {
     /// This is the CUDA kernel that calculates the forcing terms on the device
     __global__ void AddForcingTermsKernel(
-        const CudaVectorMatrixParam rate_constants_param,
-        const CudaVectorMatrixParam state_variables_param,
-        CudaVectorMatrixParam forcing_param,
+        const CudaMatrixParam rate_constants_param,
+        const CudaMatrixParam state_variables_param,
+        CudaMatrixParam forcing_param,
         const ProcessSetParam devstruct)
     {
       /// Calculate global thread ID
@@ -190,7 +190,7 @@ namespace micm
     }
 
     std::chrono::nanoseconds SubtractJacobianTermsKernelDriver(
-        CudaMatrixParam& matrixParam,
+        CudaMatrixParam_to_be_removed& matrixParam,
         CudaSparseMatrixParam& sparseMatrix,
         const ProcessSetParam& devstruct)
     {
@@ -244,9 +244,9 @@ namespace micm
     }  // end of SubtractJacobianTermsKernelDriver
 
     void AddForcingTermsKernelDriver(
-        const CudaVectorMatrixParam& rate_constants_param,
-        const CudaVectorMatrixParam& state_variables_param,
-        CudaVectorMatrixParam& forcing_param,
+        const CudaMatrixParam& rate_constants_param,
+        const CudaMatrixParam& state_variables_param,
+        CudaMatrixParam& forcing_param,
         const ProcessSetParam& devstruct)
     {
       size_t number_of_blocks = (rate_constants_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;

--- a/src/solver/linear_solver.cu
+++ b/src/solver/linear_solver.cu
@@ -116,7 +116,7 @@ namespace micm
     }
 
     std::chrono::nanoseconds
-    SolveKernelDriver(CudaSparseMatrixParam& sparseMatrix, CudaMatrixParam& denseMatrix, const LinearSolverParam& devstruct)
+    SolveKernelDriver(CudaSparseMatrixParam& sparseMatrix, CudaMatrixParam_to_be_removed& denseMatrix, const LinearSolverParam& devstruct)
     {
       /// Create device pointers
       double* d_lower_matrix;

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -88,8 +88,8 @@ namespace micm
     // Modified version from NVIDIA's reduction example:
     // https://developer.download.nvidia.com/assets/cuda/files/reduction.pdf
     __global__ void NormalizedErrorKernel(
-        const CudaVectorMatrixParam y_old_param,
-        const CudaVectorMatrixParam y_new_param,
+        const CudaMatrixParam y_old_param,
+        const CudaMatrixParam y_new_param,
         const RosenbrockSolverParameters ros_param,
         CudaRosenbrockSolverParam devstruct,
         const size_t n,
@@ -189,8 +189,8 @@ namespace micm
 
     // CUDA kernel to compute the scaled vectors; prepare the input for cublas call later
     __global__ void ScaledErrorKernel(
-        const CudaVectorMatrixParam y_old_param,
-        const CudaVectorMatrixParam y_new_param,
+        const CudaMatrixParam y_old_param,
+        const CudaMatrixParam y_new_param,
         const RosenbrockSolverParameters ros_param,
         CudaRosenbrockSolverParam devstruct)
     {
@@ -237,9 +237,9 @@ namespace micm
 
     // Host code that will launch the NormalizedError CUDA kernel
     double NormalizedErrorDriver(
-        const CudaVectorMatrixParam& y_old_param,
-        const CudaVectorMatrixParam& y_new_param,
-        const CudaVectorMatrixParam& errors_param,
+        const CudaMatrixParam& y_old_param,
+        const CudaMatrixParam& y_new_param,
+        const CudaMatrixParam& errors_param,
         const RosenbrockSolverParameters& ros_param,
         cublasHandle_t handle,
         CudaRosenbrockSolverParam devstruct)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(MICM_ENABLE_CUDA)
   target_sources(micm_cuda
        PRIVATE
-       cuda_vector_matrix.cu
+       cuda_matrix.cu
   )
 endif()

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -1,31 +1,31 @@
 #include <cuda_runtime.h>
 
-#include <micm/util/cuda_vector_matrix.cuh>
+#include <micm/util/cuda_matrix.cuh>
 #include <vector>
 
 namespace micm
 {
   namespace cuda
   {
-    int MallocVector(CudaVectorMatrixParam& param, std::size_t number_of_elements)
+    int MallocVector(CudaMatrixParam& param, std::size_t number_of_elements)
     {
       param.number_of_elements_ = number_of_elements;
       return cudaMalloc(&(param.d_data_), sizeof(double) * number_of_elements);
     }
-    int FreeVector(CudaVectorMatrixParam& param)
+    int FreeVector(CudaMatrixParam& param)
     {
       return cudaFree(param.d_data_);
     }
-    int CopyToDevice(CudaVectorMatrixParam& param, std::vector<double>& h_data)
+    int CopyToDevice(CudaMatrixParam& param, std::vector<double>& h_data)
     {
       return cudaMemcpy(param.d_data_, h_data.data(), sizeof(double) * param.number_of_elements_, cudaMemcpyHostToDevice);
     }
-    int CopyToHost(CudaVectorMatrixParam& param, std::vector<double>& h_data)
+    int CopyToHost(CudaMatrixParam& param, std::vector<double>& h_data)
     {
       cudaDeviceSynchronize();
       return cudaMemcpy(h_data.data(), param.d_data_, sizeof(double) * param.number_of_elements_, cudaMemcpyDeviceToHost);
     }
-    int CopyToDeviceFromDevice(CudaVectorMatrixParam& vectorMatrixDest, const CudaVectorMatrixParam& vectorMatrixSrc)
+    int CopyToDeviceFromDevice(CudaMatrixParam& vectorMatrixDest, const CudaMatrixParam& vectorMatrixSrc)
     {
       return cudaMemcpy(
           vectorMatrixDest.d_data_,

--- a/test/unit/process/test_cuda_process_set.cpp
+++ b/test/unit/process/test_cuda_process_set.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <micm/process/cuda_process_set.hpp>
 #include <micm/process/process_set.hpp>
-#include <micm/util/cuda_vector_matrix.hpp>
+#include <micm/util/cuda_dense_matrix.hpp>
 #include <micm/util/matrix.hpp>
 #include <micm/util/sparse_matrix_standard_ordering.hpp>
 #include <micm/util/sparse_matrix_vector_ordering.hpp>
@@ -191,11 +191,11 @@ template<class T>
 using Group10000SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<10000>>;
 
 template<class T>
-using Group10000CudaVectorMatrix = micm::CudaVectorMatrix<T, 10000>;
+using Group10000CudaDenseMatrix = micm::CudaDenseMatrix<T, 10000>;
 
 TEST(RandomCudaProcessSet, Forcing)
 {
-  testRandomSystemAddForcingTerms<Group10000VectorMatrix, Group10000CudaVectorMatrix>(10000, 500, 400);
+  testRandomSystemAddForcingTerms<Group10000VectorMatrix, Group10000CudaDenseMatrix>(10000, 500, 400);
 }
 TEST(RandomCudaProcessSet, Jacobian)
 {

--- a/test/unit/util/CMakeLists.txt
+++ b/test/unit/util/CMakeLists.txt
@@ -17,6 +17,6 @@ if(MICM_ENABLE_CUDA)
   target_sources(micm_cuda_test_utils PRIVATE cuda_matrix_utils.cu)
   set_target_properties(micm_cuda_test_utils PROPERTIES LINKER_LANGUAGE CXX)
   
-  create_standard_test(NAME cuda_vector_matrix SOURCES test_cuda_vector_matrix.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils)
-  create_standard_test(NAME cuda_sparse_vector_matrix SOURCES test_cuda_sparse_matrix_vector_ordering.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils)
+  create_standard_test(NAME cuda_dense_matrix SOURCES test_cuda_dense_matrix.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils)
+  create_standard_test(NAME cuda_sparse_matrix SOURCES test_cuda_sparse_matrix.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils)
 endif()

--- a/test/unit/util/cuda_matrix_utils.cu
+++ b/test/unit/util/cuda_matrix_utils.cu
@@ -13,7 +13,7 @@ namespace micm
           }
       }
 
-      void SquareDriver(CudaVectorMatrixParam& param)
+      void SquareDriver(CudaMatrixParam& param)
       {
           Square<<<param.number_of_elements_, 1>>>(param.d_data_, param.number_of_elements_);
       }
@@ -27,7 +27,7 @@ namespace micm
           }
       }
 
-      void AddOneDriver(CudaVectorMatrixParam& param)
+      void AddOneDriver(CudaMatrixParam& param)
       {
         AddOne<<<param.number_of_elements_, BLOCK_SIZE>>>(param.d_data_, param.number_of_elements_);
       }

--- a/test/unit/util/cuda_matrix_utils.cuh
+++ b/test/unit/util/cuda_matrix_utils.cuh
@@ -4,7 +4,7 @@ namespace micm
 {
     namespace cuda
     {
-        void SquareDriver(CudaVectorMatrixParam& param);
-        void AddOneDriver(CudaVectorMatrixParam& param);
+        void SquareDriver(CudaMatrixParam& param);
+        void AddOneDriver(CudaMatrixParam& param);
     }
 }

--- a/test/unit/util/test_cuda_dense_matrix.cpp
+++ b/test/unit/util/test_cuda_dense_matrix.cpp
@@ -1,27 +1,27 @@
 #include <gtest/gtest.h>
 
-#include <micm/util/cuda_vector_matrix.cuh>
-#include <micm/util/cuda_vector_matrix.hpp>
+#include <micm/util/cuda_matrix.cuh>
+#include <micm/util/cuda_dense_matrix.hpp>
 #include <numeric>
 
 #include "cuda_matrix_utils.cuh"
 #include "test_matrix_policy.hpp"
 
 template<class T>
-using Group1MatrixAlias = micm::CudaVectorMatrix<T, 1>;
+using Group1MatrixAlias = micm::CudaDenseMatrix<T, 1>;
 template<class T>
-using Group2MatrixAlias = micm::CudaVectorMatrix<T, 2>;
+using Group2MatrixAlias = micm::CudaDenseMatrix<T, 2>;
 template<class T>
-using Group3MatrixAlias = micm::CudaVectorMatrix<T, 3>;
+using Group3MatrixAlias = micm::CudaDenseMatrix<T, 3>;
 template<class T>
-using Group4MatrixAlias = micm::CudaVectorMatrix<T, 4>;
+using Group4MatrixAlias = micm::CudaDenseMatrix<T, 4>;
 
-TEST(CudaVectorMatrix, DeviceMemCopy)
+TEST(CudaDenseMatrix, DeviceMemCopy)
 {
   std::vector<double> h_vector{ 1, 2, 3, 4 };
   double* h_data = h_vector.data();
   std::size_t num_elements = h_vector.size();
-  CudaVectorMatrixParam param;
+  CudaMatrixParam param;
 
   micm::cuda::MallocVector(param, num_elements);
   micm::cuda::CopyToDevice(param, h_vector);
@@ -34,10 +34,10 @@ TEST(CudaVectorMatrix, DeviceMemCopy)
   EXPECT_EQ(h_vector[3], 4 * 4);
 }
 
-TEST(CudaVectorMatrix, IntDataType)
+TEST(CudaDenseMatrix, IntDataType)
 {
   std::vector<std::vector<int>> h_vector{ { 1, 2 }, { 3, 4 } };
-  auto matrix = micm::CudaVectorMatrix<int, 2>(h_vector);
+  auto matrix = micm::CudaDenseMatrix<int, 2>(h_vector);
 
   matrix[0][0] = 5;
 
@@ -47,10 +47,10 @@ TEST(CudaVectorMatrix, IntDataType)
   EXPECT_EQ(matrix[1][1], 4);
 }
 
-TEST(CudaVectorMatrix, IntDataTypeCopyAssignment)
+TEST(CudaDenseMatrix, IntDataTypeCopyAssignment)
 {
   std::vector<std::vector<int>> h_vector{ { 1, 2 }, { 3, 4 } };
-  auto matrix = micm::CudaVectorMatrix<int, 2>(h_vector);
+  auto matrix = micm::CudaDenseMatrix<int, 2>(h_vector);
 
   matrix[0][0] = 5;
 
@@ -73,10 +73,10 @@ TEST(CudaVectorMatrix, IntDataTypeCopyAssignment)
   EXPECT_EQ(matrix2[1][1], 4);
 }
 
-TEST(CudaVectorMatrix, IntDataTypeMoveAssignment)
+TEST(CudaDenseMatrix, IntDataTypeMoveAssignment)
 {
   std::vector<std::vector<int>> h_vector{ { 1, 2 }, { 3, 4 } };
-  auto matrix = micm::CudaVectorMatrix<int, 2>(h_vector);
+  auto matrix = micm::CudaDenseMatrix<int, 2>(h_vector);
 
   matrix[0][0] = 5;
 
@@ -95,7 +95,7 @@ TEST(CudaVectorMatrix, IntDataTypeMoveAssignment)
 }
 
 template<class T, std::size_t L = MICM_DEFAULT_VECTOR_SIZE>
-static void ModifyAndSyncToHost(micm::CudaVectorMatrix<T, L>& matrix)
+static void ModifyAndSyncToHost(micm::CudaDenseMatrix<T, L>& matrix)
 {
   matrix.CopyToDevice();
   auto matrixParam = matrix.AsDeviceParam();
@@ -103,10 +103,10 @@ static void ModifyAndSyncToHost(micm::CudaVectorMatrix<T, L>& matrix)
   matrix.CopyToHost();
 }
 
-TEST(CudaVectorMatrix, CopyConstructorVerifyDeviceMemoryEqual)
+TEST(CudaDenseMatrix, CopyConstructorVerifyDeviceMemoryEqual)
 {
   std::vector<std::vector<double>> h_vector{ { 1, 2 }, { 3, 4 } };
-  auto matrix = micm::CudaVectorMatrix<double, 2>(h_vector);
+  auto matrix = micm::CudaDenseMatrix<double, 2>(h_vector);
 
   matrix[0][0] = 5;
 
@@ -161,10 +161,10 @@ TEST(CudaVectorMatrix, CopyConstructorVerifyDeviceMemoryEqual)
   EXPECT_EQ(matrix2[1][1], 16);
 }
 
-TEST(CudaVectorMatrix, CopyConstructorSquareAfterCopyAssignment)
+TEST(CudaDenseMatrix, CopyConstructorSquareAfterCopyAssignment)
 {
   std::vector<std::vector<double>> h_vector{ { 1, 2 }, { 3, 4 } };
-  auto matrix = micm::CudaVectorMatrix<double, 2>(h_vector);
+  auto matrix = micm::CudaDenseMatrix<double, 2>(h_vector);
 
   auto matrix2 = matrix;
 
@@ -193,10 +193,10 @@ TEST(CudaVectorMatrix, CopyConstructorSquareAfterCopyAssignment)
   EXPECT_EQ(matrix2[1][1], 16);
 }
 
-TEST(CudaVectorMatrix, CopyConstructorDeSyncedHostDevice)
+TEST(CudaDenseMatrix, CopyConstructorDeSyncedHostDevice)
 {
   std::vector<std::vector<double>> h_vector{ { 1, 2 }, { 3, 4 } };
-  auto matrix = micm::CudaVectorMatrix<double, 2>(h_vector);
+  auto matrix = micm::CudaDenseMatrix<double, 2>(h_vector);
 
   EXPECT_EQ(matrix[0][0], 1);
   EXPECT_EQ(matrix[0][1], 2);
@@ -239,12 +239,12 @@ TEST(CudaVectorMatrix, CopyConstructorDeSyncedHostDevice)
   EXPECT_EQ(matrix2[1][1], 16);
 }
 
-TEST(CudaVectorMatrix, CopyAssignment)
+TEST(CudaDenseMatrix, CopyAssignment)
 {
   std::vector<std::vector<double>> h_vector{ { 1, 2 }, { 3, 4 } };
-  auto matrix = micm::CudaVectorMatrix<double, 2>(h_vector);
+  auto matrix = micm::CudaDenseMatrix<double, 2>(h_vector);
 
-  micm::CudaVectorMatrix<double, 2> matrix2;
+  micm::CudaDenseMatrix<double, 2> matrix2;
   matrix2 = matrix;
 
   matrix[0][0] = 5;
@@ -271,10 +271,10 @@ TEST(CudaVectorMatrix, CopyAssignment)
   EXPECT_EQ(matrix2[1][1], 16);
 }
 
-TEST(CudaVectorMatrix, MoveConstructor)
+TEST(CudaDenseMatrix, MoveConstructor)
 {
   std::vector<std::vector<double>> h_vector{ { 1, 2 }, { 3, 4 } };
-  auto matrix = micm::CudaVectorMatrix<double, 2>(h_vector);
+  auto matrix = micm::CudaDenseMatrix<double, 2>(h_vector);
 
   EXPECT_EQ(matrix[0][0], 1);
   EXPECT_EQ(matrix[0][1], 2);
@@ -306,12 +306,12 @@ TEST(CudaVectorMatrix, MoveConstructor)
   EXPECT_EQ(matrix2[1][1], 16);
 }
 
-TEST(CudaVectorMatrix, MoveAssignment)
+TEST(CudaDenseMatrix, MoveAssignment)
 {
   std::vector<std::vector<double>> h_vector{ { 1, 2 }, { 3, 4 } };
-  auto matrix = micm::CudaVectorMatrix<double, 2>(h_vector);
+  auto matrix = micm::CudaDenseMatrix<double, 2>(h_vector);
 
-  micm::CudaVectorMatrix<double, 2> matrix2;
+  micm::CudaDenseMatrix<double, 2> matrix2;
   matrix2 = std::move(matrix);
 
   EXPECT_EQ(matrix2[0][0], 1);
@@ -351,7 +351,7 @@ TEST(VectorMatrix, SmallVectorMatrix)
   EXPECT_EQ(data[1 + 2 * 3], 64.7 * 64.7);
 }
 
-TEST(CudaVectorMatrix, SmallConstVectorMatrix)
+TEST(CudaDenseMatrix, SmallConstVectorMatrix)
 {
   auto matrix = testSmallConstMatrix<Group4MatrixAlias>();
 
@@ -373,7 +373,7 @@ TEST(CudaVectorMatrix, SmallConstVectorMatrix)
   EXPECT_EQ(data[1 + 4 * 3], 64.7);
 }
 
-TEST(CudaVectorMatrix, InitializeVectorMatrix)
+TEST(CudaDenseMatrix, InitializeVectorMatrix)
 {
   auto matrix = testInializeMatrix<Group1MatrixAlias>();
   matrix.CopyToDevice();
@@ -384,7 +384,7 @@ TEST(CudaVectorMatrix, InitializeVectorMatrix)
   EXPECT_EQ(matrix[1][2], 12.4);
 }
 
-TEST(CudaVectorMatrix, InitializeConstVectorMatrix)
+TEST(CudaDenseMatrix, InitializeConstVectorMatrix)
 {
   auto matrix = testInializeConstMatrix<Group2MatrixAlias>();
   matrix.CopyToDevice();
@@ -395,7 +395,7 @@ TEST(CudaVectorMatrix, InitializeConstVectorMatrix)
   EXPECT_EQ(matrix[1][2], 12.4);
 }
 
-TEST(CudaVectorMatrix, LoopOverVectorMatrix)
+TEST(CudaDenseMatrix, LoopOverVectorMatrix)
 {
   Group2MatrixAlias<double> matrix(3, 4, 0);
   for (std::size_t i{}; i < matrix.size(); ++i)
@@ -420,7 +420,7 @@ TEST(CudaVectorMatrix, LoopOverVectorMatrix)
   EXPECT_EQ(matrix[0][3], 3);
 }
 
-TEST(CudaVectorMatrix, LoopOverConstVectorMatrix)
+TEST(CudaDenseMatrix, LoopOverConstVectorMatrix)
 {
   Group2MatrixAlias<double> matrix(3, 4, 0);
   for (std::size_t i{}; i < matrix.size(); ++i)
@@ -447,7 +447,7 @@ TEST(CudaVectorMatrix, LoopOverConstVectorMatrix)
   EXPECT_EQ(matrix[0][3], 3);
 }
 
-TEST(CudaVectorMatrix, ConversionToVector)
+TEST(CudaDenseMatrix, ConversionToVector)
 {
   auto matrix = testConversionToVector<Group3MatrixAlias>();
   matrix.CopyToDevice();
@@ -460,7 +460,7 @@ TEST(CudaVectorMatrix, ConversionToVector)
   EXPECT_EQ(slice[2], 314.2);
 }
 
-TEST(CudaVectorMatrix, ConstConversionToVector)
+TEST(CudaDenseMatrix, ConstConversionToVector)
 {
   auto matrix = testConstConversionToVector<Group1MatrixAlias>();
   matrix.CopyToDevice();
@@ -473,7 +473,7 @@ TEST(CudaVectorMatrix, ConstConversionToVector)
   EXPECT_EQ(slice[2], 314.2);
 }
 
-TEST(CudaVectorMatrix, ConversionFromVector)
+TEST(CudaDenseMatrix, ConversionFromVector)
 {
   Group2MatrixAlias<double> zero_matrix = std::vector<std::vector<double>>{};
 
@@ -494,7 +494,7 @@ TEST(CudaVectorMatrix, ConversionFromVector)
   EXPECT_EQ(matrix[1][2], 31.2);
 }
 
-TEST(CudaVectorMatrix, AssignmentFromVector)
+TEST(CudaDenseMatrix, AssignmentFromVector)
 {
   auto matrix = testAssignmentFromVector<Group2MatrixAlias>();
   matrix.CopyToDevice();
@@ -507,13 +507,13 @@ TEST(CudaVectorMatrix, AssignmentFromVector)
   EXPECT_EQ(matrix[3][0], 0.0);
 }
 
-TEST(CudaVectorMatrix, Axpy)
+TEST(CudaDenseMatrix, Axpy)
 {
   const double alpha = 2.0;
 
   // Generate a 20 x 10 matrix with all elements set to 10.0
-  auto gpu_x = micm::CudaVectorMatrix<double, 10>(20, 10, 10.0);
-  auto gpu_y = micm::CudaVectorMatrix<double, 10>(20, 10, 20.0);
+  auto gpu_x = micm::CudaDenseMatrix<double, 10>(20, 10, 10.0);
+  auto gpu_y = micm::CudaDenseMatrix<double, 10>(20, 10, 20.0);
   gpu_x[0][1] = 20.0;
   gpu_x[1][1] = 30.0;
 

--- a/test/unit/util/test_cuda_sparse_matrix.cpp
+++ b/test/unit/util/test_cuda_sparse_matrix.cpp
@@ -6,17 +6,17 @@
 #include "cuda_matrix_utils.cuh"
 #include "test_sparse_matrix_policy.hpp"
 
-TEST(CudaSparseVectorMatrix, ZeroMatrix)
+TEST(CudaSparseMatrix, ZeroMatrix)
 {
   auto matrix = testZeroMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrdering<3>>();
 }
 
-TEST(CudaSparseVectorMatrix, ConstZeroMatrix)
+TEST(CudaSparseMatrix, ConstZeroMatrix)
 {
   const auto matrix = testConstZeroMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrdering<3>>();
 }
 
-TEST(CudaSparseVectorMatrix, CopyAssignmentZeroMatrix)
+TEST(CudaSparseMatrix, CopyAssignmentZeroMatrix)
 {
   auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::create(2)
                      .with_element(0, 0)
@@ -44,7 +44,7 @@ TEST(CudaSparseVectorMatrix, CopyAssignmentZeroMatrix)
   }
 }
 
-TEST(CudaSparseVectorMatrix, CopyAssignmentConstZeroMatrix)
+TEST(CudaSparseMatrix, CopyAssignmentConstZeroMatrix)
 {
   auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::create(2)
                      .with_element(0, 0)
@@ -82,7 +82,7 @@ TEST(CudaSparseVectorMatrix, CopyAssignmentConstZeroMatrix)
   }
 }
 
-TEST(CudaSparseVectorMatrix, CopyAssignmentDeSynchedHostZeroMatrix)
+TEST(CudaSparseMatrix, CopyAssignmentDeSynchedHostZeroMatrix)
 {
   auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::create(2)
                      .with_element(0, 0)
@@ -138,7 +138,7 @@ TEST(CudaSparseVectorMatrix, CopyAssignmentDeSynchedHostZeroMatrix)
   }
 }
 
-TEST(CudaSparseVectorMatrix, MoveAssignmentConstZeroMatrix)
+TEST(CudaSparseMatrix, MoveAssignmentConstZeroMatrix)
 {
   auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::create(2)
                      .with_element(0, 0)
@@ -172,7 +172,7 @@ TEST(CudaSparseVectorMatrix, MoveAssignmentConstZeroMatrix)
   }
 }
 
-TEST(CudaSparseVectorMatrix, MoveAssignmentDeSyncedHostZeroMatrix)
+TEST(CudaSparseMatrix, MoveAssignmentDeSyncedHostZeroMatrix)
 {
   auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::create(2)
                      .with_element(0, 0)
@@ -211,12 +211,12 @@ TEST(CudaSparseVectorMatrix, MoveAssignmentDeSyncedHostZeroMatrix)
   }
 }
 
-TEST(CudaSparseVectorMatrix, SetScalar)
+TEST(CudaSparseMatrix, SetScalar)
 {
   testSetScalar<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrdering<3>>();
 }
 
-TEST(CudaSparseVectorMatrix, SingleBlockMatrix)
+TEST(CudaSparseMatrix, SingleBlockMatrix)
 {
   auto matrix = testSingleBlockMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrdering<4>>();
 
@@ -237,7 +237,7 @@ TEST(CudaSparseVectorMatrix, SingleBlockMatrix)
   EXPECT_EQ(matrix.NumberOfGroups(1), 1);
 }
 
-TEST(CudaSparseVectorMatrix, ConstSingleBlockMatrix)
+TEST(CudaSparseMatrix, ConstSingleBlockMatrix)
 {
   auto matrix = testConstSingleBlockMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrdering<2>>();
 
@@ -256,7 +256,7 @@ TEST(CudaSparseVectorMatrix, ConstSingleBlockMatrix)
   EXPECT_EQ(matrix.NumberOfGroups(1), 1);
 }
 
-TEST(CudaSparseVectorMatrix, MultiBlockMatrix)
+TEST(CudaSparseMatrix, MultiBlockMatrix)
 {
   auto matrix = testMultiBlockMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrdering<2>>();
 


### PR DESCRIPTION
This PR renames the previous `CudaVectorMatrix` class to `CudaDenseMatrix` class for clarity. Now we only have `CudaDenseMatrix` and `CudaSparseMatrix`, and they are only for the vector matrix on GPU.

Maybe we should highlight somewhere that the GPU code only works with the vector matrix?

All the 40 tests passed on Derecho's A100 GPU by using `nvhpc/23.7`.

Fixed #442 