### PR TITLE
Add exceptions for species property lookups

### DIFF
--- a/include/micm/solver/rosenbrock_solver_parameters.hpp
+++ b/include/micm/solver/rosenbrock_solver_parameters.hpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cmath>
 #include <iostream>
 
 namespace micm

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -109,7 +109,7 @@ namespace micm
       try {
         return properties_string_.at(key);
       } catch (const std::out_of_range& e) {
-        throw std::runtime_error("Species property not found");
+        throw std::runtime_error("Species property '" + key + "' not found");
       }
     }
     else if constexpr (std::is_same<T, double>::value)
@@ -117,7 +117,7 @@ namespace micm
       try {
         return properties_double_.at(key);
       } catch (const std::out_of_range& e) {
-        throw std::runtime_error("Species property not found");
+        throw std::runtime_error("Species property '" + key + "' not found");
       }
     }
     else if constexpr (std::is_same<T, bool>::value)
@@ -125,7 +125,7 @@ namespace micm
       try {
         return properties_bool_.at(key);
       } catch (const std::out_of_range& e) {
-        throw std::runtime_error("Species property not found");
+        throw std::runtime_error("Species property '" + key + "' not found");
       }
     }
     else if constexpr (std::is_same<T, int>::value)
@@ -133,7 +133,7 @@ namespace micm
       try {
         return properties_int_.at(key);
       } catch (const std::out_of_range& e) {
-        throw std::runtime_error("Species property not found");
+        throw std::runtime_error("Species property '" + key + "' not found");
       }
     }
     else

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -106,23 +106,39 @@ namespace micm
   {
     if constexpr (std::is_same<T, std::string>::value)
     {
-      return properties_string_.at(key);
+      try {
+        return properties_string_.at(key);
+      } catch (const std::out_of_range& e) {
+        throw std::runtime_error("Species property not found");
+      }
     }
     else if constexpr (std::is_same<T, double>::value)
     {
-      return properties_double_.at(key);
+      try {
+        return properties_double_.at(key);
+      } catch (const std::out_of_range& e) {
+        throw std::runtime_error("Species property not found");
+      }
     }
     else if constexpr (std::is_same<T, bool>::value)
     {
-      return properties_bool_.at(key);
+      try {
+        return properties_bool_.at(key);
+      } catch (const std::out_of_range& e) {
+        throw std::runtime_error("Species property not found");
+      }
     }
     else if constexpr (std::is_same<T, int>::value)
     {
-      return properties_int_.at(key);
+      try {
+        return properties_int_.at(key);
+      } catch (const std::out_of_range& e) {
+        throw std::runtime_error("Species property not found");
+      }
     }
     else
     {
-      throw std::runtime_error("Invalid type for property");
+      throw std::runtime_error("Invalid type for species property");
     }
   }
 

--- a/test/unit/system/test_species.cpp
+++ b/test/unit/system/test_species.cpp
@@ -32,7 +32,7 @@ TEST(Species, GetProperty)
     try {
       species.GetProperty<std::string>("not there");
     } catch(std::runtime_error& e) {
-      EXPECT_STREQ(e.what(), "Species property not found");
+      EXPECT_STREQ(e.what(), "Species property 'not there' not found");
       throw;
     }
   }, std::runtime_error);
@@ -40,7 +40,7 @@ TEST(Species, GetProperty)
     try {
       species.GetProperty<double>("not there");
     } catch(std::runtime_error& e) {
-      EXPECT_STREQ(e.what(), "Species property not found");
+      EXPECT_STREQ(e.what(), "Species property 'not there' not found");
       throw;
     }
   }, std::runtime_error);
@@ -48,7 +48,7 @@ TEST(Species, GetProperty)
     try {
       species.GetProperty<int>("not there");
     } catch(std::runtime_error& e) {
-      EXPECT_STREQ(e.what(), "Species property not found");
+      EXPECT_STREQ(e.what(), "Species property 'not there' not found");
       throw;
     }
   }, std::runtime_error);
@@ -56,7 +56,7 @@ TEST(Species, GetProperty)
     try {
       species.GetProperty<bool>("not there");
     } catch(std::runtime_error& e) {
-      EXPECT_STREQ(e.what(), "Species property not found");
+      EXPECT_STREQ(e.what(), "Species property 'not there' not found");
       throw;
     }
   }, std::runtime_error);

--- a/test/unit/system/test_species.cpp
+++ b/test/unit/system/test_species.cpp
@@ -22,6 +22,54 @@ TEST(Species, StringAndVectorConstructor)
   EXPECT_EQ(species.GetProperty<double>("name2 [units2]"), 2.0);
 }
 
+TEST(Species, GetProperty)
+{
+  micm::Species species("thing", { { "name [units]", 1.0 }, { "name2 [units2]", 2.0 } });
+
+  EXPECT_EQ(species.GetProperty<double>("name [units]"), 1.0);
+  EXPECT_EQ(species.GetProperty<double>("name2 [units2]"), 2.0);
+  EXPECT_THROW({
+    try {
+      species.GetProperty<std::string>("not there");
+    } catch(std::runtime_error& e) {
+      EXPECT_STREQ(e.what(), "Species property not found");
+      throw;
+    }
+  }, std::runtime_error);
+  EXPECT_THROW({
+    try {
+      species.GetProperty<double>("not there");
+    } catch(std::runtime_error& e) {
+      EXPECT_STREQ(e.what(), "Species property not found");
+      throw;
+    }
+  }, std::runtime_error);
+  EXPECT_THROW({
+    try {
+      species.GetProperty<int>("not there");
+    } catch(std::runtime_error& e) {
+      EXPECT_STREQ(e.what(), "Species property not found");
+      throw;
+    }
+  }, std::runtime_error);
+  EXPECT_THROW({
+    try {
+      species.GetProperty<bool>("not there");
+    } catch(std::runtime_error& e) {
+      EXPECT_STREQ(e.what(), "Species property not found");
+      throw;
+    }
+  }, std::runtime_error);
+  EXPECT_THROW({
+    try {
+      species.GetProperty<long double>("name [units]");
+    } catch(std::runtime_error& e) {
+      EXPECT_STREQ(e.what(), "Invalid type for species property");
+      throw;
+    }
+  }, std::runtime_error);
+}
+
 TEST(Species, ThirdBody)
 {
   micm::Species species = micm::Species::ThirdBody();


### PR DESCRIPTION
Adds descriptive messages to exceptions thrown when looking up nonexistent species properties.

Also adds a missing header include.