### PR TITLE
add support for non-double properties

### DIFF
--- a/include/micm/configure/solver_config.hpp
+++ b/include/micm/configure/solver_config.hpp
@@ -372,10 +372,11 @@ namespace micm
     {
       // required keys
       const std::string NAME = "name";
+      const std::string TYPE = "type";
 
       auto status = ValidateSchema(
           object,
-          { NAME, "type" },
+          { NAME, TYPE },
           { "tracer type", "absolute tolerance", "diffusion coefficient [m2 s-1]", "molecular weight [kg mol-1]" });
       if (status != ConfigParseStatus::Success)
       {
@@ -383,15 +384,24 @@ namespace micm
       }
 
       std::string name = object[NAME].get<std::string>();
+      Species species{ name };
 
       // Load remaining keys as properties
-      std::map<std::string, double> properties{};
       for (auto& [key, value] : object.items())
       {
-        if (value.is_number_float())
-          properties[key] = value;
+        if (key != NAME && key != TYPE)
+          if (value.is_string())
+            species.SetProperty<std::string>(key, value);
+          else if (value.is_number_integer())
+            species.SetProperty<int>(key, value);
+          else if (value.is_number_float())
+            species.SetProperty<double>(key, value);
+          else if (value.is_boolean())
+            species.SetProperty<bool>(key, value);
+          else
+            std::cerr << "Unknown type for property " << key << std::endl;
       }
-      species_arr_.push_back(Species(name, properties));
+      species_arr_.push_back(species);
 
       return ConfigParseStatus::Success;
     }

--- a/include/micm/process/surface_rate_constant.hpp
+++ b/include/micm/process/surface_rate_constant.hpp
@@ -64,8 +64,8 @@ namespace micm
 
   inline SurfaceRateConstant::SurfaceRateConstant(const SurfaceRateConstantParameters& parameters)
       : parameters_(parameters),
-        diffusion_coefficient_(parameters.species_.properties_.at(GAS_DIFFUSION_COEFFICIENT)),
-        mean_free_speed_factor_(8.0 * GAS_CONSTANT / (M_PI * parameters.species_.properties_.at(MOLECULAR_WEIGHT)))
+        diffusion_coefficient_(parameters.species_.GetProperty<double>(GAS_DIFFUSION_COEFFICIENT)),
+        mean_free_speed_factor_(8.0 * GAS_CONSTANT / (M_PI * parameters.species_.GetProperty<double>(MOLECULAR_WEIGHT)))
   {
   }
 

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -21,7 +21,10 @@ namespace micm
     std::string name_;
 
     /// @brief A list of properties of this species
-    std::map<std::string, double> properties_;
+    std::map<std::string, std::string> properties_string_;
+    std::map<std::string, double> properties_double_;
+    std::map<std::string, bool> properties_bool_;
+    std::map<std::string, int> properties_int_;
 
     /// @brief A function that if provided will be used to parameterize
     ///        the concentration of this species during solving.
@@ -49,6 +52,14 @@ namespace micm
     /// @brief Returns whether a species is parameterized
     bool IsParameterized() const;
 
+    /// @brief Return the value of a species property
+    template<class T>
+    T GetProperty(const std::string& key) const;
+
+    /// @brief Set the value of a species property
+    template<class T>
+    void SetProperty(const std::string& key, T value);
+
     /// @brief Return a Species instance parameterized on air density
     static Species ThirdBody();
   };
@@ -61,7 +72,10 @@ namespace micm
     }
 
     name_ = other.name_;
-    properties_ = other.properties_;  // This performs a shallow copy
+    properties_string_ = other.properties_string_;
+    properties_double_ = other.properties_double_;
+    properties_int_ = other.properties_int_;
+    properties_bool_ = other.properties_bool_;
     parameterize_ = other.parameterize_;
 
     return *this;
@@ -69,7 +83,10 @@ namespace micm
 
   inline Species::Species(const Species& other)
       : name_(other.name_),
-        properties_(other.properties_),
+        properties_string_(other.properties_string_),
+        properties_double_(other.properties_double_),
+        properties_int_(other.properties_int_),
+        properties_bool_(other.properties_bool_),
         parameterize_(other.parameterize_){};
 
   inline Species::Species(const std::string& name)
@@ -77,11 +94,61 @@ namespace micm
 
   inline Species::Species(const std::string& name, const std::map<std::string, double>& properties)
       : name_(name),
