### PR TITLE
Update the CUDA implementation of AlphaMinusJacobian and NormalizedError with the CUDA matrix class

### DIFF
--- a/include/micm/solver/cuda_rosenbrock.cuh
+++ b/include/micm/solver/cuda_rosenbrock.cuh
@@ -17,7 +17,7 @@ namespace micm{
       void FreeConstData(CudaRosenbrockSolverParam& devstruct);
 
       /// @brief Compute alpha - J[i] for each element i at the diagnoal of Jacobian matrix
-      /// @param jacobian_param the data member of Jacobian matrix with type "CudaSparseMatrix"
+      /// @param jacobian_param Dimensions and device data pointers for the Jacobian
       /// @param alpha scalar variable
       /// @param devstruct device struct including the locations of diagonal elements of the Jacobian matrix
       /// @return

--- a/include/micm/solver/cuda_rosenbrock.cuh
+++ b/include/micm/solver/cuda_rosenbrock.cuh
@@ -24,7 +24,7 @@ namespace micm{
       /// @param devstruct device struct including the locations of diagonal elements of the Jacobian matrix
       /// @return
       void AlphaMinusJacobianDriver(CudaMatrixParam& jacobian_param,
-                                    const double alpha,
+                                    const double& alpha,
                                     const CudaRosenbrockSolverParam& devstruct);
 
       /// @brief Computes the scaled norm of the matrix errors on the GPU; assume all the data are GPU resident already

--- a/include/micm/solver/cuda_rosenbrock.cuh
+++ b/include/micm/solver/cuda_rosenbrock.cuh
@@ -1,10 +1,8 @@
 // Copyright (C) 2023-2024 National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
-#include <chrono>
 #include <micm/util/cuda_param.hpp>
 #include <micm/solver/rosenbrock_solver_parameters.hpp>
-#include <vector>
 #include "cublas_v2.h"
 
 namespace micm{
@@ -34,9 +32,9 @@ namespace micm{
       /// @param ros_param struct of Rosenbrock solver parameters
       /// @param handle cublas handle
       /// @return the scaled norm of the matrix errors
-      double NormalizedErrorDriver(const CudaVectorMatrixParam& y_old_param,
-                                   const CudaVectorMatrixParam& y_new_param,
-                                   const CudaVectorMatrixParam& errors_param,
+      double NormalizedErrorDriver(const CudaMatrixParam& y_old_param,
+                                   const CudaMatrixParam& y_new_param,
+                                   const CudaMatrixParam& errors_param,
                                    const RosenbrockSolverParameters& ros_param,
                                    cublasHandle_t handle,
                                    CudaRosenbrockSolverParam devstruct);

--- a/include/micm/solver/cuda_rosenbrock.cuh
+++ b/include/micm/solver/cuda_rosenbrock.cuh
@@ -18,14 +18,12 @@ namespace micm{
       ///   members of class "CudaRosenbrockSolverParam" on the device
       void FreeConstData(CudaRosenbrockSolverParam& devstruct);
 
-      /// @brief Compute alpha - J[i] for each element i at the diagnoal of matrix J
-      /// @param h_jacobian sparse matrix on the host (will be replaced by the CudaSparseMatrix class)
-      /// @param num_elements number of elements in the h_jacobian (will be replaced by the CudaSparseMatrix class)
+      /// @brief Compute alpha - J[i] for each element i at the diagnoal of Jacobian matrix
+      /// @param jacobian_param the data member of Jacobian matrix with type "CudaSparseMatrix"
       /// @param alpha scalar variable
       /// @param devstruct device struct including the locations of diagonal elements of the Jacobian matrix
       /// @return
-      void AlphaMinusJacobianDriver(double* h_jacobian,
-                                    const size_t num_elements,
+      void AlphaMinusJacobianDriver(CudaMatrixParam& jacobian_param,
                                     const double alpha,
                                     const CudaRosenbrockSolverParam& devstruct);
 

--- a/include/micm/solver/cuda_rosenbrock.hpp
+++ b/include/micm/solver/cuda_rosenbrock.hpp
@@ -96,8 +96,8 @@ namespace micm
       micm::cuda::FreeConstData(this->devstruct_);
     };
 
-    void AlphaMinusJacobian(SparseMatrixPolicy<double>& jacobian, double alpha) const requires
-        VectorizableSparse<SparseMatrixPolicy<double>>
+    void AlphaMinusJacobian(SparseMatrixPolicy<double>& jacobian, const double& alpha) const
+        requires VectorizableSparse<SparseMatrixPolicy<double>>
     {
       auto jacobian_param = jacobian.AsDeviceParam(); // we need to update jacobian so it can't be constant and must be an lvalue
       micm::cuda::AlphaMinusJacobianDriver(jacobian_param, alpha, this->devstruct_);

--- a/include/micm/solver/cuda_rosenbrock.hpp
+++ b/include/micm/solver/cuda_rosenbrock.hpp
@@ -60,7 +60,6 @@ namespace micm
     {
       CudaRosenbrockSolverParam hoststruct;
       hoststruct.errors_size_ = parameters.number_of_grid_cells_ * system.StateSize();
-      hoststruct.num_grid_cells_ = parameters.number_of_grid_cells_;
       hoststruct.jacobian_diagonal_elements_ = this->state_parameters_.jacobian_diagonal_elements_.data();
       hoststruct.jacobian_diagonal_elements_size_ = this->state_parameters_.jacobian_diagonal_elements_.size();
       // Copy the data from host struct to device struct
@@ -83,7 +82,6 @@ namespace micm
     {
       CudaRosenbrockSolverParam hoststruct;
       hoststruct.errors_size_ = parameters.number_of_grid_cells_ * system.StateSize();
-      hoststruct.num_grid_cells_ = parameters.number_of_grid_cells_;
       hoststruct.jacobian_diagonal_elements_ = this->state_parameters_.jacobian_diagonal_elements_.data();
       hoststruct.jacobian_diagonal_elements_size_ = this->state_parameters_.jacobian_diagonal_elements_.size();
       // Copy the data from host struct to device struct
@@ -101,9 +99,8 @@ namespace micm
     void AlphaMinusJacobian(SparseMatrixPolicy<double>& jacobian, double alpha) const requires
         VectorizableSparse<SparseMatrixPolicy<double>>
     {
-      double* h_jacobian = jacobian.AsVector().data();
-      size_t num_elements = jacobian.AsVector().size();
-      micm::cuda::AlphaMinusJacobianDriver(h_jacobian, num_elements, alpha, this->devstruct_);
+      auto jacobian_param = jacobian.AsDeviceParam(); // we need to update jacobian so it can't be constant and must be an lvalue
+      micm::cuda::AlphaMinusJacobianDriver(jacobian_param, alpha, this->devstruct_);
     }
 
     /// @brief Computes the scaled norm of the vector errors on the GPU; assume all the data are GPU resident already

--- a/include/micm/solver/cuda_rosenbrock.hpp
+++ b/include/micm/solver/cuda_rosenbrock.hpp
@@ -1,3 +1,6 @@
+// Copyright (C) 2023-2024 National Center for Atmospheric Research,
+//
+// SPDX-License-Identifier: Apache-2.0
 #pragma once
 
 #include <algorithm>
@@ -16,6 +19,8 @@
 #include <micm/solver/state.hpp>
 #include <micm/system/system.hpp>
 #include <micm/util/cuda_param.hpp>
+#include <micm/util/cuda_dense_matrix.hpp>
+#include <micm/util/cuda_sparse_matrix.hpp>
 #include <micm/util/jacobian.hpp>
 #include <micm/util/matrix.hpp>
 #include <micm/util/sparse_matrix.hpp>
@@ -26,8 +31,8 @@ namespace micm
 {
 
   template<
-      template<class> class MatrixPolicy = Matrix,
-      template<class> class SparseMatrixPolicy = StandardSparseMatrix,
+      template<class> class MatrixPolicy,
+      template<class> class SparseMatrixPolicy,
       class LinearSolverPolicy = CudaLinearSolver<double, SparseMatrixPolicy>,
       class ProcessSetPolicy = CudaProcessSet>
 

--- a/include/micm/solver/cuda_rosenbrock.hpp
+++ b/include/micm/solver/cuda_rosenbrock.hpp
@@ -2,12 +2,9 @@
 
 #include <algorithm>
 #include <cassert>
-#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <functional>
-#include <iostream>
-#include <limits>
 #include <micm/process/cuda_process_set.hpp>
 #include <micm/process/process.hpp>
 #include <micm/process/process_set.hpp>

--- a/include/micm/solver/rosenbrock_solver_parameters.hpp
+++ b/include/micm/solver/rosenbrock_solver_parameters.hpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstddef>
 #include <iostream>
+#include <limits>
 
 namespace micm
 {

--- a/include/micm/util/cuda_dense_matrix.hpp
+++ b/include/micm/util/cuda_dense_matrix.hpp
@@ -104,6 +104,7 @@ namespace micm
     CudaDenseMatrix(CudaDenseMatrix&& other) noexcept
         : VectorMatrix<T, L>(other)
     {
+      this->param_.d_data_ = nullptr;
       std::swap(this->param_, other.param_);
       std::swap(this->handle_, other.handle_);
     }

--- a/include/micm/util/cuda_dense_matrix.hpp
+++ b/include/micm/util/cuda_dense_matrix.hpp
@@ -48,6 +48,7 @@ namespace micm
     CudaDenseMatrix() requires(std::is_same_v<T, double>)
         : VectorMatrix<T, L>()
     {
+      this->param_.number_of_grid_cells_ = 0;
       CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), "cudaMalloc");
     }
     CudaDenseMatrix()
@@ -82,6 +83,7 @@ namespace micm
     CudaDenseMatrix(const std::vector<std::vector<T>> other) requires(std::is_same_v<T, double>)
         : VectorMatrix<T, L>(other)
     {
+      this->param_.number_of_grid_cells_ = 0;
       CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), "cudaMalloc");
       CHECK_CUBLAS_ERROR(cublasCreate(&(this->handle_)), "CUBLAS initialization failed...");
     }

--- a/include/micm/util/cuda_dense_matrix.hpp
+++ b/include/micm/util/cuda_dense_matrix.hpp
@@ -1,3 +1,8 @@
+// Copyright (C) 2023-2024 National Center for Atmospheric Research,
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
 #include <micm/util/cuda_matrix.cuh>
 #include <micm/util/vector_matrix.hpp>
 #include <type_traits>

--- a/include/micm/util/cuda_dense_matrix.hpp
+++ b/include/micm/util/cuda_dense_matrix.hpp
@@ -104,8 +104,8 @@ namespace micm
     CudaDenseMatrix(CudaDenseMatrix&& other) noexcept
         : VectorMatrix<T, L>(other)
     {
-      this->param_ = std::move(other.param_);
-      this->handle_ = std::move(other.handle_);
+      std::swap(this->param_, other.param_);
+      std::swap(this->handle_, other.handle_);
     }
 
     CudaDenseMatrix& operator=(const CudaDenseMatrix& other)
@@ -124,8 +124,8 @@ namespace micm
       if (this != &other)
       {
         VectorMatrix<T, L>::operator=(other);
-        this->param_ = std::move(other.param_);
-        this->handle_ = std::move(other.handle_);
+        std::swap(this->param_, other.param_);
+        std::swap(this->handle_, other.handle_);
       }
       return *this;
     }

--- a/include/micm/util/cuda_matrix.cuh
+++ b/include/micm/util/cuda_matrix.cuh
@@ -6,6 +6,7 @@
 #include <vector>
 #include <cuda_runtime.h>
 #include <micm/util/cuda_param.hpp>
+#include "cublas_v2.h"
 
 namespace micm
 {
@@ -39,5 +40,19 @@ namespace micm
     /// @param vectorMatrixSrc Struct containing allocated source device memory to copy from
     /// @returns Error code from copying to destination device memory from source device memory, if any
     cudaError_t CopyToDeviceFromDevice(CudaMatrixParam& vectorMatrixDest, const CudaMatrixParam& vectorMatrixSrc);
+
+    /// @brief Checks for CUDA errors and prints error message if any
+    /// @param err Error code to check
+    /// @param file File where error occurred
+    /// @param line Line number where error occurred
+    /// @param str Additional string to print with error message
+    void CHECK_CUDA_ERROR(cudaError_t err, const char *file, int line, std::string str);
+
+    /// @brief Checks for cuBLAS errors and prints error message if any
+    /// @param err Error code to check
+    /// @param file File where error occurred
+    /// @param line Line number where error occurred
+    /// @param str Additional string to print with error message
+    void CHECK_CUBLAS_ERROR(cublasStatus_t err, const char *file, int line, std::string str);
   }
 }

--- a/include/micm/util/cuda_matrix.cuh
+++ b/include/micm/util/cuda_matrix.cuh
@@ -46,13 +46,13 @@ namespace micm
     /// @param file File where error occurred
     /// @param line Line number where error occurred
     /// @param str Additional string to print with error message
-    void CHECK_CUDA_ERROR(cudaError_t err, const char *file, int line, std::string str);
+    void CheckCudaError(cudaError_t err, const char *file, int line, std::string str);
 
     /// @brief Checks for cuBLAS errors and prints error message if any
     /// @param err Error code to check
     /// @param file File where error occurred
     /// @param line Line number where error occurred
     /// @param str Additional string to print with error message
-    void CHECK_CUBLAS_ERROR(cublasStatus_t err, const char *file, int line, std::string str);
+    void CheckCublasError(cublasStatus_t err, const char *file, int line, std::string str);
   }
 }

--- a/include/micm/util/cuda_matrix.cuh
+++ b/include/micm/util/cuda_matrix.cuh
@@ -1,4 +1,10 @@
+// Copyright (C) 2023-2024 National Center for Atmospheric Research,
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
 #include <vector>
+#include <cuda_runtime.h>
 #include <micm/util/cuda_param.hpp>
 
 namespace micm
@@ -9,29 +15,29 @@ namespace micm
     /// @param vectorMatrix Reference to struct containing information about allocated memory
     /// @param num_elements Requested number of elements to allocate
     /// @returns Error code from allocating data on the device, if any
-    int MallocVector(CudaMatrixParam& vectorMatrix, std::size_t num_elements);
+    cudaError_t MallocVector(CudaMatrixParam& vectorMatrix, std::size_t num_elements);
 
     /// @brief Free memory allocated on device
     /// @param vectorMatrix Struct containing allocated device memory
     /// @returns Error code from free-ing data on device, if any
-    int FreeVector(CudaMatrixParam& vectorMatrix);
+    cudaError_t FreeVector(CudaMatrixParam& vectorMatrix);
 
     /// @brief Copies data from the host to the device
     /// @param vectorMatrix Struct containing allocated device memory
     /// @param h_data Host data to copy from
     /// @returns Error code from copying to device from the host, if any
-    int CopyToDevice(CudaMatrixParam& vectorMatrix, std::vector<double>& h_data);
+    cudaError_t CopyToDevice(CudaMatrixParam& vectorMatrix, std::vector<double>& h_data);
 
     /// @brief Copies data from the device to the host
     /// @param vectorMatrix Struct containing allocated device memory
     /// @param h_data Host data to copy data to
     /// @returns Error code from copying from the device to the host, if any
-    int CopyToHost(CudaMatrixParam& vectorMatrix, std::vector<double>& h_data);
+    cudaError_t CopyToHost(CudaMatrixParam& vectorMatrix, std::vector<double>& h_data);
 
     /// @brief Copies data to the destination device memory block from the source device memory block
     /// @param vectorMatrixDest Struct containing allocated destination device memory to copy to
     /// @param vectorMatrixSrc Struct containing allocated source device memory to copy from
     /// @returns Error code from copying to destination device memory from source device memory, if any
-    int CopyToDeviceFromDevice(CudaMatrixParam& vectorMatrixDest, const CudaMatrixParam& vectorMatrixSrc);
+    cudaError_t CopyToDeviceFromDevice(CudaMatrixParam& vectorMatrixDest, const CudaMatrixParam& vectorMatrixSrc);
   }
 }

--- a/include/micm/util/cuda_param.hpp
+++ b/include/micm/util/cuda_param.hpp
@@ -118,7 +118,6 @@ struct CudaMatrixParam
 /// This struct could be allocated on the host or device;
 struct CudaRosenbrockSolverParam
 {
-  size_t num_grid_cells_;
   // for NormalizedError function
   double* errors_input_;
   double* errors_output_;

--- a/include/micm/util/cuda_sparse_matrix.hpp
+++ b/include/micm/util/cuda_sparse_matrix.hpp
@@ -9,6 +9,8 @@
 #include <type_traits>
 #include <cuda_runtime.h>
 
+#define CHECK_CUDA_ERROR(err, msg) micm::cuda::CheckCudaError(err, __FILE__, __LINE__, msg)
+
 namespace micm
 {
   template<class T, class OrderingPolicy>
@@ -28,7 +30,7 @@ namespace micm
         : SparseMatrix<T, OrderingPolicy>(builder)
     {
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
-      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), __FILE__, __LINE__, "cudaMalloc");
+      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), "cudaMalloc");
     }
     CudaSparseMatrix(const SparseMatrixBuilder<T, OrderingPolicy>& builder)
         : SparseMatrix<T, OrderingPolicy>(builder)
@@ -41,7 +43,7 @@ namespace micm
     {
       SparseMatrix<T, OrderingPolicy>::operator=(builder);
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
-      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), __FILE__, __LINE__, "cudaMalloc");
+      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), "cudaMalloc");
       return *this;
     }
 
@@ -57,8 +59,8 @@ namespace micm
     {
       this->param_ = other.param_;
       this->param_.d_data_ = nullptr;
-      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), __FILE__, __LINE__, "cudaMalloc");
-      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::CopyToDeviceFromDevice(this->param_, other.param_), __FILE__, __LINE__, "cudaMemcpyDeviceToDevice");
+      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), "cudaMalloc");
+      CHECK_CUDA_ERROR(micm::cuda::CopyToDeviceFromDevice(this->param_, other.param_), "cudaMemcpyDeviceToDevice");
     }
 
     CudaSparseMatrix(const CudaSparseMatrix& other)
@@ -79,8 +81,8 @@ namespace micm
       SparseMatrix<T, OrderingPolicy>::operator=(other);
       this->param_ = other.param_;
       this->param_.d_data_ = nullptr;
-      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), __FILE__, __LINE__, "cudaMalloc");
-      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::CopyToDeviceFromDevice(this->param_, other.param_), __FILE__, __LINE__, "cudaMemcpyDeviceToDevice");
+      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), "cudaMalloc");
+      CHECK_CUDA_ERROR(micm::cuda::CopyToDeviceFromDevice(this->param_, other.param_), "cudaMemcpyDeviceToDevice");
       return *this;
     }
 
@@ -96,8 +98,7 @@ namespace micm
 
     ~CudaSparseMatrix() requires(std::is_same_v<T, double>)
     {
-      std::cout << "Freeing device memory at address: " << this->param_.d_data_ << std::endl;
-      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::FreeVector(this->param_), __FILE__, __LINE__, "cudaFree");
+      CHECK_CUDA_ERROR(micm::cuda::FreeVector(this->param_), "cudaFree");
       this->param_.d_data_ = nullptr;
     }
 
@@ -108,12 +109,12 @@ namespace micm
 
     void CopyToDevice()
     {
-       micm::cuda::CHECK_CUDA_ERROR(micm::cuda::CopyToDevice(this->param_, this->data_), __FILE__, __LINE__, "cudaMemcpyHostToDevice");
+      CHECK_CUDA_ERROR(micm::cuda::CopyToDevice(this->param_, this->data_), "cudaMemcpyHostToDevice");
     }
 
     void CopyToHost()
     {
-      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::CopyToHost(this->param_, this->data_), __FILE__, __LINE__, "cudaMemcpyDeviceToHost");
+      CHECK_CUDA_ERROR(micm::cuda::CopyToHost(this->param_, this->data_), "cudaMemcpyDeviceToHost");
     }
 
     CudaMatrixParam AsDeviceParam()

--- a/include/micm/util/cuda_sparse_matrix.hpp
+++ b/include/micm/util/cuda_sparse_matrix.hpp
@@ -7,6 +7,7 @@
 #include <micm/util/cuda_param.hpp>
 #include <micm/util/sparse_matrix.hpp>
 #include <type_traits>
+#include <cuda_runtime.h>
 
 namespace micm
 {
@@ -23,11 +24,7 @@ namespace micm
         : SparseMatrix<T, OrderingPolicy>(builder)
     {
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
-      cudaError_t err = micm::cuda::MallocVector(this->param_, this->data_.size());
-      if (err != cudaSuccess)
-      {
-          throw std::runtime_error("cudaMalloc failed: " + std::string(cudaGetErrorString(err)));
-      }
+      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), __FILE__, __LINE__, "cudaMalloc");
     }
     CudaSparseMatrix(const SparseMatrixBuilder<T, OrderingPolicy>& builder)
         : SparseMatrix<T, OrderingPolicy>(builder)
@@ -39,11 +36,7 @@ namespace micm
     {
       SparseMatrix<T, OrderingPolicy>::operator=(builder);
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
-      cudaError_t err = micm::cuda::MallocVector(this->param_, this->data_.size());
-      if (err != cudaSuccess)
-      {
-          throw std::runtime_error("cudaMalloc failed: " + std::string(cudaGetErrorString(err)));
-      }
+      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), __FILE__, __LINE__, "cudaMalloc");
       return *this;
     }
 
@@ -58,8 +51,8 @@ namespace micm
     {
       this->param_ = other.param_;
       this->param_.d_data_ = nullptr;
-      micm::cuda::MallocVector(this->param_, this->data_.size());
-      micm::cuda::CopyToDeviceFromDevice(this->param_, other.param_);
+      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), __FILE__, __LINE__, "cudaMalloc");
+      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::CopyToDeviceFromDevice(this->param_, other.param_), __FILE__, __LINE__, "cudaMemcpyDeviceToDevice");
     }
 
     CudaSparseMatrix(const CudaSparseMatrix& other)
@@ -79,8 +72,8 @@ namespace micm
       SparseMatrix<T, OrderingPolicy>::operator=(other);
       this->param_ = other.param_;
       this->param_.d_data_ = nullptr;
-      micm::cuda::MallocVector(this->param_, this->data_.size());
-      micm::cuda::CopyToDeviceFromDevice(this->param_, other.param_); 
+      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), __FILE__, __LINE__, "cudaMalloc");
+      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::CopyToDeviceFromDevice(this->param_, other.param_), __FILE__, __LINE__, "cudaMemcpyDeviceToDevice");
       return *this;
     }
 
@@ -97,11 +90,7 @@ namespace micm
 
     ~CudaSparseMatrix() requires(std::is_same_v<T, double>)
     {
-      cudaError_t err = micm::cuda::FreeVector(this->param_);
-      if (err != cudaSuccess)
-      {
-          throw std::runtime_error("cudaFree failed: " + std::string(cudaGetErrorString(err)));
-      }
+       micm::cuda::CHECK_CUDA_ERROR(micm::cuda::FreeVector(this->param_), __FILE__, __LINE__, "cudaFree");
     }
 
     ~CudaSparseMatrix()
@@ -110,20 +99,14 @@ namespace micm
 
     void CopyToDevice()
     {
-      cudaError_t err = micm::cuda::CopyToDevice(this->param_, this->data_);
-      if (err != cudaSuccess)
-      {
-          throw std::runtime_error("cudaMemcpyHostToDevice failed: " + std::string(cudaGetErrorString(err)));
-      }
+       micm::cuda::CHECK_CUDA_ERROR(micm::cuda::CopyToDevice(this->param_, this->data_), __FILE__, __LINE__, "cudaMemcpyHostToDevice");
     }
+
     void CopyToHost()
     {
-      cudaError_t err = micm::cuda::CopyToHost(this->param_, this->data_);
-      if (err != cudaSuccess)
-      {
-          throw std::runtime_error("cudaMemcpyDeviceToHost failed: " + std::string(cudaGetErrorString(err)));
-      }
+      micm::cuda::CHECK_CUDA_ERROR(micm::cuda::CopyToHost(this->param_, this->data_), __FILE__, __LINE__, "cudaMemcpyDeviceToHost");
     }
+
     CudaMatrixParam AsDeviceParam()
     {
       return this->param_;

--- a/include/micm/util/cuda_sparse_matrix.hpp
+++ b/include/micm/util/cuda_sparse_matrix.hpp
@@ -109,11 +109,13 @@ namespace micm
 
     void CopyToDevice()
     {
+      static_assert(std::is_same_v<T, double>);
       CHECK_CUDA_ERROR(micm::cuda::CopyToDevice(this->param_, this->data_), "cudaMemcpyHostToDevice");
     }
 
     void CopyToHost()
     {
+      static_assert(std::is_same_v<T, double>);
       CHECK_CUDA_ERROR(micm::cuda::CopyToHost(this->param_, this->data_), "cudaMemcpyDeviceToHost");
     }
 

--- a/include/micm/util/cuda_sparse_matrix.hpp
+++ b/include/micm/util/cuda_sparse_matrix.hpp
@@ -22,7 +22,8 @@ namespace micm
     CudaSparseMatrix(const SparseMatrixBuilder<T, OrderingPolicy>& builder) requires(std::is_same_v<T, double>)
         : SparseMatrix<T, OrderingPolicy>(builder)
     {
-      micm::cuda::MallocVector(param_, this->data_.size());
+      this->param_.number_of_grid_cells_ = this->number_of_blocks_;
+      micm::cuda::MallocVector(this->param_, this->data_.size());
     }
     CudaSparseMatrix(const SparseMatrixBuilder<T, OrderingPolicy>& builder)
         : SparseMatrix<T, OrderingPolicy>(builder)
@@ -33,7 +34,8 @@ namespace micm
         std::is_same_v<T, double>)
     {
       SparseMatrix<T, OrderingPolicy>::operator=(builder);
-      micm::cuda::MallocVector(param_, this->data_.size());
+      this->param_.number_of_grid_cells_ = this->number_of_blocks_;
+      micm::cuda::MallocVector(this->param_, this->data_.size());
       return *this;
     }
 