-        properties_(properties){};
+        properties_double_(properties){};
 
   inline bool Species::IsParameterized() const
   {
     return parameterize_ != nullptr;
+  }
+
+  template<class T>
+  inline T Species::GetProperty(const std::string& key) const
+  {
+    if constexpr (std::is_same<T, std::string>::value)
+    {
+      return properties_string_.at(key);
+    }
+    else if constexpr (std::is_same<T, double>::value)
+    {
+      return properties_double_.at(key);
+    }
+    else if constexpr (std::is_same<T, bool>::value)
+    {
+      return properties_bool_.at(key);
+    }
+    else if constexpr (std::is_same<T, int>::value)
+    {
+      return properties_int_.at(key);
+    }
+    else
+    {
+      throw std::runtime_error("Invalid type for property");
+    }
+  }
+
+  template<class T>
+  inline void Species::SetProperty(const std::string& key, T value)
+  {
+    if constexpr (std::is_same<T, std::string>::value || std::is_same<T, const char*>::value)
+    {
+      properties_string_[key] = value;
+    }
+    else if constexpr (std::is_same<T, double>::value)
+    {
+      properties_double_[key] = value;
+    }
+    else if constexpr (std::is_same<T, bool>::value)
+    {
+      properties_bool_[key] = value;
+    }
+    else if constexpr (std::is_same<T, int>::value)
+    {
+      properties_int_[key] = value;
+    }
+    else
+    {
+      throw std::runtime_error("Invalid type for property");
+    }
   }
 
   inline Species Species::ThirdBody()

--- a/test/unit/configure/test_solver_config.cpp
+++ b/test/unit/configure/test_solver_config.cpp
@@ -82,7 +82,7 @@ TEST(SolverConfig, ReadAndParseSystemObject)
   // Check 'name' and 'properties' in 'Species'
   std::vector<std::pair<std::string, short>> species_name_and_num_properties = {
     std::make_pair("M", 0),   std::make_pair("Ar", 1), std::make_pair("CO2", 1),
-    std::make_pair("H2O", 1), std::make_pair("N2", 1), std::make_pair("O1D", 1),
+    std::make_pair("H2O", 1), std::make_pair("N2", 2), std::make_pair("O1D", 1),
     std::make_pair("O", 1),   std::make_pair("O2", 1), std::make_pair("O3", 1)
   };
 
@@ -90,9 +90,15 @@ TEST(SolverConfig, ReadAndParseSystemObject)
   for (const auto& s : solver_params.system_.gas_phase_.species_)
   {
     EXPECT_EQ(s.name_, species_name_and_num_properties[idx].first);
-    EXPECT_EQ(s.properties_.size(), species_name_and_num_properties[idx].second);
+    EXPECT_EQ(s.properties_double_.size(), species_name_and_num_properties[idx].second);
     idx++;
   }
+  // check some specific properties
+  EXPECT_EQ(solver_params.system_.gas_phase_.species_[4].GetProperty<double>("absolute tolerance"), 1.0e-12);
+  EXPECT_EQ(solver_params.system_.gas_phase_.species_[4].GetProperty<double>("molecular weight [kg mol-1]"), 0.0280134);
+  EXPECT_EQ(solver_params.system_.gas_phase_.species_[4].GetProperty<std::string>("__custom string property"), "foo");
+  EXPECT_EQ(solver_params.system_.gas_phase_.species_[4].GetProperty<bool>("__custom bool property"), true);
+  EXPECT_EQ(solver_params.system_.gas_phase_.species_[4].GetProperty<int>("__custom int property"), 12);
 }
 
 TEST(SolverConfig, ReadAndParseProcessObjects)

--- a/test/unit/system/test_species.cpp
+++ b/test/unit/system/test_species.cpp
@@ -17,9 +17,9 @@ TEST(Species, StringAndVectorConstructor)
   micm::Species species("thing", { { "name [units]", 1.0 }, { "name2 [units2]", 2.0 } });
 
   EXPECT_EQ(species.name_, "thing");
-  EXPECT_EQ(species.properties_.size(), 2);
-  EXPECT_EQ(species.properties_["name [units]"], 1.0);
-  EXPECT_EQ(species.properties_["name2 [units2]"], 2.0);
+  EXPECT_EQ(species.properties_double_.size(), 2);
+  EXPECT_EQ(species.GetProperty<double>("name [units]"), 1.0);
+  EXPECT_EQ(species.GetProperty<double>("name2 [units2]"), 2.0);
 }
 
 TEST(Species, ThirdBody)