@@ -46,8 +48,9 @@ namespace micm
     CudaSparseMatrix(const CudaSparseMatrix& other) requires(std::is_same_v<T, double>)
         : SparseMatrix<T, OrderingPolicy>(other)
     {
-      micm::cuda::MallocVector(param_, this->data_.size());
-      micm::cuda::CopyToDeviceFromDevice(param_, other.param_);
+      this->param_.number_of_grid_cells_ = this->number_of_blocks_;
+      micm::cuda::MallocVector(this->param_, this->data_.size());
+      micm::cuda::CopyToDeviceFromDevice(this->param_, other.param_);
     }
 
     CudaSparseMatrix(const CudaSparseMatrix& other)
@@ -78,7 +81,7 @@ namespace micm
 
     ~CudaSparseMatrix() requires(std::is_same_v<T, double>)
     {
-      micm::cuda::FreeVector(param_);
+      micm::cuda::FreeVector(this->param_);
     }
 
     ~CudaSparseMatrix()
@@ -87,11 +90,11 @@ namespace micm
 
     int CopyToDevice()
     {
-      return micm::cuda::CopyToDevice(param_, this->data_);
+      return micm::cuda::CopyToDevice(this->param_, this->data_);
     }
     int CopyToHost()
     {
-      return micm::cuda::CopyToHost(param_, this->data_);
+      return micm::cuda::CopyToHost(this->param_, this->data_);
     }
     CudaMatrixParam AsDeviceParam()
     {

--- a/include/micm/util/cuda_sparse_matrix.hpp
+++ b/include/micm/util/cuda_sparse_matrix.hpp
@@ -1,3 +1,8 @@
+// Copyright (C) 2023-2024 National Center for Atmospheric Research,
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
 #include <micm/util/cuda_matrix.cuh>
 #include <micm/util/cuda_param.hpp>
 #include <micm/util/sparse_matrix.hpp>
@@ -51,9 +56,8 @@ namespace micm
     }
 
     CudaSparseMatrix(CudaSparseMatrix&& other) noexcept
-        : SparseMatrix<T, OrderingPolicy>(SparseMatrix<T, OrderingPolicy>::create(other.number_of_blocks_))
+        : SparseMatrix<T, OrderingPolicy>(other)
     {
-      this->data_ = std::move(other.data_);
       this->param_ = std::move(other.param_);
     }
 
@@ -64,11 +68,12 @@ namespace micm
 
     CudaSparseMatrix& operator=(CudaSparseMatrix&& other) noexcept
     {
-      std::swap(this->data_, other.data_);
-      std::swap(this->param_, other.param_);
-      std::swap(this->number_of_blocks_, other.number_of_blocks_);
-      std::swap(this->row_ids_, other.row_ids_);
-      std::swap(this->row_start_, other.row_start_);
+      if (this != &other)
+      {
+        SparseMatrix<T, OrderingPolicy>::operator=(std::move(other));
+        std::swap(this->param_, other.param_);
+      }
+      return *this;
     }
 
     ~CudaSparseMatrix() requires(std::is_same_v<T, double>)

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -103,15 +103,15 @@ namespace micm
       // Shared memory is shared among all threads within the same block.
       extern __shared__ double sdata[];
 
-      // Local thread ID within a threadblock
+      // Calculate local thread ID within a threadblock
       size_t l_tid = threadIdx.x;
 
-      // Global thread ID
+      // Calculate global thread ID
       size_t g_tid = blockIdx.x * (BLOCK_SIZE * 2) + threadIdx.x;
 
       if (is_first_call)
       {
-        // Temporary device variables
+        // Local device variables
         double d_ymax, d_scale;
 
         // Load two elements by one thread and do first add of reduction
@@ -190,7 +190,7 @@ namespace micm
         const RosenbrockSolverParameters ros_param,
         CudaRosenbrockSolverParam devstruct)
     {
-      // Temporary device variables
+      // Local device variables
       double d_ymax, d_scale;
       double* d_y_old = y_old_param.d_data_;
       double* d_y_new = y_new_param.d_data_;
@@ -199,7 +199,7 @@ namespace micm
       double rtol = ros_param.relative_tolerance_;
       const size_t num_elements = devstruct.errors_size_;
 
-      // Global thread ID
+      // Calculate global thread ID
       size_t tid = blockIdx.x * BLOCK_SIZE + threadIdx.x;
       if (tid < num_elements)
       {
@@ -231,62 +231,61 @@ namespace micm
         CudaRosenbrockSolverParam devstruct)
     {
       double normalized_error;
-      const size_t num_elements = devstruct.errors_size_;
+      const size_t number_of_elements = devstruct.errors_size_;
 
-      if (devstruct.errors_size_ != errors_param.number_of_elements_)
+      if (number_of_elements != errors_param.number_of_elements_)
       {
         throw std::runtime_error("devstruct.errors_input_ and errors_param have different sizes.");
       }
       cudaError_t err =
           cudaMemcpy(devstruct.errors_input_, errors_param.d_data_, sizeof(double) * num_elements, cudaMemcpyDeviceToDevice);
 
-      if (num_elements > 1000000)
+      if (number_of_elements > 1000000)
       {
         // call cublas APIs
-        size_t num_blocks = (num_elements + BLOCK_SIZE - 1) / BLOCK_SIZE;
-        ScaledErrorKernel<<<num_blocks, BLOCK_SIZE>>>(y_old_param, y_new_param, ros_param, devstruct);
+        size_t number_of_blocks = (number_of_elements + BLOCK_SIZE - 1) / BLOCK_SIZE;
+        ScaledErrorKernel<<<number_of_blocks, BLOCK_SIZE>>>(y_old_param, y_new_param, ros_param, devstruct);
         // call cublas function to perform the norm:
         // https://docs.nvidia.com/cuda/cublas/index.html?highlight=dnrm2#cublas-t-nrm2
-        cublasStatus_t stat = cublasDnrm2(handle, num_elements, devstruct.errors_input_, 1, &normalized_error);
+        cublasStatus_t stat = cublasDnrm2(handle, number_of_elements, devstruct.errors_input_, 1, &normalized_error);
         if (stat != CUBLAS_STATUS_SUCCESS)
         {
           printf(cublasGetStatusString(stat));
           throw std::runtime_error("Error while calling cublasDnrm2.");
         }
-        normalized_error = normalized_error * std::sqrt(1.0 / num_elements);
+        normalized_error = normalized_error * std::sqrt(1.0 / number_of_elements);
       }
       else
       {
         // call CUDA implementation
-        size_t num_blocks = std::ceil(std::ceil(num_elements * 1.0 / BLOCK_SIZE) / 2.0);
-        num_blocks = num_blocks < 1 ? 1 : num_blocks;
-        size_t new_blocks;
-        bool is_first_call;
+        size_t number_of_blocks = std::ceil(std::ceil(number_of_elements * 1.0 / BLOCK_SIZE) / 2.0);
+        number_of_blocks = number_of_blocks < 1 ? 1 : number_of_blocks;
+        size_t new_number_of_blocks;
+        bool is_first_call = true;
 
-        is_first_call = true;
         // Kernel call
-        NormalizedErrorKernel<<<num_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double)>>>(
-            y_old_param, y_new_param, ros_param, devstruct, num_elements, is_first_call);
+        NormalizedErrorKernel<<<number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double)>>>(
+            y_old_param, y_new_param, ros_param, devstruct, number_of_elements, is_first_call);
         is_first_call = false;
-        while (num_blocks > 1)
+        while (number_of_blocks > 1)
         {
           std::swap(devstruct.errors_input_, devstruct.errors_output_);
           // Update grid size
-          new_blocks = std::ceil(std::ceil(num_blocks * 1.0 / BLOCK_SIZE) / 2.0);
-          if (new_blocks <= 1)
+          new_number_of_blocks = std::ceil(std::ceil(number_of_blocks * 1.0 / BLOCK_SIZE) / 2.0);
+          if (new_number_of_blocks <= 1)
           {
             NormalizedErrorKernel<<<1, BLOCK_SIZE, BLOCK_SIZE * sizeof(double)>>>(
-                y_old_param, y_new_param, ros_param, devstruct, num_blocks, is_first_call);
+                y_old_param, y_new_param, ros_param, devstruct, number_of_blocks, is_first_call);
             break;
           }
-          NormalizedErrorKernel<<<new_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double)>>>(
-              y_old_param, y_new_param, ros_param, devstruct, num_blocks, is_first_call);
-          num_blocks = new_blocks;
+          NormalizedErrorKernel<<<new_number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double)>>>(
+              y_old_param, y_new_param, ros_param, devstruct, number_of_blocks, is_first_call);
+          number_of_blocks = new_number_of_blocks;
         }
         cudaDeviceSynchronize();
 
         cudaMemcpy(&normalized_error, &devstruct.errors_output_[0], sizeof(double), cudaMemcpyDeviceToHost);
-        normalized_error = std::sqrt(normalized_error / num_elements);
+        normalized_error = std::sqrt(normalized_error / number_of_elements);
       }  // end of if-else for CUDA/CUBLAS implementation
       return std::max(normalized_error, 1.0e-10);
     }  // end of NormalizedErrorDriver function

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -4,6 +4,7 @@
 #include <micm/solver/rosenbrock_solver_parameters.hpp>
 #include <micm/util/cuda_param.hpp>
 #include "cublas_v2.h"
+#include <iostream>
 
 namespace micm
 {
@@ -23,9 +24,9 @@ namespace micm
 
       if (tid < number_of_grid_cells * number_of_diagonal_elements)
       {
-        quotient = tid / number_of_diagonal_elements;
-        index_as_remainder = tid - number_of_diagonal_elements * quotient;  // % operator may be more expensive
-        d_jacobian[devstruct.jacobian_diagonal_elements_[index_as_remainder] + quotient] += alpha;
+        quotient = tid / number_of_grid_cells;
+        index_as_remainder = tid - number_of_grid_cells * quotient;  // % operator may be more expensive
+        d_jacobian[devstruct.jacobian_diagonal_elements_[quotient] + index_as_remainder] += alpha;
       }
     }
 

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -238,7 +238,7 @@ namespace micm
         throw std::runtime_error("devstruct.errors_input_ and errors_param have different sizes.");
       }
       cudaError_t err =
-          cudaMemcpy(devstruct.errors_input_, errors_param.d_data_, sizeof(double) * num_elements, cudaMemcpyDeviceToDevice);
+          cudaMemcpy(devstruct.errors_input_, errors_param.d_data_, sizeof(double) * number_of_elements, cudaMemcpyDeviceToDevice);
 
       if (number_of_elements > 1000000)
       {

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -1,4 +1,5 @@
-// Copyright (C) 2023-2024 National Center for Atmospheric Research
+// Copyright (C) 2023-2024 National Center for Atmospheric Research,
+//
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/solver/rosenbrock_solver_parameters.hpp>
 #include <micm/util/cuda_param.hpp>

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -212,7 +212,7 @@ namespace micm
     // Host code that will launch the AlphaMinusJacobian CUDA kernel
     void AlphaMinusJacobianDriver(
         CudaMatrixParam& jacobian_param,
-        const double alpha,
+        const double& alpha,
         const CudaRosenbrockSolverParam& devstruct)
     {
       size_t number_of_blocks =

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -53,7 +53,7 @@ namespace micm
       return err;
     }
 
-    void CHECK_CUDA_ERROR(cudaError_t err, const char *file, int line, std::string str)
+    void CheckCudaError(cudaError_t err, const char *file, int line, std::string str)
     {
       if (err != cudaSuccess)
       {
@@ -62,7 +62,7 @@ namespace micm
       }
     }
 
-    void CHECK_CUBLAS_ERROR(cublasStatus_t err, const char *file, int line, std::string str)
+    void CheckCublasError(cublasStatus_t err, const char *file, int line, std::string str)
     {
       if (err != CUBLAS_STATUS_SUCCESS)
       {

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -1,5 +1,10 @@
-#include <cuda_runtime.h>
+// Copyright (C) 2023-2024 National Center for Atmospheric Research,
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
 
+#include <cuda_runtime.h>
+#include <iostream>
 #include <micm/util/cuda_matrix.cuh>
 #include <vector>
 
@@ -7,31 +12,41 @@ namespace micm
 {
   namespace cuda
   {
-    int MallocVector(CudaMatrixParam& param, std::size_t number_of_elements)
+    cudaError_t MallocVector(CudaMatrixParam& param, std::size_t number_of_elements)
     {
       param.number_of_elements_ = number_of_elements;
-      return cudaMalloc(&(param.d_data_), sizeof(double) * number_of_elements);
+      cudaError_t err = cudaMalloc(&(param.d_data_), sizeof(double) * number_of_elements);
+      return err;
     }
-    int FreeVector(CudaMatrixParam& param)
+    cudaError_t FreeVector(CudaMatrixParam& param)
     {
-      return cudaFree(param.d_data_);
+      if (param.d_data_ == nullptr)
+      {
+          return cudaError_t::cudaSuccess;
+      }
+      cudaError_t err = cudaFree(param.d_data_);
+      param.d_data_ = nullptr;
+      return err;
     }
-    int CopyToDevice(CudaMatrixParam& param, std::vector<double>& h_data)
+    cudaError_t CopyToDevice(CudaMatrixParam& param, std::vector<double>& h_data)
     {
-      return cudaMemcpy(param.d_data_, h_data.data(), sizeof(double) * param.number_of_elements_, cudaMemcpyHostToDevice);
+      cudaError_t err = cudaMemcpy(param.d_data_, h_data.data(), sizeof(double) * param.number_of_elements_, cudaMemcpyHostToDevice);
+      return err;
     }
-    int CopyToHost(CudaMatrixParam& param, std::vector<double>& h_data)
+    cudaError_t CopyToHost(CudaMatrixParam& param, std::vector<double>& h_data)
     {
       cudaDeviceSynchronize();
-      return cudaMemcpy(h_data.data(), param.d_data_, sizeof(double) * param.number_of_elements_, cudaMemcpyDeviceToHost);
+      cudaError_t err = cudaMemcpy(h_data.data(), param.d_data_, sizeof(double) * param.number_of_elements_, cudaMemcpyDeviceToHost);
+      return err;
     }
-    int CopyToDeviceFromDevice(CudaMatrixParam& vectorMatrixDest, const CudaMatrixParam& vectorMatrixSrc)
+    cudaError_t CopyToDeviceFromDevice(CudaMatrixParam& vectorMatrixDest, const CudaMatrixParam& vectorMatrixSrc)
     {
-      return cudaMemcpy(
+      cudaError_t err = cudaMemcpy(
           vectorMatrixDest.d_data_,
           vectorMatrixSrc.d_data_,
           sizeof(double) * vectorMatrixSrc.number_of_elements_,
           cudaMemcpyDeviceToDevice);
+      return err;
     }
   }  // namespace cuda
 }  // namespace micm

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -18,6 +18,7 @@ namespace micm
       cudaError_t err = cudaMalloc(&(param.d_data_), sizeof(double) * number_of_elements);
       return err;
     }
+
     cudaError_t FreeVector(CudaMatrixParam& param)
     {
       if (param.d_data_ == nullptr)
@@ -28,17 +29,20 @@ namespace micm
       param.d_data_ = nullptr;
       return err;
     }
+
     cudaError_t CopyToDevice(CudaMatrixParam& param, std::vector<double>& h_data)
     {
       cudaError_t err = cudaMemcpy(param.d_data_, h_data.data(), sizeof(double) * param.number_of_elements_, cudaMemcpyHostToDevice);
       return err;
     }
+
     cudaError_t CopyToHost(CudaMatrixParam& param, std::vector<double>& h_data)
     {
       cudaDeviceSynchronize();
       cudaError_t err = cudaMemcpy(h_data.data(), param.d_data_, sizeof(double) * param.number_of_elements_, cudaMemcpyDeviceToHost);
       return err;
     }
+
     cudaError_t CopyToDeviceFromDevice(CudaMatrixParam& vectorMatrixDest, const CudaMatrixParam& vectorMatrixSrc)
     {
       cudaError_t err = cudaMemcpy(
@@ -47,6 +51,24 @@ namespace micm
           sizeof(double) * vectorMatrixSrc.number_of_elements_,
           cudaMemcpyDeviceToDevice);
       return err;
+    }
+
+    void CHECK_CUDA_ERROR(cudaError_t err, const char *file, int line, std::string str)
+    {
+      if (err != cudaSuccess)
+      {
+          std::cout << "CUDA error: " << cudaGetErrorString(err) << " at " << file << ":" << line << std::endl;
+          throw std::runtime_error(str + " failed...");
+      }
+    }
+
+    void CHECK_CUBLAS_ERROR(cublasStatus_t err, const char *file, int line, std::string str)
+    {
+      if (err != CUBLAS_STATUS_SUCCESS)
+      {
+          std::cout << "CUBLAS error: " << err << " at " << file << ":" << line << std::endl;
+          throw std::runtime_error(str);
+      }
     }
   }  // namespace cuda
 }  // namespace micm

--- a/test/unit/process/test_troe_rate_constant.cpp
+++ b/test/unit/process/test_troe_rate_constant.cpp
@@ -86,5 +86,12 @@ TEST(TroeRateConstant, AnalyticalTroeExampleBC)
   double k1 = k_0 * 42.2 / (1.0 + k_0 * 42.2 / k_inf) *
               std::pow(0.9, 1.0 / (1.0 + (1.0 / 0.8) * std::pow(std::log10(k_0 * 42.2 / k_inf), 2)));
 
-  EXPECT_EQ(k, k1);
+  auto relative_error = std::abs(k - k1) / std::max(std::abs(k), std::abs(k1));
+  if (relative_error > 1.e-14)
+  {
+    std::cout << "k: " << std::setprecision(15) << k << std::endl;
+    std::cout << "k1: " << std::setprecision(15) << k1 << std::endl;
+    std::cout << "relative_error: " << std::setprecision(15) << relative_error << std::endl;
+    throw std::runtime_error("Fail to match k and k1.\n");
+  }
 }

--- a/test/unit/solver/CMakeLists.txt
+++ b/test/unit/solver/CMakeLists.txt
@@ -16,7 +16,7 @@ create_standard_test(NAME state SOURCES test_state.cpp)
 if(MICM_ENABLE_CUDA)
   create_standard_test(NAME cuda_lu_decomposition SOURCES test_cuda_lu_decomposition.cpp LIBRARIES musica::micm_cuda)
   create_standard_test(NAME cuda_linear_solver SOURCES test_cuda_linear_solver.cpp LIBRARIES musica::micm_cuda)
-#  create_standard_test(NAME cuda_rosenbrock SOURCES test_cuda_rosenbrock.cpp LIBRARIES musica::micm_cuda)
+  create_standard_test(NAME cuda_rosenbrock SOURCES test_cuda_rosenbrock.cpp LIBRARIES musica::micm_cuda)
 endif()
 
 if(MICM_ENABLE_LLVM)

--- a/test/unit/solver/test_cuda_rosenbrock.cpp
+++ b/test/unit/solver/test_cuda_rosenbrock.cpp
@@ -18,38 +18,38 @@
 template<class T>
 using Group1CPUVectorMatrix = micm::VectorMatrix<T, 1>;
 template<class T>
-using Group2CPUVectorMatrix = micm::VectorMatrix<T, 2>;
+using Group20CPUVectorMatrix = micm::VectorMatrix<T, 20>;
 template<class T>
-using Group3CPUVectorMatrix = micm::VectorMatrix<T, 3>;
+using Group300CPUVectorMatrix = micm::VectorMatrix<T, 300>;
 template<class T>
-using Group4CPUVectorMatrix = micm::VectorMatrix<T, 4>;
+using Group4000CPUVectorMatrix = micm::VectorMatrix<T, 4000>;
 
 template<class T>
 using Group1GPUVectorMatrix = micm::CudaDenseMatrix<T, 1>;
 template<class T>
-using Group2GPUVectorMatrix = micm::CudaDenseMatrix<T, 2>;
+using Group20GPUVectorMatrix = micm::CudaDenseMatrix<T, 20>;
 template<class T>
-using Group3GPUVectorMatrix = micm::CudaDenseMatrix<T, 3>;
+using Group300GPUVectorMatrix = micm::CudaDenseMatrix<T, 300>;
 template<class T>
-using Group4GPUVectorMatrix = micm::CudaDenseMatrix<T, 4>;
+using Group4000GPUVectorMatrix = micm::CudaDenseMatrix<T, 4000>;
 
 template<class T>
 using Group1CPUSparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
 template<class T>
-using Group2CPUSparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
+using Group20CPUSparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<20>>;
 template<class T>
-using Group3CPUSparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
+using Group300CPUSparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<300>>;
 template<class T>
-using Group4CPUSparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+using Group4000CPUSparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4000>>;
 
 template<class T>
 using Group1GPUSparseVectorMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
 template<class T>
-using Group2GPUSparseVectorMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
+using Group20GPUSparseVectorMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<20>>;
 template<class T>
-using Group3GPUSparseVectorMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
+using Group300GPUSparseVectorMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<300>>;
 template<class T>
-using Group4GPUSparseVectorMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+using Group4000GPUSparseVectorMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<4000>>;
 
 // the following alias works for a CudaDenserMatrix with given row and any columns
 template<class T>
@@ -142,97 +142,84 @@ RosenbrockPolicy getSolver(std::size_t number_of_grid_cells)
       micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells, false));
 }
 
-template<template<class> class CPUMatrixPolicy, template<class> class CPUSparseMatrixPolicy, class CPULinearSolverPolicy,
-         template<class> class GPUMatrixPolicy, template<class> class GPUSparseMatrixPolicy, class GPULinearSolverPolicy>
+template<template<class> class CPUMatrixPolicy, template<class> class CPUSparseMatrixPolicy,
+         template<class> class GPUMatrixPolicy, template<class> class GPUSparseMatrixPolicy>
 void testAlphaMinusJacobian(std::size_t number_of_grid_cells)
 {
-//  auto gpu_solver = getSolver<micm::CudaRosenbrockSolver>(number_of_grid_cells);
   auto gpu_solver = getSolver<micm::CudaRosenbrockSolver<GPUMatrixPolicy,GPUSparseMatrixPolicy>>(number_of_grid_cells);
+  auto gpu_jacobian = gpu_solver.GetState().jacobian_;
+  EXPECT_EQ(gpu_jacobian.size(), number_of_grid_cells);
+  EXPECT_EQ(gpu_jacobian[0].size(), 5);
+  EXPECT_EQ(gpu_jacobian[0][0].size(), 5);
+  auto& gpu_jacobian_vec = gpu_jacobian.AsVector();
+  EXPECT_GE(gpu_jacobian_vec.size(), 13 * number_of_grid_cells);
+  gpu_jacobian_vec.assign(gpu_jacobian_vec.size(), 100.0);
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    gpu_jacobian[i_cell][0][0] = 12.2;
+    gpu_jacobian[i_cell][0][1] = 24.3 * (i_cell + 2);
+    gpu_jacobian[i_cell][0][2] = 42.3;
+    gpu_jacobian[i_cell][1][0] = 0.43;
+    gpu_jacobian[i_cell][1][1] = 23.4;
+    gpu_jacobian[i_cell][1][2] = 83.4 / (i_cell + 3);
+    gpu_jacobian[i_cell][2][0] = 4.74;
+    gpu_jacobian[i_cell][2][2] = 6.91;
+    gpu_jacobian[i_cell][3][1] = 59.1;
+    gpu_jacobian[i_cell][3][3] = 83.4;
+    gpu_jacobian[i_cell][4][0] = 78.5;
+    gpu_jacobian[i_cell][4][2] = 53.6;
+    gpu_jacobian[i_cell][4][4] = 1.0;
+  }
 
-//   auto gpu_jacobian = gpu_solver.GetState().jacobian_;
-//   EXPECT_EQ(gpu_jacobian.size(), number_of_grid_cells);
-//   EXPECT_EQ(gpu_jacobian[0].size(), 5);
-//   EXPECT_EQ(gpu_jacobian[0][0].size(), 5);
-//   auto gpu_jacobian_vec = gpu_jacobian.AsVector();
-//   EXPECT_GE(gpu_jacobian_vec.size(), 13 * number_of_grid_cells);
-//   gpu_jacobian_vec.assign(gpu_jacobian_vec.size(), 100.0);
-//   for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
-//   {
-//     gpu_jacobian[i_cell][0][0] = 12.2;
-//     gpu_jacobian[i_cell][0][1] = 24.3 * (i_cell + 2);
-//     gpu_jacobian[i_cell][0][2] = 42.3;
-//     gpu_jacobian[i_cell][1][0] = 0.43;
-//     gpu_jacobian[i_cell][1][1] = 23.4;
-//     gpu_jacobian[i_cell][1][2] = 83.4 / (i_cell + 3);
-//     gpu_jacobian[i_cell][2][0] = 4.74;
-//     gpu_jacobian[i_cell][2][2] = 6.91;
-//     gpu_jacobian[i_cell][3][1] = 59.1;
-//     gpu_jacobian[i_cell][3][3] = 83.4;
-//     gpu_jacobian[i_cell][4][0] = 78.5;
-//     gpu_jacobian[i_cell][4][2] = 53.6;
-//     gpu_jacobian[i_cell][4][4] = 1.0;
-//   }
+  // Negate the Jacobian matrix (-J) here
+  std::transform(gpu_jacobian_vec.cbegin(), gpu_jacobian_vec.cend(), gpu_jacobian_vec.begin(), std::negate<>{});
+  auto cpu_jacobian = gpu_jacobian;
+  
+  gpu_jacobian.CopyToDevice();
+  gpu_solver.AlphaMinusJacobian(gpu_jacobian, 42.042);
+  gpu_jacobian.CopyToHost();
 