@@ -34,25 +34,37 @@ TEST(Species, CopyConstructor)
 {
   {
     micm::Species species("thing", { { "name [units]", 1.0 }, { "name2 [units2]", 2.0 } });
+    species.SetProperty("foo", "bar");
+    species.SetProperty("baz", 42);
+    species.SetProperty("qux", true);
 
     micm::Species species2(species);
 
     EXPECT_EQ(species2.name_, "thing");
-    EXPECT_EQ(species2.properties_.size(), 2);
-    EXPECT_EQ(species2.properties_["name [units]"], 1.0);
-    EXPECT_EQ(species2.properties_["name2 [units2]"], 2.0);
+    EXPECT_EQ(species2.properties_double_.size(), 2);
+    EXPECT_EQ(species2.GetProperty<double>("name [units]"), 1.0);
+    EXPECT_EQ(species2.GetProperty<double>("name2 [units2]"), 2.0);
+    EXPECT_EQ(species2.GetProperty<std::string>("foo"), "bar");
+    EXPECT_EQ(species2.GetProperty<int>("baz"), 42);
+    EXPECT_EQ(species2.GetProperty<bool>("qux"), true);
     EXPECT_FALSE(species2.IsParameterized());
   }
   {
     micm::Species species("thing", { { "name [units]", 1.0 }, { "name2 [units2]", 2.0 } });
     species.parameterize_ = [](const micm::Conditions& c) { return 15.4; };
+    species.SetProperty("foo", "bar");
+    species.SetProperty("baz", 42);
+    species.SetProperty("qux", true);
 
     micm::Species species2(species);
 
     EXPECT_EQ(species2.name_, "thing");
-    EXPECT_EQ(species2.properties_.size(), 2);
-    EXPECT_EQ(species2.properties_["name [units]"], 1.0);
-    EXPECT_EQ(species2.properties_["name2 [units2]"], 2.0);
+    EXPECT_EQ(species2.properties_double_.size(), 2);
+    EXPECT_EQ(species2.GetProperty<double>("name [units]"), 1.0);
+    EXPECT_EQ(species2.GetProperty<double>("name2 [units2]"), 2.0);
+    EXPECT_EQ(species2.GetProperty<std::string>("foo"), "bar");
+    EXPECT_EQ(species2.GetProperty<int>("baz"), 42);
+    EXPECT_EQ(species2.GetProperty<bool>("qux"), true);
     EXPECT_TRUE(species2.IsParameterized());
     EXPECT_EQ(species.parameterize_({}), 15.4);
   }
@@ -62,25 +74,37 @@ TEST(Species, CopyAssignment)
 {
   {
     micm::Species species("thing", { { "name [units]", 1.0 }, { "name2 [units2]", 2.0 } });
+    species.SetProperty("foo", "bar");
+    species.SetProperty("baz", 42);
+    species.SetProperty("qux", true);
 
     micm::Species species2 = species;
 
     EXPECT_EQ(species2.name_, "thing");
-    EXPECT_EQ(species2.properties_.size(), 2);
-    EXPECT_EQ(species2.properties_["name [units]"], 1.0);
-    EXPECT_EQ(species2.properties_["name2 [units2]"], 2.0);
+    EXPECT_EQ(species2.properties_double_.size(), 2);
+    EXPECT_EQ(species2.GetProperty<double>("name [units]"), 1.0);
+    EXPECT_EQ(species2.GetProperty<double>("name2 [units2]"), 2.0);
+    EXPECT_EQ(species2.GetProperty<std::string>("foo"), "bar");
+    EXPECT_EQ(species2.GetProperty<int>("baz"), 42);
+    EXPECT_EQ(species2.GetProperty<bool>("qux"), true);
     EXPECT_FALSE(species2.IsParameterized());
   }
   {
     micm::Species species("thing", { { "name [units]", 1.0 }, { "name2 [units2]", 2.0 } });
     species.parameterize_ = [](const micm::Conditions& c) { return 15.4; };
+    species.SetProperty("foo", "bar");
+    species.SetProperty("baz", 42);
+    species.SetProperty("qux", true);
 
     micm::Species species2 = species;
 
     EXPECT_EQ(species2.name_, "thing");
-    EXPECT_EQ(species2.properties_.size(), 2);
-    EXPECT_EQ(species2.properties_["name [units]"], 1.0);
-    EXPECT_EQ(species2.properties_["name2 [units2]"], 2.0);
+    EXPECT_EQ(species2.properties_double_.size(), 2);
+    EXPECT_EQ(species2.GetProperty<double>("name [units]"), 1.0);
+    EXPECT_EQ(species2.GetProperty<double>("name2 [units2]"), 2.0);
+    EXPECT_EQ(species2.GetProperty<std::string>("foo"), "bar");
+    EXPECT_EQ(species2.GetProperty<int>("baz"), 42);
+    EXPECT_EQ(species2.GetProperty<bool>("qux"), true);
     EXPECT_TRUE(species2.IsParameterized());
     EXPECT_EQ(species.parameterize_({}), 15.4);
   }

--- a/test/unit/unit_configs/chapman/species.json
+++ b/test/unit/unit_configs/chapman/species.json
@@ -27,7 +27,11 @@
     {
       "name" : "N2",
       "type" : "CHEM_SPEC",
-      "absolute tolerance" : 1.0e-12
+      "absolute tolerance" : 1.0e-12,
+      "molecular weight [kg mol-1]" : 0.0280134,
+      "__custom string property" : "foo",
+      "__custom int property" : 12,
+      "__custom bool property" : true
     },
     {
       "name" : "O1D",


### PR DESCRIPTION
Adds support for non-double species properties. Closes #407 