-//   // Negate the Jacobian matrix (-J) here
-//   std::transform(gpu_jacobian_vec.cbegin(), gpu_jacobian_vec.cend(), gpu_jacobian_vec.begin(), std::negate<>{});
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    EXPECT_EQ(gpu_jacobian[i_cell][0][0], 42.042 - 12.2);
+    EXPECT_EQ(gpu_jacobian[i_cell][0][1], -24.3 * (i_cell + 2));
+    EXPECT_EQ(gpu_jacobian[i_cell][0][2], -42.3);
+    EXPECT_EQ(gpu_jacobian[i_cell][1][0], -0.43);
+    EXPECT_EQ(gpu_jacobian[i_cell][1][1], 42.042 - 23.4);
+    EXPECT_EQ(gpu_jacobian[i_cell][1][2], -83.4 / (i_cell + 3));
+    EXPECT_EQ(gpu_jacobian[i_cell][2][0], -4.74);
+    EXPECT_EQ(gpu_jacobian[i_cell][2][2], 42.042 - 6.91);
+    EXPECT_EQ(gpu_jacobian[i_cell][3][1], -59.1);
+    EXPECT_EQ(gpu_jacobian[i_cell][3][3], 42.042 - 83.4);
+    EXPECT_EQ(gpu_jacobian[i_cell][4][0], -78.5);
+    EXPECT_EQ(gpu_jacobian[i_cell][4][2], -53.6);
+    EXPECT_EQ(gpu_jacobian[i_cell][4][4], 42.042 - 1.0);
+  }
 
-//   auto cpu_jacobian = gpu_jacobian;
+  auto cpu_solver = getSolver<micm::RosenbrockSolver<CPUMatrixPolicy,CPUSparseMatrixPolicy>>(number_of_grid_cells);
+  cpu_solver.AlphaMinusJacobian(cpu_jacobian, 42.042);
 
-//   gpu_jacobian.CopyToDevice();
-//   gpu_solver.AlphaMinusJacobian(gpu_jacobian, 42.042);
-//   gpu_jacobian.CopyToHost();
-
-//   for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
-//   {
-//     EXPECT_EQ(gpu_jacobian[i_cell][0][0], 42.042 - 12.2);
-//     EXPECT_EQ(gpu_jacobian[i_cell][0][1], -24.3 * (i_cell + 2));
-//     EXPECT_EQ(gpu_jacobian[i_cell][0][2], -42.3);
-//     EXPECT_EQ(gpu_jacobian[i_cell][1][0], -0.43);
-//     EXPECT_EQ(gpu_jacobian[i_cell][1][1], 42.042 - 23.4);
-//     EXPECT_EQ(gpu_jacobian[i_cell][1][2], -83.4 / (i_cell + 3));
-//     EXPECT_EQ(gpu_jacobian[i_cell][2][0], -4.74);
-//     EXPECT_EQ(gpu_jacobian[i_cell][2][2], 42.042 - 6.91);
-//     EXPECT_EQ(gpu_jacobian[i_cell][3][1], -59.1);
-//     EXPECT_EQ(gpu_jacobian[i_cell][3][3], 42.042 - 83.4);
-//     EXPECT_EQ(gpu_jacobian[i_cell][4][0], -78.5);
-//     EXPECT_EQ(gpu_jacobian[i_cell][4][2], -53.6);
-//     EXPECT_EQ(gpu_jacobian[i_cell][4][4], 42.042 - 1.0);
-//   }
-
-//    auto cpu_solver = getSolver<
-//        CPUMatrixPolicy,
-//        CPUSparseMatrixPolicy,
-//        micm::LinearSolver<double, CPUSparseMatrixPolicy>,
-//        micm::RosenbrockSolver<CPUMatrixPolicy, CPUSparseMatrixPolicy, micm::LinearSolver<double, CPUSparseMatrixPolicy>>>(
-//        number_of_grid_cells);
-//   cpu_solver.AlphaMinusJacobian(cpu_jacobian, 42.042);
-
-//   std::vector<double> jacobian_gpu_vector = gpu_jacobian.AsVector();
-//   std::vector<double> jacobian_cpu_vector = cpu_jacobian.AsVector();
-//   for (int i = 0; i < jacobian_cpu_vector.size(); i++)
-//   {
-//     EXPECT_EQ(jacobian_cpu_vector[i], jacobian_gpu_vector[i]);
-//   }
+   std::vector<double> jacobian_gpu_vector = gpu_jacobian.AsVector();
+   std::vector<double> jacobian_cpu_vector = cpu_jacobian.AsVector();
+  for (int i = 0; i < jacobian_cpu_vector.size(); i++)
+  {
+    EXPECT_EQ(jacobian_cpu_vector[i], jacobian_gpu_vector[i]);
+  }
 }
 
 // In this test, all the elements in the same array are identical;
 // thus the calculated RMSE should be the same no matter what the size of the array is.
-template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
-void testNormalizedErrorConst(const size_t num_grid_cells)
+template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+void testNormalizedErrorConst(const size_t number_of_grid_cells)
 {
-  auto gpu_solver = getSolver<
-      MatrixPolicy,
-      SparseMatrixPolicy,
-      LinearSolverPolicy,
-      micm::CudaRosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>>(num_grid_cells);
-
+  auto gpu_solver = getSolver<micm::CudaRosenbrockSolver<MatrixPolicy,SparseMatrixPolicy>>(number_of_grid_cells);
   double atol = gpu_solver.parameters_.absolute_tolerance_;
   double rtol = gpu_solver.parameters_.relative_tolerance_;
 
   auto state = gpu_solver.GetState();
-  auto y_old = MatrixPolicy<double>(num_grid_cells, state.state_size_, 1.0);
-  auto y_new = MatrixPolicy<double>(num_grid_cells, state.state_size_, 2.0);
-  auto errors = MatrixPolicy<double>(num_grid_cells, state.state_size_, 3.0);
+  auto y_old = MatrixPolicy<double>(number_of_grid_cells, state.state_size_, 1.0);
+  auto y_new = MatrixPolicy<double>(number_of_grid_cells, state.state_size_, 2.0);
+  auto errors = MatrixPolicy<double>(number_of_grid_cells, state.state_size_, 3.0);
 
   y_old.CopyToDevice();
   y_new.CopyToDevice();
@@ -247,25 +234,20 @@ void testNormalizedErrorConst(const size_t num_grid_cells)
 
 // In this test, the elements in the same array are different;
 // thus the calculated RMSE will change when the size of the array changes.
-template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
-void testNormalizedErrorDiff(const size_t num_grid_cells)
+template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+void testNormalizedErrorDiff(const size_t number_of_grid_cells)
 {
-  auto gpu_solver = getSolver<
-      MatrixPolicy,
-      SparseMatrixPolicy,
-      LinearSolverPolicy,
-      micm::CudaRosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>>(num_grid_cells);
-
+  auto gpu_solver = getSolver<micm::CudaRosenbrockSolver<MatrixPolicy,SparseMatrixPolicy>>(number_of_grid_cells);
   double atol = gpu_solver.parameters_.absolute_tolerance_;
   double rtol = gpu_solver.parameters_.relative_tolerance_;
 
   auto state = gpu_solver.GetState();
-  auto y_old = MatrixPolicy<double>(num_grid_cells, state.state_size_, 7.7);
-  auto y_new = MatrixPolicy<double>(num_grid_cells, state.state_size_, -13.9);
-  auto errors = MatrixPolicy<double>(num_grid_cells, state.state_size_, 81.57);
+  auto y_old = MatrixPolicy<double>(number_of_grid_cells, state.state_size_, 7.7);
+  auto y_new = MatrixPolicy<double>(number_of_grid_cells, state.state_size_, -13.9);
+  auto errors = MatrixPolicy<double>(number_of_grid_cells, state.state_size_, 81.57);
 
   double expected_error = 0.0;
-  for (size_t i = 0; i < num_grid_cells; ++i)
+  for (size_t i = 0; i < number_of_grid_cells; ++i)
   {
     for (size_t j = 0; j < state.state_size_; ++j)
     {
@@ -278,7 +260,7 @@ void testNormalizedErrorDiff(const size_t num_grid_cells)
     }
   }
   double error_min_ = 1.0e-10;
-  expected_error = std::max(std::sqrt(expected_error / (num_grid_cells * state.state_size_)), error_min_);
+  expected_error = std::max(std::sqrt(expected_error / (number_of_grid_cells * state.state_size_)), error_min_);
 
   y_old.CopyToDevice();
   y_new.CopyToDevice();
@@ -303,137 +285,105 @@ TEST(RosenbrockSolver, DenseAlphaMinusJacobian)
   testAlphaMinusJacobian<
       Group1CPUVectorMatrix,
       Group1CPUSparseVectorMatrix,
-      micm::LinearSolver<double, Group1CPUSparseVectorMatrix>,
       Group1GPUVectorMatrix,
-      Group1GPUSparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group1GPUSparseVectorMatrix>>(1);
+      Group1GPUSparseVectorMatrix>(1);
   testAlphaMinusJacobian<
-      Group2CPUVectorMatrix,
-      Group2CPUSparseVectorMatrix,
-      micm::LinearSolver<double, Group2CPUSparseVectorMatrix>,
-      Group2GPUVectorMatrix,
-      Group2GPUSparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group2GPUSparseVectorMatrix>>(2);
+      Group20CPUVectorMatrix,
+      Group20CPUSparseVectorMatrix,
+      Group20GPUVectorMatrix,
+      Group20GPUSparseVectorMatrix>(20);
   testAlphaMinusJacobian<
-      Group3CPUVectorMatrix,
-      Group3CPUSparseVectorMatrix,
-      micm::LinearSolver<double, Group3CPUSparseVectorMatrix>,
-      Group3GPUVectorMatrix,
-      Group3GPUSparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group3GPUSparseVectorMatrix>>(3);
+      Group300CPUVectorMatrix,
+      Group300CPUSparseVectorMatrix,
+      Group300GPUVectorMatrix,
+      Group300GPUSparseVectorMatrix>(300);
   testAlphaMinusJacobian<
-      Group4CPUVectorMatrix,
-      Group4CPUSparseVectorMatrix,
-      micm::LinearSolver<double, Group4CPUSparseVectorMatrix>,
-      Group4GPUVectorMatrix,
-      Group4GPUSparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group4GPUSparseVectorMatrix>>(4);
+      Group4000CPUVectorMatrix,
+      Group4000CPUSparseVectorMatrix,
+      Group4000GPUVectorMatrix,
+      Group4000GPUSparseVectorMatrix>(4000);
 }
 
-// TEST(RosenbrockSolver, CudaNormalizedError)
-// {
-//   // Based on my experience, assuming we use BLOCK_SIZE = N, it is better to test the length size (L)
-//   // of arrays at least within the following ranges for robustness: [L<N, N<L<2N, 2N<L<4N, 4N<L<N^2, N^2<L<N^3];
-//   // Here L = state_size_ * number_of_grid_cells_
-//   // Trying some odd and weird numbers is always helpful to reveal a potential bug.
+TEST(RosenbrockSolver, CudaNormalizedError)
+{
+  // Based on my experience, assuming we use BLOCK_SIZE = N, it is better to test the length size (L)
+  // of arrays at least within the following ranges for robustness: [L<N, N<L<2N, 2N<L<4N, 4N<L<N^2, N^2<L<N^3];
+  // Here L = state_size_ * number_of_grid_cells_
+  // Trying some odd and weird numbers is always helpful to reveal a potential bug.
 
-//   // tests where RMSE does not change with the size of the array
-//   testNormalizedErrorConst<
-//       Group1CudaDenseMatrix,
-//       Group1CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group1CudaSparseMatrix>>(1);
-//   testNormalizedErrorConst<
-//       Group2CudaDenseMatrix,
-//       Group2CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group2CudaSparseMatrix>>(2);
-//   testNormalizedErrorConst<
-//       Group4CudaDenseMatrix,
-//       Group4CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group4CudaSparseMatrix>>(4);
-//   testNormalizedErrorConst<
-//       Group7CudaDenseMatrix,
-//       Group7CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group7CudaSparseMatrix>>(7);
-//   testNormalizedErrorConst<
-//       Group12CudaDenseMatrix,
-//       Group12CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group12CudaSparseMatrix>>(12);
-//   testNormalizedErrorConst<
-//       Group16CudaDenseMatrix,
-//       Group16CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group16CudaSparseMatrix>>(16);
-//   testNormalizedErrorConst<
-//       Group20CudaDenseMatrix,
-//       Group20CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group20CudaSparseMatrix>>(20);
-//   testNormalizedErrorConst<
-//       Group5599CudaDenseMatrix,
-//       Group5599CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group5599CudaSparseMatrix>>(5599);
-//   testNormalizedErrorConst<
-//       Group6603CudaDenseMatrix,
-//       Group6603CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group6603CudaSparseMatrix>>(6603);
-//   testNormalizedErrorConst<
-//       Group200041CudaDenseMatrix,
-//       Group200041CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group200041CudaSparseMatrix>>(200041);
-//   testNormalizedErrorConst<
-//       Group421875CudaDenseMatrix,
-//       Group421875CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group421875CudaSparseMatrix>>(421875);
-//   testNormalizedErrorConst<
-//       Group3395043CudaDenseMatrix,
-//       Group3395043CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group3395043CudaSparseMatrix>>(3395043);
+  // tests where RMSE does not change with the size of the array
+  testNormalizedErrorConst<
+      Group1CudaDenseMatrix,
+      Group1CudaSparseMatrix>(1);
+  testNormalizedErrorConst<
+      Group2CudaDenseMatrix,
+      Group2CudaSparseMatrix>(2);
+  testNormalizedErrorConst<
+      Group4CudaDenseMatrix,
+      Group4CudaSparseMatrix>(4);
+  testNormalizedErrorConst<
+      Group7CudaDenseMatrix,
+      Group7CudaSparseMatrix>(7);
+  testNormalizedErrorConst<
+      Group12CudaDenseMatrix,
+      Group12CudaSparseMatrix>(12);
+  testNormalizedErrorConst<
+      Group16CudaDenseMatrix,
+      Group16CudaSparseMatrix>(16);
+  testNormalizedErrorConst<
+      Group20CudaDenseMatrix,
+      Group20CudaSparseMatrix>(20);
+  testNormalizedErrorConst<
+      Group5599CudaDenseMatrix,
+      Group5599CudaSparseMatrix>(5599);
+  testNormalizedErrorConst<
+      Group6603CudaDenseMatrix,
+      Group6603CudaSparseMatrix>(6603);
+  testNormalizedErrorConst<
+      Group200041CudaDenseMatrix,
+      Group200041CudaSparseMatrix>(200041);
+  testNormalizedErrorConst<
+      Group421875CudaDenseMatrix,
+      Group421875CudaSparseMatrix>(421875);
+  testNormalizedErrorConst<
+      Group3395043CudaDenseMatrix,
+      Group3395043CudaSparseMatrix>(3395043);
 
-//   // tests where RMSE changes with the size of the array
-//   testNormalizedErrorDiff<
-//       Group1CudaDenseMatrix,
-//       Group1CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group1CudaSparseMatrix>>(1);
-//   testNormalizedErrorDiff<
-//       Group2CudaDenseMatrix,
-//       Group2CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group2CudaSparseMatrix>>(2);
-//   testNormalizedErrorDiff<
-//       Group4CudaDenseMatrix,
-//       Group4CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group4CudaSparseMatrix>>(4);
-//   testNormalizedErrorDiff<
-//       Group7CudaDenseMatrix,
-//       Group7CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group7CudaSparseMatrix>>(7);
-//   testNormalizedErrorDiff<
-//       Group12CudaDenseMatrix,
-//       Group12CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group12CudaSparseMatrix>>(12);
-//   testNormalizedErrorDiff<
-//       Group16CudaDenseMatrix,
-//       Group16CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group16CudaSparseMatrix>>(16);
-//   testNormalizedErrorDiff<
-//       Group20CudaDenseMatrix,
-//       Group20CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group20CudaSparseMatrix>>(20);
-//   testNormalizedErrorDiff<
-//       Group5599CudaDenseMatrix,
-//       Group5599CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group5599CudaSparseMatrix>>(5599);
-//   testNormalizedErrorDiff<
-//       Group6603CudaDenseMatrix,
-//       Group6603CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group6603CudaSparseMatrix>>(6603);
-//   testNormalizedErrorDiff<
-//       Group200041CudaDenseMatrix,
-//       Group200041CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group200041CudaSparseMatrix>>(200041);
-//   testNormalizedErrorDiff<
-//       Group421875CudaDenseMatrix,
-//       Group421875CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group421875CudaSparseMatrix>>(421875);
-//   testNormalizedErrorDiff<
-//       Group3395043CudaDenseMatrix,
-//       Group3395043CudaSparseMatrix,
-//       micm::CudaLinearSolver<double, Group3395043CudaSparseMatrix>>(3395043);
-// }
+  // tests where RMSE changes with the size of the array
+  testNormalizedErrorDiff<
+      Group1CudaDenseMatrix,
+      Group1CudaSparseMatrix>(1);
+  testNormalizedErrorDiff<
+      Group2CudaDenseMatrix,
+      Group2CudaSparseMatrix>(2);
+  testNormalizedErrorDiff<
+      Group4CudaDenseMatrix,
+      Group4CudaSparseMatrix>(4);
+  testNormalizedErrorDiff<
+      Group7CudaDenseMatrix,
+      Group7CudaSparseMatrix>(7);
+  testNormalizedErrorDiff<
+      Group12CudaDenseMatrix,
+      Group12CudaSparseMatrix>(12);
+  testNormalizedErrorDiff<
+      Group16CudaDenseMatrix,
+      Group16CudaSparseMatrix>(16);
+  testNormalizedErrorDiff<
+      Group20CudaDenseMatrix,
+      Group20CudaSparseMatrix>(20);
+  testNormalizedErrorDiff<
+      Group5599CudaDenseMatrix,
+      Group5599CudaSparseMatrix>(5599);
+  testNormalizedErrorDiff<
+      Group6603CudaDenseMatrix,
+      Group6603CudaSparseMatrix>(6603);
+  testNormalizedErrorDiff<
+      Group200041CudaDenseMatrix,
+      Group200041CudaSparseMatrix>(200041);
+  testNormalizedErrorDiff<
+      Group421875CudaDenseMatrix,
+      Group421875CudaSparseMatrix>(421875);
+  testNormalizedErrorDiff<
+      Group3395043CudaDenseMatrix,
+      Group3395043CudaSparseMatrix>(3395043);
+}

--- a/test/unit/solver/test_cuda_rosenbrock.cpp
+++ b/test/unit/solver/test_cuda_rosenbrock.cpp
@@ -1,3 +1,6 @@
+// Copyright (C) 2023-2024 National Center for Atmospheric Research,
+//
+// SPDX-License-Identifier: Apache-2.0
 #include <gtest/gtest.h>
 
 #include <micm/process/arrhenius_rate_constant.hpp>
@@ -10,6 +13,7 @@
 #include <micm/util/sparse_matrix.hpp>
 #include <micm/util/sparse_matrix_vector_ordering.hpp>
 #include <micm/util/vector_matrix.hpp>
+#include <iostream>
 
 template<class T>
 using Group1CPUVectorMatrix = micm::VectorMatrix<T, 1>;
@@ -99,13 +103,7 @@ using Group421875CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrix
 template<class T>
 using Group3395043CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<3395043>>;
 
-template<
-    template<class>
-    class MatrixPolicy,
-    template<class>
-    class SparseMatrixPolicy,
-    class LinearSolverPolicy,
-    class RosenbrockPolicy>
+template<class RosenbrockPolicy>
 RosenbrockPolicy getSolver(std::size_t number_of_grid_cells)
 {
   // ---- foo  bar  baz  quz  quuz
@@ -148,75 +146,73 @@ template<template<class> class CPUMatrixPolicy, template<class> class CPUSparseM
          template<class> class GPUMatrixPolicy, template<class> class GPUSparseMatrixPolicy, class GPULinearSolverPolicy>
 void testAlphaMinusJacobian(std::size_t number_of_grid_cells)
 {
-  auto gpu_solver = getSolver<
-      GPUMatrixPolicy,
-      GPUSparseMatrixPolicy,
-      GPULinearSolverPolicy,
-      micm::CudaRosenbrockSolver<GPUMatrixPolicy, GPUSparseMatrixPolicy, GPULinearSolverPolicy>>(number_of_grid_cells);
-  auto gpu_jacobian = gpu_solver.GetState().jacobian_;
-  EXPECT_EQ(gpu_jacobian.size(), number_of_grid_cells);
-  EXPECT_EQ(gpu_jacobian[0].size(), 5);
-  EXPECT_EQ(gpu_jacobian[0][0].size(), 5);
-  auto gpu_jacobian_vec = gpu_jacobian.AsVector();
-  EXPECT_GE(gpu_jacobian_vec.size(), 13 * number_of_grid_cells);
-  gpu_jacobian_vec.assign(gpu_jacobian_vec.size(), 100.0);
-  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
-  {
-    gpu_jacobian[i_cell][0][0] = 12.2;
-    gpu_jacobian[i_cell][0][1] = 24.3 * (i_cell + 2);
-    gpu_jacobian[i_cell][0][2] = 42.3;
-    gpu_jacobian[i_cell][1][0] = 0.43;
-    gpu_jacobian[i_cell][1][1] = 23.4;
-    gpu_jacobian[i_cell][1][2] = 83.4 / (i_cell + 3);
-    gpu_jacobian[i_cell][2][0] = 4.74;
-    gpu_jacobian[i_cell][2][2] = 6.91;
-    gpu_jacobian[i_cell][3][1] = 59.1;
-    gpu_jacobian[i_cell][3][3] = 83.4;
-    gpu_jacobian[i_cell][4][0] = 78.5;
-    gpu_jacobian[i_cell][4][2] = 53.6;
-    gpu_jacobian[i_cell][4][4] = 1.0;
-  }
+//  auto gpu_solver = getSolver<micm::CudaRosenbrockSolver>(number_of_grid_cells);
+  auto gpu_solver = getSolver<micm::CudaRosenbrockSolver<GPUMatrixPolicy,GPUSparseMatrixPolicy>>(number_of_grid_cells);
 
-  // Negate the Jacobian matrix (-J) here
-  std::transform(gpu_jacobian_vec.cbegin(), gpu_jacobian_vec.cend(), gpu_jacobian_vec.begin(), std::negate<>{});
+//   auto gpu_jacobian = gpu_solver.GetState().jacobian_;
+//   EXPECT_EQ(gpu_jacobian.size(), number_of_grid_cells);
+//   EXPECT_EQ(gpu_jacobian[0].size(), 5);
+//   EXPECT_EQ(gpu_jacobian[0][0].size(), 5);
+//   auto gpu_jacobian_vec = gpu_jacobian.AsVector();
+//   EXPECT_GE(gpu_jacobian_vec.size(), 13 * number_of_grid_cells);
+//   gpu_jacobian_vec.assign(gpu_jacobian_vec.size(), 100.0);
+//   for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+//   {
+//     gpu_jacobian[i_cell][0][0] = 12.2;
+//     gpu_jacobian[i_cell][0][1] = 24.3 * (i_cell + 2);
+//     gpu_jacobian[i_cell][0][2] = 42.3;
+//     gpu_jacobian[i_cell][1][0] = 0.43;
+//     gpu_jacobian[i_cell][1][1] = 23.4;
+//     gpu_jacobian[i_cell][1][2] = 83.4 / (i_cell + 3);
+//     gpu_jacobian[i_cell][2][0] = 4.74;
+//     gpu_jacobian[i_cell][2][2] = 6.91;
+//     gpu_jacobian[i_cell][3][1] = 59.1;
+//     gpu_jacobian[i_cell][3][3] = 83.4;
+//     gpu_jacobian[i_cell][4][0] = 78.5;
+//     gpu_jacobian[i_cell][4][2] = 53.6;
+//     gpu_jacobian[i_cell][4][4] = 1.0;
+//   }
 
-  auto cpu_jacobian = gpu_jacobian;
+//   // Negate the Jacobian matrix (-J) here
+//   std::transform(gpu_jacobian_vec.cbegin(), gpu_jacobian_vec.cend(), gpu_jacobian_vec.begin(), std::negate<>{});
 
-  gpu_jacobian.CopyToDevice();
-  gpu_solver.AlphaMinusJacobian(gpu_jacobian, 42.042);
-  gpu_jacobian.CopyToHost();
+//   auto cpu_jacobian = gpu_jacobian;
 
-  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
-  {
-    EXPECT_EQ(gpu_jacobian[i_cell][0][0], 42.042 - 12.2);
-    EXPECT_EQ(gpu_jacobian[i_cell][0][1], -24.3 * (i_cell + 2));
-    EXPECT_EQ(gpu_jacobian[i_cell][0][2], -42.3);
-    EXPECT_EQ(gpu_jacobian[i_cell][1][0], -0.43);
-    EXPECT_EQ(gpu_jacobian[i_cell][1][1], 42.042 - 23.4);
-    EXPECT_EQ(gpu_jacobian[i_cell][1][2], -83.4 / (i_cell + 3));
-    EXPECT_EQ(gpu_jacobian[i_cell][2][0], -4.74);
-    EXPECT_EQ(gpu_jacobian[i_cell][2][2], 42.042 - 6.91);
-    EXPECT_EQ(gpu_jacobian[i_cell][3][1], -59.1);
-    EXPECT_EQ(gpu_jacobian[i_cell][3][3], 42.042 - 83.4);
-    EXPECT_EQ(gpu_jacobian[i_cell][4][0], -78.5);
-    EXPECT_EQ(gpu_jacobian[i_cell][4][2], -53.6);
-    EXPECT_EQ(gpu_jacobian[i_cell][4][4], 42.042 - 1.0);
-  }
+//   gpu_jacobian.CopyToDevice();
+//   gpu_solver.AlphaMinusJacobian(gpu_jacobian, 42.042);
+//   gpu_jacobian.CopyToHost();
 
-  auto cpu_solver = getSolver<
-      CPUMatrixPolicy,
-      CPUSparseMatrixPolicy,
-      micm::LinearSolver<double, CPUSparseMatrixPolicy>,
-      micm::RosenbrockSolver<CPUMatrixPolicy, CPUSparseMatrixPolicy, micm::LinearSolver<double, CPUSparseMatrixPolicy>>>(
-      number_of_grid_cells);
-  cpu_solver.AlphaMinusJacobian(cpu_jacobian, 42.042);
+//   for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+//   {
+//     EXPECT_EQ(gpu_jacobian[i_cell][0][0], 42.042 - 12.2);
+//     EXPECT_EQ(gpu_jacobian[i_cell][0][1], -24.3 * (i_cell + 2));
+//     EXPECT_EQ(gpu_jacobian[i_cell][0][2], -42.3);
+//     EXPECT_EQ(gpu_jacobian[i_cell][1][0], -0.43);
+//     EXPECT_EQ(gpu_jacobian[i_cell][1][1], 42.042 - 23.4);
+//     EXPECT_EQ(gpu_jacobian[i_cell][1][2], -83.4 / (i_cell + 3));
+//     EXPECT_EQ(gpu_jacobian[i_cell][2][0], -4.74);
+//     EXPECT_EQ(gpu_jacobian[i_cell][2][2], 42.042 - 6.91);
+//     EXPECT_EQ(gpu_jacobian[i_cell][3][1], -59.1);
+//     EXPECT_EQ(gpu_jacobian[i_cell][3][3], 42.042 - 83.4);
+//     EXPECT_EQ(gpu_jacobian[i_cell][4][0], -78.5);
+//     EXPECT_EQ(gpu_jacobian[i_cell][4][2], -53.6);
+//     EXPECT_EQ(gpu_jacobian[i_cell][4][4], 42.042 - 1.0);
+//   }
 
-  std::vector<double> jacobian_gpu_vector = gpu_jacobian.AsVector();
-  std::vector<double> jacobian_cpu_vector = cpu_jacobian.AsVector();
-  for (int i = 0; i < jacobian_cpu_vector.size(); i++)
-  {
-    EXPECT_EQ(jacobian_cpu_vector[i], jacobian_gpu_vector[i]);
-  }
+//    auto cpu_solver = getSolver<
+//        CPUMatrixPolicy,
+//        CPUSparseMatrixPolicy,
+//        micm::LinearSolver<double, CPUSparseMatrixPolicy>,
+//        micm::RosenbrockSolver<CPUMatrixPolicy, CPUSparseMatrixPolicy, micm::LinearSolver<double, CPUSparseMatrixPolicy>>>(
+//        number_of_grid_cells);
+//   cpu_solver.AlphaMinusJacobian(cpu_jacobian, 42.042);
+
+//   std::vector<double> jacobian_gpu_vector = gpu_jacobian.AsVector();
+//   std::vector<double> jacobian_cpu_vector = cpu_jacobian.AsVector();
+//   for (int i = 0; i < jacobian_cpu_vector.size(); i++)
+//   {
+//     EXPECT_EQ(jacobian_cpu_vector[i], jacobian_gpu_vector[i]);
+//   }
 }
 
 // In this test, all the elements in the same array are identical;
@@ -334,110 +330,110 @@ TEST(RosenbrockSolver, DenseAlphaMinusJacobian)
       micm::CudaLinearSolver<double, Group4GPUSparseVectorMatrix>>(4);
 }
 
-TEST(RosenbrockSolver, CudaNormalizedError)
-{
-  // Based on my experience, assuming we use BLOCK_SIZE = N, it is better to test the length size (L)
-  // of arrays at least within the following ranges for robustness: [L<N, N<L<2N, 2N<L<4N, 4N<L<N^2, N^2<L<N^3];
-  // Here L = state_size_ * number_of_grid_cells_
-  // Trying some odd and weird numbers is always helpful to reveal a potential bug.
+// TEST(RosenbrockSolver, CudaNormalizedError)
+// {
+//   // Based on my experience, assuming we use BLOCK_SIZE = N, it is better to test the length size (L)
+//   // of arrays at least within the following ranges for robustness: [L<N, N<L<2N, 2N<L<4N, 4N<L<N^2, N^2<L<N^3];
+//   // Here L = state_size_ * number_of_grid_cells_
+//   // Trying some odd and weird numbers is always helpful to reveal a potential bug.
 
-  // tests where RMSE does not change with the size of the array
-  testNormalizedErrorConst<
-      Group1CudaDenseMatrix,
-      Group1CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group1CudaSparseMatrix>>(1);
-  testNormalizedErrorConst<
-      Group2CudaDenseMatrix,
-      Group2CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group2CudaSparseMatrix>>(2);
-  testNormalizedErrorConst<
-      Group4CudaDenseMatrix,
-      Group4CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group4CudaSparseMatrix>>(4);
-  testNormalizedErrorConst<
-      Group7CudaDenseMatrix,
-      Group7CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group7CudaSparseMatrix>>(7);
-  testNormalizedErrorConst<
-      Group12CudaDenseMatrix,
-      Group12CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group12CudaSparseMatrix>>(12);
-  testNormalizedErrorConst<
-      Group16CudaDenseMatrix,
-      Group16CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group16CudaSparseMatrix>>(16);
-  testNormalizedErrorConst<
-      Group20CudaDenseMatrix,
-      Group20CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group20CudaSparseMatrix>>(20);
-  testNormalizedErrorConst<
-      Group5599CudaDenseMatrix,
-      Group5599CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group5599CudaSparseMatrix>>(5599);
-  testNormalizedErrorConst<
-      Group6603CudaDenseMatrix,
-      Group6603CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group6603CudaSparseMatrix>>(6603);
-  testNormalizedErrorConst<
-      Group200041CudaDenseMatrix,
-      Group200041CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group200041CudaSparseMatrix>>(200041);
-  testNormalizedErrorConst<
-      Group421875CudaDenseMatrix,
-      Group421875CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group421875CudaSparseMatrix>>(421875);
-  testNormalizedErrorConst<
-      Group3395043CudaDenseMatrix,
-      Group3395043CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group3395043CudaSparseMatrix>>(3395043);
+//   // tests where RMSE does not change with the size of the array
+//   testNormalizedErrorConst<
+//       Group1CudaDenseMatrix,
+//       Group1CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group1CudaSparseMatrix>>(1);
+//   testNormalizedErrorConst<
+//       Group2CudaDenseMatrix,
+//       Group2CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group2CudaSparseMatrix>>(2);
+//   testNormalizedErrorConst<
+//       Group4CudaDenseMatrix,
+//       Group4CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group4CudaSparseMatrix>>(4);
+//   testNormalizedErrorConst<
+//       Group7CudaDenseMatrix,
+//       Group7CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group7CudaSparseMatrix>>(7);
+//   testNormalizedErrorConst<
+//       Group12CudaDenseMatrix,
+//       Group12CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group12CudaSparseMatrix>>(12);
+//   testNormalizedErrorConst<
+//       Group16CudaDenseMatrix,
+//       Group16CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group16CudaSparseMatrix>>(16);
+//   testNormalizedErrorConst<
+//       Group20CudaDenseMatrix,
+//       Group20CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group20CudaSparseMatrix>>(20);
+//   testNormalizedErrorConst<
+//       Group5599CudaDenseMatrix,
+//       Group5599CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group5599CudaSparseMatrix>>(5599);
+//   testNormalizedErrorConst<
+//       Group6603CudaDenseMatrix,
+//       Group6603CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group6603CudaSparseMatrix>>(6603);
+//   testNormalizedErrorConst<
+//       Group200041CudaDenseMatrix,
+//       Group200041CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group200041CudaSparseMatrix>>(200041);
+//   testNormalizedErrorConst<
+//       Group421875CudaDenseMatrix,
+//       Group421875CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group421875CudaSparseMatrix>>(421875);
+//   testNormalizedErrorConst<
+//       Group3395043CudaDenseMatrix,
+//       Group3395043CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group3395043CudaSparseMatrix>>(3395043);
 
-  // tests where RMSE changes with the size of the array
-  testNormalizedErrorDiff<
-      Group1CudaDenseMatrix,
-      Group1CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group1CudaSparseMatrix>>(1);
-  testNormalizedErrorDiff<
-      Group2CudaDenseMatrix,
-      Group2CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group2CudaSparseMatrix>>(2);
-  testNormalizedErrorDiff<
-      Group4CudaDenseMatrix,
-      Group4CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group4CudaSparseMatrix>>(4);
-  testNormalizedErrorDiff<
-      Group7CudaDenseMatrix,
-      Group7CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group7CudaSparseMatrix>>(7);
-  testNormalizedErrorDiff<
-      Group12CudaDenseMatrix,
-      Group12CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group12CudaSparseMatrix>>(12);
-  testNormalizedErrorDiff<
-      Group16CudaDenseMatrix,
-      Group16CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group16CudaSparseMatrix>>(16);
-  testNormalizedErrorDiff<
-      Group20CudaDenseMatrix,
-      Group20CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group20CudaSparseMatrix>>(20);
-  testNormalizedErrorDiff<
-      Group5599CudaDenseMatrix,
-      Group5599CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group5599CudaSparseMatrix>>(5599);
-  testNormalizedErrorDiff<
-      Group6603CudaDenseMatrix,
-      Group6603CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group6603CudaSparseMatrix>>(6603);
-  testNormalizedErrorDiff<
-      Group200041CudaDenseMatrix,
-      Group200041CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group200041CudaSparseMatrix>>(200041);
-  testNormalizedErrorDiff<
-      Group421875CudaDenseMatrix,
-      Group421875CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group421875CudaSparseMatrix>>(421875);
-  testNormalizedErrorDiff<
-      Group3395043CudaDenseMatrix,
-      Group3395043CudaSparseMatrix,
-      micm::CudaLinearSolver<double, Group3395043CudaSparseMatrix>>(3395043);
-}
+//   // tests where RMSE changes with the size of the array
+//   testNormalizedErrorDiff<
+//       Group1CudaDenseMatrix,
+//       Group1CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group1CudaSparseMatrix>>(1);
+//   testNormalizedErrorDiff<
+//       Group2CudaDenseMatrix,
+//       Group2CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group2CudaSparseMatrix>>(2);
+//   testNormalizedErrorDiff<
+//       Group4CudaDenseMatrix,
+//       Group4CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group4CudaSparseMatrix>>(4);
+//   testNormalizedErrorDiff<
+//       Group7CudaDenseMatrix,
+//       Group7CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group7CudaSparseMatrix>>(7);
+//   testNormalizedErrorDiff<
+//       Group12CudaDenseMatrix,
+//       Group12CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group12CudaSparseMatrix>>(12);
+//   testNormalizedErrorDiff<
+//       Group16CudaDenseMatrix,
+//       Group16CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group16CudaSparseMatrix>>(16);
+//   testNormalizedErrorDiff<
+//       Group20CudaDenseMatrix,
+//       Group20CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group20CudaSparseMatrix>>(20);
+//   testNormalizedErrorDiff<
+//       Group5599CudaDenseMatrix,
+//       Group5599CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group5599CudaSparseMatrix>>(5599);
+//   testNormalizedErrorDiff<
+//       Group6603CudaDenseMatrix,
+//       Group6603CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group6603CudaSparseMatrix>>(6603);
+//   testNormalizedErrorDiff<
+//       Group200041CudaDenseMatrix,
+//       Group200041CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group200041CudaSparseMatrix>>(200041);
+//   testNormalizedErrorDiff<
+//       Group421875CudaDenseMatrix,
+//       Group421875CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group421875CudaSparseMatrix>>(421875);
+//   testNormalizedErrorDiff<
+//       Group3395043CudaDenseMatrix,
+//       Group3395043CudaSparseMatrix,
+//       micm::CudaLinearSolver<double, Group3395043CudaSparseMatrix>>(3395043);
+// }

--- a/test/unit/solver/test_cuda_rosenbrock.cpp
+++ b/test/unit/solver/test_cuda_rosenbrock.cpp
@@ -4,7 +4,8 @@
 #include <micm/solver/cuda_rosenbrock.cuh>
 #include <micm/solver/cuda_rosenbrock.hpp>
 #include <micm/solver/rosenbrock.hpp>
-#include <micm/util/cuda_vector_matrix.hpp>
+#include <micm/util/cuda_dense_matrix.hpp>
+#include <micm/util/cuda_sparse_matrix.hpp>
 #include <micm/util/matrix.hpp>
 #include <micm/util/sparse_matrix.hpp>
 #include <micm/util/sparse_matrix_vector_ordering.hpp>
@@ -46,57 +47,57 @@ using Group3GPUSparseVectorMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrix
 template<class T>
 using Group4GPUSparseVectorMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
 
-// the following alias works for a CudaVectorMatrix with given row and any columns
+// the following alias works for a CudaDenserMatrix with given row and any columns
 template<class T>
-using Group1CudaVectorMatrix = micm::CudaVectorMatrix<T, 1>;
+using Group1CudaDenseMatrix = micm::CudaDenseMatrix<T, 1>;
 template<class T>
-using Group2CudaVectorMatrix = micm::CudaVectorMatrix<T, 2>;
+using Group2CudaDenseMatrix = micm::CudaDenseMatrix<T, 2>;
 template<class T>
-using Group4CudaVectorMatrix = micm::CudaVectorMatrix<T, 4>;
+using Group4CudaDenseMatrix = micm::CudaDenseMatrix<T, 4>;
 template<class T>
-using Group7CudaVectorMatrix = micm::CudaVectorMatrix<T, 7>;
+using Group7CudaDenseMatrix = micm::CudaDenseMatrix<T, 7>;
 template<class T>
-using Group12CudaVectorMatrix = micm::CudaVectorMatrix<T, 12>;
+using Group12CudaDenseMatrix = micm::CudaDenseMatrix<T, 12>;
 template<class T>
-using Group16CudaVectorMatrix = micm::CudaVectorMatrix<T, 16>;
+using Group16CudaDenseMatrix = micm::CudaDenseMatrix<T, 16>;
 template<class T>
-using Group20CudaVectorMatrix = micm::CudaVectorMatrix<T, 20>;
+using Group20CudaDenseMatrix = micm::CudaDenseMatrix<T, 20>;
 template<class T>
-using Group5599CudaVectorMatrix = micm::CudaVectorMatrix<T, 5599>;
+using Group5599CudaDenseMatrix = micm::CudaDenseMatrix<T, 5599>;
 template<class T>
-using Group6603CudaVectorMatrix = micm::CudaVectorMatrix<T, 6603>;
+using Group6603CudaDenseMatrix = micm::CudaDenseMatrix<T, 6603>;
 template<class T>
-using Group200041CudaVectorMatrix = micm::CudaVectorMatrix<T, 200041>;
+using Group200041CudaDenseMatrix = micm::CudaDenseMatrix<T, 200041>;
 template<class T>
-using Group421875CudaVectorMatrix = micm::CudaVectorMatrix<T, 421875>;
+using Group421875CudaDenseMatrix = micm::CudaDenseMatrix<T, 421875>;
 template<class T>
-using Group3395043CudaVectorMatrix = micm::CudaVectorMatrix<T, 3395043>;
+using Group3395043CudaDenseMatrix = micm::CudaDenseMatrix<T, 3395043>;
 
-// the following alias works for a CudaVectorMatrix with given rows and any columns
+// the following alias works for a CudaSparseMatrix with given rows and any columns
 template<class T>
-using Group1SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
+using Group1CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
 template<class T>
-using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
+using Group2CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
 template<class T>
-using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+using Group4CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
 template<class T>
-using Group7SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<7>>;
+using Group7CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<7>>;
 template<class T>
-using Group12SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<12>>;
+using Group12CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<12>>;
 template<class T>
-using Group16SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<16>>;
+using Group16CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<16>>;
 template<class T>
-using Group20SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<20>>;
+using Group20CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<20>>;
 template<class T>
-using Group5599SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<5599>>;
+using Group5599CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<5599>>;
 template<class T>
-using Group6603SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<6603>>;
+using Group6603CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<6603>>;
 template<class T>
-using Group200041SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<200041>>;
+using Group200041CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<200041>>;
 template<class T>
-using Group421875SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<421875>>;
+using Group421875CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<421875>>;
 template<class T>
-using Group3395043SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3395043>>;
+using Group3395043CudaSparseMatrix = micm::CudaSparseMatrix<T, micm::SparseMatrixVectorOrdering<3395043>>;
 
 template<
     template<class>
@@ -143,7 +144,7 @@ RosenbrockPolicy getSolver(std::size_t number_of_grid_cells)
       micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells, false));
 }
 
-template<template<class> class CPUMatrixPolicy, template<class> class CPUSparseMatrixPolicy, class CPULinearSolverPolicy
+template<template<class> class CPUMatrixPolicy, template<class> class CPUSparseMatrixPolicy, class CPULinearSolverPolicy,
          template<class> class GPUMatrixPolicy, template<class> class GPUSparseMatrixPolicy, class GPULinearSolverPolicy>
 void testAlphaMinusJacobian(std::size_t number_of_grid_cells)
 {
@@ -209,7 +210,7 @@ void testAlphaMinusJacobian(std::size_t number_of_grid_cells)
       micm::RosenbrockSolver<CPUMatrixPolicy, CPUSparseMatrixPolicy, micm::LinearSolver<double, CPUSparseMatrixPolicy>>>(
       number_of_grid_cells);
   cpu_solver.AlphaMinusJacobian(cpu_jacobian, 42.042);
-  
+
   std::vector<double> jacobian_gpu_vector = gpu_jacobian.AsVector();
   std::vector<double> jacobian_cpu_vector = cpu_jacobian.AsVector();
   for (int i = 0; i < jacobian_cpu_vector.size(); i++)
@@ -342,101 +343,101 @@ TEST(RosenbrockSolver, CudaNormalizedError)
 
   // tests where RMSE does not change with the size of the array
   testNormalizedErrorConst<
-      Group1CudaVectorMatrix,
-      Group1SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group1SparseVectorMatrix>>(1);
+      Group1CudaDenseMatrix,
+      Group1CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group1CudaSparseMatrix>>(1);
   testNormalizedErrorConst<
-      Group2CudaVectorMatrix,
-      Group2SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group2SparseVectorMatrix>>(2);
+      Group2CudaDenseMatrix,
+      Group2CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group2CudaSparseMatrix>>(2);
   testNormalizedErrorConst<
-      Group4CudaVectorMatrix,
-      Group4SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group4SparseVectorMatrix>>(4);
+      Group4CudaDenseMatrix,
+      Group4CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group4CudaSparseMatrix>>(4);
   testNormalizedErrorConst<
-      Group7CudaVectorMatrix,
-      Group7SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group7SparseVectorMatrix>>(7);
+      Group7CudaDenseMatrix,
+      Group7CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group7CudaSparseMatrix>>(7);
   testNormalizedErrorConst<
-      Group12CudaVectorMatrix,
-      Group12SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group12SparseVectorMatrix>>(12);
+      Group12CudaDenseMatrix,
+      Group12CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group12CudaSparseMatrix>>(12);
   testNormalizedErrorConst<
-      Group16CudaVectorMatrix,
-      Group16SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group16SparseVectorMatrix>>(16);
+      Group16CudaDenseMatrix,
+      Group16CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group16CudaSparseMatrix>>(16);
   testNormalizedErrorConst<
-      Group20CudaVectorMatrix,
-      Group20SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group20SparseVectorMatrix>>(20);
+      Group20CudaDenseMatrix,
+      Group20CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group20CudaSparseMatrix>>(20);
   testNormalizedErrorConst<
-      Group5599CudaVectorMatrix,
-      Group5599SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group5599SparseVectorMatrix>>(5599);
+      Group5599CudaDenseMatrix,
+      Group5599CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group5599CudaSparseMatrix>>(5599);
   testNormalizedErrorConst<
-      Group6603CudaVectorMatrix,
-      Group6603SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group6603SparseVectorMatrix>>(6603);
+      Group6603CudaDenseMatrix,
+      Group6603CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group6603CudaSparseMatrix>>(6603);
   testNormalizedErrorConst<
-      Group200041CudaVectorMatrix,
-      Group200041SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group200041SparseVectorMatrix>>(200041);
+      Group200041CudaDenseMatrix,
+      Group200041CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group200041CudaSparseMatrix>>(200041);
   testNormalizedErrorConst<
-      Group421875CudaVectorMatrix,
-      Group421875SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group421875SparseVectorMatrix>>(421875);
+      Group421875CudaDenseMatrix,
+      Group421875CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group421875CudaSparseMatrix>>(421875);
   testNormalizedErrorConst<
-      Group3395043CudaVectorMatrix,
-      Group3395043SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group3395043SparseVectorMatrix>>(3395043);
+      Group3395043CudaDenseMatrix,
+      Group3395043CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group3395043CudaSparseMatrix>>(3395043);
 
   // tests where RMSE changes with the size of the array
   testNormalizedErrorDiff<
-      Group1CudaVectorMatrix,
-      Group1SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group1SparseVectorMatrix>>(1);
+      Group1CudaDenseMatrix,
+      Group1CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group1CudaSparseMatrix>>(1);
   testNormalizedErrorDiff<
-      Group2CudaVectorMatrix,
-      Group2SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group2SparseVectorMatrix>>(2);
+      Group2CudaDenseMatrix,
+      Group2CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group2CudaSparseMatrix>>(2);
   testNormalizedErrorDiff<
-      Group4CudaVectorMatrix,
-      Group4SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group4SparseVectorMatrix>>(4);
+      Group4CudaDenseMatrix,
+      Group4CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group4CudaSparseMatrix>>(4);
   testNormalizedErrorDiff<
-      Group7CudaVectorMatrix,
-      Group7SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group7SparseVectorMatrix>>(7);
+      Group7CudaDenseMatrix,
+      Group7CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group7CudaSparseMatrix>>(7);
   testNormalizedErrorDiff<
-      Group12CudaVectorMatrix,
-      Group12SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group12SparseVectorMatrix>>(12);
+      Group12CudaDenseMatrix,
+      Group12CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group12CudaSparseMatrix>>(12);
   testNormalizedErrorDiff<
-      Group16CudaVectorMatrix,
-      Group16SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group16SparseVectorMatrix>>(16);
+      Group16CudaDenseMatrix,
+      Group16CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group16CudaSparseMatrix>>(16);
   testNormalizedErrorDiff<
-      Group20CudaVectorMatrix,
-      Group20SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group20SparseVectorMatrix>>(20);
+      Group20CudaDenseMatrix,
+      Group20CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group20CudaSparseMatrix>>(20);
   testNormalizedErrorDiff<
-      Group5599CudaVectorMatrix,
-      Group5599SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group5599SparseVectorMatrix>>(5599);
+      Group5599CudaDenseMatrix,
+      Group5599CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group5599CudaSparseMatrix>>(5599);
   testNormalizedErrorDiff<
-      Group6603CudaVectorMatrix,
-      Group6603SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group6603SparseVectorMatrix>>(6603);
+      Group6603CudaDenseMatrix,
+      Group6603CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group6603CudaSparseMatrix>>(6603);
   testNormalizedErrorDiff<
-      Group200041CudaVectorMatrix,
-      Group200041SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group200041SparseVectorMatrix>>(200041);
+      Group200041CudaDenseMatrix,
+      Group200041CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group200041CudaSparseMatrix>>(200041);
   testNormalizedErrorDiff<
-      Group421875CudaVectorMatrix,
-      Group421875SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group421875SparseVectorMatrix>>(421875);
+      Group421875CudaDenseMatrix,
+      Group421875CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group421875CudaSparseMatrix>>(421875);
   testNormalizedErrorDiff<
-      Group3395043CudaVectorMatrix,
-      Group3395043SparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group3395043SparseVectorMatrix>>(3395043);
+      Group3395043CudaDenseMatrix,
+      Group3395043CudaSparseMatrix,
+      micm::CudaLinearSolver<double, Group3395043CudaSparseMatrix>>(3395043);
 }

--- a/test/unit/solver/test_cuda_rosenbrock.cpp
+++ b/test/unit/solver/test_cuda_rosenbrock.cpp
@@ -307,28 +307,28 @@ TEST(RosenbrockSolver, DenseAlphaMinusJacobian)
   testAlphaMinusJacobian<
       Group1CPUVectorMatrix,
       Group1CPUSparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group1CPUSparseVectorMatrix>,
+      micm::LinearSolver<double, Group1CPUSparseVectorMatrix>,
       Group1GPUVectorMatrix,
       Group1GPUSparseVectorMatrix,
       micm::CudaLinearSolver<double, Group1GPUSparseVectorMatrix>>(1);
   testAlphaMinusJacobian<
       Group2CPUVectorMatrix,
       Group2CPUSparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group2CPUSparseVectorMatrix>,
+      micm::LinearSolver<double, Group2CPUSparseVectorMatrix>,
       Group2GPUVectorMatrix,
       Group2GPUSparseVectorMatrix,
       micm::CudaLinearSolver<double, Group2GPUSparseVectorMatrix>>(2);
   testAlphaMinusJacobian<
       Group3CPUVectorMatrix,
       Group3CPUSparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group3CPUSparseVectorMatrix>,
+      micm::LinearSolver<double, Group3CPUSparseVectorMatrix>,
       Group3GPUVectorMatrix,
       Group3GPUSparseVectorMatrix,
       micm::CudaLinearSolver<double, Group3GPUSparseVectorMatrix>>(3);
   testAlphaMinusJacobian<
       Group4CPUVectorMatrix,
       Group4CPUSparseVectorMatrix,
-      micm::CudaLinearSolver<double, Group4CPUSparseVectorMatrix>,
+      micm::LinearSolver<double, Group4CPUSparseVectorMatrix>,
       Group4GPUVectorMatrix,
       Group4GPUSparseVectorMatrix,
       micm::CudaLinearSolver<double, Group4GPUSparseVectorMatrix>>(4);


### PR DESCRIPTION
This PR updates the input type for the CUDA implementation of `AlphaMinusJacobian` and `NormalizedError` functions with the `CudaDenseMatrix` and `CudaSparseMatrix` class.

It also addresses some issues related to the copy/move constructor/assignment/destructor in the `CudaDenseMatrix` and `CudaSparseMatrix` class.

All the 41 tests all passed on Derecho's A100 GPU by using `nvhpc/23.7`.