### PR TITLE
Rename functions to consistently use CamelCase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,3 @@
----
 BasedOnStyle: Google
 AlignAfterOpenBracket: 'AlwaysBreak'
 AllowAllConstructorInitializersOnNextLine: 'false'

--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
+---
 BasedOnStyle: Google
 AlignAfterOpenBracket: 'AlwaysBreak'
 AllowAllConstructorInitializersOnNextLine: 'false'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,33 @@
 ---
+# Create new issues to allow
+# -readability-math-missing-parentheses
+#     eg) '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations
+# -readability-avoid-const-params-in-decls :
+#     eg) std::vector<std::string> UniqueNames(const std::function<std::string(const std::vector<std::string>& variables, const std::size_t i)> f) const;
+# -readability-non-const-parameter;
+#     eg) double* d_lower_matrix (micm/src/solver/linear_solver.cu)
+# -readability-convert-member-functions-to-static
+# -readability-identifier-length
+# -readability-braces-around-statements
+# -readability-make-member-function-const
+
+# Need discussion
+# -readability-implicit-bool-conversion: We could allow this while accepeting the two conditions specified in `Checks`
+#     eg) assert((!generated_) && "JIT Function already generated") (jit/jit_function.hpp)
+# -readability-isolate-declaration
+#     eg) double d_ymax, d_scale -> multiple declarations in a single statement reduces readability (micm/src/solver/rosenbrock.cu)
+# -readability-named-parameter: false positive cases
+
+# Have to fix later
+# -readability-avoid-unconditional-preprocessor-if:
+#     eg) #if 0 (micm/jit/jit_compiler.hpp)
+
+# Disabled
+# -readability-simplify-boolean-expr: Could hurt readability
+#     eg) return static_cast<bool>(elem == end)
+# -readability-magic-numbers,-warnings-as-errors: Doesn't allow the following example
+#     eg) parameters.c_[8] = -0.3399990352819905E+02; (micm/solver/rosenbrock_solver_parameters.hpp)
+
 Checks: >
   -*,
   readability-*,
@@ -17,6 +46,8 @@ Checks: >
   -readability-isolate-declaration, 
 
 WarningsAsErrors: '*'
+
+# HeaderFilterRegex: ''
 
 CheckOptions:
   - key:             readability-identifier-naming.FunctionCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,29 @@
-
 ---
-Checks: '*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm-*,-llvmlibc-*,-bugprone-easily-swappable-parameters'
-CheckOptions: [{ key: misc-non-private-member-variables-in-classes, value: IgnoreClassesWithAllMemberVariablesBeingPublic }]
-WarningsAsErrors: ''
-HeaderFilterRegex: ''
-FormatStyle: none
+Checks: >
+  -*,
+  readability-*,
+  -readability-named-parameter,
+  -readability-identifier-length,
+  -readability-convert-member-functions-to-static,
+  -readability-braces-around-statements,
+  -readability-math-missing-parentheses,
+  -readability-avoid-const-params-in-decls,
+  -readability-avoid-unconditional-preprocessor-if,
+  -readability-make-member-function-const,
+  -readability-implicit-bool-conversion,
+  -readability-simplify-boolean-expr,
+  -readability-magic-numbers,-warnings-as-errors,
+  -readability-non-const-parameter,
+  -readability-isolate-declaration, 
+
+WarningsAsErrors: '*'
+
+CheckOptions:
+  - key:             readability-identifier-naming.FunctionCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionIgnoredRegexp
+    value:           'name|message|make_error_code'
+  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
+    value:           1
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           1

--- a/README.md
+++ b/README.md
@@ -143,20 +143,20 @@ int main(const int argc, const char *argv[])
   System chemical_system{ SystemParameters{ .gas_phase_ = gas_phase } };
 
   Process r1 = Process::Create()
-                   .reactants({ foo })
-                   .products({ Yield(bar, 0.8), Yield(baz, 0.2) })
-                   .rate_constant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))
-                   .phase(gas_phase);
+                   .SetReactants({ foo })
+                   .SetProducts({ Yield(bar, 0.8), Yield(baz, 0.2) })
+                   .SetRateConstant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))
+                   .SetPhase(gas_phase);
 
   Process r2 = Process::Create()
-                   .reactants({ foo, bar })
-                   .products({ Yield(baz, 1) })
-                   .rate_constant(ArrheniusRateConstant({ .A_ = 1.0e-5, .C_ = 110.0 }))
-                   .phase(gas_phase);
+                   .SetReactants({ foo, bar })
+                   .SetProducts({ Yield(baz, 1) })
+                   .SetRateConstant(ArrheniusRateConstant({ .A_ = 1.0e-5, .C_ = 110.0 }))
+                   .SetPhase(gas_phase);
 
   std::vector<Process> reactions{ r1, r2 };
 
-  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
+  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::ThreeStageRosenbrockParameters() };
 
   State state = solver.GetState();
 

--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ int main(const int argc, const char *argv[])
 
   System chemical_system{ SystemParameters{ .gas_phase_ = gas_phase } };
 
-  Process r1 = Process::create()
+  Process r1 = Process::Create()
                    .reactants({ foo })
                    .products({ Yield(bar, 0.8), Yield(baz, 0.2) })
                    .rate_constant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))
                    .phase(gas_phase);
 
-  Process r2 = Process::create()
+  Process r2 = Process::Create()
                    .reactants({ foo, bar })
                    .products({ Yield(baz, 1) })
                    .rate_constant(ArrheniusRateConstant({ .A_ = 1.0e-5, .C_ = 110.0 }))

--- a/docs/source/user_guide/user_defined_rate_constant_tutorial.rst
+++ b/docs/source/user_guide/user_defined_rate_constant_tutorial.rst
@@ -77,26 +77,26 @@ Then setup the reaction which will use this rate constant:
         .. code-block:: diff
 
              Process r7 = Process::Create()
-                             .reactants({ f })
-                             .products({ Yields(g, 1) })
-                             .rate_constant(TunnelingRateConstant({ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 }))
-                             .phase(gas_phase);
+                             .SetReactants({ f })
+                             .SetProducts({ Yields(g, 1) })
+                             .SetRateConstant(TunnelingRateConstant({ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 }))
+                             .SetPhase(gas_phase);
 
             + Process r8 = Process::Create()
-            +                 .reactants({ c })
-            +                 .products({ Yields(g, 1) })
-            +                 .rate_constant(UserDefinedRateConstant({.label_="my rate"}))
-            +                 .phase(gas_phase);
+            +                 .SetReactants({ c })
+            +                 .SetProducts({ Yields(g, 1) })
+            +                 .SetRateConstant(UserDefinedRateConstant({.label_="my rate"}))
+            +                 .SetPhase(gas_phase);
 
             + Process r9 = Process::Create()
-            +                 .products({ Yields(a, 1) })
-            +                 .rate_constant(UserDefinedRateConstant({.label_="my emission rate"}))
-            +                 .phase(gas_phase);
+            +                 .SetProducts({ Yields(a, 1) })
+            +                 .SetRateConstant(UserDefinedRateConstant({.label_="my emission rate"}))
+            +                 .SetPhase(gas_phase);
 
             + Process r10 = Process::Create()
-            +                 .reactants({ b })
-            +                 .rate_constant(UserDefinedRateConstant({.label_="my loss rate"}))
-            +                 .phase(gas_phase);
+            +                 .SetReactants({ b })
+            +                 .SetRateConstant(UserDefinedRateConstant({.label_="my loss rate"}))
+            +                 .SetPhase(gas_phase);
 
              auto chemical_system = System(micm::SystemParameters{ .gas_phase_ = gas_phase });
             - auto reactions = std::vector<micm::Process>{ r1, r2, r3, r4, r5, r6, r7 };

--- a/docs/source/user_guide/user_defined_rate_constant_tutorial.rst
+++ b/docs/source/user_guide/user_defined_rate_constant_tutorial.rst
@@ -76,24 +76,24 @@ Then setup the reaction which will use this rate constant:
 
         .. code-block:: diff
 
-             Process r7 = Process::create()
+             Process r7 = Process::Create()
                              .reactants({ f })
-                             .products({ yields(g, 1) })
+                             .products({ Yields(g, 1) })
                              .rate_constant(TunnelingRateConstant({ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 }))
                              .phase(gas_phase);
 
-            + Process r8 = Process::create()
+            + Process r8 = Process::Create()
             +                 .reactants({ c })
-            +                 .products({ yields(g, 1) })
+            +                 .products({ Yields(g, 1) })
             +                 .rate_constant(UserDefinedRateConstant({.label_="my rate"}))
             +                 .phase(gas_phase);
 
-            + Process r9 = Process::create()
-            +                 .products({ yields(a, 1) })
+            + Process r9 = Process::Create()
+            +                 .products({ Yields(a, 1) })
             +                 .rate_constant(UserDefinedRateConstant({.label_="my emission rate"}))
             +                 .phase(gas_phase);
 
-            + Process r10 = Process::create()
+            + Process r10 = Process::Create()
             +                 .reactants({ b })
             +                 .rate_constant(UserDefinedRateConstant({.label_="my loss rate"}))
             +                 .phase(gas_phase);

--- a/examples/profile_example.cpp
+++ b/examples/profile_example.cpp
@@ -78,7 +78,7 @@ int Run(const char* filepath, const char* initial_conditions, const std::string&
   auto chemical_system = solver_params.system_;
   auto reactions = solver_params.processes_;
 
-  auto params = RosenbrockSolverParameters::three_stage_rosenbrock_parameters();
+  auto params = RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
   params.relative_tolerance_ = 0.1;
   RosenbrockSolver<> solver{ chemical_system, reactions, params };
 

--- a/include/micm/configure/solver_config.hpp
+++ b/include/micm/configure/solver_config.hpp
@@ -877,7 +877,7 @@ namespace micm
   {
    public:
     SolverConfig()
-        : ConfigTypePolicy(RosenbrockSolverParameters::three_stage_rosenbrock_parameters())
+        : ConfigTypePolicy(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
     {
     }
     SolverConfig(const RosenbrockSolverParameters& parameters)

--- a/include/micm/jit/jit_compiler.hpp
+++ b/include/micm/jit/jit_compiler.hpp
@@ -124,7 +124,7 @@ namespace micm
         execution_session_->reportError(std::move(Err));
     }
 
-    static llvm::Expected<std::shared_ptr<JitCompiler>> create()
+    static llvm::Expected<std::shared_ptr<JitCompiler>> Create()
     {
       llvm::InitializeNativeTarget();
       llvm::InitializeNativeTargetAsmPrinter();

--- a/include/micm/jit/jit_function.hpp
+++ b/include/micm/jit/jit_function.hpp
@@ -91,7 +91,7 @@ namespace micm
     JitFunction() = delete;
 
     friend class JitFunctionBuilder;
-    static JitFunctionBuilder create(std::shared_ptr<JitCompiler> compiler);
+    static JitFunctionBuilder Create(std::shared_ptr<JitCompiler> compiler);
     JitFunction(JitFunctionBuilder& function_builder);
 
     /// @brief Generates the function
@@ -147,12 +147,12 @@ namespace micm
    public:
     JitFunctionBuilder() = delete;
     JitFunctionBuilder(std::shared_ptr<JitCompiler> compiler);
-    JitFunctionBuilder& name(std::string name);
-    JitFunctionBuilder& arguments(const std::vector<std::pair<std::string, JitType>>& arguments);
-    JitFunctionBuilder& return_type(JitType type);
+    JitFunctionBuilder& Name(const std::string& name);
+    JitFunctionBuilder& Arguments(const std::vector<std::pair<std::string, JitType>>& arguments);
+    JitFunctionBuilder& ReturnType(JitType type);
   };
 
-  inline JitFunctionBuilder JitFunction::create(std::shared_ptr<JitCompiler> compiler)
+  inline JitFunctionBuilder JitFunction::Create(std::shared_ptr<JitCompiler> compiler)
   {
     return JitFunctionBuilder{ compiler };
   }
@@ -297,19 +297,19 @@ namespace micm
   inline JitFunctionBuilder::JitFunctionBuilder(std::shared_ptr<JitCompiler> compiler)
       : compiler_(compiler){};
 
-  inline JitFunctionBuilder& JitFunctionBuilder::name(std::string name)
+  inline JitFunctionBuilder& JitFunctionBuilder::Name(const std::string& name)
   {
     name_ = name;
     return *this;
   }
 
-  inline JitFunctionBuilder& JitFunctionBuilder::arguments(const std::vector<std::pair<std::string, JitType>>& arguments)
+  inline JitFunctionBuilder& JitFunctionBuilder::Arguments(const std::vector<std::pair<std::string, JitType>>& arguments)
   {
     arguments_ = arguments;
     return *this;
   }
 
-  inline JitFunctionBuilder& JitFunctionBuilder::return_type(JitType type)
+  inline JitFunctionBuilder& JitFunctionBuilder::ReturnType(JitType type)
   {
     return_type_ = type;
     return *this;

--- a/include/micm/jit/jit_function.hpp
+++ b/include/micm/jit/jit_function.hpp
@@ -159,7 +159,7 @@ namespace micm
 
   JitFunction::JitFunction(JitFunctionBuilder& function_builder)
       : generated_(false),
-        name_(function_builder.name_ + generate_random_string()),
+        name_(function_builder.name_ + GenerateRandomString()),
         compiler_(function_builder.compiler_),
         context_(std::make_unique<llvm::LLVMContext>()),
         module_(std::make_unique<llvm::Module>(name_ + " module", *context_)),

--- a/include/micm/jit/jit_function.hpp
+++ b/include/micm/jit/jit_function.hpp
@@ -147,9 +147,9 @@ namespace micm
    public:
     JitFunctionBuilder() = delete;
     JitFunctionBuilder(std::shared_ptr<JitCompiler> compiler);
-    JitFunctionBuilder& Name(const std::string& name);
-    JitFunctionBuilder& Arguments(const std::vector<std::pair<std::string, JitType>>& arguments);
-    JitFunctionBuilder& ReturnType(JitType type);
+    JitFunctionBuilder& SetName(const std::string& name);
+    JitFunctionBuilder& SetArguments(const std::vector<std::pair<std::string, JitType>>& arguments);
+    JitFunctionBuilder& SetReturnType(JitType type);
   };
 
   inline JitFunctionBuilder JitFunction::Create(std::shared_ptr<JitCompiler> compiler)
@@ -297,19 +297,19 @@ namespace micm
   inline JitFunctionBuilder::JitFunctionBuilder(std::shared_ptr<JitCompiler> compiler)
       : compiler_(compiler){};
 
-  inline JitFunctionBuilder& JitFunctionBuilder::Name(const std::string& name)
+  inline JitFunctionBuilder& JitFunctionBuilder::SetName(const std::string& name)
   {
     name_ = name;
     return *this;
   }
 
-  inline JitFunctionBuilder& JitFunctionBuilder::Arguments(const std::vector<std::pair<std::string, JitType>>& arguments)
+  inline JitFunctionBuilder& JitFunctionBuilder::SetArguments(const std::vector<std::pair<std::string, JitType>>& arguments)
   {
     arguments_ = arguments;
     return *this;
   }
 
-  inline JitFunctionBuilder& JitFunctionBuilder::ReturnType(JitType type)
+  inline JitFunctionBuilder& JitFunctionBuilder::SetReturnType(JitType type)
   {
     return_type_ = type;
     return *this;

--- a/include/micm/process/arrhenius_rate_constant.hpp
+++ b/include/micm/process/arrhenius_rate_constant.hpp
@@ -40,20 +40,20 @@ namespace micm
     ArrheniusRateConstant(const ArrheniusRateConstantParameters& parameters);
 
     /// @brief Deep copy
-    std::unique_ptr<RateConstant> clone() const override;
+    std::unique_ptr<RateConstant> Clone() const override;
 
     /// @brief Calculate the rate constant
     /// @param conditions The current environmental conditions of the chemical system
     /// @param custom_parameters User-defined rate constant parameters
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
+    double Calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
 
     /// @brief Calculate the rate constant
     /// @param conditions The current environmental conditions of the chemical system
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions) const override;
+    double Calculate(const Conditions& conditions) const override;
 
-    double calculate(const double& temperature, const double& pressure) const;
+    double Calculate(const double& temperature, const double& pressure) const;
   };
 
   inline ArrheniusRateConstant::ArrheniusRateConstant()
@@ -66,24 +66,24 @@ namespace micm
   {
   }
 
-  inline std::unique_ptr<RateConstant> ArrheniusRateConstant::clone() const
+  inline std::unique_ptr<RateConstant> ArrheniusRateConstant::Clone() const
   {
     return std::unique_ptr<RateConstant>{ new ArrheniusRateConstant{ *this } };
   }
 
-  inline double ArrheniusRateConstant::calculate(
+  inline double ArrheniusRateConstant::Calculate(
       const Conditions& conditions,
       std::vector<double>::const_iterator custom_parameters) const
   {
-    return calculate(conditions.temperature_, conditions.pressure_);
+    return Calculate(conditions.temperature_, conditions.pressure_);
   }
 
-  inline double ArrheniusRateConstant::calculate(const Conditions& conditions) const
+  inline double ArrheniusRateConstant::Calculate(const Conditions& conditions) const
   {
-    return calculate(conditions.temperature_, conditions.pressure_);
+    return Calculate(conditions.temperature_, conditions.pressure_);
   }
 
-  inline double ArrheniusRateConstant::calculate(const double& temperature, const double& pressure) const
+  inline double ArrheniusRateConstant::Calculate(const double& temperature, const double& pressure) const
   {
     return parameters_.A_ * std::exp(parameters_.C_ / temperature) * std::pow(temperature / parameters_.D_, parameters_.B_) *
            (1.0 + parameters_.E_ * pressure);

--- a/include/micm/process/branched_rate_constant.hpp
+++ b/include/micm/process/branched_rate_constant.hpp
@@ -47,24 +47,24 @@ namespace micm
     BranchedRateConstant(const BranchedRateConstantParameters& parameters);
 
     /// @brief Deep copy
-    std::unique_ptr<RateConstant> clone() const override;
+    std::unique_ptr<RateConstant> Clone() const override;
 
     /// @brief Calculate the rate constant
     /// @param conditions The current environmental conditions of the chemical system
     /// @param custom_parameters User-defined rate constant parameters
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
+    double Calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
 
     /// @brief Calculate the rate constant
     /// @param conditions The current environmental conditions of the chemical system
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions) const override;
+    double Calculate(const Conditions& conditions) const override;
 
     /// @brief Calculate the rate constant
     /// @param temperature Temperature in [K]
     /// @param air_number_density Number density in [mol m-3]
     /// @return
-    double calculate(const double& temperature, const double& air_number_density) const;
+    double Calculate(const double& temperature, const double& air_number_density) const;
 
     /// @brief Calculate A(T,[M],n)
     /// @param temperature Temperature in [K]
@@ -86,24 +86,24 @@ namespace micm
   {
   }
 
-  inline std::unique_ptr<RateConstant> BranchedRateConstant::clone() const
+  inline std::unique_ptr<RateConstant> BranchedRateConstant::Clone() const
   {
     return std::unique_ptr<RateConstant>{ new BranchedRateConstant{ *this } };
   }
 
-  inline double BranchedRateConstant::calculate(
+  inline double BranchedRateConstant::Calculate(
       const Conditions& conditions,
       std::vector<double>::const_iterator custom_parameters) const
   {
-    return calculate(conditions.temperature_, conditions.air_density_);
+    return Calculate(conditions.temperature_, conditions.air_density_);
   }
 
-  inline double BranchedRateConstant::calculate(const Conditions& conditions) const
+  inline double BranchedRateConstant::Calculate(const Conditions& conditions) const
   {
-    return calculate(conditions.temperature_, conditions.air_density_);
+    return Calculate(conditions.temperature_, conditions.air_density_);
   }
 
-  inline double BranchedRateConstant::calculate(const double& temperature, const double& air_number_density) const
+  inline double BranchedRateConstant::Calculate(const double& temperature, const double& air_number_density) const
   {
     double pre = parameters_.X_ * std::exp(-parameters_.Y_ / temperature);
     double Atmn = A(temperature, air_number_density);

--- a/include/micm/process/jit_process_set.hpp
+++ b/include/micm/process/jit_process_set.hpp
@@ -121,7 +121,7 @@ namespace micm
   template<std::size_t L>
   void JitProcessSet<L>::GenerateForcingFunction()
   {
-    std::string function_name = "add_forcing_terms_" + generate_random_string();
+    std::string function_name = "add_forcing_terms_" + GenerateRandomString();
     JitFunction func = JitFunction::create(compiler_)
                            .name(function_name)
                            .arguments({ { "rate constants", JitType::DoublePtr },
@@ -223,7 +223,7 @@ namespace micm
   template<std::size_t L>
   void JitProcessSet<L>::GenerateJacobianFunction(const SparseMatrix<double, SparseMatrixVectorOrdering<L>> &matrix)
   {
-    std::string function_name = "subtract_jacobian_terms_" + generate_random_string();
+    std::string function_name = "subtract_jacobian_terms_" + GenerateRandomString();
     JitFunction func = JitFunction::create(compiler_)
                            .name(function_name)
                            .arguments({ { "rate constants", JitType::DoublePtr },

--- a/include/micm/process/jit_process_set.hpp
+++ b/include/micm/process/jit_process_set.hpp
@@ -122,12 +122,12 @@ namespace micm
   void JitProcessSet<L>::GenerateForcingFunction()
   {
     std::string function_name = "add_forcing_terms_" + GenerateRandomString();
-    JitFunction func = JitFunction::create(compiler_)
-                           .name(function_name)
-                           .arguments({ { "rate constants", JitType::DoublePtr },
+    JitFunction func = JitFunction::Create(compiler_)
+                           .SetName(function_name)
+                           .SetArguments({ { "rate constants", JitType::DoublePtr },
                                         { "state variables", JitType::DoublePtr },
                                         { "forcing", JitType::DoublePtr } })
-                           .return_type(JitType::Void);
+                           .SetReturnType(JitType::Void);
     llvm::Type *double_type = func.GetType(JitType::Double);
     llvm::Value *zero = llvm::ConstantInt::get(*(func.context_), llvm::APInt(64, 0));
     llvm::Type *rate_array_type = llvm::ArrayType::get(double_type, L);
@@ -224,12 +224,12 @@ namespace micm
   void JitProcessSet<L>::GenerateJacobianFunction(const SparseMatrix<double, SparseMatrixVectorOrdering<L>> &matrix)
   {
     std::string function_name = "subtract_jacobian_terms_" + GenerateRandomString();
-    JitFunction func = JitFunction::create(compiler_)
-                           .name(function_name)
-                           .arguments({ { "rate constants", JitType::DoublePtr },
+    JitFunction func = JitFunction::Create(compiler_)
+                           .SetName(function_name)
+                           .SetArguments({ { "rate constants", JitType::DoublePtr },
                                         { "state variables", JitType::DoublePtr },
                                         { "jacobian", JitType::DoublePtr } })
-                           .return_type(JitType::Void);
+                           .SetReturnType(JitType::Void);
     llvm::Type *double_type = func.GetType(JitType::Double);
     llvm::Value *zero = llvm::ConstantInt::get(*(func.context_), llvm::APInt(64, 0));
     llvm::Type *rate_array_type = llvm::ArrayType::get(double_type, L);

--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -68,7 +68,7 @@ namespace micm
   /// @brief An alias that allows making products easily
   using Yield = std::pair<micm::Species, double>;
 
-  inline Yield yields(micm::Species species, double yield)
+  inline Yield Yields(const micm::Species& species, double yield)
   {
     return Yield(species, yield);
   };
@@ -95,7 +95,7 @@ namespace micm
         State<MatrixPolicy, SparseMatrixPolicy>& state);
 
     friend class ProcessBuilder;
-    static ProcessBuilder create();
+    static ProcessBuilder Create();
     Process(ProcessBuilder& builder);
     Process(const Process& other);
 
@@ -122,7 +122,7 @@ namespace micm
     {
       reactants_ = other.reactants_;
       products_ = other.products_;
-      rate_constant_ = other.rate_constant_->clone();
+      rate_constant_ = other.rate_constant_->Clone();
       phase_ = other.phase_;
 
       return *this;
@@ -167,7 +167,7 @@ namespace micm
           if (reactant.IsParameterized())
             fixed_reactants *= reactant.parameterize_(state.conditions_[i]);
         state.rate_constants_[i][(i_rate_constant++)] =
-            process.rate_constant_->calculate(state.conditions_[i], custom_parameters_iter) * fixed_reactants;
+            process.rate_constant_->Calculate(state.conditions_[i], custom_parameters_iter) * fixed_reactants;
         custom_parameters_iter += process.rate_constant_->SizeCustomParameters();
       }
     }
@@ -203,7 +203,7 @@ namespace micm
             if (reactant.IsParameterized())
               fixed_reactants *= reactant.parameterize_(state.conditions_[i_group * L + i_cell]);
           v_rate_constants[offset_rc + i_cell] =
-              process.rate_constant_->calculate(state.conditions_[i_group * L + i_cell], custom_parameters_iter) *
+              process.rate_constant_->Calculate(state.conditions_[i_group * L + i_cell], custom_parameters_iter) *
               fixed_reactants;
         }
         offset_params += params.size() * L;
@@ -212,7 +212,7 @@ namespace micm
     }
   }
 
-  inline ProcessBuilder Process::create()
+  inline ProcessBuilder Process::Create()
   {
     return ProcessBuilder{};
   };
@@ -225,7 +225,7 @@ namespace micm
   inline Process::Process(const Process& other)
       : reactants_(other.reactants_),
         products_(other.products_),
-        rate_constant_(other.rate_constant_ ? other.rate_constant_->clone() : nullptr),
+        rate_constant_(other.rate_constant_ ? other.rate_constant_->Clone() : nullptr),
         phase_(other.phase_)
   {
   }
@@ -244,7 +244,7 @@ namespace micm
 
   inline ProcessBuilder& ProcessBuilder::rate_constant(const RateConstant& rate_constant)
   {
-    rate_constant_ = rate_constant.clone();
+    rate_constant_ = rate_constant.Clone();
     return *this;
   }
 

--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -142,10 +142,10 @@ namespace micm
     {
       return Process(*this);
     }
-    ProcessBuilder& reactants(const std::vector<Species>& reactants);
-    ProcessBuilder& products(const std::vector<Yield>& products);
-    ProcessBuilder& rate_constant(const RateConstant& rate_constant);
-    ProcessBuilder& phase(const Phase& phase);
+    ProcessBuilder& SetReactants(const std::vector<Species>& reactants);
+    ProcessBuilder& SetProducts(const std::vector<Yield>& products);
+    ProcessBuilder& SetRateConstant(const RateConstant& rate_constant);
+    ProcessBuilder& SetPhase(const Phase& phase);
   };
 
   template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
@@ -230,25 +230,25 @@ namespace micm
   {
   }
 
-  inline ProcessBuilder& ProcessBuilder::reactants(const std::vector<Species>& reactants)
+  inline ProcessBuilder& ProcessBuilder::SetReactants(const std::vector<Species>& reactants)
   {
     reactants_ = reactants;
     return *this;
   }
 
-  inline ProcessBuilder& ProcessBuilder::products(const std::vector<Yield>& products)
+  inline ProcessBuilder& ProcessBuilder::SetProducts(const std::vector<Yield>& products)
   {
     products_ = products;
     return *this;
   }
 
-  inline ProcessBuilder& ProcessBuilder::rate_constant(const RateConstant& rate_constant)
+  inline ProcessBuilder& ProcessBuilder::SetRateConstant(const RateConstant& rate_constant)
   {
     rate_constant_ = rate_constant.Clone();
     return *this;
   }
 
-  inline ProcessBuilder& ProcessBuilder::phase(const Phase& phase)
+  inline ProcessBuilder& ProcessBuilder::SetPhase(const Phase& phase)
   {
     phase_ = phase;
     return *this;

--- a/include/micm/process/rate_constant.hpp
+++ b/include/micm/process/rate_constant.hpp
@@ -66,7 +66,7 @@ namespace micm
     virtual ~RateConstant(){};
 
     /// @brief Deep copy
-    virtual std::unique_ptr<RateConstant> clone() const = 0;
+    virtual std::unique_ptr<RateConstant> Clone() const = 0;
 
     /// @brief Returns a set of labels for user-defined rate constant parameters
     /// @return Vector of custom parameter labels
@@ -85,7 +85,7 @@ namespace micm
     /// @brief Calculate the rate constant for a set of conditions
     /// @param conditions The current environmental conditions of the chemical system
     /// @return The reaction rate constant
-    virtual double calculate(const Conditions& conditions) const
+    virtual double Calculate(const Conditions& conditions) const
     {
       return 0;
     }
@@ -94,7 +94,7 @@ namespace micm
     /// @param conditions The current environmental conditions of the chemical system
     /// @param custom_parameters User defined rate constant parameters
     /// @return The reaction rate constant
-    virtual double calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const
+    virtual double Calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const
     {
       return 0;
     }

--- a/include/micm/process/surface_rate_constant.hpp
+++ b/include/micm/process/surface_rate_constant.hpp
@@ -39,7 +39,7 @@ namespace micm
     SurfaceRateConstant(const SurfaceRateConstantParameters& parameters);
 
     /// @brief Deep copy
-    std::unique_ptr<RateConstant> clone() const override;
+    std::unique_ptr<RateConstant> Clone() const override;
 
     /// @brief Returns labels for the surface rate constant parameters:
     ///        aerosol effective radius [m]
@@ -55,12 +55,12 @@ namespace micm
     /// @param conditions The current environmental conditions of the chemical system
     /// @param custom_parameters User-defined rate constant parameters
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
+    double Calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
 
     /// @brief Calculate the rate constant
     /// @param conditions The current environmental conditions of the chemical system
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions) const override;
+    double Calculate(const Conditions& conditions) const override;
   };
 
   inline SurfaceRateConstant::SurfaceRateConstant(const SurfaceRateConstantParameters& parameters)
@@ -70,17 +70,17 @@ namespace micm
   {
   }
 
-  inline std::unique_ptr<RateConstant> SurfaceRateConstant::clone() const
+  inline std::unique_ptr<RateConstant> SurfaceRateConstant::Clone() const
   {
     return std::unique_ptr<RateConstant>{ new SurfaceRateConstant{ *this } };
   }
 
-  inline double SurfaceRateConstant::calculate(const Conditions& conditions) const
+  inline double SurfaceRateConstant::Calculate(const Conditions& conditions) const
   {
     throw std::system_error(make_error_code(MicmRateConstantErrc::MissingArgumentsForSurfaceRateConstant), "");
   }
 
-  inline double SurfaceRateConstant::calculate(
+  inline double SurfaceRateConstant::Calculate(
       const Conditions& conditions,
       std::vector<double>::const_iterator custom_parameters) const
   {

--- a/include/micm/process/ternary_chemical_activation_rate_constant.hpp
+++ b/include/micm/process/ternary_chemical_activation_rate_constant.hpp
@@ -45,24 +45,24 @@ namespace micm
     TernaryChemicalActivationRateConstant(const TernaryChemicalActivationRateConstantParameters& parameters);
 
     /// @brief Deep copy
-    std::unique_ptr<RateConstant> clone() const override;
+    std::unique_ptr<RateConstant> Clone() const override;
 
     /// @brief Calculate the rate constant
     /// @param conditions The current environmental conditions of the chemical system
     /// @param custom_parameters User-defined rate constant parameters
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
+    double Calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
 
     /// @brief Calculate the rate constant
     /// @param conditions The current environmental conditions of the chemical system
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions) const override;
+    double Calculate(const Conditions& conditions) const override;
 
     /// @brief Calculate the rate constant
     /// @param temperature Temperature in [K]
     /// @param air_number_density Number density in [mol m-3]
     /// @return
-    double calculate(const double& temperature, const double& air_number_density) const;
+    double Calculate(const double& temperature, const double& air_number_density) const;
   };
 
   inline TernaryChemicalActivationRateConstant::TernaryChemicalActivationRateConstant()
@@ -76,26 +76,26 @@ namespace micm
   {
   }
 
-  inline std::unique_ptr<RateConstant> TernaryChemicalActivationRateConstant::clone() const
+  inline std::unique_ptr<RateConstant> TernaryChemicalActivationRateConstant::Clone() const
   {
     return std::unique_ptr<RateConstant>{ new TernaryChemicalActivationRateConstant{ *this } };
   }
 
-  inline double TernaryChemicalActivationRateConstant::calculate(const Conditions& conditions) const
+  inline double TernaryChemicalActivationRateConstant::Calculate(const Conditions& conditions) const
   {
-    double val = calculate(conditions.temperature_, conditions.air_density_);
+    double val = Calculate(conditions.temperature_, conditions.air_density_);
     return val;
   }
 
-  inline double TernaryChemicalActivationRateConstant::calculate(
+  inline double TernaryChemicalActivationRateConstant::Calculate(
       const Conditions& conditions,
       std::vector<double>::const_iterator custom_parameters) const
   {
-    double val = calculate(conditions.temperature_, conditions.air_density_);
+    double val = Calculate(conditions.temperature_, conditions.air_density_);
     return val;
   }
 
-  inline double TernaryChemicalActivationRateConstant::calculate(const double& temperature, const double& air_number_density)
+  inline double TernaryChemicalActivationRateConstant::Calculate(const double& temperature, const double& air_number_density)
       const
   {
     double k0 =

--- a/include/micm/process/troe_rate_constant.hpp
+++ b/include/micm/process/troe_rate_constant.hpp
@@ -45,24 +45,24 @@ namespace micm
     TroeRateConstant(const TroeRateConstantParameters& parameters);
 
     /// @brief Deep copy
-    std::unique_ptr<RateConstant> clone() const override;
+    std::unique_ptr<RateConstant> Clone() const override;
 
     /// @brief Calculate the rate constant
     /// @param conditions The current environmental conditions of the chemical system
     /// @param custom_parameters User-defined rate constant parameters
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
+    double Calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
 
     /// @brief Calculate the rate constant
     /// @param conditions The current environmental conditions of the chemical system
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions) const override;
+    double Calculate(const Conditions& conditions) const override;
 
     /// @brief Calculate the rate constant
     /// @param temperature Temperature in [K]
     /// @param air_number_density Number density in [mol m-3]
     /// @return
-    double calculate(const double& temperature, const double& air_number_density) const;
+    double Calculate(const double& temperature, const double& air_number_density) const;
   };
 
   inline TroeRateConstant::TroeRateConstant()
@@ -75,24 +75,24 @@ namespace micm
   {
   }
 
-  inline std::unique_ptr<RateConstant> TroeRateConstant::clone() const
+  inline std::unique_ptr<RateConstant> TroeRateConstant::Clone() const
   {
     return std::unique_ptr<RateConstant>{ new TroeRateConstant{ *this } };
   }
 
-  inline double TroeRateConstant::calculate(const Conditions& conditions) const
+  inline double TroeRateConstant::Calculate(const Conditions& conditions) const
   {
-    return calculate(conditions.temperature_, conditions.air_density_);
+    return Calculate(conditions.temperature_, conditions.air_density_);
   }
 
-  inline double TroeRateConstant::calculate(
+  inline double TroeRateConstant::Calculate(
       const Conditions& conditions,
       std::vector<double>::const_iterator custom_parameters) const
   {
-    return calculate(conditions.temperature_, conditions.air_density_);
+    return Calculate(conditions.temperature_, conditions.air_density_);
   }
 
-  inline double TroeRateConstant::calculate(const double& temperature, const double& air_number_density) const
+  inline double TroeRateConstant::Calculate(const double& temperature, const double& air_number_density) const
   {
     double k0 =
         parameters_.k0_A_ * std::exp(parameters_.k0_C_ / temperature) * std::pow(temperature / 300.0, parameters_.k0_B_);

--- a/include/micm/process/tunneling_rate_constant.hpp
+++ b/include/micm/process/tunneling_rate_constant.hpp
@@ -35,23 +35,23 @@ namespace micm
     TunnelingRateConstant(const TunnelingRateConstantParameters& parameters);
 
     /// @brief Deep copy
-    std::unique_ptr<RateConstant> clone() const override;
+    std::unique_ptr<RateConstant> Clone() const override;
 
     /// @brief Calculate the rate constant
     /// @param conditions The current environmental conditions of the chemical system
     /// @param custom_parameters User-defined rate constant parameters
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
+    double Calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
 
     /// @brief Calculate the rate constant
     /// @param conditions The current environmental conditions of the chemical system
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions) const override;
+    double Calculate(const Conditions& conditions) const override;
 
     /// @brief Calculate the rate constant
     /// @param temperature Temperature in [K]
     /// @return the calculated rate constant
-    double calculate(const double& temperature) const;
+    double Calculate(const double& temperature) const;
   };
 
   inline TunnelingRateConstant::TunnelingRateConstant()
@@ -64,24 +64,24 @@ namespace micm
   {
   }
 
-  inline std::unique_ptr<RateConstant> TunnelingRateConstant::clone() const
+  inline std::unique_ptr<RateConstant> TunnelingRateConstant::Clone() const
   {
     return std::unique_ptr<RateConstant>{ new TunnelingRateConstant{ *this } };
   }
 
-  inline double TunnelingRateConstant::calculate(const Conditions& conditions) const
+  inline double TunnelingRateConstant::Calculate(const Conditions& conditions) const
   {
-    return calculate(conditions.temperature_);
+    return Calculate(conditions.temperature_);
   }
 
-  inline double TunnelingRateConstant::calculate(
+  inline double TunnelingRateConstant::Calculate(
       const Conditions& conditions,
       std::vector<double>::const_iterator custom_parameters) const
   {
-    return calculate(conditions.temperature_);
+    return Calculate(conditions.temperature_);
   }
 
-  inline double TunnelingRateConstant::calculate(const double& temperature) const
+  inline double TunnelingRateConstant::Calculate(const double& temperature) const
   {
     return parameters_.A_ * std::exp(-parameters_.B_ / temperature + parameters_.C_ / std::pow(temperature, 3));
   }

--- a/include/micm/process/user_defined_rate_constant.hpp
+++ b/include/micm/process/user_defined_rate_constant.hpp
@@ -32,7 +32,7 @@ namespace micm
     UserDefinedRateConstant(const UserDefinedRateConstantParameters& parameters);
 
     /// @brief Deep copy
-    std::unique_ptr<RateConstant> clone() const override;
+    std::unique_ptr<RateConstant> Clone() const override;
 
     /// @brief Returns a label for the user-defined rate constant parameter
     /// @return Rate constant label
@@ -46,12 +46,12 @@ namespace micm
     /// @param conditions The current environmental conditions of the chemical system
     /// @param custom_parameters User-defined rate constant parameters
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
+    double Calculate(const Conditions& conditions, std::vector<double>::const_iterator custom_parameters) const override;
 
     /// @brief Calculate the rate constant
     /// @param conditions The current environmental conditions of the chemical system
     /// @return A rate constant based off of the conditions in the system
-    double calculate(const Conditions& conditions) const override;
+    double Calculate(const Conditions& conditions) const override;
   };
 
   inline UserDefinedRateConstant::UserDefinedRateConstant()
@@ -64,17 +64,17 @@ namespace micm
   {
   }
 
-  inline std::unique_ptr<RateConstant> UserDefinedRateConstant::clone() const
+  inline std::unique_ptr<RateConstant> UserDefinedRateConstant::Clone() const
   {
     return std::unique_ptr<RateConstant>{ new UserDefinedRateConstant{ *this } };
   }
 
-  inline double UserDefinedRateConstant::calculate(const Conditions& conditions) const
+  inline double UserDefinedRateConstant::Calculate(const Conditions& conditions) const
   {
     throw std::system_error(make_error_code(MicmRateConstantErrc::MissingArgumentsForUserDefinedRateConstant), "");
   }
 
-  inline double UserDefinedRateConstant::calculate(
+  inline double UserDefinedRateConstant::Calculate(
       const Conditions& conditions,
       std::vector<double>::const_iterator custom_parameters) const
   {

--- a/include/micm/profiler/instrumentation.hpp
+++ b/include/micm/profiler/instrumentation.hpp
@@ -78,8 +78,7 @@ namespace micm
       json << "\"dur\":" << (result.elapsed_time.count()) << ',';
       json << "\"name\":\"" << result.name << "\",";
       json << "\"ph\":\"X\",";
-      json << "\"pid\":\""
-           << "0\",";
+      json << "\"pid\":0,";
       json << "\"tid\":\"" << result.threadID << "\",";
       json << "\"ts\":" << result.start.count();
       json << "}";
@@ -132,7 +131,6 @@ namespace micm
       }
     }
 
-   private:
     std::mutex mutex_;
     InstrumentationSession* current_session_;
     std::ofstream output_stream_;

--- a/include/micm/solver/cuda_linear_solver.hpp
+++ b/include/micm/solver/cuda_linear_solver.hpp
@@ -87,8 +87,8 @@ namespace micm
       denseMatrix.b_size_ = b.AsVector().size();
       denseMatrix.x_size_ = x.AsVector().size();
       denseMatrix.n_grids_ = b.NumRows();  // number of grids
-      denseMatrix.b_column_counts_ = b[0].size();
-      denseMatrix.x_column_counts_ = x[0].size();
+      denseMatrix.b_column_counts_ = b.NumColumns();
+      denseMatrix.x_column_counts_ = x.NumColumns();
 
       /// Call the "SolveKernelDriver" function that invokes the
       ///   CUDA kernel to perform the "solve" function on the device

--- a/include/micm/solver/jit_linear_solver.inl
+++ b/include/micm/solver/jit_linear_solver.inl
@@ -95,7 +95,7 @@ namespace micm
   template<std::size_t L, template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
   inline void JitLinearSolver<L, SparseMatrixPolicy, LuDecompositionPolicy>::GenerateSolveFunction()
   {
-    std::string function_name = "linear_solve_" + generate_random_string();
+    std::string function_name = "linear_solve_" + GenerateRandomString();
     JitFunction func = JitFunction::create(compiler_)
                            .name(function_name)
                            .arguments({ { "b", JitType::DoublePtr },

--- a/include/micm/solver/jit_linear_solver.inl
+++ b/include/micm/solver/jit_linear_solver.inl
@@ -40,7 +40,7 @@ namespace micm
         compiler_(compiler)
   {
     solve_function_ = NULL;
-    if (matrix.Size() != L || matrix.GroupVectorSize() != L)
+    if (matrix.NumberOfBlocks() != L || matrix.GroupVectorSize() != L)
     {
       std::string msg =
           "JIT functions require the number of grid cells solved together to match the vector dimension template parameter, "
@@ -96,13 +96,13 @@ namespace micm
   inline void JitLinearSolver<L, SparseMatrixPolicy, LuDecompositionPolicy>::GenerateSolveFunction()
   {
     std::string function_name = "linear_solve_" + GenerateRandomString();
-    JitFunction func = JitFunction::create(compiler_)
-                           .name(function_name)
-                           .arguments({ { "b", JitType::DoublePtr },
-                                        { "x", JitType::DoublePtr },
-                                        { "L", JitType::DoublePtr },
-                                        { "U", JitType::DoublePtr } })
-                           .return_type(JitType::Void);
+    JitFunction func = JitFunction::Create(compiler_)
+                           .SetName(function_name)
+                           .SetArguments({ { "b", JitType::DoublePtr },
+                                           { "x", JitType::DoublePtr },
+                                           { "L", JitType::DoublePtr },
+                                           { "U", JitType::DoublePtr } })
+                           .SetReturnType(JitType::Void);
     llvm::Type *double_type = func.GetType(JitType::Double);
     auto Lij_yj = LinearSolver<double, SparseMatrixPolicy, LuDecompositionPolicy>::Lij_yj_.begin();
     auto Uij_xj = LinearSolver<double, SparseMatrixPolicy, LuDecompositionPolicy>::Uij_xj_.begin();

--- a/include/micm/solver/jit_lu_decomposition.inl
+++ b/include/micm/solver/jit_lu_decomposition.inl
@@ -34,7 +34,7 @@ namespace micm
         compiler_(compiler)
   {
     decompose_function_ = NULL;
-    if (matrix.Size() > L)
+    if (matrix.NumberOfBlocks() > L)
     {
       std::string msg =
           "JIT functions require the number of grid cells solved together to match the vector dimension template parameter, "
@@ -59,12 +59,12 @@ namespace micm
   void JitLuDecomposition<L>::GenerateDecomposeFunction()
   {
     std::string function_name = "lu_decompose_" + GenerateRandomString();
-    JitFunction func = JitFunction::create(compiler_)
-                           .name(function_name)
-                           .arguments({ { "A matrix", JitType::DoublePtr },
+    JitFunction func = JitFunction::Create(compiler_)
+                           .SetName(function_name)
+                           .SetArguments({ { "A matrix", JitType::DoublePtr },
                                         { "lower matrix", JitType::DoublePtr },
                                         { "upper matrix", JitType::DoublePtr } })
-                           .return_type(JitType::Void);
+                           .SetReturnType(JitType::Void);
     llvm::Type *double_type = func.GetType(JitType::Double);
     llvm::Value *zero = llvm::ConstantInt::get(*(func.context_), llvm::APInt(64, 0));
     auto do_aik = do_aik_.begin();

--- a/include/micm/solver/jit_lu_decomposition.inl
+++ b/include/micm/solver/jit_lu_decomposition.inl
@@ -58,7 +58,7 @@ namespace micm
   template<std::size_t L>
   void JitLuDecomposition<L>::GenerateDecomposeFunction()
   {
-    std::string function_name = "lu_decompose_" + generate_random_string();
+    std::string function_name = "lu_decompose_" + GenerateRandomString();
     JitFunction func = JitFunction::create(compiler_)
                            .name(function_name)
                            .arguments({ { "A matrix", JitType::DoublePtr },

--- a/include/micm/solver/jit_rosenbrock.hpp
+++ b/include/micm/solver/jit_rosenbrock.hpp
@@ -133,10 +133,10 @@ namespace micm
       std::size_t number_of_nonzero_jacobian_elements = jacobian.AsVector().size();
 
       // Create the JitFunction with the modified name
-      JitFunction func = JitFunction::create(compiler_)
-                             .name("alpha_minus_jacobian")
-                             .arguments({ { "jacobian", JitType::DoublePtr }, { "alpha", JitType::Double } })
-                             .return_type(JitType::Void);
+      JitFunction func = JitFunction::Create(compiler_)
+                             .SetName("alpha_minus_jacobian")
+                             .SetArguments({ { "jacobian", JitType::DoublePtr }, { "alpha", JitType::Double } })
+                             .SetReturnType(JitType::Void);
 
       // constants
       llvm::Value* zero = llvm::ConstantInt::get(*(func.context_), llvm::APInt(64, 0));

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -78,7 +78,7 @@ namespace micm
     auto lu = lu_decomp_.template GetLUMatrices<T, SparseMatrixPolicy>(matrix, initial_value);
     auto lower_matrix = std::move(lu.first);
     auto upper_matrix = std::move(lu.second);
-    for (std::size_t i = 0; i < lower_matrix[0].size(); ++i)
+    for (std::size_t i = 0; i < lower_matrix.NumRows(); ++i)
     {
       std::size_t nLij = 0;
       for (std::size_t j_id = lower_matrix.RowStartVector()[i]; j_id < lower_matrix.RowStartVector()[i + 1]; ++j_id)
@@ -92,7 +92,7 @@ namespace micm
       // There must always be a non-zero element on the diagonal
       nLij_Lii_.push_back(std::make_pair(nLij, lower_matrix.VectorIndex(0, i, i)));
     }
-    for (std::size_t i = upper_matrix[0].size() - 1; i != static_cast<std::size_t>(-1); --i)
+    for (std::size_t i = upper_matrix.NumRows() - 1; i != static_cast<std::size_t>(-1); --i)
     {
       std::size_t nUij = 0;
       for (std::size_t j_id = upper_matrix.RowStartVector()[i]; j_id < upper_matrix.RowStartVector()[i + 1]; ++j_id)

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -127,7 +127,7 @@ namespace micm
     /// @brief Initialize arrays for the LU decomposition
     /// @param A Sparse matrix to decompose
     template<typename T, class SparseMatrixPolicy>
-    void Initialize(const SparseMatrixPolicy& A, T initial_value);
+    void Initialize(const SparseMatrixPolicy& matrix, T initial_value);
   };
 
 }  // namespace micm

--- a/include/micm/solver/lu_decomposition.inl
+++ b/include/micm/solver/lu_decomposition.inl
@@ -163,12 +163,12 @@ namespace micm
         }
       }
     }
-    auto L_builder = SparseMatrixPolicy::Create(n).NumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
+    auto L_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
     for (auto& pair : L_ids)
     {
       L_builder = L_builder.WithElement(pair.first, pair.second);
     }
-    auto U_builder = SparseMatrixPolicy::Create(n).NumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
+    auto U_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
     for (auto& pair : U_ids)
     {
       U_builder = U_builder.WithElement(pair.first, pair.second);

--- a/include/micm/solver/lu_decomposition.inl
+++ b/include/micm/solver/lu_decomposition.inl
@@ -36,13 +36,13 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    std::size_t n = matrix[0].size();
+    std::size_t n = matrix.NumRows();
     auto LU = GetLUMatrices<T, SparseMatrixPolicy>(matrix, initial_value);
     const auto& L_row_start = LU.first.RowStartVector();
     const auto& L_row_ids = LU.first.RowIdsVector();
     const auto& U_row_start = LU.second.RowStartVector();
     const auto& U_row_ids = LU.second.RowIdsVector();
-    for (std::size_t i = 0; i < matrix[0].size(); ++i)
+    for (std::size_t i = 0; i < matrix.NumRows(); ++i)
     {
       std::pair<std::size_t, std::size_t> iLU(0, 0);
       // Upper triangular matrix
@@ -122,7 +122,7 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    std::size_t n = A[0].size();
+    std::size_t n = A.NumRows();
     std::set<std::pair<std::size_t, std::size_t>> L_ids, U_ids;
     const auto& row_start = A.RowStartVector();
     const auto& row_ids = A.RowIdsVector();
@@ -163,15 +163,15 @@ namespace micm
         }
       }
     }
-    auto L_builder = SparseMatrixPolicy::create(n).NumberOfBlocks(A.Size()).initial_value(initial_value);
+    auto L_builder = SparseMatrixPolicy::Create(n).NumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
     for (auto& pair : L_ids)
     {
-      L_builder = L_builder.with_element(pair.first, pair.second);
+      L_builder = L_builder.WithElement(pair.first, pair.second);
     }
-    auto U_builder = SparseMatrixPolicy::create(n).NumberOfBlocks(A.Size()).initial_value(initial_value);
+    auto U_builder = SparseMatrixPolicy::Create(n).NumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
     for (auto& pair : U_ids)
     {
-      U_builder = U_builder.with_element(pair.first, pair.second);
+      U_builder = U_builder.WithElement(pair.first, pair.second);
     }
     std::pair<SparseMatrixPolicy, SparseMatrixPolicy> LU(L_builder, U_builder);
     return LU;
@@ -195,7 +195,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     // Loop over blocks
-    for (std::size_t i_block = 0; i_block < A.Size(); ++i_block)
+    for (std::size_t i_block = 0; i_block < A.NumberOfBlocks(); ++i_block)
     {
       auto A_vector = std::next(A.AsVector().begin(), i_block * A.FlatBlockSize());
       auto L_vector = std::next(L.AsVector().begin(), i_block * L.FlatBlockSize());

--- a/include/micm/solver/lu_decomposition.inl
+++ b/include/micm/solver/lu_decomposition.inl
@@ -163,12 +163,12 @@ namespace micm
         }
       }
     }
-    auto L_builder = SparseMatrixPolicy::create(n).number_of_blocks(A.Size()).initial_value(initial_value);
+    auto L_builder = SparseMatrixPolicy::create(n).NumberOfBlocks(A.Size()).initial_value(initial_value);
     for (auto& pair : L_ids)
     {
       L_builder = L_builder.with_element(pair.first, pair.second);
     }
-    auto U_builder = SparseMatrixPolicy::create(n).number_of_blocks(A.Size()).initial_value(initial_value);
+    auto U_builder = SparseMatrixPolicy::create(n).NumberOfBlocks(A.Size()).initial_value(initial_value);
     for (auto& pair : U_ids)
     {
       U_builder = U_builder.with_element(pair.first, pair.second);

--- a/include/micm/solver/lu_decomposition.inl
+++ b/include/micm/solver/lu_decomposition.inl
@@ -257,14 +257,14 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    std::size_t A_Size = A.Size();
+    std::size_t A_BlockSize = A.NumberOfBlocks();
     std::size_t A_GroupVectorSize = A.GroupVectorSize();
     std::size_t A_GroupSizeOfFlatBlockSize = A.GroupSize(A.FlatBlockSize());
     std::size_t L_GroupSizeOfFlatBlockSize = L.GroupSize(L.FlatBlockSize());
     std::size_t U_GroupSizeOfFlatBlockSize = U.GroupSize(U.FlatBlockSize());
 
     // Loop over groups of blocks
-    for (std::size_t i_group = 0; i_group < A.NumberOfGroups(A_Size); ++i_group)
+    for (std::size_t i_group = 0; i_group < A.NumberOfGroups(A_BlockSize); ++i_group)
     {
       auto A_vector = std::next(A.AsVector().begin(), i_group * A_GroupSizeOfFlatBlockSize);
       auto L_vector = std::next(L.AsVector().begin(), i_group * L_GroupSizeOfFlatBlockSize);
@@ -279,7 +279,7 @@ namespace micm
       auto lkj_uji = lkj_uji_.begin();
       auto uii = uii_.begin();
       is_singular = false;
-      const std::size_t n_cells = std::min(A_GroupVectorSize, A_Size - i_group * A_GroupVectorSize);
+      const std::size_t n_cells = std::min(A_GroupVectorSize, A_BlockSize - i_group * A_GroupVectorSize);
       for (auto& inLU : niLU_)
       {
         // Upper trianglur matrix

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -214,7 +214,7 @@ namespace micm
 
     process_set_ = std::move(create_process_set(processes, variable_map));
 
-    auto jacobian = build_jacobian<SparseMatrixPolicy>(
+    auto jacobian = BuildJacobian<SparseMatrixPolicy>(
         process_set_.NonZeroJacobianElements(), parameters_.number_of_grid_cells_, system.StateSize());
 
     std::vector<std::size_t> jacobian_diagonal_elements;

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -218,8 +218,8 @@ namespace micm
         process_set_.NonZeroJacobianElements(), parameters_.number_of_grid_cells_, system.StateSize());
 
     std::vector<std::size_t> jacobian_diagonal_elements;
-    jacobian_diagonal_elements.reserve(jacobian[0].size());
-    for (std::size_t i = 0; i < jacobian[0].size(); ++i)
+    jacobian_diagonal_elements.reserve(jacobian.NumRows());
+    for (std::size_t i = 0; i < jacobian.NumRows(); ++i)
       jacobian_diagonal_elements.push_back(jacobian.VectorIndex(0, i, i));
 
     state_parameters_ = { .number_of_grid_cells_ = parameters_.number_of_grid_cells_,
@@ -482,7 +482,7 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    for (std::size_t i_block = 0; i_block < jacobian.Size(); ++i_block)
+    for (std::size_t i_block = 0; i_block < jacobian.NumberOfBlocks(); ++i_block)
     {
       auto jacobian_vector = std::next(jacobian.AsVector().begin(), i_block * jacobian.FlatBlockSize());
       for (const auto& i_elem : state_parameters_.jacobian_diagonal_elements_)

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -84,7 +84,7 @@ namespace micm
       class ProcessSetPolicy>
   inline RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy, ProcessSetPolicy>::RosenbrockSolver()
       : processes_(),
-        parameters_(RosenbrockSolverParameters::three_stage_rosenbrock_parameters()),
+        parameters_(RosenbrockSolverParameters::ThreeStageRosenbrockParameters()),
         state_parameters_(),
         process_set_(),
         linear_solver_()
@@ -504,7 +504,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     const std::size_t n_cells = jacobian.GroupVectorSize();
-    for (std::size_t i_group = 0; i_group < jacobian.NumberOfGroups(jacobian.Size()); ++i_group)
+    for (std::size_t i_group = 0; i_group < jacobian.NumberOfGroups(jacobian.NumberOfBlocks()); ++i_group)
     {
       auto jacobian_vector = std::next(jacobian.AsVector().begin(), i_group * jacobian.GroupSize(jacobian.FlatBlockSize()));
       for (const auto& i_elem : state_parameters_.jacobian_diagonal_elements_)

--- a/include/micm/solver/rosenbrock_solver_parameters.hpp
+++ b/include/micm/solver/rosenbrock_solver_parameters.hpp
@@ -65,41 +65,41 @@ namespace micm
     bool ignore_unused_species_{ false };  // Allow unused species to be included in state and solve
 
     // Print RosenbrockSolverParameters to console
-    void print() const;
+    void Print() const;
 
     /// @brief an L-stable method, 2 stages, order 2
     /// @param number_of_grid_cells
     /// @param reorder_state
     /// @return
-    static RosenbrockSolverParameters two_stage_rosenbrock_parameters(
+    static RosenbrockSolverParameters TwoStageRosenbrockParameters(
         size_t number_of_grid_cells = 1,
         bool reorder_state = true);
     /// @brief an L-stable method, 3 stages, order 3, 2 function evaluations
     /// @param number_of_grid_cells
     /// @param reorder_state
     /// @return
-    static RosenbrockSolverParameters three_stage_rosenbrock_parameters(
+    static RosenbrockSolverParameters ThreeStageRosenbrockParameters(
         size_t number_of_grid_cells = 1,
         bool reorder_state = true);
     /// @brief L-stable rosenbrock method of order 4, with 4 stages
     /// @param number_of_grid_cells
     /// @param reorder_state
     /// @return
-    static RosenbrockSolverParameters four_stage_rosenbrock_parameters(
+    static RosenbrockSolverParameters FourStageRosenbrockParameters(
         size_t number_of_grid_cells = 1,
         bool reorder_state = true);
     /// @brief A stiffly-stable method, 4 stages, order 3
     /// @param number_of_grid_cells
     /// @param reorder_state
     /// @return
-    static RosenbrockSolverParameters four_stage_differential_algebraic_rosenbrock_parameters(
+    static RosenbrockSolverParameters FourStageDifferentialAlgebraicRosenbrockParameters(
         size_t number_of_grid_cells = 1,
         bool reorder_state = true);
     /// @brief stiffly-stable rosenbrock method of order 4, with 6 stages
     /// @param number_of_grid_cells
     /// @param reorder_state
     /// @return
-    static RosenbrockSolverParameters six_stage_differential_algebraic_rosenbrock_parameters(
+    static RosenbrockSolverParameters SixStageDifferentialAlgebraicRosenbrockParameters(
         size_t number_of_grid_cells = 1,
         bool reorder_state = true);
 
@@ -107,7 +107,7 @@ namespace micm
     RosenbrockSolverParameters() = default;
   };
 
-  inline void RosenbrockSolverParameters::print() const
+  inline void RosenbrockSolverParameters::Print() const
   {
     std::cout << "stages_: " << stages_ << std::endl;
     std::cout << "upper_limit_tolerance_: " << upper_limit_tolerance_ << std::endl;
@@ -159,7 +159,7 @@ namespace micm
     std::cout << "number_of_grid_cells_: " << number_of_grid_cells_ << std::endl;
   }
 
-  inline RosenbrockSolverParameters RosenbrockSolverParameters::two_stage_rosenbrock_parameters(
+  inline RosenbrockSolverParameters RosenbrockSolverParameters::TwoStageRosenbrockParameters(
       size_t number_of_grid_cells,
       bool reorder_state)
   {
@@ -203,7 +203,7 @@ namespace micm
     return parameters;
   }
 
-  inline RosenbrockSolverParameters RosenbrockSolverParameters::three_stage_rosenbrock_parameters(
+  inline RosenbrockSolverParameters RosenbrockSolverParameters::ThreeStageRosenbrockParameters(
       size_t number_of_grid_cells,
       bool reorder_state)
   {
@@ -259,7 +259,7 @@ namespace micm
     return parameters;
   }
 
-  inline RosenbrockSolverParameters RosenbrockSolverParameters::four_stage_rosenbrock_parameters(
+  inline RosenbrockSolverParameters RosenbrockSolverParameters::FourStageRosenbrockParameters(
       size_t number_of_grid_cells,
       bool reorder_state)
   {
@@ -328,7 +328,7 @@ namespace micm
     return parameters;
   }
 
-  inline RosenbrockSolverParameters RosenbrockSolverParameters::four_stage_differential_algebraic_rosenbrock_parameters(
+  inline RosenbrockSolverParameters RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters(
       size_t number_of_grid_cells,
       bool reorder_state)
   {
@@ -383,7 +383,7 @@ namespace micm
     return parameters;
   }
 
-  inline RosenbrockSolverParameters RosenbrockSolverParameters::six_stage_differential_algebraic_rosenbrock_parameters(
+  inline RosenbrockSolverParameters RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters(
       size_t number_of_grid_cells,
       bool reorder_state)
   {

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -90,7 +90,7 @@ namespace micm
     for (auto& label : parameters.custom_rate_parameter_labels_)
       custom_rate_parameter_map_[label] = index++;
 
-    jacobian_ = build_jacobian<SparseMatrixPolicy>(
+    jacobian_ = BuildJacobian<SparseMatrixPolicy>(
         parameters.nonzero_jacobian_elements_, parameters.number_of_grid_cells_, state_size_);
 
     auto lu = LuDecomposition::GetLUMatrices<double, SparseMatrixPolicy>(jacobian_, 1.0e-30);

--- a/include/micm/system/conditions.hpp
+++ b/include/micm/system/conditions.hpp
@@ -10,7 +10,7 @@ namespace micm
   struct Conditions
   {
     double temperature_{ 0.0 };  // K
-    double pressure_{ 0.0 };     // Pa;
+    double pressure_{ 0.0 };     // Pa
     double air_density_{ 1.0 };  // mol m-3
   };
 }  // namespace micm

--- a/include/micm/system/phase.hpp
+++ b/include/micm/system/phase.hpp
@@ -23,7 +23,6 @@ namespace micm
     /// @brief The list of species
     std::vector<Species> species_;
 
-   public:
     /// @brief Default constructor
     Phase()
         : species_()

--- a/include/micm/system/system.hpp
+++ b/include/micm/system/system.hpp
@@ -32,7 +32,6 @@ namespace micm
     /// @brief This is a catchall for anything that is not the gas phase.
     std::unordered_map<std::string, Phase> phases_;
 
-   public:
     /// @brief Default constructor
     System()
         : gas_phase_(),

--- a/include/micm/util/jacobian.hpp
+++ b/include/micm/util/jacobian.hpp
@@ -12,17 +12,17 @@ namespace micm
   template<template<class> class SparseMatrixPolicy>
   SparseMatrixPolicy<double> BuildJacobian(
       const std::set<std::pair<std::size_t, std::size_t>>& nonzero_jacobian_elements,
-      size_t number_of_grid_cells,
-      size_t state_size)
+      std::size_t number_of_grid_cells,
+      std::size_t state_size)
   {
     MICM_PROFILE_FUNCTION();
 
-    auto builder = SparseMatrixPolicy<double>::create(state_size).NumberOfBlocks(number_of_grid_cells);
+    auto builder = SparseMatrixPolicy<double>::Create(state_size).NumberOfBlocks(number_of_grid_cells);
     for (auto& elem : nonzero_jacobian_elements)
-      builder = builder.with_element(elem.first, elem.second);
+      builder = builder.WithElement(elem.first, elem.second);
     // Always include diagonal elements
     for (std::size_t i = 0; i < state_size; ++i)
-      builder = builder.with_element(i, i);
+      builder = builder.WithElement(i, i);
 
     return SparseMatrixPolicy<double>(builder);
   }

--- a/include/micm/util/jacobian.hpp
+++ b/include/micm/util/jacobian.hpp
@@ -17,7 +17,7 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    auto builder = SparseMatrixPolicy<double>::Create(state_size).NumberOfBlocks(number_of_grid_cells);
+    auto builder = SparseMatrixPolicy<double>::Create(state_size).SetNumberOfBlocks(number_of_grid_cells);
     for (auto& elem : nonzero_jacobian_elements)
       builder = builder.WithElement(elem.first, elem.second);
     // Always include diagonal elements

--- a/include/micm/util/jacobian.hpp
+++ b/include/micm/util/jacobian.hpp
@@ -10,14 +10,14 @@ namespace micm
 {
   // annonymous namespace to hide jacobian builder
   template<template<class> class SparseMatrixPolicy>
-  SparseMatrixPolicy<double> build_jacobian(
-      std::set<std::pair<std::size_t, std::size_t>> nonzero_jacobian_elements,
+  SparseMatrixPolicy<double> BuildJacobian(
+      const std::set<std::pair<std::size_t, std::size_t>>& nonzero_jacobian_elements,
       size_t number_of_grid_cells,
       size_t state_size)
   {
     MICM_PROFILE_FUNCTION();
 
-    auto builder = SparseMatrixPolicy<double>::create(state_size).number_of_blocks(number_of_grid_cells);
+    auto builder = SparseMatrixPolicy<double>::create(state_size).NumberOfBlocks(number_of_grid_cells);
     for (auto& elem : nonzero_jacobian_elements)
       builder = builder.with_element(elem.first, elem.second);
     // Always include diagonal elements

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -69,7 +69,7 @@ namespace micm
       {
         return std::vector<T>(this->begin(), this->end());
       }
-      std::size_t size() const
+      std::size_t Size() const
       {
         return y_dim_;
       }
@@ -112,7 +112,7 @@ namespace micm
       {
         return std::vector<T>(this->begin(), this->end());
       }
-      std::size_t size() const
+      std::size_t Size() const
       {
         return y_dim_;
       }

--- a/include/micm/util/property_keys.hpp
+++ b/include/micm/util/property_keys.hpp
@@ -4,5 +4,7 @@
  */
 #pragma once
 
+#include <string>
+
 static const std::string GAS_DIFFUSION_COEFFICIENT = "diffusion coefficient [m2 s-1]";
 static const std::string MOLECULAR_WEIGHT = "molecular weight [kg mol-1]";

--- a/include/micm/util/random_string.hpp
+++ b/include/micm/util/random_string.hpp
@@ -10,7 +10,7 @@
 
 namespace micm
 {
-  std::string generate_random_string()
+  std::string GenerateRandomString()
   {
     auto now = std::chrono::system_clock::now();
     auto epoch = now.time_since_epoch();

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -274,7 +274,7 @@ namespace micm
       return SparseMatrix<T, OrderingPolicy>(*this);
     }
 
-    SparseMatrixBuilder& number_of_blocks(std::size_t n)
+    SparseMatrixBuilder& NumberOfBlocks(std::size_t n)
     {
       number_of_blocks_ = n;
       return *this;

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -284,6 +284,7 @@ namespace micm
       return SparseMatrix<T, OrderingPolicy>(*this);
     }
 
+    // TODO(jiwon) - Name SetNumberOfBlocks
     SparseMatrixBuilder& NumberOfBlocks(std::size_t n)
     {
       number_of_blocks_ = n;

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -73,7 +73,7 @@ namespace micm
       {
       }
 
-      std::size_t size() const
+      std::size_t Size() const
       {
         return matrix_.row_start_.size() - 1;
       }
@@ -98,7 +98,7 @@ namespace micm
       {
       }
 
-      std::size_t size() const
+      std::size_t Size() const
       {
         return matrix_.row_start_.size() - 1;
       }
@@ -121,7 +121,7 @@ namespace micm
       {
       }
 
-      std::size_t size() const
+      std::size_t Size() const
       {
         return matrix_.row_start_.size() - 1;
       }
@@ -144,7 +144,7 @@ namespace micm
       {
       }
 
-      std::size_t size() const
+      std::size_t Size() const
       {
         return matrix_.row_start_.size() - 1;
       }
@@ -156,7 +156,7 @@ namespace micm
     };
 
    public:
-    static SparseMatrixBuilder<T, OrderingPolicy> create(std::size_t block_size)
+    static SparseMatrixBuilder<T, OrderingPolicy> Create(std::size_t block_size)
     {
       return SparseMatrixBuilder<T, OrderingPolicy>{ block_size };
     }
@@ -215,9 +215,19 @@ namespace micm
       return false;
     }
 
-    std::size_t Size() const
+    std::size_t NumberOfBlocks() const
     {
       return number_of_blocks_;
+    }
+
+    std::size_t NumRows() const
+    {
+      return row_start_.size() - 1;
+    }
+
+    std::size_t NumColumns() const
+    {
+      return NumRows();
     }
 
     std::size_t FlatBlockSize() const
@@ -280,7 +290,7 @@ namespace micm
       return *this;
     }
 
-    SparseMatrixBuilder& with_element(std::size_t x, std::size_t y)
+    SparseMatrixBuilder& WithElement(std::size_t x, std::size_t y)
     {
       if (x >= block_size_ || y >= block_size_)
         throw std::system_error(make_error_code(MicmMatrixErrc::ElementOutOfRange));
@@ -288,7 +298,7 @@ namespace micm
       return *this;
     }
 
-    SparseMatrixBuilder& initial_value(T inital_value)
+    SparseMatrixBuilder& InitialValue(T inital_value)
     {
       initial_value_ = inital_value;
       return *this;

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -284,8 +284,7 @@ namespace micm
       return SparseMatrix<T, OrderingPolicy>(*this);
     }
 
-    // TODO(jiwon) - Name SetNumberOfBlocks
-    SparseMatrixBuilder& NumberOfBlocks(std::size_t n)
+    SparseMatrixBuilder& SetNumberOfBlocks(std::size_t n)
     {
       number_of_blocks_ = n;
       return *this;

--- a/include/micm/util/sparse_matrix_standard_ordering.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering.hpp
@@ -27,13 +27,13 @@ namespace micm
       return number_of_blocks * row_ids.size();
     };
 
-    std::size_t VectorIndex(
+    static std::size_t VectorIndex(
         std::size_t number_of_blocks,
         const std::vector<std::size_t>& row_ids,
         const std::vector<std::size_t>& row_start,
         std::size_t block,
         std::size_t row,
-        std::size_t column) const
+        std::size_t column)
     {
       if (row >= row_start.size() - 1 || column >= row_start.size() - 1 || block >= number_of_blocks)
         throw std::system_error(make_error_code(MicmMatrixErrc::ElementOutOfRange));

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -91,7 +91,7 @@ namespace micm
         return vec;
       }
 
-      std::size_t size() const
+      std::size_t Size() const
       {
         return y_dim_;
       }
@@ -130,7 +130,7 @@ namespace micm
         return vec;
       }
 
-      std::size_t size() const
+      std::size_t Size() const
       {
         return y_dim_;
       }

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -255,7 +255,7 @@ namespace micm
       const std::size_t l = x_dim_ % L;
       for (std::size_t i = 0; i < y_dim_; ++i)
         for (std::size_t j = 0; j < l; ++j)
-          y_iter[i * L + j] += alpha * x_iter[i * L + j];
+          y_iter[(i * L) + j] += alpha * x_iter[(i * L) + j];
     }
 
     void ForEach(const std::function<void(T &, const T &)> f, const VectorMatrix &a)
@@ -268,7 +268,7 @@ namespace micm
       const std::size_t l = x_dim_ % L;
       for (std::size_t y = 0; y < y_dim_; ++y)
         for (std::size_t x = 0; x < l; ++x)
-          f(this_iter[y * L + x], a_iter[y * L + x]);
+          f(this_iter[(y * L) + x], a_iter[(y * L) + x]);
     }
 
     void ForEach(const std::function<void(T &, const T &, const T &)> f, const VectorMatrix &a, const VectorMatrix &b)
@@ -286,7 +286,7 @@ namespace micm
       {
         for (std::size_t y = 0; y < y_dim_; ++y)
           for (std::size_t x = 0; x < l; ++x)
-            f(this_iter[y * L + x], a_iter[y * L + x], b_iter[y * L + x]);
+            f(this_iter[(y * L) + x], a_iter[(y * L) + x], b_iter[(y * L) + x]);
       }
     }
 

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -82,7 +82,7 @@ namespace micm
     // Specific CUDA device function to do reduction within a warp
     // Use volatile to prevent compiler optimization (caching in registers)
     // No need to synchronize threads in the same warp
-    __device__ void warpReduce(volatile double* sdata, size_t tid)
+    __device__ void WarpReduce(volatile double* sdata, size_t tid)
     {
       if (BLOCK_SIZE >= 64)
         sdata[tid] += sdata[tid + 32];
@@ -190,7 +190,7 @@ namespace micm
         __syncthreads();
       }
       if (l_tid < 32)
-        warpReduce(sdata, l_tid);
+        WarpReduce(sdata, l_tid);
 
       // Let the thread 0 of this threadblock write its result to output array, inexed by this threadblock
       if (l_tid == 0)

--- a/test/integration/analytical_jit_rosenbrock.cpp
+++ b/test/integration/analytical_jit_rosenbrock.cpp
@@ -19,7 +19,7 @@ using DefaultJitRosenbrockSolver = micm::JitRosenbrockSolver<
 
 TEST(AnalyticalExamplesJitRosenbrock, Troe)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -29,14 +29,14 @@ TEST(AnalyticalExamplesJitRosenbrock, Troe)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, TroeSuperStiffButAnalytical)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -46,14 +46,14 @@ TEST(AnalyticalExamplesJitRosenbrock, TroeSuperStiffButAnalytical)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, Photolysis)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -63,14 +63,14 @@ TEST(AnalyticalExamplesJitRosenbrock, Photolysis)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, PhotolysisSuperStiffButAnalytical)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -80,14 +80,14 @@ TEST(AnalyticalExamplesJitRosenbrock, PhotolysisSuperStiffButAnalytical)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, TernaryChemicalActivation)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -97,14 +97,14 @@ TEST(AnalyticalExamplesJitRosenbrock, TernaryChemicalActivation)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, TernaryChemicalActivationSuperStiffButAnalytical)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -114,14 +114,14 @@ TEST(AnalyticalExamplesJitRosenbrock, TernaryChemicalActivationSuperStiffButAnal
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, Tunneling)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -131,14 +131,14 @@ TEST(AnalyticalExamplesJitRosenbrock, Tunneling)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, TunnelingSuperStiffButAnalytical)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -148,14 +148,14 @@ TEST(AnalyticalExamplesJitRosenbrock, TunnelingSuperStiffButAnalytical)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, Arrhenius)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -165,14 +165,14 @@ TEST(AnalyticalExamplesJitRosenbrock, Arrhenius)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, ArrheniusSuperStiffButAnalytical)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -182,14 +182,14 @@ TEST(AnalyticalExamplesJitRosenbrock, ArrheniusSuperStiffButAnalytical)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, Branched)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -199,14 +199,14 @@ TEST(AnalyticalExamplesJitRosenbrock, Branched)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, BranchedSuperStiffButAnalytical)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -216,14 +216,14 @@ TEST(AnalyticalExamplesJitRosenbrock, BranchedSuperStiffButAnalytical)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, Robertson)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -233,14 +233,14 @@ TEST(AnalyticalExamplesJitRosenbrock, Robertson)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, SurfaceRxn)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -250,7 +250,7 @@ TEST(AnalyticalExamplesJitRosenbrock, SurfaceRxn)
       [&](const micm::System& s, const std::vector<micm::Process>& p) -> DefaultJitRosenbrockSolver
       {
         return DefaultJitRosenbrockSolver{
-          jit.get(), s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          jit.get(), s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -90,15 +90,15 @@ void test_analytical_troe(
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::TroeRateConstant({ .k0_A_ = 4.0e-10 }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ b })
-                         .products({ yields(c, 1) })
+                         .products({ Yields(c, 1) })
                          .rate_constant(micm::TroeRateConstant({ .k0_A_ = 1.2e-3,
                                                                  .k0_B_ = 167,
                                                                  .k0_C_ = 3,
@@ -209,21 +209,21 @@ void test_analytical_stiff_troe(
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a1 })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::TroeRateConstant({ .k0_A_ = 4.0e-10 }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ a2 })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::TroeRateConstant({ .k0_A_ = 4.0e-10 }))
                          .phase(gas_phase);
 
-  micm::Process r3 = micm::Process::create()
+  micm::Process r3 = micm::Process::Create()
                          .reactants({ b })
-                         .products({ yields(c, 1) })
+                         .products({ Yields(c, 1) })
                          .rate_constant(micm::TroeRateConstant({ .k0_A_ = 1.2e-3,
                                                                  .k0_B_ = 167,
                                                                  .k0_C_ = 3,
@@ -234,15 +234,15 @@ void test_analytical_stiff_troe(
                                                                  .N_ = 0.8 }))
                          .phase(gas_phase);
 
-  micm::Process r4 = micm::Process::create()
+  micm::Process r4 = micm::Process::Create()
                          .reactants({ a1 })
-                         .products({ yields(a2, 1) })
+                         .products({ Yields(a2, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
                          .phase(gas_phase);
 
-  micm::Process r5 = micm::Process::create()
+  micm::Process r5 = micm::Process::Create()
                          .reactants({ a2 })
-                         .products({ yields(a1, 1) })
+                         .products({ Yields(a1, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
                          .phase(gas_phase);
 
@@ -344,15 +344,15 @@ void test_analytical_photolysis(
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "photoA" }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ b })
-                         .products({ yields(c, 1) })
+                         .products({ Yields(c, 1) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "photoB" }))
                          .phase(gas_phase);
 
@@ -453,33 +453,33 @@ void test_analytical_stiff_photolysis(
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a1 })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "photoA1B" }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ a2 })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "photoA2B" }))
                          .phase(gas_phase);
 
-  micm::Process r3 = micm::Process::create()
+  micm::Process r3 = micm::Process::Create()
                          .reactants({ b })
-                         .products({ yields(c, 1) })
+                         .products({ Yields(c, 1) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "photoB" }))
                          .phase(gas_phase);
 
-  micm::Process r4 = micm::Process::create()
+  micm::Process r4 = micm::Process::Create()
                          .reactants({ a1 })
-                         .products({ yields(a2, 1) })
+                         .products({ Yields(a2, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
                          .phase(gas_phase);
 
-  micm::Process r5 = micm::Process::create()
+  micm::Process r5 = micm::Process::Create()
                          .reactants({ a2 })
-                         .products({ yields(a1, 1) })
+                         .products({ Yields(a1, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
                          .phase(gas_phase);
 
@@ -581,15 +581,15 @@ void test_analytical_ternary_chemical_activation(
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 4.0e-10, .kinf_A_ = 1 }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ b })
-                         .products({ yields(c, 1) })
+                         .products({ Yields(c, 1) })
                          .rate_constant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2e-3,
                                                                                       .k0_B_ = 167,
                                                                                       .k0_C_ = 3,
@@ -700,21 +700,21 @@ void test_analytical_stiff_ternary_chemical_activation(
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a1 })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 4.0e-10, .kinf_A_ = 1 }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ a2 })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 4.0e-10, .kinf_A_ = 1 }))
                          .phase(gas_phase);
 
-  micm::Process r3 = micm::Process::create()
+  micm::Process r3 = micm::Process::Create()
                          .reactants({ b })
-                         .products({ yields(c, 1) })
+                         .products({ Yields(c, 1) })
                          .rate_constant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2e-3,
                                                                                       .k0_B_ = 167,
                                                                                       .k0_C_ = 3,
@@ -725,15 +725,15 @@ void test_analytical_stiff_ternary_chemical_activation(
                                                                                       .N_ = 0.8 }))
                          .phase(gas_phase);
 
-  micm::Process r4 = micm::Process::create()
+  micm::Process r4 = micm::Process::Create()
                          .reactants({ a1 })
-                         .products({ yields(a2, 1) })
+                         .products({ Yields(a2, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
                          .phase(gas_phase);
 
-  micm::Process r5 = micm::Process::create()
+  micm::Process r5 = micm::Process::Create()
                          .reactants({ a2 })
-                         .products({ yields(a1, 1) })
+                         .products({ Yields(a1, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
                          .phase(gas_phase);
 
@@ -836,15 +836,15 @@ void test_analytical_tunneling(
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::TunnelingRateConstant({ .A_ = 4.0e-3 }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ b })
-                         .products({ yields(c, 1) })
+                         .products({ Yields(c, 1) })
                          .rate_constant(micm::TunnelingRateConstant({ .A_ = 1.2e-4, .B_ = 167, .C_ = 1.0e8 }))
                          .phase(gas_phase);
 
@@ -942,33 +942,33 @@ void test_analytical_stiff_tunneling(
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a1 })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::TunnelingRateConstant({ .A_ = 4.0e-3 }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ a2 })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::TunnelingRateConstant({ .A_ = 4.0e-3 }))
                          .phase(gas_phase);
 
-  micm::Process r3 = micm::Process::create()
+  micm::Process r3 = micm::Process::Create()
                          .reactants({ b })
-                         .products({ yields(c, 1) })
+                         .products({ Yields(c, 1) })
                          .rate_constant(micm::TunnelingRateConstant({ .A_ = 1.2e-4, .B_ = 167, .C_ = 1.0e8 }))
                          .phase(gas_phase);
 
-  micm::Process r4 = micm::Process::create()
+  micm::Process r4 = micm::Process::Create()
                          .reactants({ a1 })
-                         .products({ yields(a2, 1) })
+                         .products({ Yields(a2, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
                          .phase(gas_phase);
 
-  micm::Process r5 = micm::Process::create()
+  micm::Process r5 = micm::Process::Create()
                          .reactants({ a2 })
-                         .products({ yields(a1, 1) })
+                         .products({ Yields(a1, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
                          .phase(gas_phase);
 
@@ -1066,16 +1066,16 @@ void test_analytical_arrhenius(
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e-3, .C_ = 50 }))
                          .phase(gas_phase);
 
   micm::Process r2 =
-      micm::Process::create()
+      micm::Process::Create()
           .reactants({ b })
-          .products({ yields(c, 1) })
+          .products({ Yields(c, 1) })
           .rate_constant(micm::ArrheniusRateConstant({ .A_ = 1.2e-4, .B_ = 7, .C_ = 75, .D_ = 50, .E_ = 0.5 }))
           .phase(gas_phase);
 
@@ -1173,34 +1173,34 @@ void test_analytical_stiff_arrhenius(
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a1 })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e-3, .C_ = 50 }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ a2 })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e-3, .C_ = 50 }))
                          .phase(gas_phase);
 
   micm::Process r3 =
-      micm::Process::create()
+      micm::Process::Create()
           .reactants({ b })
-          .products({ yields(c, 1) })
+          .products({ Yields(c, 1) })
           .rate_constant(micm::ArrheniusRateConstant({ .A_ = 1.2e-4, .B_ = 167, .C_ = 75, .D_ = 50, .E_ = 0.5 }))
           .phase(gas_phase);
 
-  micm::Process r4 = micm::Process::create()
+  micm::Process r4 = micm::Process::Create()
                          .reactants({ a1 })
-                         .products({ yields(a2, 1) })
+                         .products({ Yields(a2, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
                          .phase(gas_phase);
 
-  micm::Process r5 = micm::Process::create()
+  micm::Process r5 = micm::Process::Create()
                          .reactants({ a2 })
-                         .products({ yields(a1, 1) })
+                         .products({ Yields(a1, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
                          .phase(gas_phase);
 
@@ -1300,9 +1300,9 @@ void test_analytical_branched(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
   micm::Process r1 =
-      micm::Process::create()
+      micm::Process::Create()
           .reactants({ a })
-          .products({ yields(b, 1) })
+          .products({ Yields(b, 1) })
           .rate_constant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
                                                       .X_ = 1.2,
                                                       .Y_ = 204.3,
@@ -1311,9 +1311,9 @@ void test_analytical_branched(
           .phase(gas_phase);
 
   micm::Process r2 =
-      micm::Process::create()
+      micm::Process::Create()
           .reactants({ b })
-          .products({ yields(c, 1) })
+          .products({ Yields(c, 1) })
           .rate_constant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate,
                                                       .X_ = 1.2,
                                                       .Y_ = 204.3,
@@ -1431,9 +1431,9 @@ void test_analytical_stiff_branched(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
 
   micm::Process r1 =
-      micm::Process::create()
+      micm::Process::Create()
           .reactants({ a1 })
-          .products({ yields(b, 1) })
+          .products({ Yields(b, 1) })
           .rate_constant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
                                                       .X_ = 1.2,
                                                       .Y_ = 204.3,
@@ -1442,9 +1442,9 @@ void test_analytical_stiff_branched(
           .phase(gas_phase);
 
   micm::Process r2 =
-      micm::Process::create()
+      micm::Process::Create()
           .reactants({ a2 })
-          .products({ yields(b, 1) })
+          .products({ Yields(b, 1) })
           .rate_constant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
                                                       .X_ = 1.2,
                                                       .Y_ = 204.3,
@@ -1453,9 +1453,9 @@ void test_analytical_stiff_branched(
           .phase(gas_phase);
 
   micm::Process r3 =
-      micm::Process::create()
+      micm::Process::Create()
           .reactants({ b })
-          .products({ yields(c, 1) })
+          .products({ Yields(c, 1) })
           .rate_constant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate,
                                                       .X_ = 1.2,
                                                       .Y_ = 204.3,
@@ -1463,15 +1463,15 @@ void test_analytical_stiff_branched(
                                                       .n_ = 2 }))
           .phase(gas_phase);
 
-  micm::Process r4 = micm::Process::create()
+  micm::Process r4 = micm::Process::Create()
                          .reactants({ a1 })
-                         .products({ yields(a2, 1) })
+                         .products({ Yields(a2, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
                          .phase(gas_phase);
 
-  micm::Process r5 = micm::Process::create()
+  micm::Process r5 = micm::Process::Create()
                          .reactants({ a2 })
-                         .products({ yields(a1, 1) })
+                         .products({ Yields(a1, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
                          .phase(gas_phase);
 
@@ -1591,21 +1591,21 @@ void test_analytical_robertson(
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ b, b })
-                         .products({ yields(b, 1), yields(c, 1) })
+                         .products({ Yields(b, 1), Yields(c, 1) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .phase(gas_phase);
 
-  micm::Process r3 = micm::Process::create()
+  micm::Process r3 = micm::Process::Create()
                          .reactants({ b, c })
-                         .products({ yields(a, 1), yields(c, 1) })
+                         .products({ Yields(a, 1), Yields(c, 1) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .phase(gas_phase);
 

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -91,15 +91,15 @@ void test_analytical_troe(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::TroeRateConstant({ .k0_A_ = 4.0e-10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::TroeRateConstant({ .k0_A_ = 4.0e-10 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ b })
-                         .products({ Yields(c, 1) })
-                         .rate_constant(micm::TroeRateConstant({ .k0_A_ = 1.2e-3,
+                         .SetReactants({ b })
+                         .SetProducts({ Yields(c, 1) })
+                         .SetRateConstant(micm::TroeRateConstant({ .k0_A_ = 1.2e-3,
                                                                  .k0_B_ = 167,
                                                                  .k0_C_ = 3,
                                                                  .kinf_A_ = 136,
@@ -107,7 +107,7 @@ void test_analytical_troe(
                                                                  .kinf_C_ = 24,
                                                                  .Fc_ = 0.9,
                                                                  .N_ = 0.8 }))
-                         .phase(gas_phase);
+                         .SetPhase(gas_phase);
 
   OdeSolverPolicy solver =
       create_solver(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2 });
@@ -210,21 +210,21 @@ void test_analytical_stiff_troe(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a1 })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::TroeRateConstant({ .k0_A_ = 4.0e-10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a1 })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::TroeRateConstant({ .k0_A_ = 4.0e-10 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ a2 })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::TroeRateConstant({ .k0_A_ = 4.0e-10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a2 })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::TroeRateConstant({ .k0_A_ = 4.0e-10 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
-                         .reactants({ b })
-                         .products({ Yields(c, 1) })
-                         .rate_constant(micm::TroeRateConstant({ .k0_A_ = 1.2e-3,
+                         .SetReactants({ b })
+                         .SetProducts({ Yields(c, 1) })
+                         .SetRateConstant(micm::TroeRateConstant({ .k0_A_ = 1.2e-3,
                                                                  .k0_B_ = 167,
                                                                  .k0_C_ = 3,
                                                                  .kinf_A_ = 136,
@@ -232,19 +232,19 @@ void test_analytical_stiff_troe(
                                                                  .kinf_C_ = 24,
                                                                  .Fc_ = 0.9,
                                                                  .N_ = 0.8 }))
-                         .phase(gas_phase);
+                         .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
-                         .reactants({ a1 })
-                         .products({ Yields(a2, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a1 })
+                         .SetProducts({ Yields(a2, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
-                         .reactants({ a2 })
-                         .products({ Yields(a1, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a2 })
+                         .SetProducts({ Yields(a1, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
+                         .SetPhase(gas_phase);
 
   OdeSolverPolicy solver = create_solver(
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2, r3, r4, r5 });
@@ -345,16 +345,16 @@ void test_analytical_photolysis(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "photoA" }))
-                         .phase(gas_phase);
+                         .SetReactants({ a })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "photoA" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ b })
-                         .products({ Yields(c, 1) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "photoB" }))
-                         .phase(gas_phase);
+                         .SetReactants({ b })
+                         .SetProducts({ Yields(c, 1) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "photoB" }))
+                         .SetPhase(gas_phase);
 
   OdeSolverPolicy solver =
       create_solver(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2 });
@@ -454,34 +454,34 @@ void test_analytical_stiff_photolysis(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a1 })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "photoA1B" }))
-                         .phase(gas_phase);
+                         .SetReactants({ a1 })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "photoA1B" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ a2 })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "photoA2B" }))
-                         .phase(gas_phase);
+                         .SetReactants({ a2 })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "photoA2B" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
-                         .reactants({ b })
-                         .products({ Yields(c, 1) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "photoB" }))
-                         .phase(gas_phase);
+                         .SetReactants({ b })
+                         .SetProducts({ Yields(c, 1) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "photoB" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
-                         .reactants({ a1 })
-                         .products({ Yields(a2, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a1 })
+                         .SetProducts({ Yields(a2, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
-                         .reactants({ a2 })
-                         .products({ Yields(a1, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a2 })
+                         .SetProducts({ Yields(a1, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
+                         .SetPhase(gas_phase);
 
   OdeSolverPolicy solver = create_solver(
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2, r3, r4, r5 });
@@ -582,15 +582,15 @@ void test_analytical_ternary_chemical_activation(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 4.0e-10, .kinf_A_ = 1 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 4.0e-10, .kinf_A_ = 1 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ b })
-                         .products({ Yields(c, 1) })
-                         .rate_constant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2e-3,
+                         .SetReactants({ b })
+                         .SetProducts({ Yields(c, 1) })
+                         .SetRateConstant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2e-3,
                                                                                       .k0_B_ = 167,
                                                                                       .k0_C_ = 3,
                                                                                       .kinf_A_ = 136,
@@ -598,7 +598,7 @@ void test_analytical_ternary_chemical_activation(
                                                                                       .kinf_C_ = 24,
                                                                                       .Fc_ = 0.9,
                                                                                       .N_ = 0.8 }))
-                         .phase(gas_phase);
+                         .SetPhase(gas_phase);
 
   OdeSolverPolicy solver =
       create_solver(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2 });
@@ -701,21 +701,21 @@ void test_analytical_stiff_ternary_chemical_activation(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a1 })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 4.0e-10, .kinf_A_ = 1 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a1 })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 4.0e-10, .kinf_A_ = 1 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ a2 })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 4.0e-10, .kinf_A_ = 1 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a2 })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 4.0e-10, .kinf_A_ = 1 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
-                         .reactants({ b })
-                         .products({ Yields(c, 1) })
-                         .rate_constant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2e-3,
+                         .SetReactants({ b })
+                         .SetProducts({ Yields(c, 1) })
+                         .SetRateConstant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2e-3,
                                                                                       .k0_B_ = 167,
                                                                                       .k0_C_ = 3,
                                                                                       .kinf_A_ = 136,
@@ -723,19 +723,19 @@ void test_analytical_stiff_ternary_chemical_activation(
                                                                                       .kinf_C_ = 24,
                                                                                       .Fc_ = 0.9,
                                                                                       .N_ = 0.8 }))
-                         .phase(gas_phase);
+                         .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
-                         .reactants({ a1 })
-                         .products({ Yields(a2, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a1 })
+                         .SetProducts({ Yields(a2, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
-                         .reactants({ a2 })
-                         .products({ Yields(a1, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a2 })
+                         .SetProducts({ Yields(a1, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
+                         .SetPhase(gas_phase);
 
   OdeSolverPolicy solver = create_solver(
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2, r3, r4, r5 });
@@ -837,16 +837,16 @@ void test_analytical_tunneling(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::TunnelingRateConstant({ .A_ = 4.0e-3 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::TunnelingRateConstant({ .A_ = 4.0e-3 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ b })
-                         .products({ Yields(c, 1) })
-                         .rate_constant(micm::TunnelingRateConstant({ .A_ = 1.2e-4, .B_ = 167, .C_ = 1.0e8 }))
-                         .phase(gas_phase);
+                         .SetReactants({ b })
+                         .SetProducts({ Yields(c, 1) })
+                         .SetRateConstant(micm::TunnelingRateConstant({ .A_ = 1.2e-4, .B_ = 167, .C_ = 1.0e8 }))
+                         .SetPhase(gas_phase);
 
   OdeSolverPolicy solver =
       create_solver(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2 });
@@ -943,34 +943,34 @@ void test_analytical_stiff_tunneling(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a1 })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::TunnelingRateConstant({ .A_ = 4.0e-3 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a1 })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::TunnelingRateConstant({ .A_ = 4.0e-3 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ a2 })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::TunnelingRateConstant({ .A_ = 4.0e-3 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a2 })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::TunnelingRateConstant({ .A_ = 4.0e-3 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
-                         .reactants({ b })
-                         .products({ Yields(c, 1) })
-                         .rate_constant(micm::TunnelingRateConstant({ .A_ = 1.2e-4, .B_ = 167, .C_ = 1.0e8 }))
-                         .phase(gas_phase);
+                         .SetReactants({ b })
+                         .SetProducts({ Yields(c, 1) })
+                         .SetRateConstant(micm::TunnelingRateConstant({ .A_ = 1.2e-4, .B_ = 167, .C_ = 1.0e8 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
-                         .reactants({ a1 })
-                         .products({ Yields(a2, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a1 })
+                         .SetProducts({ Yields(a2, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
-                         .reactants({ a2 })
-                         .products({ Yields(a1, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a2 })
+                         .SetProducts({ Yields(a1, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
+                         .SetPhase(gas_phase);
 
   OdeSolverPolicy solver = create_solver(
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2, r3, r4, r5 });
@@ -1067,17 +1067,17 @@ void test_analytical_arrhenius(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e-3, .C_ = 50 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e-3, .C_ = 50 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 =
       micm::Process::Create()
-          .reactants({ b })
-          .products({ Yields(c, 1) })
-          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 1.2e-4, .B_ = 7, .C_ = 75, .D_ = 50, .E_ = 0.5 }))
-          .phase(gas_phase);
+          .SetReactants({ b })
+          .SetProducts({ Yields(c, 1) })
+          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 1.2e-4, .B_ = 7, .C_ = 75, .D_ = 50, .E_ = 0.5 }))
+          .SetPhase(gas_phase);
 
   OdeSolverPolicy solver =
       create_solver(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2 });
@@ -1174,35 +1174,35 @@ void test_analytical_stiff_arrhenius(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a1 })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e-3, .C_ = 50 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a1 })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e-3, .C_ = 50 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ a2 })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e-3, .C_ = 50 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a2 })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e-3, .C_ = 50 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r3 =
       micm::Process::Create()
-          .reactants({ b })
-          .products({ Yields(c, 1) })
-          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 1.2e-4, .B_ = 167, .C_ = 75, .D_ = 50, .E_ = 0.5 }))
-          .phase(gas_phase);
+          .SetReactants({ b })
+          .SetProducts({ Yields(c, 1) })
+          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 1.2e-4, .B_ = 167, .C_ = 75, .D_ = 50, .E_ = 0.5 }))
+          .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
-                         .reactants({ a1 })
-                         .products({ Yields(a2, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a1 })
+                         .SetProducts({ Yields(a2, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
-                         .reactants({ a2 })
-                         .products({ Yields(a1, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a2 })
+                         .SetProducts({ Yields(a1, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
+                         .SetPhase(gas_phase);
 
   OdeSolverPolicy solver = create_solver(
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2, r3, r4, r5 });
@@ -1301,25 +1301,25 @@ void test_analytical_branched(
 
   micm::Process r1 =
       micm::Process::Create()
-          .reactants({ a })
-          .products({ Yields(b, 1) })
-          .rate_constant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
+          .SetReactants({ a })
+          .SetProducts({ Yields(b, 1) })
+          .SetRateConstant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
                                                       .X_ = 1.2,
                                                       .Y_ = 204.3,
                                                       .a0_ = 1.0e-3,
                                                       .n_ = 2 }))
-          .phase(gas_phase);
+          .SetPhase(gas_phase);
 
   micm::Process r2 =
       micm::Process::Create()
-          .reactants({ b })
-          .products({ Yields(c, 1) })
-          .rate_constant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate,
+          .SetReactants({ b })
+          .SetProducts({ Yields(c, 1) })
+          .SetRateConstant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate,
                                                       .X_ = 1.2,
                                                       .Y_ = 204.3,
                                                       .a0_ = 1.0e-3,
                                                       .n_ = 2 }))
-          .phase(gas_phase);
+          .SetPhase(gas_phase);
 
   OdeSolverPolicy solver =
       create_solver(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2 });
@@ -1432,48 +1432,48 @@ void test_analytical_stiff_branched(
 
   micm::Process r1 =
       micm::Process::Create()
-          .reactants({ a1 })
-          .products({ Yields(b, 1) })
-          .rate_constant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
+          .SetReactants({ a1 })
+          .SetProducts({ Yields(b, 1) })
+          .SetRateConstant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
                                                       .X_ = 1.2,
                                                       .Y_ = 204.3,
                                                       .a0_ = 1.0e-3,
                                                       .n_ = 2 }))
-          .phase(gas_phase);
+          .SetPhase(gas_phase);
 
   micm::Process r2 =
       micm::Process::Create()
-          .reactants({ a2 })
-          .products({ Yields(b, 1) })
-          .rate_constant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
+          .SetReactants({ a2 })
+          .SetProducts({ Yields(b, 1) })
+          .SetRateConstant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
                                                       .X_ = 1.2,
                                                       .Y_ = 204.3,
                                                       .a0_ = 1.0e-3,
                                                       .n_ = 2 }))
-          .phase(gas_phase);
+          .SetPhase(gas_phase);
 
   micm::Process r3 =
       micm::Process::Create()
-          .reactants({ b })
-          .products({ Yields(c, 1) })
-          .rate_constant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate,
+          .SetReactants({ b })
+          .SetProducts({ Yields(c, 1) })
+          .SetRateConstant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate,
                                                       .X_ = 1.2,
                                                       .Y_ = 204.3,
                                                       .a0_ = 1.0e-3,
                                                       .n_ = 2 }))
-          .phase(gas_phase);
+          .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
-                         .reactants({ a1 })
-                         .products({ Yields(a2, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a1 })
+                         .SetProducts({ Yields(a2, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
-                         .reactants({ a2 })
-                         .products({ Yields(a1, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a2 })
+                         .SetProducts({ Yields(a1, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
+                         .SetPhase(gas_phase);
 
   OdeSolverPolicy solver = create_solver(
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2, r3, r4, r5 });
@@ -1592,22 +1592,22 @@ void test_analytical_robertson(
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
-                         .phase(gas_phase);
+                         .SetReactants({ a })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ b, b })
-                         .products({ Yields(b, 1), Yields(c, 1) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
-                         .phase(gas_phase);
+                         .SetReactants({ b, b })
+                         .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
-                         .reactants({ b, c })
-                         .products({ Yields(a, 1), Yields(c, 1) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
-                         .phase(gas_phase);
+                         .SetReactants({ b, c })
+                         .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
+                         .SetPhase(gas_phase);
 
   OdeSolverPolicy solver = create_solver(
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2, r3 });

--- a/test/integration/analytical_rosenbrock.cpp
+++ b/test/integration/analytical_rosenbrock.cpp
@@ -205,17 +205,17 @@ TEST(AnalyticalExamples, Oregonator)
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ b })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .phase(gas_phase);
 
-  micm::Process r3 = micm::Process::create()
+  micm::Process r3 = micm::Process::Create()
                          .reactants({ b })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .phase(gas_phase);
@@ -323,31 +323,31 @@ TEST(AnalyticalExamples, Oregonator2)
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a, b })
-                         .products({ yields(b, 1 - std::pow((1 / 77.27), 2)) })
+                         .products({ Yields(b, 1 - std::pow((1 / 77.27), 2)) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ c })
-                         .products({ yields(b, 1 / (0.161 * 77.27)) })
+                         .products({ Yields(b, 1 / (0.161 * 77.27)) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .phase(gas_phase);
 
-  micm::Process r3 = micm::Process::create()
+  micm::Process r3 = micm::Process::Create()
                          .reactants({ b })
-                         .products({ yields(a, std::pow(77.27, 2)) })
+                         .products({ Yields(a, std::pow(77.27, 2)) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .phase(gas_phase);
 
-  micm::Process r4 = micm::Process::create()
+  micm::Process r4 = micm::Process::Create()
                          .reactants({ a })
-                         .products({ yields(a, 2), yields(c, 0.161 / 77.27) })
+                         .products({ Yields(a, 2), Yields(c, 0.161 / 77.27) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r4" }))
                          .phase(gas_phase);
 
-  micm::Process r5 = micm::Process::create()
+  micm::Process r5 = micm::Process::Create()
                          .reactants({ a, a })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r5" }))
                          .phase(gas_phase);
@@ -470,35 +470,35 @@ TEST(AnalyticalExamples, HIRES)
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ y1, y2, y3, y4, y5, y6, y7, y8 } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ y1 })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .phase(gas_phase);
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ y2 })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .phase(gas_phase);
-  micm::Process r3 = micm::Process::create()
+  micm::Process r3 = micm::Process::Create()
                          .reactants({ y3 })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .phase(gas_phase);
-  micm::Process r4 = micm::Process::create()
+  micm::Process r4 = micm::Process::Create()
                          .reactants({ y4 })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r4" }))
                          .phase(gas_phase);
-  micm::Process r5 = micm::Process::create()
+  micm::Process r5 = micm::Process::Create()
                          .reactants({ y5 })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r5" }))
                          .phase(gas_phase);
-  micm::Process r6 = micm::Process::create()
+  micm::Process r6 = micm::Process::Create()
                          .reactants({ y6 })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r6" }))
                          .phase(gas_phase);
-  micm::Process r7 = micm::Process::create()
+  micm::Process r7 = micm::Process::Create()
                          .reactants({ y7 })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r7" }))
                          .phase(gas_phase);
-  micm::Process r8 = micm::Process::create()
+  micm::Process r8 = micm::Process::Create()
                          .reactants({ y8 })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r8" }))
                          .phase(gas_phase);
@@ -596,19 +596,19 @@ TEST(AnalyticalExamples, E5)
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ y1, y2, y3, y4 } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ y1 })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .phase(gas_phase);
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ y2 })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .phase(gas_phase);
-  micm::Process r3 = micm::Process::create()
+  micm::Process r3 = micm::Process::Create()
                          .reactants({ y3 })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .phase(gas_phase);
-  micm::Process r4 = micm::Process::create()
+  micm::Process r4 = micm::Process::Create()
                          .reactants({ y4 })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r4" }))
                          .phase(gas_phase);

--- a/test/integration/analytical_rosenbrock.cpp
+++ b/test/integration/analytical_rosenbrock.cpp
@@ -19,7 +19,7 @@ TEST(AnalyticalExamples, Troe)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -31,7 +31,7 @@ TEST(AnalyticalExamples, TroeSuperStiffButAnalytical)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -43,7 +43,7 @@ TEST(AnalyticalExamples, Photolysis)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -55,7 +55,7 @@ TEST(AnalyticalExamples, PhotolysisSuperStiffButAnalytical)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -67,7 +67,7 @@ TEST(AnalyticalExamples, TernaryChemicalActivation)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -79,7 +79,7 @@ TEST(AnalyticalExamples, TernaryChemicalActivationSuperStiffButAnalytical)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -91,7 +91,7 @@ TEST(AnalyticalExamples, Tunneling)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -103,7 +103,7 @@ TEST(AnalyticalExamples, TunnelingSuperStiffButAnalytical)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -115,7 +115,7 @@ TEST(AnalyticalExamples, Arrhenius)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -127,7 +127,7 @@ TEST(AnalyticalExamples, ArrheniusSuperStiffButAnalytical)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -139,7 +139,7 @@ TEST(AnalyticalExamples, Branched)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -151,7 +151,7 @@ TEST(AnalyticalExamples, BranchedSuperStiffButAnalytical)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -163,7 +163,7 @@ TEST(AnalyticalExamples, Robertson)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -175,7 +175,7 @@ TEST(AnalyticalExamples, SurfaceRxn)
          const std::vector<micm::Process>& p) -> micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>
       {
         return micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest>{
-          s, p, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+          s, p, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
         };
       });
 }
@@ -206,21 +206,21 @@ TEST(AnalyticalExamples, Oregonator)
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
-                         .phase(gas_phase);
+                         .SetReactants({ a })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ b })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
-                         .phase(gas_phase);
+                         .SetReactants({ b })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
-                         .reactants({ b })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
-                         .phase(gas_phase);
+                         .SetReactants({ b })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
+                         .SetPhase(gas_phase);
 
-  auto params = micm::RosenbrockSolverParameters::six_stage_differential_algebraic_rosenbrock_parameters();
+  auto params = micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters();
   params.relative_tolerance_ = 1e-4;
   params.absolute_tolerance_ = std::vector<double>(3, 1e-6 * params.relative_tolerance_);
   Oregonator<micm::Matrix, SparseMatrixTest> solver(
@@ -324,35 +324,35 @@ TEST(AnalyticalExamples, Oregonator2)
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a, b })
-                         .products({ Yields(b, 1 - std::pow((1 / 77.27), 2)) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
-                         .phase(gas_phase);
+                         .SetReactants({ a, b })
+                         .SetProducts({ Yields(b, 1 - std::pow((1 / 77.27), 2)) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ c })
-                         .products({ Yields(b, 1 / (0.161 * 77.27)) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
-                         .phase(gas_phase);
+                         .SetReactants({ c })
+                         .SetProducts({ Yields(b, 1 / (0.161 * 77.27)) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
-                         .reactants({ b })
-                         .products({ Yields(a, std::pow(77.27, 2)) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
-                         .phase(gas_phase);
+                         .SetReactants({ b })
+                         .SetProducts({ Yields(a, std::pow(77.27, 2)) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
-                         .reactants({ a })
-                         .products({ Yields(a, 2), Yields(c, 0.161 / 77.27) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r4" }))
-                         .phase(gas_phase);
+                         .SetReactants({ a })
+                         .SetProducts({ Yields(a, 2), Yields(c, 0.161 / 77.27) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r4" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
-                         .reactants({ a, a })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r5" }))
-                         .phase(gas_phase);
+                         .SetReactants({ a, a })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r5" }))
+                         .SetPhase(gas_phase);
 
-  auto params = micm::RosenbrockSolverParameters::six_stage_differential_algebraic_rosenbrock_parameters();
+  auto params = micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters();
   params.relative_tolerance_ = 1e-4;
   params.absolute_tolerance_ = std::vector<double>(3, 1e-6 * params.relative_tolerance_);
   Oregonator<micm::Matrix, SparseMatrixTest> solver(
@@ -471,39 +471,39 @@ TEST(AnalyticalExamples, HIRES)
   micm::Phase gas_phase{ std::vector<micm::Species>{ y1, y2, y3, y4, y5, y6, y7, y8 } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ y1 })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
-                         .phase(gas_phase);
+                         .SetReactants({ y1 })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
+                         .SetPhase(gas_phase);
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ y2 })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
-                         .phase(gas_phase);
+                         .SetReactants({ y2 })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
+                         .SetPhase(gas_phase);
   micm::Process r3 = micm::Process::Create()
-                         .reactants({ y3 })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
-                         .phase(gas_phase);
+                         .SetReactants({ y3 })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
+                         .SetPhase(gas_phase);
   micm::Process r4 = micm::Process::Create()
-                         .reactants({ y4 })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r4" }))
-                         .phase(gas_phase);
+                         .SetReactants({ y4 })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r4" }))
+                         .SetPhase(gas_phase);
   micm::Process r5 = micm::Process::Create()
-                         .reactants({ y5 })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r5" }))
-                         .phase(gas_phase);
+                         .SetReactants({ y5 })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r5" }))
+                         .SetPhase(gas_phase);
   micm::Process r6 = micm::Process::Create()
-                         .reactants({ y6 })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r6" }))
-                         .phase(gas_phase);
+                         .SetReactants({ y6 })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r6" }))
+                         .SetPhase(gas_phase);
   micm::Process r7 = micm::Process::Create()
-                         .reactants({ y7 })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r7" }))
-                         .phase(gas_phase);
+                         .SetReactants({ y7 })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r7" }))
+                         .SetPhase(gas_phase);
   micm::Process r8 = micm::Process::Create()
-                         .reactants({ y8 })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r8" }))
-                         .phase(gas_phase);
+                         .SetReactants({ y8 })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r8" }))
+                         .SetPhase(gas_phase);
 
-  auto params = micm::RosenbrockSolverParameters::six_stage_differential_algebraic_rosenbrock_parameters();
+  auto params = micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters();
   params.relative_tolerance_ = 1e-3;
   params.absolute_tolerance_ = std::vector<double>(8, 1e-4 * params.relative_tolerance_);
   HIRES<micm::Matrix, SparseMatrixTest> solver(
@@ -597,23 +597,23 @@ TEST(AnalyticalExamples, E5)
   micm::Phase gas_phase{ std::vector<micm::Species>{ y1, y2, y3, y4 } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ y1 })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
-                         .phase(gas_phase);
+                         .SetReactants({ y1 })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
+                         .SetPhase(gas_phase);
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ y2 })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
-                         .phase(gas_phase);
+                         .SetReactants({ y2 })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
+                         .SetPhase(gas_phase);
   micm::Process r3 = micm::Process::Create()
-                         .reactants({ y3 })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
-                         .phase(gas_phase);
+                         .SetReactants({ y3 })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
+                         .SetPhase(gas_phase);
   micm::Process r4 = micm::Process::Create()
-                         .reactants({ y4 })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r4" }))
-                         .phase(gas_phase);
+                         .SetReactants({ y4 })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r4" }))
+                         .SetPhase(gas_phase);
 
-  auto params = micm::RosenbrockSolverParameters::six_stage_differential_algebraic_rosenbrock_parameters();
+  auto params = micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters();
   params.relative_tolerance_ = 1e-2;
   params.absolute_tolerance_ = std::vector<double>(4, 1.7e-24);
   E5<micm::Matrix, SparseMatrixTest> solver(

--- a/test/integration/analytical_surface_rxn_policy.hpp
+++ b/test/integration/analytical_surface_rxn_policy.hpp
@@ -56,16 +56,16 @@ void test_analytical_surface_rxn(
 
   // Process
   micm::Process surface_process = micm::Process::Create()
-                                      .reactants({ foo })
-                                      .products({ micm::Yields(bar, bar_yield), micm::Yields(baz, baz_yield) })
-                                      .rate_constant(surface)
-                                      .phase(gas_phase);
+                                      .SetReactants({ foo })
+                                      .SetProducts({ micm::Yields(bar, bar_yield), micm::Yields(baz, baz_yield) })
+                                      .SetRateConstant(surface)
+                                      .SetPhase(gas_phase);
 
   auto reactions = std::vector<micm::Process>{ surface_process };
 
   // Solver
   // micm::RosenbrockSolver<> solver{
-  //   chemical_system, reactions, micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters()
+  //   chemical_system, reactions, micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters()
   // };
 
   // Solver

--- a/test/integration/analytical_surface_rxn_policy.hpp
+++ b/test/integration/analytical_surface_rxn_policy.hpp
@@ -55,9 +55,9 @@ void test_analytical_surface_rxn(
   micm::SurfaceRateConstant surface{ { .label_ = "foo", .species_ = foo, .reaction_probability_ = rxn_gamma } };
 
   // Process
-  micm::Process surface_process = micm::Process::create()
+  micm::Process surface_process = micm::Process::Create()
                                       .reactants({ foo })
-                                      .products({ micm::yields(bar, bar_yield), micm::yields(baz, baz_yield) })
+                                      .products({ micm::Yields(bar, bar_yield), micm::Yields(baz, baz_yield) })
                                       .rate_constant(surface)
                                       .phase(gas_phase);
 

--- a/test/integration/chapman.cpp
+++ b/test/integration/chapman.cpp
@@ -98,51 +98,51 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
   micm::Phase gas_phase{ std::vector<micm::Species>{ o, o1d, o2, o3, m, ar, n2, h2o, co2 } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ o1d, n2 })
-                         .products({ Yields(o, 1), Yields(n2, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
-                         .phase(gas_phase);
+                         .SetReactants({ o1d, n2 })
+                         .SetProducts({ Yields(o, 1), Yields(n2, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ o1d, o2 })
-                         .products({ Yields(o, 1), Yields(o2, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant(
+                         .SetReactants({ o1d, o2 })
+                         .SetProducts({ Yields(o, 1), Yields(o2, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .B_ = 0, .C_ = 55 }))
-                         .phase(gas_phase);
+                         .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
-                         .reactants({ o, o3 })
-                         .products({ Yields(o2, 2) })
-                         .rate_constant(micm::ArrheniusRateConstant(
+                         .SetReactants({ o, o3 })
+                         .SetProducts({ Yields(o2, 2) })
+                         .SetRateConstant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 8e-12, .B_ = 0, .C_ = -2060 }))
-                         .phase(gas_phase);
+                         .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
-                         .reactants({ o, o2, m })
-                         .products({ Yields(o3, 1), Yields(m, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant(
+                         .SetReactants({ o, o2, m })
+                         .SetProducts({ Yields(o3, 1), Yields(m, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 6.0e-34, .B_ = 0, .C_ = 2.4 }))
-                         .phase(gas_phase);
+                         .SetPhase(gas_phase);
 
   micm::Process photo_1 = micm::Process::Create()
-                              .reactants({ o2 })
-                              .products({ Yields(o, 2) })
-                              .rate_constant(micm::UserDefinedRateConstant({ .label_ = "jO2" }))
-                              .phase(gas_phase);
+                              .SetReactants({ o2 })
+                              .SetProducts({ Yields(o, 2) })
+                              .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "jO2" }))
+                              .SetPhase(gas_phase);
 
   micm::Process photo_2 = micm::Process::Create()
-                              .reactants({ o3 })
-                              .products({ Yields(o1d, 1), Yields(o2, 1) })
-                              .rate_constant(micm::UserDefinedRateConstant({ .label_ = "jO3a" }))
-                              .phase(gas_phase);
+                              .SetReactants({ o3 })
+                              .SetProducts({ Yields(o1d, 1), Yields(o2, 1) })
+                              .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "jO3a" }))
+                              .SetPhase(gas_phase);
 
   micm::Process photo_3 = micm::Process::Create()
-                              .reactants({ o3 })
-                              .products({ Yields(o, 1), Yields(o2, 1) })
-                              .rate_constant(micm::UserDefinedRateConstant({ .label_ = "jO3b" }))
-                              .phase(gas_phase);
+                              .SetReactants({ o3 })
+                              .SetProducts({ Yields(o, 1), Yields(o2, 1) })
+                              .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "jO3b" }))
+                              .SetPhase(gas_phase);
 
-  auto options = micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters();
+  auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
   options.ignore_unused_species_ = true;
 
   micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest> solver{

--- a/test/integration/chapman.cpp
+++ b/test/integration/chapman.cpp
@@ -97,48 +97,48 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ o, o1d, o2, o3, m, ar, n2, h2o, co2 } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ o1d, n2 })
-                         .products({ yields(o, 1), yields(n2, 1) })
+                         .products({ Yields(o, 1), Yields(n2, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ o1d, o2 })
-                         .products({ yields(o, 1), yields(o2, 1) })
+                         .products({ Yields(o, 1), Yields(o2, 1) })
                          .rate_constant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .B_ = 0, .C_ = 55 }))
                          .phase(gas_phase);
 
-  micm::Process r3 = micm::Process::create()
+  micm::Process r3 = micm::Process::Create()
                          .reactants({ o, o3 })
-                         .products({ yields(o2, 2) })
+                         .products({ Yields(o2, 2) })
                          .rate_constant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 8e-12, .B_ = 0, .C_ = -2060 }))
                          .phase(gas_phase);
 
-  micm::Process r4 = micm::Process::create()
+  micm::Process r4 = micm::Process::Create()
                          .reactants({ o, o2, m })
-                         .products({ yields(o3, 1), yields(m, 1) })
+                         .products({ Yields(o3, 1), Yields(m, 1) })
                          .rate_constant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 6.0e-34, .B_ = 0, .C_ = 2.4 }))
                          .phase(gas_phase);
 
-  micm::Process photo_1 = micm::Process::create()
+  micm::Process photo_1 = micm::Process::Create()
                               .reactants({ o2 })
-                              .products({ yields(o, 2) })
+                              .products({ Yields(o, 2) })
                               .rate_constant(micm::UserDefinedRateConstant({ .label_ = "jO2" }))
                               .phase(gas_phase);
 
-  micm::Process photo_2 = micm::Process::create()
+  micm::Process photo_2 = micm::Process::Create()
                               .reactants({ o3 })
-                              .products({ yields(o1d, 1), yields(o2, 1) })
+                              .products({ Yields(o1d, 1), Yields(o2, 1) })
                               .rate_constant(micm::UserDefinedRateConstant({ .label_ = "jO3a" }))
                               .phase(gas_phase);
 
-  micm::Process photo_3 = micm::Process::create()
+  micm::Process photo_3 = micm::Process::Create()
                               .reactants({ o3 })
-                              .products({ yields(o, 1), yields(o2, 1) })
+                              .products({ Yields(o, 1), Yields(o2, 1) })
                               .rate_constant(micm::UserDefinedRateConstant({ .label_ = "jO3b" }))
                               .phase(gas_phase);
 

--- a/test/integration/e5.hpp
+++ b/test/integration/e5.hpp
@@ -22,19 +22,19 @@ class E5 : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Linea
     this->processes_ = processes;
     this->parameters_ = parameters;
 
-    auto builder = SparseMatrixPolicy<double>::create(4).NumberOfBlocks(1).initial_value(0.0);
+    auto builder = SparseMatrixPolicy<double>::Create(4).NumberOfBlocks(1).InitialValue(0.0);
     for (int i = 0; i < 4; ++i)
     {
       for (int j = 0; j < 4; ++j)
       {
-        builder = builder.with_element(i, j);
+        builder = builder.WithElement(i, j);
         nonzero_jacobian_elements_.insert(std::make_pair(i, j));
       }
     }
     SparseMatrixPolicy<double> jacobian = SparseMatrixPolicy<double>(builder);
 
     std::vector<std::size_t> jacobian_diagonal_elements;
-    for (std::size_t i = 0; i < jacobian[0].size(); ++i)
+    for (std::size_t i = 0; i < jacobian.NumRows(); ++i)
       jacobian_diagonal_elements.push_back(jacobian.VectorIndex(0, i, i));
 
     std::vector<std::string> param_labels{};

--- a/test/integration/e5.hpp
+++ b/test/integration/e5.hpp
@@ -22,7 +22,7 @@ class E5 : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Linea
     this->processes_ = processes;
     this->parameters_ = parameters;
 
-    auto builder = SparseMatrixPolicy<double>::Create(4).NumberOfBlocks(1).InitialValue(0.0);
+    auto builder = SparseMatrixPolicy<double>::Create(4).SetNumberOfBlocks(1).InitialValue(0.0);
     for (int i = 0; i < 4; ++i)
     {
       for (int j = 0; j < 4; ++j)

--- a/test/integration/e5.hpp
+++ b/test/integration/e5.hpp
@@ -22,7 +22,7 @@ class E5 : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Linea
     this->processes_ = processes;
     this->parameters_ = parameters;
 
-    auto builder = SparseMatrixPolicy<double>::create(4).number_of_blocks(1).initial_value(0.0);
+    auto builder = SparseMatrixPolicy<double>::create(4).NumberOfBlocks(1).initial_value(0.0);
     for (int i = 0; i < 4; ++i)
     {
       for (int j = 0; j < 4; ++j)
@@ -64,7 +64,7 @@ class E5 : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Linea
   {
     auto state = micm::State<MatrixPolicy, SparseMatrixPolicy>{ this->state_parameters_ };
 
-    state.jacobian_ = micm::build_jacobian<SparseMatrixPolicy>(
+    state.jacobian_ = micm::BuildJacobian<SparseMatrixPolicy>(
         nonzero_jacobian_elements_,
         this->state_parameters_.number_of_grid_cells_,
         this->state_parameters_.variable_names_.size());

--- a/test/integration/hires.hpp
+++ b/test/integration/hires.hpp
@@ -23,19 +23,19 @@ class HIRES : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Li
     this->processes_ = processes;
     this->parameters_ = parameters;
 
-    auto builder = SparseMatrixPolicy<double>::create(8).NumberOfBlocks(1).initial_value(0.0);
+    auto builder = SparseMatrixPolicy<double>::Create(8).NumberOfBlocks(1).InitialValue(0.0);
     for (int i = 0; i < 8; ++i)
     {
       for (int j = 0; j < 8; ++j)
       {
-        builder = builder.with_element(i, j);
+        builder = builder.WithElement(i, j);
         nonzero_jacobian_elements_.insert(std::make_pair(i, j));
       }
     }
     SparseMatrixPolicy<double> jacobian = SparseMatrixPolicy<double>(builder);
 
     std::vector<std::size_t> jacobian_diagonal_elements;
-    for (std::size_t i = 0; i < jacobian[0].size(); ++i)
+    for (std::size_t i = 0; i < jacobian.NumRows(); ++i)
       jacobian_diagonal_elements.push_back(jacobian.VectorIndex(0, i, i));
 
     std::vector<std::string> param_labels{};

--- a/test/integration/hires.hpp
+++ b/test/integration/hires.hpp
@@ -23,7 +23,7 @@ class HIRES : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Li
     this->processes_ = processes;
     this->parameters_ = parameters;
 
-    auto builder = SparseMatrixPolicy<double>::create(8).number_of_blocks(1).initial_value(0.0);
+    auto builder = SparseMatrixPolicy<double>::create(8).NumberOfBlocks(1).initial_value(0.0);
     for (int i = 0; i < 8; ++i)
     {
       for (int j = 0; j < 8; ++j)
@@ -65,7 +65,7 @@ class HIRES : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Li
   {
     auto state = micm::State<MatrixPolicy, SparseMatrixPolicy>{ this->state_parameters_ };
 
-    state.jacobian_ = micm::build_jacobian<SparseMatrixPolicy>(
+    state.jacobian_ = micm::BuildJacobian<SparseMatrixPolicy>(
         nonzero_jacobian_elements_,
         this->state_parameters_.number_of_grid_cells_,
         this->state_parameters_.variable_names_.size());

--- a/test/integration/hires.hpp
+++ b/test/integration/hires.hpp
@@ -23,7 +23,7 @@ class HIRES : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Li
     this->processes_ = processes;
     this->parameters_ = parameters;
 
-    auto builder = SparseMatrixPolicy<double>::Create(8).NumberOfBlocks(1).InitialValue(0.0);
+    auto builder = SparseMatrixPolicy<double>::Create(8).SetNumberOfBlocks(1).InitialValue(0.0);
     for (int i = 0; i < 8; ++i)
     {
       for (int j = 0; j < 8; ++j)

--- a/test/integration/integrated_reaction_rates.cpp
+++ b/test/integration/integrated_reaction_rates.cpp
@@ -27,16 +27,16 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c, irr_1, irr_2 } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a })
-                         .products({ yields(b, 1), yields(irr_1, 1) })
+                         .products({ Yields(b, 1), Yields(irr_1, 1) })
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
                          .phase(gas_phase);
 
   micm::Process r2 =
       micm::Process::create()
           .reactants({ b })
-          .products({ yields(c, 1), yields(irr_2, 1) })
+          .products({ Yields(c, 1), Yields(irr_2, 1) })
           .rate_constant(micm::UserDefinedRateConstant(micm::UserDefinedRateConstantParameters{ .label_ = "r2" }))
           .phase(gas_phase);
 

--- a/test/integration/integrated_reaction_rates.cpp
+++ b/test/integration/integrated_reaction_rates.cpp
@@ -28,19 +28,19 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c, irr_1, irr_2 } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a })
-                         .products({ Yields(b, 1), Yields(irr_1, 1) })
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
-                         .phase(gas_phase);
+                         .SetReactants({ a })
+                         .SetProducts({ Yields(b, 1), Yields(irr_1, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 =
-      micm::Process::create()
-          .reactants({ b })
-          .products({ Yields(c, 1), Yields(irr_2, 1) })
-          .rate_constant(micm::UserDefinedRateConstant(micm::UserDefinedRateConstantParameters{ .label_ = "r2" }))
-          .phase(gas_phase);
+      micm::Process::Create()
+          .SetReactants({ b })
+          .SetProducts({ Yields(c, 1), Yields(irr_2, 1) })
+          .SetRateConstant(micm::UserDefinedRateConstant(micm::UserDefinedRateConstantParameters{ .label_ = "r2" }))
+          .SetPhase(gas_phase);
 
-  auto options = micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters();
+  auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
 
   micm::RosenbrockSolver<micm::Matrix, SparseMatrixTest> solver{
     micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1, r2 }, options

--- a/test/integration/jit_terminator.cpp
+++ b/test/integration/jit_terminator.cpp
@@ -26,13 +26,13 @@ void RunTerminatorTest()
               micm::JitLinearSolver<number_of_grid_cells, SparseMatrixPolicy>,
               micm::JitProcessSet<number_of_grid_cells>>
       {
-        auto jit{ micm::JitCompiler::create() };
+        auto jit{ micm::JitCompiler::Create() };
         if (auto err = jit.takeError())
         {
           llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
           EXPECT_TRUE(false);
         }
-        auto solver_params = micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells, true);
+        auto solver_params = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters(number_of_grid_cells, true);
         solver_params.relative_tolerance_ = 1.0e-8;
         solver_params.max_number_of_steps_ = 100000;
         return micm::JitRosenbrockSolver<

--- a/test/integration/oregonator.hpp
+++ b/test/integration/oregonator.hpp
@@ -24,7 +24,7 @@ class Oregonator : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolic
     this->parameters_ = parameters;
     this->parameters_.absolute_tolerance_ = std::vector<double>(3, 1.0e-3);
 
-    auto builder = SparseMatrixPolicy<double>::Create(3).NumberOfBlocks(1).InitialValue(0.0);
+    auto builder = SparseMatrixPolicy<double>::Create(3).SetNumberOfBlocks(1).InitialValue(0.0);
     for (int i = 0; i < 3; ++i)
     {
       for (int j = 0; j < 3; ++j)

--- a/test/integration/oregonator.hpp
+++ b/test/integration/oregonator.hpp
@@ -24,7 +24,7 @@ class Oregonator : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolic
     this->parameters_ = parameters;
     this->parameters_.absolute_tolerance_ = std::vector<double>(3, 1.0e-3);
 
-    auto builder = SparseMatrixPolicy<double>::create(3).number_of_blocks(1).initial_value(0.0);
+    auto builder = SparseMatrixPolicy<double>::create(3).NumberOfBlocks(1).initial_value(0.0);
     for (int i = 0; i < 3; ++i)
     {
       for (int j = 0; j < 3; ++j)
@@ -66,7 +66,7 @@ class Oregonator : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolic
   {
     auto state = micm::State<MatrixPolicy, SparseMatrixPolicy>{ this->state_parameters_ };
 
-    state.jacobian_ = micm::build_jacobian<SparseMatrixPolicy>(
+    state.jacobian_ = micm::BuildJacobian<SparseMatrixPolicy>(
         nonzero_jacobian_elements_,
         this->state_parameters_.number_of_grid_cells_,
         this->state_parameters_.variable_names_.size());

--- a/test/integration/oregonator.hpp
+++ b/test/integration/oregonator.hpp
@@ -24,19 +24,19 @@ class Oregonator : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolic
     this->parameters_ = parameters;
     this->parameters_.absolute_tolerance_ = std::vector<double>(3, 1.0e-3);
 
-    auto builder = SparseMatrixPolicy<double>::create(3).NumberOfBlocks(1).initial_value(0.0);
+    auto builder = SparseMatrixPolicy<double>::Create(3).NumberOfBlocks(1).InitialValue(0.0);
     for (int i = 0; i < 3; ++i)
     {
       for (int j = 0; j < 3; ++j)
       {
-        builder = builder.with_element(i, j);
+        builder = builder.WithElement(i, j);
         nonzero_jacobian_elements_.insert(std::make_pair(i, j));
       }
     }
     SparseMatrixPolicy<double> jacobian = SparseMatrixPolicy<double>(builder);
 
     std::vector<std::size_t> jacobian_diagonal_elements;
-    for (std::size_t i = 0; i < jacobian[0].size(); ++i)
+    for (std::size_t i = 0; i < jacobian.NumRows(); ++i)
       jacobian_diagonal_elements.push_back(jacobian.VectorIndex(0, i, i));
 
     std::vector<std::string> param_labels{};

--- a/test/integration/terminator.cpp
+++ b/test/integration/terminator.cpp
@@ -20,7 +20,7 @@ void RunTerminatorTest(std::size_t number_of_grid_cells)
       [&](const micm::System& s, const std::vector<micm::Process>& p)
           -> micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>
       {
-        auto solver_params = micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells, true);
+        auto solver_params = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters(number_of_grid_cells, true);
         solver_params.relative_tolerance_ = 1.0e-8;
         solver_params.max_number_of_steps_ = 100000;
         return micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>{ s, p, solver_params };
@@ -30,7 +30,7 @@ void RunTerminatorTest(std::size_t number_of_grid_cells)
       [&](const micm::System& s, const std::vector<micm::Process>& p)
           -> micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>
       {
-        auto solver_params = micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells, true);
+        auto solver_params = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters(number_of_grid_cells, true);
         solver_params.relative_tolerance_ = 1.0e-8;
         solver_params.max_number_of_steps_ = 100000;
         solver_params.check_singularity_ = true;

--- a/test/integration/terminator.hpp
+++ b/test/integration/terminator.hpp
@@ -33,17 +33,17 @@ void TestTerminator(
   micm::Phase gas_phase{ std::vector<micm::Species>{ cl2, cl } };
 
   micm::Process toy_r1 = micm::Process::Create()
-                             .reactants({ cl2 })
-                             .products({ micm::Yield(cl, 2.0) })
-                             .phase(gas_phase)
-                             .rate_constant(micm::UserDefinedRateConstant({ .label_ = "toy_k1" }));
+                             .SetReactants({ cl2 })
+                             .SetProducts({ micm::Yield(cl, 2.0) })
+                             .SetPhase(gas_phase)
+                             .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "toy_k1" }));
 
   constexpr double k2 = 1.0;
   micm::Process toy_r2 = micm::Process::Create()
-                             .reactants({ cl, cl })
-                             .products({ micm::Yield(cl2, 1.0) })
-                             .phase(gas_phase)
-                             .rate_constant(micm::ArrheniusRateConstant({ .A_ = k2 }));
+                             .SetReactants({ cl, cl })
+                             .SetProducts({ micm::Yield(cl2, 1.0) })
+                             .SetPhase(gas_phase)
+                             .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = k2 }));
 
   auto solver = create_solver(
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ toy_r1, toy_r2 });

--- a/test/integration/terminator.hpp
+++ b/test/integration/terminator.hpp
@@ -32,14 +32,14 @@ void TestTerminator(
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ cl2, cl } };
 
-  micm::Process toy_r1 = micm::Process::create()
+  micm::Process toy_r1 = micm::Process::Create()
                              .reactants({ cl2 })
                              .products({ micm::Yield(cl, 2.0) })
                              .phase(gas_phase)
                              .rate_constant(micm::UserDefinedRateConstant({ .label_ = "toy_k1" }));
 
   constexpr double k2 = 1.0;
-  micm::Process toy_r2 = micm::Process::create()
+  micm::Process toy_r2 = micm::Process::Create()
                              .reactants({ cl, cl })
                              .products({ micm::Yield(cl2, 1.0) })
                              .phase(gas_phase)

--- a/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
+++ b/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
@@ -762,26 +762,26 @@ namespace micm
     ArrheniusRateConstantParameters params;
     params.A_ = 2.15e-11;
     params.C_ = 110;
-    state.rate_constants_[0][3] = ArrheniusRateConstant(params).calculate(temperature, pressure);
+    state.rate_constants_[0][3] = ArrheniusRateConstant(params).Calculate(temperature, pressure);
 
     // O1D_O2_1
     // k_O1D_O2_1: O1D + O2 -> 1*O + 1*O2
     params.A_ = 3.3e-11;
     params.C_ = 55;
-    state.rate_constants_[0][4] = ArrheniusRateConstant(params).calculate(temperature, pressure);
+    state.rate_constants_[0][4] = ArrheniusRateConstant(params).Calculate(temperature, pressure);
 
     // O_O3_1
     // k_O_O3_1: O + O3 -> 2*O2
     params.A_ = 8e-12;
     params.C_ = -2060;
-    state.rate_constants_[0][5] = ArrheniusRateConstant(params).calculate(temperature, pressure);
+    state.rate_constants_[0][5] = ArrheniusRateConstant(params).Calculate(temperature, pressure);
 
     // M_O_O2_1
     // k_M_O_O2_1: M + O + O2 -> 1*O3 + 1*M
     params.A_ = 6e-34;
     params.B_ = 2.4;
     params.C_ = 0;
-    state.rate_constants_[0][6] = ArrheniusRateConstant(params).calculate(temperature, pressure);
+    state.rate_constants_[0][6] = ArrheniusRateConstant(params).Calculate(temperature, pressure);
   }
 
   inline std::vector<double> ChapmanODESolver::lin_factor(

--- a/test/regression/RosenbrockChapman/jit_util.hpp
+++ b/test/regression/RosenbrockChapman/jit_util.hpp
@@ -15,10 +15,10 @@ getTwoStageMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
 
-  auto options = micm::RosenbrockSolverParameters::two_stage_rosenbrock_parameters(number_of_grid_cells);
+  auto options = micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters(number_of_grid_cells);
   options.ignore_unused_species_ = true;
 
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -41,10 +41,10 @@ getThreeStageMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
 
-  auto options = micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells);
+  auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters(number_of_grid_cells);
   options.ignore_unused_species_ = true;
 
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -67,10 +67,10 @@ getFourStageMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
 
-  auto options = micm::RosenbrockSolverParameters::four_stage_rosenbrock_parameters(number_of_grid_cells);
+  auto options = micm::RosenbrockSolverParameters::FourStageRosenbrockParameters(number_of_grid_cells);
   options.ignore_unused_species_ = true;
 
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -94,10 +94,10 @@ getFourStageDAMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
   std::vector<micm::Process> processes = createProcesses(gas_phase);
 
   auto options =
-      micm::RosenbrockSolverParameters::four_stage_differential_algebraic_rosenbrock_parameters(number_of_grid_cells);
+      micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters(number_of_grid_cells);
   options.ignore_unused_species_ = true;
 
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -121,10 +121,10 @@ getSixStageDAMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
   std::vector<micm::Process> processes = createProcesses(gas_phase);
 
   auto options =
-      micm::RosenbrockSolverParameters::six_stage_differential_algebraic_rosenbrock_parameters(number_of_grid_cells);
+      micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters(number_of_grid_cells);
   options.ignore_unused_species_ = true;
 
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");

--- a/test/regression/RosenbrockChapman/regression_test_dforce_dy_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_dforce_dy_policy.hpp
@@ -33,8 +33,8 @@ void testJacobian(OdeSolverPolicy& solver)
   {
     double number_density_air = 1.0;
     std::vector<double> rate_constants = state.rate_constants_[i];
-    std::vector<double> variables(state.variables_[i].size());
-    for (std::size_t j{}; j < state.variables_[i].size(); ++j)
+    std::vector<double> variables(state.variables_.NumColumns());
+    for (std::size_t j{}; j < state.variables_.NumColumns(); ++j)
       variables[j] = state.variables_[i][state.variable_map_[fixed_solver.species_names()[j]]];
     std::vector<double> fixed_jacobian = fixed_solver.dforce_dy(rate_constants, variables, number_density_air);
 

--- a/test/regression/RosenbrockChapman/regression_test_p_force_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_p_force_policy.hpp
@@ -37,8 +37,8 @@ void testRateConstants(OdeSolverPolicy& solver)
     fixed_state.custom_rate_parameters_[0] = photo_rates[i];
     fixed_solver.UpdateState(fixed_state);
 
-    EXPECT_EQ(state.rate_constants_[i].size(), fixed_state.rate_constants_[0].size());
-    for (size_t j{}; j < state.rate_constants_[i].size(); ++j)
+    EXPECT_EQ(state.rate_constants_.NumColumns(), fixed_state.rate_constants_.NumColumns());
+    for (size_t j{}; j < state.rate_constants_.NumColumns(); ++j)
     {
       EXPECT_EQ(state.rate_constants_[i][j], fixed_state.rate_constants_[0][j]);
     }
@@ -68,12 +68,12 @@ void testForcing(OdeSolverPolicy& solver)
   {
     double number_density_air = 1.0;
     std::vector<double> rate_constants = state.rate_constants_[i];
-    std::vector<double> variables(state.variables_[i].size());
-    for (std::size_t j{}; j < state.variables_[i].size(); ++j)
+    std::vector<double> variables(state.variables_.NumColumns());
+    for (std::size_t j{}; j < state.variables_.NumColumns(); ++j)
       variables[j] = state.variables_[i][state.variable_map_[fixed_solver.species_names()[j]]];
     std::vector<double> fixed_forcing = fixed_solver.force(rate_constants, variables, number_density_air);
 
-    EXPECT_EQ(forcing[i].size(), fixed_forcing.size());
+    EXPECT_EQ(forcing.NumColumns(), fixed_forcing.size());
     for (std::size_t j{}; j < fixed_forcing.size(); ++j)
     {
       double a = forcing[i][state.variable_map_[fixed_solver.species_names()[j]]];

--- a/test/regression/RosenbrockChapman/regression_test_solve_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_solve_policy.hpp
@@ -28,10 +28,10 @@ void testSolve(OdeSolverPolicy& solver, double relative_tolerance = 1.0e-8)
   state.conditions_[1].pressure_ = 100789.2;   // [Pa]
   state.conditions_[2].temperature_ = 299.31;  // [K]
   state.conditions_[2].pressure_ = 101398.0;   // [Pa]
-  std::vector<std::vector<double>> variables(3, std::vector<double>(fixed_state.variables_[0].size(), 0.0));
+  std::vector<std::vector<double>> variables(3, std::vector<double>(fixed_state.variables_.NumColumns(), 0.0));
   double abs_tol = 0.0;
   for (int i = 0; i < 3; ++i)
-    for (int j = 0; j < fixed_state.variables_[0].size(); ++j)
+    for (int j = 0; j < fixed_state.variables_.NumColumns(); ++j)
     {
       variables[i][j] = get_double();
       abs_tol = std::max(abs_tol, variables[i][j]);
@@ -48,7 +48,7 @@ void testSolve(OdeSolverPolicy& solver, double relative_tolerance = 1.0e-8)
       fixed_state.custom_rate_parameters_[0][j] = photo_rates[i][j];
     fixed_state.conditions_[0].temperature_ = state.conditions_[i].temperature_;
     fixed_state.conditions_[0].pressure_ = state.conditions_[i].pressure_;
-    for (int j = 0; j < fixed_state.variables_[0].size(); ++j)
+    for (int j = 0; j < fixed_state.variables_.NumColumns(); ++j)
       fixed_state.variables_[0][j] = variables[i][state.variable_map_[fixed_solver.species_names()[j]]];
     fixed_solver.UpdateState(fixed_state);
     fixed_results[i] = fixed_solver.Solve(0.0, 500.0, fixed_state);

--- a/test/regression/RosenbrockChapman/util.hpp
+++ b/test/regression/RosenbrockChapman/util.hpp
@@ -35,48 +35,48 @@ micm::Phase createGasPhase()
 std::vector<micm::Process> createProcesses(const micm::Phase& gas_phase)
 {
   micm::Process r1 =
-      micm::Process::create()
+      micm::Process::Create()
           .reactants({ micm::Species("O1D"), micm::Species("N2") })
-          .products({ yields(micm::Species("O"), 1), yields(micm::Species("N2"), 1) })
+          .products({ Yields(micm::Species("O"), 1), Yields(micm::Species("N2"), 1) })
           .rate_constant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 2.15e-11, .C_ = 110 }))
           .phase(gas_phase);
 
   micm::Process r2 =
-      micm::Process::create()
+      micm::Process::Create()
           .reactants({ micm::Species("O1D"), micm::Species("O2") })
-          .products({ yields(micm::Species("O"), 1), yields(micm::Species("O2"), 1) })
+          .products({ Yields(micm::Species("O"), 1), Yields(micm::Species("O2"), 1) })
           .rate_constant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .C_ = 55 }))
           .phase(gas_phase);
 
   micm::Process r3 =
-      micm::Process::create()
+      micm::Process::Create()
           .reactants({ micm::Species("O"), micm::Species("O3") })
-          .products({ yields(micm::Species("O2"), 2) })
+          .products({ Yields(micm::Species("O2"), 2) })
           .rate_constant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 8e-12, .C_ = -2060 }))
           .phase(gas_phase);
 
   micm::Process r4 =
-      micm::Process::create()
+      micm::Process::Create()
           .reactants({ micm::Species("O"), micm::Species("O2"), micm::Species("M") })
-          .products({ yields(micm::Species("O3"), 1), yields(micm::Species("M"), 1) })
+          .products({ Yields(micm::Species("O3"), 1), Yields(micm::Species("M"), 1) })
           .rate_constant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 6.0e-34, .B_ = 2.4 }))
           .phase(gas_phase);
 
-  micm::Process photo_1 = micm::Process::create()
+  micm::Process photo_1 = micm::Process::Create()
                               .reactants({ micm::Species("O2") })
-                              .products({ yields(micm::Species("O"), 2) })
+                              .products({ Yields(micm::Species("O"), 2) })
                               .rate_constant(micm::UserDefinedRateConstant({ .label_ = "jO2" }))
                               .phase(gas_phase);
 
-  micm::Process photo_2 = micm::Process::create()
+  micm::Process photo_2 = micm::Process::Create()
                               .reactants({ micm::Species("O3") })
-                              .products({ yields(micm::Species("O1D"), 1), yields(micm::Species("O2"), 1) })
+                              .products({ Yields(micm::Species("O1D"), 1), Yields(micm::Species("O2"), 1) })
                               .rate_constant(micm::UserDefinedRateConstant({ .label_ = "jO3a" }))
                               .phase(gas_phase);
 
-  micm::Process photo_3 = micm::Process::create()
+  micm::Process photo_3 = micm::Process::Create()
                               .reactants({ micm::Species("O3") })
-                              .products({ yields(micm::Species("O"), 1), yields(micm::Species("O2"), 1) })
+                              .products({ Yields(micm::Species("O"), 1), Yields(micm::Species("O2"), 1) })
                               .rate_constant(micm::UserDefinedRateConstant({ .label_ = "jO3b" }))
                               .phase(gas_phase);
 

--- a/test/regression/RosenbrockChapman/util.hpp
+++ b/test/regression/RosenbrockChapman/util.hpp
@@ -36,49 +36,49 @@ std::vector<micm::Process> createProcesses(const micm::Phase& gas_phase)
 {
   micm::Process r1 =
       micm::Process::Create()
-          .reactants({ micm::Species("O1D"), micm::Species("N2") })
-          .products({ Yields(micm::Species("O"), 1), Yields(micm::Species("N2"), 1) })
-          .rate_constant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 2.15e-11, .C_ = 110 }))
-          .phase(gas_phase);
+          .SetReactants({ micm::Species("O1D"), micm::Species("N2") })
+          .SetProducts({ Yields(micm::Species("O"), 1), Yields(micm::Species("N2"), 1) })
+          .SetRateConstant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 2.15e-11, .C_ = 110 }))
+          .SetPhase(gas_phase);
 
   micm::Process r2 =
       micm::Process::Create()
-          .reactants({ micm::Species("O1D"), micm::Species("O2") })
-          .products({ Yields(micm::Species("O"), 1), Yields(micm::Species("O2"), 1) })
-          .rate_constant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .C_ = 55 }))
-          .phase(gas_phase);
+          .SetReactants({ micm::Species("O1D"), micm::Species("O2") })
+          .SetProducts({ Yields(micm::Species("O"), 1), Yields(micm::Species("O2"), 1) })
+          .SetRateConstant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .C_ = 55 }))
+          .SetPhase(gas_phase);
 
   micm::Process r3 =
       micm::Process::Create()
-          .reactants({ micm::Species("O"), micm::Species("O3") })
-          .products({ Yields(micm::Species("O2"), 2) })
-          .rate_constant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 8e-12, .C_ = -2060 }))
-          .phase(gas_phase);
+          .SetReactants({ micm::Species("O"), micm::Species("O3") })
+          .SetProducts({ Yields(micm::Species("O2"), 2) })
+          .SetRateConstant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 8e-12, .C_ = -2060 }))
+          .SetPhase(gas_phase);
 
   micm::Process r4 =
       micm::Process::Create()
-          .reactants({ micm::Species("O"), micm::Species("O2"), micm::Species("M") })
-          .products({ Yields(micm::Species("O3"), 1), Yields(micm::Species("M"), 1) })
-          .rate_constant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 6.0e-34, .B_ = 2.4 }))
-          .phase(gas_phase);
+          .SetReactants({ micm::Species("O"), micm::Species("O2"), micm::Species("M") })
+          .SetProducts({ Yields(micm::Species("O3"), 1), Yields(micm::Species("M"), 1) })
+          .SetRateConstant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 6.0e-34, .B_ = 2.4 }))
+          .SetPhase(gas_phase);
 
   micm::Process photo_1 = micm::Process::Create()
-                              .reactants({ micm::Species("O2") })
-                              .products({ Yields(micm::Species("O"), 2) })
-                              .rate_constant(micm::UserDefinedRateConstant({ .label_ = "jO2" }))
-                              .phase(gas_phase);
+                              .SetReactants({ micm::Species("O2") })
+                              .SetProducts({ Yields(micm::Species("O"), 2) })
+                              .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "jO2" }))
+                              .SetPhase(gas_phase);
 
   micm::Process photo_2 = micm::Process::Create()
-                              .reactants({ micm::Species("O3") })
-                              .products({ Yields(micm::Species("O1D"), 1), Yields(micm::Species("O2"), 1) })
-                              .rate_constant(micm::UserDefinedRateConstant({ .label_ = "jO3a" }))
-                              .phase(gas_phase);
+                              .SetReactants({ micm::Species("O3") })
+                              .SetProducts({ Yields(micm::Species("O1D"), 1), Yields(micm::Species("O2"), 1) })
+                              .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "jO3a" }))
+                              .SetPhase(gas_phase);
 
   micm::Process photo_3 = micm::Process::Create()
-                              .reactants({ micm::Species("O3") })
-                              .products({ Yields(micm::Species("O"), 1), Yields(micm::Species("O2"), 1) })
-                              .rate_constant(micm::UserDefinedRateConstant({ .label_ = "jO3b" }))
-                              .phase(gas_phase);
+                              .SetReactants({ micm::Species("O3") })
+                              .SetProducts({ Yields(micm::Species("O"), 1), Yields(micm::Species("O2"), 1) })
+                              .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "jO3b" }))
+                              .SetPhase(gas_phase);
 
   return { photo_1, photo_2, photo_3, r1, r2, r3, r4 };
 }
@@ -90,7 +90,7 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> get
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
 
-  auto options = micm::RosenbrockSolverParameters::two_stage_rosenbrock_parameters(number_of_grid_cells);
+  auto options = micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters(number_of_grid_cells);
   options.ignore_unused_species_ = true;
 
   return micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>(
@@ -104,7 +104,7 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> get
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
 
-  auto options = micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells);
+  auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters(number_of_grid_cells);
   options.ignore_unused_species_ = true;
 
   return micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>(
@@ -118,7 +118,7 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> get
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
 
-  auto options = micm::RosenbrockSolverParameters::four_stage_rosenbrock_parameters(number_of_grid_cells);
+  auto options = micm::RosenbrockSolverParameters::FourStageRosenbrockParameters(number_of_grid_cells);
   options.ignore_unused_species_ = true;
 
   return micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>(
@@ -133,7 +133,7 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> get
   std::vector<micm::Process> processes = createProcesses(gas_phase);
 
   auto options =
-      micm::RosenbrockSolverParameters::four_stage_differential_algebraic_rosenbrock_parameters(number_of_grid_cells);
+      micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters(number_of_grid_cells);
   options.ignore_unused_species_ = true;
 
   return micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>(
@@ -148,7 +148,7 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> get
   std::vector<micm::Process> processes = createProcesses(gas_phase);
 
   auto options =
-      micm::RosenbrockSolverParameters::six_stage_differential_algebraic_rosenbrock_parameters(number_of_grid_cells);
+      micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters(number_of_grid_cells);
   options.ignore_unused_species_ = true;
 
   return micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>(

--- a/test/tutorial/test_README_example.cpp
+++ b/test/tutorial/test_README_example.cpp
@@ -16,13 +16,13 @@ int main(const int argc, const char *argv[])
 
   System chemical_system{ SystemParameters{ .gas_phase_ = gas_phase } };
 
-  Process r1 = Process::create()
+  Process r1 = Process::Create()
                    .reactants({ foo })
                    .products({ Yield(bar, 0.8), Yield(baz, 0.2) })
                    .rate_constant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))
                    .phase(gas_phase);
 
-  Process r2 = Process::create()
+  Process r2 = Process::Create()
                    .reactants({ foo, bar })
                    .products({ Yield(baz, 1) })
                    .rate_constant(ArrheniusRateConstant({ .A_ = 1.0e-5, .C_ = 110.0 }))

--- a/test/tutorial/test_README_example.cpp
+++ b/test/tutorial/test_README_example.cpp
@@ -17,20 +17,20 @@ int main(const int argc, const char *argv[])
   System chemical_system{ SystemParameters{ .gas_phase_ = gas_phase } };
 
   Process r1 = Process::Create()
-                   .reactants({ foo })
-                   .products({ Yield(bar, 0.8), Yield(baz, 0.2) })
-                   .rate_constant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))
-                   .phase(gas_phase);
+                   .SetReactants({ foo })
+                   .SetProducts({ Yield(bar, 0.8), Yield(baz, 0.2) })
+                   .SetRateConstant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))
+                   .SetPhase(gas_phase);
 
   Process r2 = Process::Create()
-                   .reactants({ foo, bar })
-                   .products({ Yield(baz, 1) })
-                   .rate_constant(ArrheniusRateConstant({ .A_ = 1.0e-5, .C_ = 110.0 }))
-                   .phase(gas_phase);
+                   .SetReactants({ foo, bar })
+                   .SetProducts({ Yield(baz, 1) })
+                   .SetRateConstant(ArrheniusRateConstant({ .A_ = 1.0e-5, .C_ = 110.0 }))
+                   .SetPhase(gas_phase);
 
   std::vector<Process> reactions{ r1, r2 };
 
-  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
+  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::ThreeStageRosenbrockParameters() };
 
   State state = solver.GetState();
 

--- a/test/tutorial/test_jit_tutorial.cpp
+++ b/test/tutorial/test_jit_tutorial.cpp
@@ -77,24 +77,24 @@ int main(const int argc, const char* argv[])
   System chemical_system{ SystemParameters{ .gas_phase_ = gas_phase } };
 
   Process r1 = Process::Create()
-                   .reactants({ foo })
-                   .products({ Yield(bar, 0.8), Yield(baz, 0.2) })
-                   .rate_constant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))
-                   .phase(gas_phase);
+                   .SetReactants({ foo })
+                   .SetProducts({ Yield(bar, 0.8), Yield(baz, 0.2) })
+                   .SetRateConstant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))
+                   .SetPhase(gas_phase);
 
   Process r2 = Process::Create()
-                   .reactants({ foo, bar })
-                   .products({ Yield(baz, 1) })
-                   .rate_constant(ArrheniusRateConstant({ .A_ = 1.0e-5, .C_ = 110.0 }))
-                   .phase(gas_phase);
+                   .SetReactants({ foo, bar })
+                   .SetProducts({ Yield(baz, 1) })
+                   .SetRateConstant(ArrheniusRateConstant({ .A_ = 1.0e-5, .C_ = 110.0 }))
+                   .SetPhase(gas_phase);
 
   std::vector<Process> reactions{ r1, r2 };
 
-  auto solver_parameters = RosenbrockSolverParameters::three_stage_rosenbrock_parameters(n_grid_cells);
+  auto solver_parameters = RosenbrockSolverParameters::ThreeStageRosenbrockParameters(n_grid_cells);
 
   RosenbrockSolver<GroupVectorMatrix, GroupSparseVectorMatrix> solver{ chemical_system, reactions, solver_parameters };
 
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
 
   auto start = std::chrono::high_resolution_clock::now();
   JitRosenbrockSolver<

--- a/test/tutorial/test_jit_tutorial.cpp
+++ b/test/tutorial/test_jit_tutorial.cpp
@@ -76,13 +76,13 @@ int main(const int argc, const char* argv[])
 
   System chemical_system{ SystemParameters{ .gas_phase_ = gas_phase } };
 
-  Process r1 = Process::create()
+  Process r1 = Process::Create()
                    .reactants({ foo })
                    .products({ Yield(bar, 0.8), Yield(baz, 0.2) })
                    .rate_constant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))
                    .phase(gas_phase);
 
-  Process r2 = Process::create()
+  Process r2 = Process::Create()
                    .reactants({ foo, bar })
                    .products({ Yield(baz, 1) })
                    .rate_constant(ArrheniusRateConstant({ .A_ = 1.0e-5, .C_ = 110.0 }))

--- a/test/tutorial/test_multiple_grid_cells.cpp
+++ b/test/tutorial/test_multiple_grid_cells.cpp
@@ -16,26 +16,26 @@ int main()
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ a })
-                         .products({ Yields(b, 1) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
-                         .phase(gas_phase);
+                         .SetReactants({ a })
+                         .SetProducts({ Yields(b, 1) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ b, b })
-                         .products({ Yields(b, 1), Yields(c, 1) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
-                         .phase(gas_phase);
+                         .SetReactants({ b, b })
+                         .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
+                         .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
-                         .reactants({ b, c })
-                         .products({ Yields(a, 1), Yields(c, 1) })
-                         .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
-                         .phase(gas_phase);
+                         .SetReactants({ b, c })
+                         .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                         .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
+                         .SetPhase(gas_phase);
 
   micm::RosenbrockSolver<> solver{ micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }),
                                    std::vector<micm::Process>{ r1, r2, r3 },
-                                   micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(3, false) };
+                                   micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters(3, false) };
 
   auto state = solver.GetState();
 

--- a/test/tutorial/test_multiple_grid_cells.cpp
+++ b/test/tutorial/test_multiple_grid_cells.cpp
@@ -15,21 +15,21 @@ int main()
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ a })
-                         .products({ yields(b, 1) })
+                         .products({ Yields(b, 1) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ b, b })
-                         .products({ yields(b, 1), yields(c, 1) })
+                         .products({ Yields(b, 1), Yields(c, 1) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .phase(gas_phase);
 
-  micm::Process r3 = micm::Process::create()
+  micm::Process r3 = micm::Process::Create()
                          .reactants({ b, c })
-                         .products({ yields(a, 1), yields(c, 1) })
+                         .products({ Yields(a, 1), Yields(c, 1) })
                          .rate_constant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .phase(gas_phase);
 

--- a/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
@@ -30,10 +30,10 @@ int main(const int argc, const char* argv[])
   Phase gas_phase{ std::vector<Species>{ a, b, c, d, e, f, g } };
 
   Process r1 = Process::Create()
-                   .reactants({ a })
-                   .products({ Yields(b, 1) })
-                   .rate_constant(ArrheniusRateConstant({ .A_ = 2.15e-1, .B_ = 0, .C_ = 110 }))
-                   .phase(gas_phase);
+                   .SetReactants({ a })
+                   .SetProducts({ Yields(b, 1) })
+                   .SetRateConstant(ArrheniusRateConstant({ .A_ = 2.15e-1, .B_ = 0, .C_ = 110 }))
+                   .SetPhase(gas_phase);
 
   // a branched reaction has two output pathways
   // this is represnted internal to micm as two different reactions
@@ -41,30 +41,30 @@ int main(const int argc, const char* argv[])
   branched_params.branch_ = BranchedRateConstantParameters::Branch::Alkoxy;
 
   Process r2 = Process::Create()
-                   .reactants({ b })
-                   .products({ Yields(c, 1) })
-                   .rate_constant(BranchedRateConstant(branched_params))
-                   .phase(gas_phase);
+                   .SetReactants({ b })
+                   .SetProducts({ Yields(c, 1) })
+                   .SetRateConstant(BranchedRateConstant(branched_params))
+                   .SetPhase(gas_phase);
 
   branched_params.branch_ = BranchedRateConstantParameters::Branch::Nitrate;
   Process r3 = Process::Create()
-                   .reactants({ b })
-                   .products({ Yields(d, 1) })
-                   .rate_constant(BranchedRateConstant(branched_params))
-                   .phase(gas_phase);
+                   .SetReactants({ b })
+                   .SetProducts({ Yields(d, 1) })
+                   .SetRateConstant(BranchedRateConstant(branched_params))
+                   .SetPhase(gas_phase);
 
   // A surface rate constant also needs to know the effective radius and particle number concentration
   // we will set those later
   Process r4 = Process::Create()
-                   .reactants({ c })
-                   .products({ Yields(e, 1) })
-                   .rate_constant(SurfaceRateConstant({ .label_ = "C", .species_ = c, .reaction_probability_ = 0.90 }))
-                   .phase(gas_phase);
+                   .SetReactants({ c })
+                   .SetProducts({ Yields(e, 1) })
+                   .SetRateConstant(SurfaceRateConstant({ .label_ = "C", .species_ = c, .reaction_probability_ = 0.90 }))
+                   .SetPhase(gas_phase);
 
   Process r5 = Process::Create()
-                   .reactants({ d })
-                   .products({ Yields(f, 2) })
-                   .rate_constant(TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2,
+                   .SetReactants({ d })
+                   .SetProducts({ Yields(f, 2) })
+                   .SetRateConstant(TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2,
                                                                           .k0_B_ = 2.3,
                                                                           .k0_C_ = 302.3,
                                                                           .kinf_A_ = 2.6,
@@ -72,14 +72,14 @@ int main(const int argc, const char* argv[])
                                                                           .kinf_C_ = 402.1,
                                                                           .Fc_ = 0.9,
                                                                           .N_ = 1.2 }))
-                   .phase(gas_phase);
+                   .SetPhase(gas_phase);
 
   // to have a stoichiemetric coefficient of more than one for reactants,
   // list the reactant that many times
   Process r6 = Process::Create()
-                   .reactants({ e, e })
-                   .products({ Yields(g, 1) })
-                   .rate_constant(TroeRateConstant({ .k0_A_ = 1.2e4,
+                   .SetReactants({ e, e })
+                   .SetProducts({ Yields(g, 1) })
+                   .SetRateConstant(TroeRateConstant({ .k0_A_ = 1.2e4,
                                                      .k0_B_ = 167.0,
                                                      .k0_C_ = 3.0,
                                                      .kinf_A_ = 136.0,
@@ -87,18 +87,18 @@ int main(const int argc, const char* argv[])
                                                      .kinf_C_ = 24.0,
                                                      .Fc_ = 0.9,
                                                      .N_ = 0.8 }))
-                   .phase(gas_phase);
+                   .SetPhase(gas_phase);
 
   Process r7 = Process::Create()
-                   .reactants({ f })
-                   .products({ Yields(g, 1) })
-                   .rate_constant(TunnelingRateConstant({ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 }))
-                   .phase(gas_phase);
+                   .SetReactants({ f })
+                   .SetProducts({ Yields(g, 1) })
+                   .SetRateConstant(TunnelingRateConstant({ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 }))
+                   .SetPhase(gas_phase);
 
   auto chemical_system = System(micm::SystemParameters{ .gas_phase_ = gas_phase });
   auto reactions = std::vector<micm::Process>{ r1, r2, r3, r4, r5, r6, r7 };
 
-  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
+  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::ThreeStageRosenbrockParameters() };
   State state = solver.GetState();
 
   state.conditions_[0].temperature_ = 287.45;  // K

--- a/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
@@ -29,9 +29,9 @@ int main(const int argc, const char* argv[])
 
   Phase gas_phase{ std::vector<Species>{ a, b, c, d, e, f, g } };
 
-  Process r1 = Process::create()
+  Process r1 = Process::Create()
                    .reactants({ a })
-                   .products({ yields(b, 1) })
+                   .products({ Yields(b, 1) })
                    .rate_constant(ArrheniusRateConstant({ .A_ = 2.15e-1, .B_ = 0, .C_ = 110 }))
                    .phase(gas_phase);
 
@@ -40,30 +40,30 @@ int main(const int argc, const char* argv[])
   auto branched_params = BranchedRateConstantParameters{ .X_ = 1.2, .Y_ = 204.3, .a0_ = 1.0e-3, .n_ = 2 };
   branched_params.branch_ = BranchedRateConstantParameters::Branch::Alkoxy;
 
-  Process r2 = Process::create()
+  Process r2 = Process::Create()
                    .reactants({ b })
-                   .products({ yields(c, 1) })
+                   .products({ Yields(c, 1) })
                    .rate_constant(BranchedRateConstant(branched_params))
                    .phase(gas_phase);
 
   branched_params.branch_ = BranchedRateConstantParameters::Branch::Nitrate;
-  Process r3 = Process::create()
+  Process r3 = Process::Create()
                    .reactants({ b })
-                   .products({ yields(d, 1) })
+                   .products({ Yields(d, 1) })
                    .rate_constant(BranchedRateConstant(branched_params))
                    .phase(gas_phase);
 
   // A surface rate constant also needs to know the effective radius and particle number concentration
   // we will set those later
-  Process r4 = Process::create()
+  Process r4 = Process::Create()
                    .reactants({ c })
-                   .products({ yields(e, 1) })
+                   .products({ Yields(e, 1) })
                    .rate_constant(SurfaceRateConstant({ .label_ = "C", .species_ = c, .reaction_probability_ = 0.90 }))
                    .phase(gas_phase);
 
-  Process r5 = Process::create()
+  Process r5 = Process::Create()
                    .reactants({ d })
-                   .products({ yields(f, 2) })
+                   .products({ Yields(f, 2) })
                    .rate_constant(TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2,
                                                                           .k0_B_ = 2.3,
                                                                           .k0_C_ = 302.3,
@@ -76,9 +76,9 @@ int main(const int argc, const char* argv[])
 
   // to have a stoichiemetric coefficient of more than one for reactants,
   // list the reactant that many times
-  Process r6 = Process::create()
+  Process r6 = Process::Create()
                    .reactants({ e, e })
-                   .products({ yields(g, 1) })
+                   .products({ Yields(g, 1) })
                    .rate_constant(TroeRateConstant({ .k0_A_ = 1.2e4,
                                                      .k0_B_ = 167.0,
                                                      .k0_C_ = 3.0,
@@ -89,9 +89,9 @@ int main(const int argc, const char* argv[])
                                                      .N_ = 0.8 }))
                    .phase(gas_phase);
 
-  Process r7 = Process::create()
+  Process r7 = Process::Create()
                    .reactants({ f })
-                   .products({ yields(g, 1) })
+                   .products({ Yields(g, 1) })
                    .rate_constant(TunnelingRateConstant({ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 }))
                    .phase(gas_phase);
 

--- a/test/tutorial/test_rate_constants_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_user_defined_by_hand.cpp
@@ -31,10 +31,10 @@ int main(const int argc, const char* argv[])
   Phase gas_phase{ std::vector<Species>{ a, b, c, d, e, f, g } };
 
   Process r1 = Process::Create()
-                   .reactants({ a })
-                   .products({ Yields(b, 1) })
-                   .rate_constant(ArrheniusRateConstant({ .A_ = 2.15e-1, .B_ = 0, .C_ = 110 }))
-                   .phase(gas_phase);
+                   .SetReactants({ a })
+                   .SetProducts({ Yields(b, 1) })
+                   .SetRateConstant(ArrheniusRateConstant({ .A_ = 2.15e-1, .B_ = 0, .C_ = 110 }))
+                   .SetPhase(gas_phase);
 
   // a branched reaction has two output pathways
   // this is represnted internal to micm as two different reactions
@@ -42,30 +42,30 @@ int main(const int argc, const char* argv[])
   branched_params.branch_ = BranchedRateConstantParameters::Branch::Alkoxy;
 
   Process r2 = Process::Create()
-                   .reactants({ b })
-                   .products({ Yields(c, 1) })
-                   .rate_constant(BranchedRateConstant(branched_params))
-                   .phase(gas_phase);
+                   .SetReactants({ b })
+                   .SetProducts({ Yields(c, 1) })
+                   .SetRateConstant(BranchedRateConstant(branched_params))
+                   .SetPhase(gas_phase);
 
   branched_params.branch_ = BranchedRateConstantParameters::Branch::Nitrate;
   Process r3 = Process::Create()
-                   .reactants({ b })
-                   .products({ Yields(d, 1) })
-                   .rate_constant(BranchedRateConstant(branched_params))
-                   .phase(gas_phase);
+                   .SetReactants({ b })
+                   .SetProducts({ Yields(d, 1) })
+                   .SetRateConstant(BranchedRateConstant(branched_params))
+                   .SetPhase(gas_phase);
 
   // A surface rate constant also needs to know the effective radius and particle number concentration
   // we will set those later
   Process r4 = Process::Create()
-                   .reactants({ c })
-                   .products({ Yields(e, 1) })
-                   .rate_constant(SurfaceRateConstant({ .label_ = "C", .species_ = c, .reaction_probability_ = 0.90 }))
-                   .phase(gas_phase);
+                   .SetReactants({ c })
+                   .SetProducts({ Yields(e, 1) })
+                   .SetRateConstant(SurfaceRateConstant({ .label_ = "C", .species_ = c, .reaction_probability_ = 0.90 }))
+                   .SetPhase(gas_phase);
 
   Process r5 = Process::Create()
-                   .reactants({ d })
-                   .products({ Yields(f, 2) })
-                   .rate_constant(TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2,
+                   .SetReactants({ d })
+                   .SetProducts({ Yields(f, 2) })
+                   .SetRateConstant(TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2,
                                                                           .k0_B_ = 2.3,
                                                                           .k0_C_ = 302.3,
                                                                           .kinf_A_ = 2.6,
@@ -73,14 +73,14 @@ int main(const int argc, const char* argv[])
                                                                           .kinf_C_ = 402.1,
                                                                           .Fc_ = 0.9,
                                                                           .N_ = 1.2 }))
-                   .phase(gas_phase);
+                   .SetPhase(gas_phase);
 
   // to have a stoichiemetric coefficient of more than one for reactants,
   // list the reactant that many times
   Process r6 = Process::Create()
-                   .reactants({ e, e })
-                   .products({ Yields(g, 1) })
-                   .rate_constant(TroeRateConstant({ .k0_A_ = 1.2e4,
+                   .SetReactants({ e, e })
+                   .SetProducts({ Yields(g, 1) })
+                   .SetRateConstant(TroeRateConstant({ .k0_A_ = 1.2e4,
                                                      .k0_B_ = 167.0,
                                                      .k0_C_ = 3.0,
                                                      .kinf_A_ = 136.0,
@@ -88,34 +88,34 @@ int main(const int argc, const char* argv[])
                                                      .kinf_C_ = 24.0,
                                                      .Fc_ = 0.9,
                                                      .N_ = 0.8 }))
-                   .phase(gas_phase);
+                   .SetPhase(gas_phase);
 
   Process r7 = Process::Create()
-                   .reactants({ f })
-                   .products({ Yields(g, 1) })
-                   .rate_constant(TunnelingRateConstant({ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 }))
-                   .phase(gas_phase);
+                   .SetReactants({ f })
+                   .SetProducts({ Yields(g, 1) })
+                   .SetRateConstant(TunnelingRateConstant({ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 }))
+                   .SetPhase(gas_phase);
 
   Process r8 = Process::Create()
-                   .reactants({ c })
-                   .products({ Yields(g, 1) })
-                   .rate_constant(UserDefinedRateConstant({ .label_ = "my photolysis rate" }))
-                   .phase(gas_phase);
+                   .SetReactants({ c })
+                   .SetProducts({ Yields(g, 1) })
+                   .SetRateConstant(UserDefinedRateConstant({ .label_ = "my photolysis rate" }))
+                   .SetPhase(gas_phase);
 
   Process r9 = Process::Create()
-                   .products({ Yields(a, 1) })
-                   .rate_constant(UserDefinedRateConstant({ .label_ = "my emission rate" }))
-                   .phase(gas_phase);
+                   .SetProducts({ Yields(a, 1) })
+                   .SetRateConstant(UserDefinedRateConstant({ .label_ = "my emission rate" }))
+                   .SetPhase(gas_phase);
 
   Process r10 = Process::Create()
-                    .reactants({ b })
-                    .rate_constant(UserDefinedRateConstant({ .label_ = "my loss rate" }))
-                    .phase(gas_phase);
+                    .SetReactants({ b })
+                    .SetRateConstant(UserDefinedRateConstant({ .label_ = "my loss rate" }))
+                    .SetPhase(gas_phase);
 
   auto chemical_system = System(micm::SystemParameters{ .gas_phase_ = gas_phase });
   auto reactions = std::vector<micm::Process>{ r1, r2, r3, r4, r5, r6, r7, r8, r9, r10 };
 
-  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
+  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::ThreeStageRosenbrockParameters() };
   State state = solver.GetState();
 
   state.conditions_[0].temperature_ = 287.45;  // K

--- a/test/tutorial/test_rate_constants_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_user_defined_by_hand.cpp
@@ -30,9 +30,9 @@ int main(const int argc, const char* argv[])
 
   Phase gas_phase{ std::vector<Species>{ a, b, c, d, e, f, g } };
 
-  Process r1 = Process::create()
+  Process r1 = Process::Create()
                    .reactants({ a })
-                   .products({ yields(b, 1) })
+                   .products({ Yields(b, 1) })
                    .rate_constant(ArrheniusRateConstant({ .A_ = 2.15e-1, .B_ = 0, .C_ = 110 }))
                    .phase(gas_phase);
 
@@ -41,30 +41,30 @@ int main(const int argc, const char* argv[])
   auto branched_params = BranchedRateConstantParameters{ .X_ = 1.2, .Y_ = 204.3, .a0_ = 1.0e-3, .n_ = 2 };
   branched_params.branch_ = BranchedRateConstantParameters::Branch::Alkoxy;
 
-  Process r2 = Process::create()
+  Process r2 = Process::Create()
                    .reactants({ b })
-                   .products({ yields(c, 1) })
+                   .products({ Yields(c, 1) })
                    .rate_constant(BranchedRateConstant(branched_params))
                    .phase(gas_phase);
 
   branched_params.branch_ = BranchedRateConstantParameters::Branch::Nitrate;
-  Process r3 = Process::create()
+  Process r3 = Process::Create()
                    .reactants({ b })
-                   .products({ yields(d, 1) })
+                   .products({ Yields(d, 1) })
                    .rate_constant(BranchedRateConstant(branched_params))
                    .phase(gas_phase);
 
   // A surface rate constant also needs to know the effective radius and particle number concentration
   // we will set those later
-  Process r4 = Process::create()
+  Process r4 = Process::Create()
                    .reactants({ c })
-                   .products({ yields(e, 1) })
+                   .products({ Yields(e, 1) })
                    .rate_constant(SurfaceRateConstant({ .label_ = "C", .species_ = c, .reaction_probability_ = 0.90 }))
                    .phase(gas_phase);
 
-  Process r5 = Process::create()
+  Process r5 = Process::Create()
                    .reactants({ d })
-                   .products({ yields(f, 2) })
+                   .products({ Yields(f, 2) })
                    .rate_constant(TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2,
                                                                           .k0_B_ = 2.3,
                                                                           .k0_C_ = 302.3,
@@ -77,9 +77,9 @@ int main(const int argc, const char* argv[])
 
   // to have a stoichiemetric coefficient of more than one for reactants,
   // list the reactant that many times
-  Process r6 = Process::create()
+  Process r6 = Process::Create()
                    .reactants({ e, e })
-                   .products({ yields(g, 1) })
+                   .products({ Yields(g, 1) })
                    .rate_constant(TroeRateConstant({ .k0_A_ = 1.2e4,
                                                      .k0_B_ = 167.0,
                                                      .k0_C_ = 3.0,
@@ -90,24 +90,24 @@ int main(const int argc, const char* argv[])
                                                      .N_ = 0.8 }))
                    .phase(gas_phase);
 
-  Process r7 = Process::create()
+  Process r7 = Process::Create()
                    .reactants({ f })
-                   .products({ yields(g, 1) })
+                   .products({ Yields(g, 1) })
                    .rate_constant(TunnelingRateConstant({ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 }))
                    .phase(gas_phase);
 
-  Process r8 = Process::create()
+  Process r8 = Process::Create()
                    .reactants({ c })
-                   .products({ yields(g, 1) })
+                   .products({ Yields(g, 1) })
                    .rate_constant(UserDefinedRateConstant({ .label_ = "my photolysis rate" }))
                    .phase(gas_phase);
 
-  Process r9 = Process::create()
-                   .products({ yields(a, 1) })
+  Process r9 = Process::Create()
+                   .products({ Yields(a, 1) })
                    .rate_constant(UserDefinedRateConstant({ .label_ = "my emission rate" }))
                    .phase(gas_phase);
 
-  Process r10 = Process::create()
+  Process r10 = Process::Create()
                     .reactants({ b })
                     .rate_constant(UserDefinedRateConstant({ .label_ = "my loss rate" }))
                     .phase(gas_phase);

--- a/test/tutorial/test_solver_configuration.cpp
+++ b/test/tutorial/test_solver_configuration.cpp
@@ -90,21 +90,21 @@ int main()
 
   Phase gas_phase{ std::vector<Species>{ a, b, c } };
 
-  Process r1 = Process::create()
+  Process r1 = Process::Create()
                    .reactants({ a })
-                   .products({ yields(b, 1) })
+                   .products({ Yields(b, 1) })
                    .rate_constant(UserDefinedRateConstant({ .label_ = "r1" }))
                    .phase(gas_phase);
 
-  Process r2 = Process::create()
+  Process r2 = Process::Create()
                    .reactants({ b, b })
-                   .products({ yields(b, 1), yields(c, 1) })
+                   .products({ Yields(b, 1), Yields(c, 1) })
                    .rate_constant(UserDefinedRateConstant({ .label_ = "r2" }))
                    .phase(gas_phase);
 
-  Process r3 = Process::create()
+  Process r3 = Process::Create()
                    .reactants({ b, c })
-                   .products({ yields(a, 1), yields(c, 1) })
+                   .products({ Yields(a, 1), Yields(c, 1) })
                    .rate_constant(UserDefinedRateConstant({ .label_ = "r3" }))
                    .phase(gas_phase);
 

--- a/test/tutorial/test_solver_configuration.cpp
+++ b/test/tutorial/test_solver_configuration.cpp
@@ -91,39 +91,39 @@ int main()
   Phase gas_phase{ std::vector<Species>{ a, b, c } };
 
   Process r1 = Process::Create()
-                   .reactants({ a })
-                   .products({ Yields(b, 1) })
-                   .rate_constant(UserDefinedRateConstant({ .label_ = "r1" }))
-                   .phase(gas_phase);
+                   .SetReactants({ a })
+                   .SetProducts({ Yields(b, 1) })
+                   .SetRateConstant(UserDefinedRateConstant({ .label_ = "r1" }))
+                   .SetPhase(gas_phase);
 
   Process r2 = Process::Create()
-                   .reactants({ b, b })
-                   .products({ Yields(b, 1), Yields(c, 1) })
-                   .rate_constant(UserDefinedRateConstant({ .label_ = "r2" }))
-                   .phase(gas_phase);
+                   .SetReactants({ b, b })
+                   .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                   .SetRateConstant(UserDefinedRateConstant({ .label_ = "r2" }))
+                   .SetPhase(gas_phase);
 
   Process r3 = Process::Create()
-                   .reactants({ b, c })
-                   .products({ Yields(a, 1), Yields(c, 1) })
-                   .rate_constant(UserDefinedRateConstant({ .label_ = "r3" }))
-                   .phase(gas_phase);
+                   .SetReactants({ b, c })
+                   .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                   .SetRateConstant(UserDefinedRateConstant({ .label_ = "r3" }))
+                   .SetPhase(gas_phase);
 
   auto system = System(SystemParameters{ .gas_phase_ = gas_phase });
   auto reactions = std::vector<Process>{ r1, r2, r3 };
 
-  RosenbrockSolver<> two_stage{ system, reactions, RosenbrockSolverParameters::two_stage_rosenbrock_parameters() };
+  RosenbrockSolver<> two_stage{ system, reactions, RosenbrockSolverParameters::TwoStageRosenbrockParameters() };
 
-  RosenbrockSolver<> three_stage{ system, reactions, RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
+  RosenbrockSolver<> three_stage{ system, reactions, RosenbrockSolverParameters::ThreeStageRosenbrockParameters() };
 
-  RosenbrockSolver<> four_stage{ system, reactions, RosenbrockSolverParameters::four_stage_rosenbrock_parameters() };
+  RosenbrockSolver<> four_stage{ system, reactions, RosenbrockSolverParameters::FourStageRosenbrockParameters() };
 
   RosenbrockSolver<> four_stage_da{ system,
                                     reactions,
-                                    RosenbrockSolverParameters::four_stage_differential_algebraic_rosenbrock_parameters() };
+                                    RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters() };
 
   RosenbrockSolver<> six_stage_da{ system,
                                    reactions,
-                                   RosenbrockSolverParameters::six_stage_differential_algebraic_rosenbrock_parameters() };
+                                   RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters() };
 
   std::cout << "Two stages: " << std::endl;
   test_solver_type(two_stage);

--- a/test/tutorial/test_solver_results.cpp
+++ b/test/tutorial/test_solver_results.cpp
@@ -17,26 +17,26 @@ int main()
   Phase gas_phase{ std::vector<Species>{ a, b, c } };
 
   Process r1 = Process::Create()
-                   .reactants({ a })
-                   .products({ Yields(b, 1) })
-                   .rate_constant(UserDefinedRateConstant({ .label_ = "r1" }))
-                   .phase(gas_phase);
+                   .SetReactants({ a })
+                   .SetProducts({ Yields(b, 1) })
+                   .SetRateConstant(UserDefinedRateConstant({ .label_ = "r1" }))
+                   .SetPhase(gas_phase);
 
   Process r2 = Process::Create()
-                   .reactants({ b, b })
-                   .products({ Yields(b, 1), Yields(c, 1) })
-                   .rate_constant(UserDefinedRateConstant({ .label_ = "r2" }))
-                   .phase(gas_phase);
+                   .SetReactants({ b, b })
+                   .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                   .SetRateConstant(UserDefinedRateConstant({ .label_ = "r2" }))
+                   .SetPhase(gas_phase);
 
   Process r3 = Process::Create()
-                   .reactants({ b, c })
-                   .products({ Yields(a, 1), Yields(c, 1) })
-                   .rate_constant(UserDefinedRateConstant({ .label_ = "r3" }))
-                   .phase(gas_phase);
+                   .SetReactants({ b, c })
+                   .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                   .SetRateConstant(UserDefinedRateConstant({ .label_ = "r3" }))
+                   .SetPhase(gas_phase);
 
   RosenbrockSolver<> solver{ System(SystemParameters{ .gas_phase_ = gas_phase }),
                              std::vector<Process>{ r1, r2, r3 },
-                             RosenbrockSolverParameters::three_stage_rosenbrock_parameters(3, false) };
+                             RosenbrockSolverParameters::ThreeStageRosenbrockParameters(3, false) };
 
   auto state = solver.GetState();
 

--- a/test/tutorial/test_solver_results.cpp
+++ b/test/tutorial/test_solver_results.cpp
@@ -16,21 +16,21 @@ int main()
 
   Phase gas_phase{ std::vector<Species>{ a, b, c } };
 
-  Process r1 = Process::create()
+  Process r1 = Process::Create()
                    .reactants({ a })
-                   .products({ yields(b, 1) })
+                   .products({ Yields(b, 1) })
                    .rate_constant(UserDefinedRateConstant({ .label_ = "r1" }))
                    .phase(gas_phase);
 
-  Process r2 = Process::create()
+  Process r2 = Process::Create()
                    .reactants({ b, b })
-                   .products({ yields(b, 1), yields(c, 1) })
+                   .products({ Yields(b, 1), Yields(c, 1) })
                    .rate_constant(UserDefinedRateConstant({ .label_ = "r2" }))
                    .phase(gas_phase);
 
-  Process r3 = Process::create()
+  Process r3 = Process::Create()
                    .reactants({ b, c })
-                   .products({ yields(a, 1), yields(c, 1) })
+                   .products({ Yields(a, 1), Yields(c, 1) })
                    .rate_constant(UserDefinedRateConstant({ .label_ = "r3" }))
                    .phase(gas_phase);
 

--- a/test/tutorial/test_vectorized_matrix_solver.cpp
+++ b/test/tutorial/test_vectorized_matrix_solver.cpp
@@ -66,21 +66,21 @@ int main()
 
   Phase gas_phase{ std::vector<Species>{ a, b, c } };
 
-  Process r1 = Process::create()
+  Process r1 = Process::Create()
                    .reactants({ a })
-                   .products({ yields(b, 1) })
+                   .products({ Yields(b, 1) })
                    .rate_constant(UserDefinedRateConstant({ .label_ = "r1" }))
                    .phase(gas_phase);
 
-  Process r2 = Process::create()
+  Process r2 = Process::Create()
                    .reactants({ b, b })
-                   .products({ yields(b, 1), yields(c, 1) })
+                   .products({ Yields(b, 1), Yields(c, 1) })
                    .rate_constant(UserDefinedRateConstant({ .label_ = "r2" }))
                    .phase(gas_phase);
 
-  Process r3 = Process::create()
+  Process r3 = Process::Create()
                    .reactants({ b, c })
-                   .products({ yields(a, 1), yields(c, 1) })
+                   .products({ Yields(a, 1), Yields(c, 1) })
                    .rate_constant(UserDefinedRateConstant({ .label_ = "r3" }))
                    .phase(gas_phase);
 

--- a/test/tutorial/test_vectorized_matrix_solver.cpp
+++ b/test/tutorial/test_vectorized_matrix_solver.cpp
@@ -67,24 +67,24 @@ int main()
   Phase gas_phase{ std::vector<Species>{ a, b, c } };
 
   Process r1 = Process::Create()
-                   .reactants({ a })
-                   .products({ Yields(b, 1) })
-                   .rate_constant(UserDefinedRateConstant({ .label_ = "r1" }))
-                   .phase(gas_phase);
+                   .SetReactants({ a })
+                   .SetProducts({ Yields(b, 1) })
+                   .SetRateConstant(UserDefinedRateConstant({ .label_ = "r1" }))
+                   .SetPhase(gas_phase);
 
   Process r2 = Process::Create()
-                   .reactants({ b, b })
-                   .products({ Yields(b, 1), Yields(c, 1) })
-                   .rate_constant(UserDefinedRateConstant({ .label_ = "r2" }))
-                   .phase(gas_phase);
+                   .SetReactants({ b, b })
+                   .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                   .SetRateConstant(UserDefinedRateConstant({ .label_ = "r2" }))
+                   .SetPhase(gas_phase);
 
   Process r3 = Process::Create()
-                   .reactants({ b, c })
-                   .products({ Yields(a, 1), Yields(c, 1) })
-                   .rate_constant(UserDefinedRateConstant({ .label_ = "r3" }))
-                   .phase(gas_phase);
+                   .SetReactants({ b, c })
+                   .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                   .SetRateConstant(UserDefinedRateConstant({ .label_ = "r3" }))
+                   .SetPhase(gas_phase);
 
-  auto params = RosenbrockSolverParameters::three_stage_rosenbrock_parameters(3, false);
+  auto params = RosenbrockSolverParameters::ThreeStageRosenbrockParameters(3, false);
   auto system = System(SystemParameters{ .gas_phase_ = gas_phase });
   auto reactions = std::vector<Process>{ r1, r2, r3 };
 
@@ -138,19 +138,19 @@ int main()
     std::cout << std::endl;
   }
 
-  micm::SparseMatrix<std::string> sparse_matrix{ micm::SparseMatrix<std::string>::create(4)
-                                                     .with_element(0, 1)
-                                                     .with_element(2, 1)
-                                                     .with_element(2, 3)
-                                                     .with_element(3, 2)
+  micm::SparseMatrix<std::string> sparse_matrix{ micm::SparseMatrix<std::string>::Create(4)
+                                                     .WithElement(0, 1)
+                                                     .WithElement(2, 1)
+                                                     .WithElement(2, 3)
+                                                     .WithElement(3, 2)
                                                      .NumberOfBlocks(3) };
 
   micm::SparseMatrix<std::string, micm::SparseMatrixVectorOrdering<3>> sparse_vector_matrix{
-    micm::SparseMatrix<std::string, micm::SparseMatrixVectorOrdering<3>>::create(4)
-        .with_element(0, 1)
-        .with_element(2, 1)
-        .with_element(2, 3)
-        .with_element(3, 2)
+    micm::SparseMatrix<std::string, micm::SparseMatrixVectorOrdering<3>>::Create(4)
+        .WithElement(0, 1)
+        .WithElement(2, 1)
+        .WithElement(2, 3)
+        .WithElement(3, 2)
         .NumberOfBlocks(3)
   };
 

--- a/test/tutorial/test_vectorized_matrix_solver.cpp
+++ b/test/tutorial/test_vectorized_matrix_solver.cpp
@@ -143,7 +143,7 @@ int main()
                                                      .with_element(2, 1)
                                                      .with_element(2, 3)
                                                      .with_element(3, 2)
-                                                     .number_of_blocks(3) };
+                                                     .NumberOfBlocks(3) };
 
   micm::SparseMatrix<std::string, micm::SparseMatrixVectorOrdering<3>> sparse_vector_matrix{
     micm::SparseMatrix<std::string, micm::SparseMatrixVectorOrdering<3>>::create(4)
@@ -151,7 +151,7 @@ int main()
         .with_element(2, 1)
         .with_element(2, 3)
         .with_element(3, 2)
-        .number_of_blocks(3)
+        .NumberOfBlocks(3)
   };
 
   sparse_matrix[0][0][1] = sparse_vector_matrix[0][0][1] = "0.0.1";

--- a/test/tutorial/test_vectorized_matrix_solver.cpp
+++ b/test/tutorial/test_vectorized_matrix_solver.cpp
@@ -143,7 +143,7 @@ int main()
                                                      .WithElement(2, 1)
                                                      .WithElement(2, 3)
                                                      .WithElement(3, 2)
-                                                     .NumberOfBlocks(3) };
+                                                     .SetNumberOfBlocks(3) };
 
   micm::SparseMatrix<std::string, micm::SparseMatrixVectorOrdering<3>> sparse_vector_matrix{
     micm::SparseMatrix<std::string, micm::SparseMatrixVectorOrdering<3>>::Create(4)
@@ -151,7 +151,7 @@ int main()
         .WithElement(2, 1)
         .WithElement(2, 3)
         .WithElement(3, 2)
-        .NumberOfBlocks(3)
+        .SetNumberOfBlocks(3)
   };
 
   sparse_matrix[0][0][1] = sparse_vector_matrix[0][0][1] = "0.0.1";

--- a/test/unit/jit/test_jit_function.cpp
+++ b/test/unit/jit/test_jit_function.cpp
@@ -6,13 +6,13 @@
 // This test creates a function that adds two integers and returns the sum
 TEST(JitFunction, SimpleInt32Function)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction func = micm::JitFunction::create(jit.get())
+  micm::JitFunction func = micm::JitFunction::Create(jit.get())
                                .name("foo_int32")
                                .arguments({ { "foo", micm::JitType::Int32 }, { "bar", micm::JitType::Int32 } })
                                .return_type(micm::JitType::Int32);
@@ -30,13 +30,13 @@ TEST(JitFunction, SimpleInt32Function)
 // This test creates a function that adds two integers and returns the sum
 TEST(JitFunction, SimpleInt64Function)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction func = micm::JitFunction::create(jit.get())
+  micm::JitFunction func = micm::JitFunction::Create(jit.get())
                                .name("foo_int64")
                                .arguments({ { "foo", micm::JitType::Int64 }, { "bar", micm::JitType::Int64 } })
                                .return_type(micm::JitType::Int64);
@@ -53,13 +53,13 @@ TEST(JitFunction, SimpleInt64Function)
 // This test creates a function that adds two floats and returns the sum
 TEST(JitFunction, SimpleFloatFunction)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction func = micm::JitFunction::create(jit.get())
+  micm::JitFunction func = micm::JitFunction::Create(jit.get())
                                .name("foo_float")
                                .arguments({ { "foo", micm::JitType::Float }, { "bar", micm::JitType::Float } })
                                .return_type(micm::JitType::Float);
@@ -76,13 +76,13 @@ TEST(JitFunction, SimpleFloatFunction)
 // This test creates a function that adds two doubles and returns the sum
 TEST(JitFunction, SimpleDoubleFunction)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction func = micm::JitFunction::create(jit.get())
+  micm::JitFunction func = micm::JitFunction::Create(jit.get())
                                .name("foo_double")
                                .arguments({ { "foo", micm::JitType::Double }, { "bar", micm::JitType::Double } })
                                .return_type(micm::JitType::Double);
@@ -99,13 +99,13 @@ TEST(JitFunction, SimpleDoubleFunction)
 // This test creates a function that returns an OR of two booleans
 TEST(JitFunction, SimpleBoolFunction)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction func = micm::JitFunction::create(jit.get())
+  micm::JitFunction func = micm::JitFunction::Create(jit.get())
                                .name("foo_bool")
                                .arguments({ { "foo", micm::JitType::Bool }, { "bar", micm::JitType::Bool } })
                                .return_type(micm::JitType::Bool);
@@ -123,13 +123,13 @@ TEST(JitFunction, SimpleBoolFunction)
 // second element of the second array as the sum, and also returns the sum
 TEST(JitFunction, SimpleInt32PtrFunction)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction func = micm::JitFunction::create(jit.get())
+  micm::JitFunction func = micm::JitFunction::Create(jit.get())
                                .name("foo_int32_ptr")
                                .arguments({ { "foo", micm::JitType::Int32Ptr }, { "bar", micm::JitType::Int32Ptr } })
                                .return_type(micm::JitType::Int32);
@@ -160,13 +160,13 @@ TEST(JitFunction, SimpleInt32PtrFunction)
 // second element of the second array as the sum, and also returns the sum
 TEST(JitFunction, SimpleInt64PtrFunction)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction func = micm::JitFunction::create(jit.get())
+  micm::JitFunction func = micm::JitFunction::Create(jit.get())
                                .name("foo_int64_ptr")
                                .arguments({ { "foo", micm::JitType::Int64Ptr }, { "bar", micm::JitType::Int64Ptr } })
                                .return_type(micm::JitType::Int64);
@@ -197,13 +197,13 @@ TEST(JitFunction, SimpleInt64PtrFunction)
 // second element of the second array as the sum, and also returns the sum
 TEST(JitFunction, SimpleFloatPtrFunction)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction func = micm::JitFunction::create(jit.get())
+  micm::JitFunction func = micm::JitFunction::Create(jit.get())
                                .name("foo_float_ptr")
                                .arguments({ { "foo", micm::JitType::FloatPtr }, { "bar", micm::JitType::FloatPtr } })
                                .return_type(micm::JitType::Float);
@@ -234,13 +234,13 @@ TEST(JitFunction, SimpleFloatPtrFunction)
 // second element of the second array as the sum, and also returns the sum
 TEST(JitFunction, SimpleDoublePtrFunction)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction func = micm::JitFunction::create(jit.get())
+  micm::JitFunction func = micm::JitFunction::Create(jit.get())
                                .name("foo_double_ptr")
                                .arguments({ { "foo", micm::JitType::DoublePtr }, { "bar", micm::JitType::DoublePtr } })
                                .return_type(micm::JitType::Double);
@@ -271,14 +271,14 @@ TEST(JitFunction, SimpleDoublePtrFunction)
 // and iterates 10 times and returns the summed value
 TEST(JitFunction, SimpleLoop)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
   micm::JitFunction func =
-      micm::JitFunction::create(jit.get()).name("foo_loop").arguments({}).return_type(micm::JitType::Int32);
+      micm::JitFunction::Create(jit.get()).name("foo_loop").arguments({}).return_type(micm::JitType::Int32);
   auto loop = func.StartLoop("foo loop", 0, 10);
   llvm::PHINode *ret_val = func.builder_->CreatePHI(func.GetType(micm::JitType::Int32), 2, "ret val");
   ret_val->addIncoming(llvm::ConstantInt::get(*(func.context_), llvm::APInt(32, 1)), func.entry_block_);
@@ -297,13 +297,13 @@ TEST(JitFunction, SimpleLoop)
 // arguments and 10 and 100, respectively
 TEST(JitFunction, MultipleFunctions)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction foo_func = micm::JitFunction::create(jit.get())
+  micm::JitFunction foo_func = micm::JitFunction::Create(jit.get())
                                    .name("foo")
                                    .arguments({ { "arg", micm::JitType::Int32 } })
                                    .return_type(micm::JitType::Int32);
@@ -312,7 +312,7 @@ TEST(JitFunction, MultipleFunctions)
   foo_func.builder_->CreateRet(foo_ret_val);
   auto foo_target = foo_func.Generate();
   int32_t (*foo_func_ptr)(int) = (int32_t(*)(int))(intptr_t)foo_target.second;
-  micm::JitFunction bar_func = micm::JitFunction::create(jit.get())
+  micm::JitFunction bar_func = micm::JitFunction::Create(jit.get())
                                    .name("bar")
                                    .arguments({ { "arg", micm::JitType::Int32 } })
                                    .return_type(micm::JitType::Int32);
@@ -332,13 +332,13 @@ TEST(JitFunction, MultipleFunctions)
 // and returns the sum
 TEST(JitFunction, LocalArray)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction func = micm::JitFunction::create(jit.get())
+  micm::JitFunction func = micm::JitFunction::Create(jit.get())
                                .name("foo")
                                .arguments({ { "arg", micm::JitType::Int64 } })
                                .return_type(micm::JitType::Int64);
@@ -385,13 +385,13 @@ TEST(JitFunction, LocalArray)
 // add a unique number to the function argument and return the sum
 TEST(JitFunction, SameNameFunctions)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction func1 = micm::JitFunction::create(jit.get())
+  micm::JitFunction func1 = micm::JitFunction::Create(jit.get())
                                 .name("foobar")
                                 .arguments({ { "foo", micm::JitType::Int32 } })
                                 .return_type(micm::JitType::Int32);
@@ -402,7 +402,7 @@ TEST(JitFunction, SameNameFunctions)
   auto func1_target = func1.Generate();
   int32_t (*func1_ptr)(int32_t) = (int32_t(*)(int32_t))(intptr_t)func1_target.second;
 
-  micm::JitFunction func2 = micm::JitFunction::create(jit.get())
+  micm::JitFunction func2 = micm::JitFunction::Create(jit.get())
                                 .name("foobar")
                                 .arguments({ { "foo", micm::JitType::Int32 } })
                                 .return_type(micm::JitType::Int32);
@@ -413,7 +413,7 @@ TEST(JitFunction, SameNameFunctions)
   auto func2_target = func2.Generate();
   int32_t (*func2_ptr)(int32_t) = (int32_t(*)(int32_t))(intptr_t)func2_target.second;
 
-  micm::JitFunction func3 = micm::JitFunction::create(jit.get())
+  micm::JitFunction func3 = micm::JitFunction::Create(jit.get())
                                 .name("foobar")
                                 .arguments({ { "foo", micm::JitType::Int32 } })
                                 .return_type(micm::JitType::Int32);

--- a/test/unit/jit/test_jit_function.cpp
+++ b/test/unit/jit/test_jit_function.cpp
@@ -13,9 +13,9 @@ TEST(JitFunction, SimpleInt32Function)
     EXPECT_TRUE(false);
   }
   micm::JitFunction func = micm::JitFunction::Create(jit.get())
-                               .name("foo_int32")
-                               .arguments({ { "foo", micm::JitType::Int32 }, { "bar", micm::JitType::Int32 } })
-                               .return_type(micm::JitType::Int32);
+                               .SetName("foo_int32")
+                               .SetArguments({ { "foo", micm::JitType::Int32 }, { "bar", micm::JitType::Int32 } })
+                               .SetReturnType(micm::JitType::Int32);
   llvm::Value *ret_val = func.builder_->CreateNSWAdd(func.arguments_[0].ptr_, func.arguments_[1].ptr_, "add args");
   func.builder_->CreateRet(ret_val);
 
@@ -37,9 +37,9 @@ TEST(JitFunction, SimpleInt64Function)
     EXPECT_TRUE(false);
   }
   micm::JitFunction func = micm::JitFunction::Create(jit.get())
-                               .name("foo_int64")
-                               .arguments({ { "foo", micm::JitType::Int64 }, { "bar", micm::JitType::Int64 } })
-                               .return_type(micm::JitType::Int64);
+                               .SetName("foo_int64")
+                               .SetArguments({ { "foo", micm::JitType::Int64 }, { "bar", micm::JitType::Int64 } })
+                               .SetReturnType(micm::JitType::Int64);
   llvm::Value *ret_val = func.builder_->CreateNSWAdd(func.arguments_[0].ptr_, func.arguments_[1].ptr_, "add args");
   func.builder_->CreateRet(ret_val);
   auto func_target = func.Generate();
@@ -60,9 +60,9 @@ TEST(JitFunction, SimpleFloatFunction)
     EXPECT_TRUE(false);
   }
   micm::JitFunction func = micm::JitFunction::Create(jit.get())
-                               .name("foo_float")
-                               .arguments({ { "foo", micm::JitType::Float }, { "bar", micm::JitType::Float } })
-                               .return_type(micm::JitType::Float);
+                               .SetName("foo_float")
+                               .SetArguments({ { "foo", micm::JitType::Float }, { "bar", micm::JitType::Float } })
+                               .SetReturnType(micm::JitType::Float);
   llvm::Value *ret_val = func.builder_->CreateFAdd(func.arguments_[0].ptr_, func.arguments_[1].ptr_, "add args");
   func.builder_->CreateRet(ret_val);
   auto func_target = func.Generate();
@@ -83,9 +83,9 @@ TEST(JitFunction, SimpleDoubleFunction)
     EXPECT_TRUE(false);
   }
   micm::JitFunction func = micm::JitFunction::Create(jit.get())
-                               .name("foo_double")
-                               .arguments({ { "foo", micm::JitType::Double }, { "bar", micm::JitType::Double } })
-                               .return_type(micm::JitType::Double);
+                               .SetName("foo_double")
+                               .SetArguments({ { "foo", micm::JitType::Double }, { "bar", micm::JitType::Double } })
+                               .SetReturnType(micm::JitType::Double);
   llvm::Value *ret_val = func.builder_->CreateFAdd(func.arguments_[0].ptr_, func.arguments_[1].ptr_, "add args");
   func.builder_->CreateRet(ret_val);
   auto func_target = func.Generate();
@@ -106,9 +106,9 @@ TEST(JitFunction, SimpleBoolFunction)
     EXPECT_TRUE(false);
   }
   micm::JitFunction func = micm::JitFunction::Create(jit.get())
-                               .name("foo_bool")
-                               .arguments({ { "foo", micm::JitType::Bool }, { "bar", micm::JitType::Bool } })
-                               .return_type(micm::JitType::Bool);
+                               .SetName("foo_bool")
+                               .SetArguments({ { "foo", micm::JitType::Bool }, { "bar", micm::JitType::Bool } })
+                               .SetReturnType(micm::JitType::Bool);
   llvm::Value *ret_val = func.builder_->CreateOr(func.arguments_[0].ptr_, func.arguments_[1].ptr_, "add args");
   func.builder_->CreateRet(ret_val);
   auto func_target = func.Generate();
@@ -130,9 +130,9 @@ TEST(JitFunction, SimpleInt32PtrFunction)
     EXPECT_TRUE(false);
   }
   micm::JitFunction func = micm::JitFunction::Create(jit.get())
-                               .name("foo_int32_ptr")
-                               .arguments({ { "foo", micm::JitType::Int32Ptr }, { "bar", micm::JitType::Int32Ptr } })
-                               .return_type(micm::JitType::Int32);
+                               .SetName("foo_int32_ptr")
+                               .SetArguments({ { "foo", micm::JitType::Int32Ptr }, { "bar", micm::JitType::Int32Ptr } })
+                               .SetReturnType(micm::JitType::Int32);
   llvm::Value *index_list[1];
   index_list[0] = llvm::ConstantInt::get(*(func.context_), llvm::APInt(64, 2));
   llvm::Value *foo_val = func.GetArrayElement(func.arguments_[0], index_list, micm::JitType::Int32);
@@ -167,9 +167,9 @@ TEST(JitFunction, SimpleInt64PtrFunction)
     EXPECT_TRUE(false);
   }
   micm::JitFunction func = micm::JitFunction::Create(jit.get())
-                               .name("foo_int64_ptr")
-                               .arguments({ { "foo", micm::JitType::Int64Ptr }, { "bar", micm::JitType::Int64Ptr } })
-                               .return_type(micm::JitType::Int64);
+                               .SetName("foo_int64_ptr")
+                               .SetArguments({ { "foo", micm::JitType::Int64Ptr }, { "bar", micm::JitType::Int64Ptr } })
+                               .SetReturnType(micm::JitType::Int64);
   llvm::Value *index_list[1];
   index_list[0] = llvm::ConstantInt::get(*(func.context_), llvm::APInt(64, 2));
   llvm::Value *foo_val = func.GetArrayElement(func.arguments_[0], index_list, micm::JitType::Int64);
@@ -204,9 +204,9 @@ TEST(JitFunction, SimpleFloatPtrFunction)
     EXPECT_TRUE(false);
   }
   micm::JitFunction func = micm::JitFunction::Create(jit.get())
-                               .name("foo_float_ptr")
-                               .arguments({ { "foo", micm::JitType::FloatPtr }, { "bar", micm::JitType::FloatPtr } })
-                               .return_type(micm::JitType::Float);
+                               .SetName("foo_float_ptr")
+                               .SetArguments({ { "foo", micm::JitType::FloatPtr }, { "bar", micm::JitType::FloatPtr } })
+                               .SetReturnType(micm::JitType::Float);
   llvm::Value *index_list[1];
   index_list[0] = llvm::ConstantInt::get(*(func.context_), llvm::APInt(64, 2));
   llvm::Value *foo_val = func.GetArrayElement(func.arguments_[0], index_list, micm::JitType::Float);
@@ -241,9 +241,9 @@ TEST(JitFunction, SimpleDoublePtrFunction)
     EXPECT_TRUE(false);
   }
   micm::JitFunction func = micm::JitFunction::Create(jit.get())
-                               .name("foo_double_ptr")
-                               .arguments({ { "foo", micm::JitType::DoublePtr }, { "bar", micm::JitType::DoublePtr } })
-                               .return_type(micm::JitType::Double);
+                               .SetName("foo_double_ptr")
+                               .SetArguments({ { "foo", micm::JitType::DoublePtr }, { "bar", micm::JitType::DoublePtr } })
+                               .SetReturnType(micm::JitType::Double);
   llvm::Value *index_list[1];
   index_list[0] = llvm::ConstantInt::get(*(func.context_), llvm::APInt(64, 2));
   llvm::Value *foo_val = func.GetArrayElement(func.arguments_[0], index_list, micm::JitType::Double);
@@ -277,8 +277,10 @@ TEST(JitFunction, SimpleLoop)
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error] ");
     EXPECT_TRUE(false);
   }
-  micm::JitFunction func =
-      micm::JitFunction::Create(jit.get()).name("foo_loop").arguments({}).return_type(micm::JitType::Int32);
+  micm::JitFunction func = micm::JitFunction::Create(jit.get())
+                               .SetName("foo_loop")
+                               .SetArguments({})
+                               .SetReturnType(micm::JitType::Int32);
   auto loop = func.StartLoop("foo loop", 0, 10);
   llvm::PHINode *ret_val = func.builder_->CreatePHI(func.GetType(micm::JitType::Int32), 2, "ret val");
   ret_val->addIncoming(llvm::ConstantInt::get(*(func.context_), llvm::APInt(32, 1)), func.entry_block_);
@@ -304,18 +306,18 @@ TEST(JitFunction, MultipleFunctions)
     EXPECT_TRUE(false);
   }
   micm::JitFunction foo_func = micm::JitFunction::Create(jit.get())
-                                   .name("foo")
-                                   .arguments({ { "arg", micm::JitType::Int32 } })
-                                   .return_type(micm::JitType::Int32);
+                                   .SetName("foo")
+                                   .SetArguments({ { "arg", micm::JitType::Int32 } })
+                                   .SetReturnType(micm::JitType::Int32);
   llvm::Value *foo_ret_val = foo_func.builder_->CreateNSWAdd(
       foo_func.arguments_[0].ptr_, llvm::ConstantInt::get(*(foo_func.context_), llvm::APInt(32, 10)), "add args");
   foo_func.builder_->CreateRet(foo_ret_val);
   auto foo_target = foo_func.Generate();
   int32_t (*foo_func_ptr)(int) = (int32_t(*)(int))(intptr_t)foo_target.second;
   micm::JitFunction bar_func = micm::JitFunction::Create(jit.get())
-                                   .name("bar")
-                                   .arguments({ { "arg", micm::JitType::Int32 } })
-                                   .return_type(micm::JitType::Int32);
+                                   .SetName("bar")
+                                   .SetArguments({ { "arg", micm::JitType::Int32 } })
+                                   .SetReturnType(micm::JitType::Int32);
   llvm::Value *bar_ret_val = bar_func.builder_->CreateNSWAdd(
       bar_func.arguments_[0].ptr_, llvm::ConstantInt::get(*(bar_func.context_), llvm::APInt(32, 100)), "add args");
   bar_func.builder_->CreateRet(bar_ret_val);
@@ -339,9 +341,9 @@ TEST(JitFunction, LocalArray)
     EXPECT_TRUE(false);
   }
   micm::JitFunction func = micm::JitFunction::Create(jit.get())
-                               .name("foo")
-                               .arguments({ { "arg", micm::JitType::Int64 } })
-                               .return_type(micm::JitType::Int64);
+                               .SetName("foo")
+                               .SetArguments({ { "arg", micm::JitType::Int64 } })
+                               .SetReturnType(micm::JitType::Int64);
 
   auto int_type = func.GetType(micm::JitType::Int64);
   llvm::Value *zero = llvm::ConstantInt::get(*(func.context_), llvm::APInt(64, 0));
@@ -392,9 +394,9 @@ TEST(JitFunction, SameNameFunctions)
     EXPECT_TRUE(false);
   }
   micm::JitFunction func1 = micm::JitFunction::Create(jit.get())
-                                .name("foobar")
-                                .arguments({ { "foo", micm::JitType::Int32 } })
-                                .return_type(micm::JitType::Int32);
+                                .SetName("foobar")
+                                .SetArguments({ { "foo", micm::JitType::Int32 } })
+                                .SetReturnType(micm::JitType::Int32);
   llvm::Value *const_val = llvm::ConstantInt::get(*(func1.context_), llvm::APInt(64, 2));
   llvm::Value *ret_val = func1.builder_->CreateNSWAdd(func1.arguments_[0].ptr_, const_val, "add args");
   func1.builder_->CreateRet(ret_val);
@@ -403,9 +405,9 @@ TEST(JitFunction, SameNameFunctions)
   int32_t (*func1_ptr)(int32_t) = (int32_t(*)(int32_t))(intptr_t)func1_target.second;
 
   micm::JitFunction func2 = micm::JitFunction::Create(jit.get())
-                                .name("foobar")
-                                .arguments({ { "foo", micm::JitType::Int32 } })
-                                .return_type(micm::JitType::Int32);
+                                .SetName("foobar")
+                                .SetArguments({ { "foo", micm::JitType::Int32 } })
+                                .SetReturnType(micm::JitType::Int32);
   const_val = llvm::ConstantInt::get(*(func2.context_), llvm::APInt(64, 12));
   ret_val = func2.builder_->CreateNSWAdd(func2.arguments_[0].ptr_, const_val, "add args");
   func2.builder_->CreateRet(ret_val);
@@ -414,9 +416,9 @@ TEST(JitFunction, SameNameFunctions)
   int32_t (*func2_ptr)(int32_t) = (int32_t(*)(int32_t))(intptr_t)func2_target.second;
 
   micm::JitFunction func3 = micm::JitFunction::Create(jit.get())
-                                .name("foobar")
-                                .arguments({ { "foo", micm::JitType::Int32 } })
-                                .return_type(micm::JitType::Int32);
+                                .SetName("foobar")
+                                .SetArguments({ { "foo", micm::JitType::Int32 } })
+                                .SetReturnType(micm::JitType::Int32);
   const_val = llvm::ConstantInt::get(*(func3.context_), llvm::APInt(64, 24));
   ret_val = func3.builder_->CreateNSWAdd(func3.arguments_[0].ptr_, const_val, "add args");
   func3.builder_->CreateRet(ret_val);

--- a/test/unit/openmp/test_openmp.cpp
+++ b/test/unit/openmp/test_openmp.cpp
@@ -24,7 +24,7 @@ TEST(OpenMP, OneSolverManyStates)
 
   std::vector<std::vector<double>> results(n_threads);
 
-  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::three_stage_rosenbrock_parameters() };
+  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::ThreeStageRosenbrockParameters() };
 
 #pragma omp parallel num_threads(n_threads)
   {

--- a/test/unit/openmp/test_openmp_jit_solver.cpp
+++ b/test/unit/openmp/test_openmp_jit_solver.cpp
@@ -35,13 +35,13 @@ TEST(OpenMP, JITOneSolverManyStates)
 
   std::vector<std::vector<double>> results(n_threads);
 
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   JitRosenbrockSolver<
       Group1VectorMatrix,
       Group1SparseVectorMatrix,
       JitLinearSolver<1, Group1SparseVectorMatrix>,
       micm::JitProcessSet<1>>
-      solver(jit.get(), chemical_system, reactions, RosenbrockSolverParameters::three_stage_rosenbrock_parameters());
+      solver(jit.get(), chemical_system, reactions, RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
 
 #pragma omp parallel num_threads(n_threads)
   {

--- a/test/unit/process/test_arrhenius_rate_constant.cpp
+++ b/test/unit/process/test_arrhenius_rate_constant.cpp
@@ -11,34 +11,34 @@ TEST(ArrheniusRateConstant, CalculateWithSystem)
     .temperature_ = 301.24  // [K]
   };
 
-  auto k = zero.calculate(conditions);
+  auto k = zero.Calculate(conditions);
   EXPECT_NEAR(k, 1, 0.01);
 
   micm::ArrheniusRateConstantParameters parameters;
   parameters.A_ = 1;
 
   micm::ArrheniusRateConstant basic(parameters);
-  k = basic.calculate(conditions);
+  k = basic.Calculate(conditions);
   EXPECT_NEAR(k, 1, 0.01);
 
   // values from https://jpldataeval.jpl.nasa.gov/pdf/JPL_00-03.pdf
   parameters.A_ = 2.2e-10;
   micm::ArrheniusRateConstant o1d(parameters);
-  k = o1d.calculate(conditions);
+  k = o1d.Calculate(conditions);
   EXPECT_NEAR(k, 2.2e-10, 0.01);
 
   // O + HO2 -> OH + O2
   parameters.A_ = 3e-11;
   parameters.C_ = -200;
   micm::ArrheniusRateConstant hox(parameters);
-  k = hox.calculate(conditions);
+  k = hox.Calculate(conditions);
   EXPECT_NEAR(k, 3e-11 * std::exp(-200 / 301.24), 0.01);
 
   // OH + HCl → H2O + Cl
   parameters.A_ = 2.6e-12;
   parameters.C_ = -350;
   micm::ArrheniusRateConstant clox(parameters);
-  k = clox.calculate(conditions);
+  k = clox.Calculate(conditions);
   EXPECT_NEAR(k, 2.6e-12 * std::exp(-350 / 301.24), 0.01);
 }
 
@@ -49,33 +49,33 @@ TEST(ArrheniusRateConstant, CalculateWithPrescribedArugments)
   };
 
   micm::ArrheniusRateConstant zero{};
-  auto k = zero.calculate(conditions);
+  auto k = zero.Calculate(conditions);
   EXPECT_NEAR(k, 1, 0.01);
 
   micm::ArrheniusRateConstantParameters parameters;
   parameters.A_ = 1;
 
   micm::ArrheniusRateConstant basic(parameters);
-  k = basic.calculate(conditions);
+  k = basic.Calculate(conditions);
   EXPECT_NEAR(k, 1, 0.01);
 
   // values from https://jpldataeval.jpl.nasa.gov/pdf/JPL_00-03.pdf
   parameters.A_ = 2.2e-10;
   micm::ArrheniusRateConstant o1d(parameters);
-  k = o1d.calculate(conditions);
+  k = o1d.Calculate(conditions);
   EXPECT_NEAR(k, 2.2e-10, 0.01);
 
   // O + HO2 -> OH + O2
   parameters.A_ = 3e-11;
   parameters.C_ = -200;
   micm::ArrheniusRateConstant hox(parameters);
-  k = hox.calculate(conditions);
+  k = hox.Calculate(conditions);
   EXPECT_NEAR(k, 3e-11 * std::exp(200 / 301.24), 0.01);
 
   // OH + HCl → H2O + Cl
   parameters.A_ = 2.6e-12;
   parameters.C_ = -350;
   micm::ArrheniusRateConstant clox(parameters);
-  k = clox.calculate(conditions);
+  k = clox.Calculate(conditions);
   EXPECT_NEAR(k, 2.6e-12 * std::exp(-350 / 301.24), 0.01);
 }

--- a/test/unit/process/test_branched_rate_constant.cpp
+++ b/test/unit/process/test_branched_rate_constant.cpp
@@ -15,7 +15,7 @@ TEST(BranchedRateConstant, CalculateAlkoxyBranchWithAllArugments)
 
   micm::BranchedRateConstant branched{ micm::BranchedRateConstantParameters{
       .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy, .X_ = 1.2, .Y_ = 204.3, .a0_ = 1.0e-3, .n_ = 2 } };
-  auto k = branched.calculate(conditions);
+  auto k = branched.Calculate(conditions);
   double air_dens_n_cm3 = 42.2 * AVOGADRO_CONSTANT * 1.0e-6;
   double a = 2.0e-22 * std::exp(2) * 2.45e19;
   double b = 0.43 * std::pow((293.0 / 298.0), -8.0);
@@ -37,7 +37,7 @@ TEST(BranchedRateConstant, CalculateNitrateBranchWithAllArugments)
 
   micm::BranchedRateConstant branched{ micm::BranchedRateConstantParameters{
       .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate, .X_ = 1.2, .Y_ = 204.3, .a0_ = 1.0e-3, .n_ = 2 } };
-  auto k = branched.calculate(conditions);
+  auto k = branched.Calculate(conditions);
   double air_dens_n_cm3 = 42.2 * AVOGADRO_CONSTANT * 1.0e-6;
   double a = 2.0e-22 * std::exp(2) * 2.45e19;
   double b = 0.43 * std::pow((293.0 / 298.0), -8.0);

--- a/test/unit/process/test_cuda_process_set.cpp
+++ b/test/unit/process/test_cuda_process_set.cpp
@@ -69,7 +69,7 @@ void testRandomSystemAddForcingTerms(std::size_t n_cells, std::size_t n_reaction
     {
       products.push_back(Yields(std::to_string(get_species_id()), 1.2));
     }
-    processes.push_back(micm::Process::create().reactants(reactants).products(products).phase(gas_phase));
+    processes.push_back(micm::Process::Create().SetReactants(reactants).SetProducts(products).SetPhase(gas_phase));
   }
 
   micm::ProcessSet cpu_set{ processes, cpu_state.variable_map_ };
@@ -164,7 +164,7 @@ void testRandomSystemSubtractJacobianTerms(std::size_t n_cells, std::size_t n_re
     {
       products.push_back(Yields(std::to_string(get_species_id()), 1.2));
     }
-    processes.push_back(micm::Process::create().reactants(reactants).products(products).phase(gas_phase));
+    processes.push_back(micm::Process::Create().SetReactants(reactants).SetProducts(products).SetPhase(gas_phase));
   }
 
   micm::ProcessSet cpu_set{ processes, cpu_state.variable_map_ };
@@ -184,13 +184,13 @@ void testRandomSystemSubtractJacobianTerms(std::size_t n_cells, std::size_t n_re
 
   auto non_zero_elements = cpu_set.NonZeroJacobianElements();
 
-  auto cpu_builder = CPUSparseMatrixPolicy<double>::create(n_species).NumberOfBlocks(n_cells).initial_value(100.0);
+  auto cpu_builder = CPUSparseMatrixPolicy<double>::Create(n_species).NumberOfBlocks(n_cells).InitialValue(100.0);
   for (auto& elem : non_zero_elements)
-    cpu_builder = cpu_builder.with_element(elem.first, elem.second);
+    cpu_builder = cpu_builder.WithElement(elem.first, elem.second);
   CPUSparseMatrixPolicy<double> cpu_jacobian{ cpu_builder };
-  auto gpu_builder = GPUSparseMatrixPolicy<double>::create(n_species).NumberOfBlocks(n_cells).initial_value(100.0);
+  auto gpu_builder = GPUSparseMatrixPolicy<double>::Create(n_species).NumberOfBlocks(n_cells).InitialValue(100.0);
   for (auto& elem : non_zero_elements)
-    gpu_builder = gpu_builder.with_element(elem.first, elem.second);
+    gpu_builder = gpu_builder.WithElement(elem.first, elem.second);
   GPUSparseMatrixPolicy<double> gpu_jacobian{ gpu_builder };
   gpu_jacobian.CopyToDevice();
 

--- a/test/unit/process/test_cuda_process_set.cpp
+++ b/test/unit/process/test_cuda_process_set.cpp
@@ -184,11 +184,11 @@ void testRandomSystemSubtractJacobianTerms(std::size_t n_cells, std::size_t n_re
 
   auto non_zero_elements = cpu_set.NonZeroJacobianElements();
 
-  auto cpu_builder = CPUSparseMatrixPolicy<double>::create(n_species).number_of_blocks(n_cells).initial_value(100.0);
+  auto cpu_builder = CPUSparseMatrixPolicy<double>::create(n_species).NumberOfBlocks(n_cells).initial_value(100.0);
   for (auto& elem : non_zero_elements)
     cpu_builder = cpu_builder.with_element(elem.first, elem.second);
   CPUSparseMatrixPolicy<double> cpu_jacobian{ cpu_builder };
-  auto gpu_builder = GPUSparseMatrixPolicy<double>::create(n_species).number_of_blocks(n_cells).initial_value(100.0);
+  auto gpu_builder = GPUSparseMatrixPolicy<double>::create(n_species).NumberOfBlocks(n_cells).initial_value(100.0);
   for (auto& elem : non_zero_elements)
     gpu_builder = gpu_builder.with_element(elem.first, elem.second);
   GPUSparseMatrixPolicy<double> gpu_jacobian{ gpu_builder };

--- a/test/unit/process/test_cuda_process_set.cpp
+++ b/test/unit/process/test_cuda_process_set.cpp
@@ -67,7 +67,7 @@ void testRandomSystemAddForcingTerms(std::size_t n_cells, std::size_t n_reaction
     std::vector<yields> products{};
     for (std::size_t i_prod = 0; i_prod < n_product; ++i_prod)
     {
-      products.push_back(yields(std::to_string(get_species_id()), 1.2));
+      products.push_back(Yields(std::to_string(get_species_id()), 1.2));
     }
     processes.push_back(micm::Process::create().reactants(reactants).products(products).phase(gas_phase));
   }
@@ -162,7 +162,7 @@ void testRandomSystemSubtractJacobianTerms(std::size_t n_cells, std::size_t n_re
     std::vector<yields> products{};
     for (std::size_t i_prod = 0; i_prod < n_product; ++i_prod)
     {
-      products.push_back(yields(std::to_string(get_species_id()), 1.2));
+      products.push_back(Yields(std::to_string(get_species_id()), 1.2));
     }
     processes.push_back(micm::Process::create().reactants(reactants).products(products).phase(gas_phase));
   }

--- a/test/unit/process/test_cuda_process_set.cpp
+++ b/test/unit/process/test_cuda_process_set.cpp
@@ -15,7 +15,6 @@
 #include <random>
 #include <vector>
 
-using yields = std::pair<micm::Species, double>;
 using index_pair = std::pair<std::size_t, std::size_t>;
 
 void compare_pair(const index_pair& a, const index_pair& b)
@@ -64,10 +63,10 @@ void testRandomSystemAddForcingTerms(std::size_t n_cells, std::size_t n_reaction
       reactants.push_back({ std::to_string(get_species_id()) });
     }
     auto n_product = get_n_product();
-    std::vector<yields> products{};
+    std::vector<micm::Yield> products{};
     for (std::size_t i_prod = 0; i_prod < n_product; ++i_prod)
     {
-      products.push_back(Yields(std::to_string(get_species_id()), 1.2));
+      products.push_back(micm::Yields(std::to_string(get_species_id()), 1.2));
     }
     processes.push_back(micm::Process::Create().SetReactants(reactants).SetProducts(products).SetPhase(gas_phase));
   }
@@ -159,10 +158,10 @@ void testRandomSystemSubtractJacobianTerms(std::size_t n_cells, std::size_t n_re
       reactants.push_back({ std::to_string(get_species_id()) });
     }
     auto n_product = get_n_product();
-    std::vector<yields> products{};
+    std::vector<micm::Yield> products{};
     for (std::size_t i_prod = 0; i_prod < n_product; ++i_prod)
     {
-      products.push_back(Yields(std::to_string(get_species_id()), 1.2));
+      products.push_back(micm::Yields(std::to_string(get_species_id()), 1.2));
     }
     processes.push_back(micm::Process::Create().SetReactants(reactants).SetProducts(products).SetPhase(gas_phase));
   }

--- a/test/unit/process/test_cuda_process_set.cpp
+++ b/test/unit/process/test_cuda_process_set.cpp
@@ -183,11 +183,11 @@ void testRandomSystemSubtractJacobianTerms(std::size_t n_cells, std::size_t n_re
 
   auto non_zero_elements = cpu_set.NonZeroJacobianElements();
 
-  auto cpu_builder = CPUSparseMatrixPolicy<double>::Create(n_species).NumberOfBlocks(n_cells).InitialValue(100.0);
+  auto cpu_builder = CPUSparseMatrixPolicy<double>::Create(n_species).SetNumberOfBlocks(n_cells).InitialValue(100.0);
   for (auto& elem : non_zero_elements)
     cpu_builder = cpu_builder.WithElement(elem.first, elem.second);
   CPUSparseMatrixPolicy<double> cpu_jacobian{ cpu_builder };
-  auto gpu_builder = GPUSparseMatrixPolicy<double>::Create(n_species).NumberOfBlocks(n_cells).InitialValue(100.0);
+  auto gpu_builder = GPUSparseMatrixPolicy<double>::Create(n_species).SetNumberOfBlocks(n_cells).InitialValue(100.0);
   for (auto& elem : non_zero_elements)
     gpu_builder = gpu_builder.WithElement(elem.first, elem.second);
   GPUSparseMatrixPolicy<double> gpu_jacobian{ gpu_builder };

--- a/test/unit/process/test_jit_forcing_calculation.cpp
+++ b/test/unit/process/test_jit_forcing_calculation.cpp
@@ -38,18 +38,18 @@ TEST(JitProcessSet, ForcingFunction)
                              .number_of_rate_constants_ = 3,
                              .variable_names_{ "A", "B", "C", "D", "E", "F" } });
 
-  micm::Process r1 = micm::Process::Create().reactants({ a, b }).products({ micm::Yield{ d, 3.2 } }).phase(gas_phase);
+  micm::Process r1 = micm::Process::Create().SetReactants({ a, b }).SetProducts({ micm::Yield{ d, 3.2 } }).SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ e, c })
-                         .products({ micm::Yield{ a, 1.0 }, micm::Yield{ f, 2.0 } })
-                         .phase(gas_phase);
+                         .SetReactants({ e, c })
+                         .SetProducts({ micm::Yield{ a, 1.0 }, micm::Yield{ f, 2.0 } })
+                         .SetPhase(gas_phase);
 
-  micm::Process r3 = micm::Process::Create().reactants({ c, b }).products({ micm::Yield{ a, 1.0 } }).phase(gas_phase);
+  micm::Process r3 = micm::Process::Create().SetReactants({ c, b }).SetProducts({ micm::Yield{ a, 1.0 } }).SetPhase(gas_phase);
 
   std::vector<micm::Process> processes{ r1, r2, r3 };
 
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");

--- a/test/unit/process/test_jit_forcing_calculation.cpp
+++ b/test/unit/process/test_jit_forcing_calculation.cpp
@@ -38,14 +38,14 @@ TEST(JitProcessSet, ForcingFunction)
                              .number_of_rate_constants_ = 3,
                              .variable_names_{ "A", "B", "C", "D", "E", "F" } });
 
-  micm::Process r1 = micm::Process::create().reactants({ a, b }).products({ micm::Yield{ d, 3.2 } }).phase(gas_phase);
+  micm::Process r1 = micm::Process::Create().reactants({ a, b }).products({ micm::Yield{ d, 3.2 } }).phase(gas_phase);
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ e, c })
                          .products({ micm::Yield{ a, 1.0 }, micm::Yield{ f, 2.0 } })
                          .phase(gas_phase);
 
-  micm::Process r3 = micm::Process::create().reactants({ c, b }).products({ micm::Yield{ a, 1.0 } }).phase(gas_phase);
+  micm::Process r3 = micm::Process::Create().reactants({ c, b }).products({ micm::Yield{ a, 1.0 } }).phase(gas_phase);
 
   std::vector<micm::Process> processes{ r1, r2, r3 };
 

--- a/test/unit/process/test_jit_process_set.cpp
+++ b/test/unit/process/test_jit_process_set.cpp
@@ -23,7 +23,7 @@ using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorO
 
 TEST(JitProcessSet, VectorMatrix)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -38,7 +38,7 @@ TEST(JitProcessSet, VectorMatrix)
 
 TEST(RandomJitProcessSet, VectorMatrix)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -20,9 +20,9 @@ void testProcessUpdateState(const std::size_t number_of_grid_cells)
   micm::SurfaceRateConstant rc2({ .label_ = "foo_surf", .species_ = foo });
   micm::UserDefinedRateConstant rc3({ .label_ = "bar_user" });
 
-  micm::Process r1 = micm::Process::create().rate_constant(rc1).reactants({ foo, bar });
-  micm::Process r2 = micm::Process::create().rate_constant(rc2);
-  micm::Process r3 = micm::Process::create().rate_constant(rc3);
+  micm::Process r1 = micm::Process::Create().rate_constant(rc1).reactants({ foo, bar });
+  micm::Process r2 = micm::Process::Create().rate_constant(rc2);
+  micm::Process r3 = micm::Process::Create().rate_constant(rc3);
   std::vector<micm::Process> processes = { r1, r2, r3 };
 
   std::vector<std::string> param_labels{};
@@ -55,11 +55,11 @@ void testProcessUpdateState(const std::size_t number_of_grid_cells)
     state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["bar_user"]] = params[2];
     std::vector<double>::const_iterator param_iter = params.begin();
     expected_rate_constants[i_cell][0] =
-        rc1.calculate(state.conditions_[i_cell], param_iter) * (state.conditions_[i_cell].air_density_ * 0.82);
+        rc1.Calculate(state.conditions_[i_cell], param_iter) * (state.conditions_[i_cell].air_density_ * 0.82);
     param_iter += rc1.SizeCustomParameters();
-    expected_rate_constants[i_cell][1] = rc2.calculate(state.conditions_[i_cell], param_iter);
+    expected_rate_constants[i_cell][1] = rc2.Calculate(state.conditions_[i_cell], param_iter);
     param_iter += rc2.SizeCustomParameters();
-    expected_rate_constants[i_cell][2] = rc3.calculate(state.conditions_[i_cell], param_iter);
+    expected_rate_constants[i_cell][2] = rc3.Calculate(state.conditions_[i_cell], param_iter);
     param_iter += rc3.SizeCustomParameters();
   }
 
@@ -99,9 +99,9 @@ TEST(Process, SurfaceRateConstantOnlyHasOneReactant)
   micm::Species e("e");
 
   micm::Phase gas_phase({ c, e });
-  EXPECT_ANY_THROW(micm::Process r = micm::Process::create()
+  EXPECT_ANY_THROW(micm::Process r = micm::Process::Create()
                                          .reactants({ c, c })
-                                         .products({ yields(e, 1) })
+                                         .products({ Yields(e, 1) })
                                          .rate_constant(micm::SurfaceRateConstant(
                                              { .label_ = "c", .species_ = c, .reaction_probability_ = 0.90 }))
                                          .phase(gas_phase););

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -20,9 +20,9 @@ void testProcessUpdateState(const std::size_t number_of_grid_cells)
   micm::SurfaceRateConstant rc2({ .label_ = "foo_surf", .species_ = foo });
   micm::UserDefinedRateConstant rc3({ .label_ = "bar_user" });
 
-  micm::Process r1 = micm::Process::Create().rate_constant(rc1).reactants({ foo, bar });
-  micm::Process r2 = micm::Process::Create().rate_constant(rc2);
-  micm::Process r3 = micm::Process::Create().rate_constant(rc3);
+  micm::Process r1 = micm::Process::Create().SetRateConstant(rc1).SetReactants({ foo, bar });
+  micm::Process r2 = micm::Process::Create().SetRateConstant(rc2);
+  micm::Process r3 = micm::Process::Create().SetRateConstant(rc3);
   std::vector<micm::Process> processes = { r1, r2, r3 };
 
   std::vector<std::string> param_labels{};
@@ -100,9 +100,9 @@ TEST(Process, SurfaceRateConstantOnlyHasOneReactant)
 
   micm::Phase gas_phase({ c, e });
   EXPECT_ANY_THROW(micm::Process r = micm::Process::Create()
-                                         .reactants({ c, c })
-                                         .products({ Yields(e, 1) })
-                                         .rate_constant(micm::SurfaceRateConstant(
+                                         .SetReactants({ c, c })
+                                         .SetProducts({ Yields(e, 1) })
+                                         .SetRateConstant(micm::SurfaceRateConstant(
                                              { .label_ = "c", .species_ = c, .reaction_probability_ = 0.90 }))
-                                         .phase(gas_phase););
+                                         .SetPhase(gas_phase););
 }

--- a/test/unit/process/test_process_set_policy.hpp
+++ b/test/unit/process/test_process_set_policy.hpp
@@ -99,7 +99,7 @@ void testProcessSet(const std::function<ProcessSetPolicy(
   compare_pair(*(++elem), index_pair(4, 0));
   compare_pair(*(++elem), index_pair(4, 2));
 
-  auto builder = SparseMatrixPolicy<double>::create(5).number_of_blocks(2).initial_value(100.0);
+  auto builder = SparseMatrixPolicy<double>::create(5).NumberOfBlocks(2).initial_value(100.0);
   for (auto& elem : non_zero_elements)
     builder = builder.with_element(elem.first, elem.second);
   SparseMatrixPolicy<double> jacobian{ builder };

--- a/test/unit/process/test_process_set_policy.hpp
+++ b/test/unit/process/test_process_set_policy.hpp
@@ -35,12 +35,12 @@ void testProcessSet(const std::function<ProcessSetPolicy(
                              .variable_names_{ "foo", "bar", "baz", "quz", "quuz", "corge" } });
 
   micm::Process r1 =
-      micm::Process::create().reactants({ foo, baz }).products({ yields(bar, 1), yields(quuz, 2.4) }).phase(gas_phase);
+      micm::Process::Create().reactants({ foo, baz }).products({ Yields(bar, 1), Yields(quuz, 2.4) }).phase(gas_phase);
 
   micm::Process r2 =
-      micm::Process::create().reactants({ bar, qux }).products({ yields(foo, 1), yields(quz, 1.4) }).phase(gas_phase);
+      micm::Process::Create().reactants({ bar, qux }).products({ Yields(foo, 1), Yields(quz, 1.4) }).phase(gas_phase);
 
-  micm::Process r3 = micm::Process::create().reactants({ quz }).products({}).phase(gas_phase);
+  micm::Process r3 = micm::Process::Create().reactants({ quz }).products({}).phase(gas_phase);
 
   auto used_species = ProcessSetPolicy::SpeciesUsed(std::vector<micm::Process>{ r1, r2, r3 });
 
@@ -171,9 +171,9 @@ void testRandomSystem(
     std::vector<yields> products{};
     for (std::size_t i_prod = 0; i_prod < n_product; ++i_prod)
     {
-      products.push_back(yields(std::to_string(get_species_id()), 1.2));
+      products.push_back(Yields(std::to_string(get_species_id()), 1.2));
     }
-    auto proc = micm::Process(micm::Process::create().reactants(reactants).products(products).phase(gas_phase));
+    auto proc = micm::Process(micm::Process::Create().reactants(reactants).products(products).phase(gas_phase));
     processes.push_back(proc);
   }
   ProcessSetPolicy set = create_set(processes, state);

--- a/test/unit/process/test_process_set_policy.hpp
+++ b/test/unit/process/test_process_set_policy.hpp
@@ -35,12 +35,12 @@ void testProcessSet(const std::function<ProcessSetPolicy(
                              .variable_names_{ "foo", "bar", "baz", "quz", "quuz", "corge" } });
 
   micm::Process r1 =
-      micm::Process::Create().reactants({ foo, baz }).products({ Yields(bar, 1), Yields(quuz, 2.4) }).phase(gas_phase);
+      micm::Process::Create().SetReactants({ foo, baz }).SetProducts({ Yields(bar, 1), Yields(quuz, 2.4) }).SetPhase(gas_phase);
 
   micm::Process r2 =
-      micm::Process::Create().reactants({ bar, qux }).products({ Yields(foo, 1), Yields(quz, 1.4) }).phase(gas_phase);
+      micm::Process::Create().SetReactants({ bar, qux }).SetProducts({ Yields(foo, 1), Yields(quz, 1.4) }).SetPhase(gas_phase);
 
-  micm::Process r3 = micm::Process::Create().reactants({ quz }).products({}).phase(gas_phase);
+  micm::Process r3 = micm::Process::Create().SetReactants({ quz }).SetProducts({}).SetPhase(gas_phase);
 
   auto used_species = ProcessSetPolicy::SpeciesUsed(std::vector<micm::Process>{ r1, r2, r3 });
 
@@ -56,7 +56,7 @@ void testProcessSet(const std::function<ProcessSetPolicy(
   ProcessSetPolicy set = create_set(std::vector<micm::Process>{ r1, r2, r3 }, state);
 
   EXPECT_EQ(state.variables_.NumRows(), 2);
-  EXPECT_EQ(state.variables_[0].size(), 6);
+  EXPECT_EQ(state.variables_.NumColumns(), 6);
   state.variables_[0] = { 0.1, 0.2, 0.3, 0.4, 0.5, 0.0 };
   state.variables_[1] = { 1.1, 1.2, 1.3, 1.4, 1.5, 0.0 };
   MatrixPolicy<double> rate_constants{ 2, 3 };
@@ -99,9 +99,9 @@ void testProcessSet(const std::function<ProcessSetPolicy(
   compare_pair(*(++elem), index_pair(4, 0));
   compare_pair(*(++elem), index_pair(4, 2));
 
-  auto builder = SparseMatrixPolicy<double>::create(5).NumberOfBlocks(2).initial_value(100.0);
+  auto builder = SparseMatrixPolicy<double>::Create(5).NumberOfBlocks(2).InitialValue(100.0);
   for (auto& elem : non_zero_elements)
-    builder = builder.with_element(elem.first, elem.second);
+    builder = builder.WithElement(elem.first, elem.second);
   SparseMatrixPolicy<double> jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   set.template SubtractJacobianTerms<MatrixPolicy, SparseMatrixPolicy>(rate_constants, state.variables_, jacobian);
@@ -171,9 +171,9 @@ void testRandomSystem(
     std::vector<yields> products{};
     for (std::size_t i_prod = 0; i_prod < n_product; ++i_prod)
     {
-      products.push_back(Yields(std::to_string(get_species_id()), 1.2));
+      products.push_back(micm::Yields(std::to_string(get_species_id()), 1.2));
     }
-    auto proc = micm::Process(micm::Process::Create().reactants(reactants).products(products).phase(gas_phase));
+    auto proc = micm::Process(micm::Process::Create().SetReactants(reactants).SetProducts(products).SetPhase(gas_phase));
     processes.push_back(proc);
   }
   ProcessSetPolicy set = create_set(processes, state);

--- a/test/unit/process/test_process_set_policy.hpp
+++ b/test/unit/process/test_process_set_policy.hpp
@@ -99,7 +99,7 @@ void testProcessSet(const std::function<ProcessSetPolicy(
   compare_pair(*(++elem), index_pair(4, 0));
   compare_pair(*(++elem), index_pair(4, 2));
 
-  auto builder = SparseMatrixPolicy<double>::Create(5).NumberOfBlocks(2).InitialValue(100.0);
+  auto builder = SparseMatrixPolicy<double>::Create(5).SetNumberOfBlocks(2).InitialValue(100.0);
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   SparseMatrixPolicy<double> jacobian{ builder };

--- a/test/unit/process/test_surface_rate_constant.cpp
+++ b/test/unit/process/test_surface_rate_constant.cpp
@@ -24,7 +24,7 @@ TEST(SurfaceRateConstant, CalculateDefaultProbability)
   EXPECT_EQ(surface.SizeCustomParameters(), 2);
   EXPECT_EQ(surface.CustomParameters()[0], "foo.effective radius [m]");
   EXPECT_EQ(surface.CustomParameters()[1], "foo.particle number concentration [# m-3]");
-  auto k = surface.calculate(state.conditions_[0], params);
+  auto k = surface.Calculate(state.conditions_[0], params);
   double k_test = 4.0 * 2.5e6 * M_PI * std::pow(1.0e-7, 2) /
                   (1.0e-7 / 2.3e2 + 4.0 / (std::sqrt(8.0 * GAS_CONSTANT * 273.65 / (M_PI * 0.025))));
   EXPECT_NEAR(k, k_test, k_test * 1.0e-10);
@@ -49,7 +49,7 @@ TEST(SurfaceRateConstant, CalculateSpecifiedProbability)
   EXPECT_EQ(surface.SizeCustomParameters(), 2);
   EXPECT_EQ(surface.CustomParameters()[0], "foo.effective radius [m]");
   EXPECT_EQ(surface.CustomParameters()[1], "foo.particle number concentration [# m-3]");
-  auto k = surface.calculate(state.conditions_[0], params);
+  auto k = surface.Calculate(state.conditions_[0], params);
   double k_test = 4.0 * 2.5e6 * M_PI * std::pow(1.0e-7, 2) /
                   (1.0e-7 / 2.3e2 + 4.0 / (std::sqrt(8.0 * GAS_CONSTANT * 273.65 / (M_PI * 0.025)) * 0.74));
   EXPECT_NEAR(k, k_test, k_test * 1.0e-10);

--- a/test/unit/process/test_ternary_chemical_activation_rate_constant.cpp
+++ b/test/unit/process/test_ternary_chemical_activation_rate_constant.cpp
@@ -14,7 +14,7 @@ TEST(TernaryChemicalActivationRateConstant, CalculateWithMinimalArugments)
   ternary_params.k0_A_ = 1.0;
   ternary_params.kinf_A_ = 1.0;
   micm::TernaryChemicalActivationRateConstant ternary{ ternary_params };
-  auto k = ternary.calculate(conditions);
+  auto k = ternary.Calculate(conditions);
   double k0 = 1.0;
   double kinf = 1.0;
   EXPECT_EQ(k, k0 / (1.0 + k0 * 42.2 / kinf) * std::pow(0.6, 1.0 / (1 + std::pow(std::log10(k0 * 42.2 / kinf), 2))));
@@ -36,7 +36,7 @@ TEST(TernaryChemicalActivationRateConstant, CalculateWithAllArugments)
       .kinf_C_ = 402.1,
       .Fc_ = 0.9,
       .N_ = 1.2 } };
-  auto k = ternary.calculate(conditions);
+  auto k = ternary.Calculate(conditions);
   double k0 = 1.2 * std::exp(302.3 / temperature) * std::pow(temperature / 300.0, 2.3);
   double kinf = 2.6 * std::exp(402.1 / temperature) * std::pow(temperature / 300.0, -3.1);
   EXPECT_EQ(

--- a/test/unit/process/test_troe_rate_constant.cpp
+++ b/test/unit/process/test_troe_rate_constant.cpp
@@ -14,7 +14,7 @@ TEST(TroeRateConstant, CalculateWithMinimalArugments)
   troe_params.k0_A_ = 1.0;
   troe_params.kinf_A_ = 1.0;
   micm::TroeRateConstant troe{ troe_params };
-  auto k = troe.calculate(conditions);
+  auto k = troe.Calculate(conditions);
   double k0 = 1.0;
   double kinf = 1.0;
   EXPECT_EQ(k, 42.2 * k0 / (1.0 + 42.2 * k0 / kinf) * std::pow(0.6, 1.0 / (1 + std::pow(std::log10(42.2 * k0 / kinf), 2))));
@@ -35,7 +35,7 @@ TEST(TroeRateConstant, CalculateWithAllArugments)
                                                                  .kinf_C_ = 402.1,
                                                                  .Fc_ = 0.9,
                                                                  .N_ = 1.2 } };
-  auto k = troe.calculate(conditions);
+  auto k = troe.Calculate(conditions);
   double k0 = 1.2 * std::exp(302.3 / temperature) * std::pow(temperature / 300.0, 2.3);
   double kinf = 2.6 * std::exp(402.1 / temperature) * std::pow(temperature / 300.0, -3.1);
   EXPECT_EQ(
@@ -56,7 +56,7 @@ TEST(TroeRateConstant, AnalyticalTroeExampleAB)
   troe_params.k0_A_ = 4.0e-18;
   micm::TroeRateConstant troe{ troe_params };
 
-  auto k = troe.calculate(conditions);
+  auto k = troe.Calculate(conditions);
 
   double k_0 = 4.0e-18;
   double k_inf = 1;
@@ -79,7 +79,7 @@ TEST(TroeRateConstant, AnalyticalTroeExampleBC)
   };
   micm::TroeRateConstant troe{ troe_params };
 
-  auto k = troe.calculate(conditions);
+  auto k = troe.Calculate(conditions);
 
   double k_0 = 1.2e-12 * std::exp(3.0 / 301.24) * std::pow(301.24 / 300.0, 167.0);
   double k_inf = 136.0 * std::exp(24.0 / 301.24) * std::pow(301.24 / 300.0, 5.0);

--- a/test/unit/process/test_tunneling_rate_constant.cpp
+++ b/test/unit/process/test_tunneling_rate_constant.cpp
@@ -11,7 +11,7 @@ TEST(TunnelingRateConstant, CalculateWithMinimalArugments)
   };
   micm::TunnelingRateConstantParameters tunneling_params;
   micm::TunnelingRateConstant tunneling{ tunneling_params };
-  auto k = tunneling.calculate(conditions);
+  auto k = tunneling.Calculate(conditions);
   EXPECT_NEAR(k, 1.0, 1.0e-8);
 }
 
@@ -22,6 +22,6 @@ TEST(TunnelingRateConstant, CalculateWithAllArugments)
     .temperature_ = temperature,  // [K]
   };
   micm::TunnelingRateConstant tunneling{ micm::TunnelingRateConstantParameters{ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 } };
-  auto k = tunneling.calculate(conditions);
+  auto k = tunneling.Calculate(conditions);
   EXPECT_NEAR(k, 1.2 * std::exp(-2.3 / temperature) * std::exp(302.3 / std::pow(temperature, 3)), 1.0e-8);
 }

--- a/test/unit/process/test_user_defined_rate_constant.cpp
+++ b/test/unit/process/test_user_defined_rate_constant.cpp
@@ -18,7 +18,7 @@ TEST(UserDefinedRateConstant, CalculateWithSystem)
 
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
   micm::UserDefinedRateConstant photo{};
-  auto k = photo.calculate(state.conditions_[0], params);
+  auto k = photo.Calculate(state.conditions_[0], params);
   EXPECT_EQ(k, 0.5);
 }
 
@@ -36,7 +36,7 @@ TEST(UserDefinedRateConstant, ConstructorWithRate)
 
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
   micm::UserDefinedRateConstant photo{};
-  auto k = photo.calculate(state.conditions_[0], params);
+  auto k = photo.Calculate(state.conditions_[0], params);
   EXPECT_EQ(k, 1.1);
 }
 
@@ -53,7 +53,7 @@ TEST(UserDefinedRateConstant, ConstructorWithRateAndName)
   state.custom_rate_parameters_[0][0] = 1.1;
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
   micm::UserDefinedRateConstant photo({ .label_ = "a name" });
-  auto k = photo.calculate(state.conditions_[0], params);
+  auto k = photo.Calculate(state.conditions_[0], params);
   EXPECT_EQ(k, 1.1);
   EXPECT_EQ(photo.CustomParameters()[0], "a name");
 }
@@ -71,7 +71,7 @@ TEST(UserDefinedRateConstant, CustomScalingFactor)
   state.custom_rate_parameters_[0][0] = 1.2;
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
   micm::UserDefinedRateConstant photo({ .label_ = "a name", .scaling_factor_ = 2.0 });
-  auto k = photo.calculate(state.conditions_[0], params);
+  auto k = photo.Calculate(state.conditions_[0], params);
   EXPECT_EQ(k, 1.2 * 2.0);
   EXPECT_EQ(photo.CustomParameters()[0], "a name");
 }

--- a/test/unit/solver/test_cuda_linear_solver.cpp
+++ b/test/unit/solver/test_cuda_linear_solver.cpp
@@ -45,7 +45,7 @@ std::vector<double> linearSolverGenerator(
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::Create(10).NumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())

--- a/test/unit/solver/test_cuda_linear_solver.cpp
+++ b/test/unit/solver/test_cuda_linear_solver.cpp
@@ -45,11 +45,11 @@ std::vector<double> linearSolverGenerator(
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::create(10).NumberOfBlocks(number_of_blocks).initial_value(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::Create(10).NumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())
-        builder = builder.with_element(i, j);
+        builder = builder.WithElement(i, j);
 
   SparseMatrixPolicy<double> A(builder);
   MatrixPolicy<double> b(number_of_blocks, 10, 0.0);

--- a/test/unit/solver/test_cuda_linear_solver.cpp
+++ b/test/unit/solver/test_cuda_linear_solver.cpp
@@ -45,7 +45,7 @@ std::vector<double> linearSolverGenerator(
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::create(10).number_of_blocks(number_of_blocks).initial_value(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::create(10).NumberOfBlocks(number_of_blocks).initial_value(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())

--- a/test/unit/solver/test_cuda_lu_decomposition.cpp
+++ b/test/unit/solver/test_cuda_lu_decomposition.cpp
@@ -58,7 +58,7 @@ void testRandomMatrix(size_t n_grids)
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
-  auto builder = CPUSparseMatrixPolicy<double>::create(10).number_of_blocks(n_grids).initial_value(1.0e-30);
+  auto builder = CPUSparseMatrixPolicy<double>::create(10).NumberOfBlocks(n_grids).initial_value(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())

--- a/test/unit/solver/test_cuda_lu_decomposition.cpp
+++ b/test/unit/solver/test_cuda_lu_decomposition.cpp
@@ -20,16 +20,16 @@ void check_results(
     const SparseMatrixPolicy<T>& U,
     const std::function<void(const T, const T)> f)
 {
-  EXPECT_EQ(A.Size(), L.Size());
-  EXPECT_EQ(A.Size(), U.Size());
-  for (std::size_t i_block = 0; i_block < A.Size(); ++i_block)
+  EXPECT_EQ(A.NumberOfBlocks(), L.NumberOfBlocks());
+  EXPECT_EQ(A.NumberOfBlocks(), U.NumberOfBlocks());
+  for (std::size_t i_block = 0; i_block < A.NumberOfBlocks(); ++i_block)
   {
-    for (std::size_t i = 0; i < A[i_block].size(); ++i)
+    for (std::size_t i = 0; i < A.NumRows(); ++i)
     {
-      for (std::size_t j = 0; j < A[i_block].size(); ++j)
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
       {
         T result{};
-        for (std::size_t k = 0; k < A[i_block].size(); ++k)
+        for (std::size_t k = 0; k < A.NumRows(); ++k)
         {
           if (!(L.IsZero(i, k) || U.IsZero(k, j)))
           {

--- a/test/unit/solver/test_cuda_lu_decomposition.cpp
+++ b/test/unit/solver/test_cuda_lu_decomposition.cpp
@@ -58,7 +58,7 @@ void testRandomMatrix(size_t n_grids)
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
-  auto builder = CPUSparseMatrixPolicy<double>::Create(10).NumberOfBlocks(n_grids).InitialValue(1.0e-30);
+  auto builder = CPUSparseMatrixPolicy<double>::Create(10).SetNumberOfBlocks(n_grids).InitialValue(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())

--- a/test/unit/solver/test_cuda_lu_decomposition.cpp
+++ b/test/unit/solver/test_cuda_lu_decomposition.cpp
@@ -58,11 +58,11 @@ void testRandomMatrix(size_t n_grids)
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
-  auto builder = CPUSparseMatrixPolicy<double>::create(10).NumberOfBlocks(n_grids).initial_value(1.0e-30);
+  auto builder = CPUSparseMatrixPolicy<double>::Create(10).NumberOfBlocks(n_grids).InitialValue(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())
-        builder = builder.with_element(i, j);
+        builder = builder.WithElement(i, j);
 
   CPUSparseMatrixPolicy<double> cpu_A(builder);
   GPUSparseMatrixPolicy<double> gpu_A(builder);

--- a/test/unit/solver/test_cuda_rosenbrock.cpp
+++ b/test/unit/solver/test_cuda_rosenbrock.cpp
@@ -125,19 +125,19 @@ RosenbrockPolicy getSolver(std::size_t number_of_grid_cells)
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar, baz, quz, quuz } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ foo, baz })
-                         .products({ yields(bar, 1), yields(quuz, 2.4) })
+                         .products({ Yields(bar, 1), Yields(quuz, 2.4) })
                          .phase(gas_phase)
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ bar })
-                         .products({ yields(foo, 1), yields(quz, 1.4) })
+                         .products({ Yields(foo, 1), Yields(quz, 1.4) })
                          .phase(gas_phase)
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 1.0e-6 }));
 
-  micm::Process r3 = micm::Process::create().reactants({ quz }).products({}).phase(gas_phase).rate_constant(
+  micm::Process r3 = micm::Process::Create().reactants({ quz }).products({}).phase(gas_phase).rate_constant(
       micm::ArrheniusRateConstant({ .A_ = 3.5e-6 }));
 
   return RosenbrockPolicy(

--- a/test/unit/solver/test_cuda_rosenbrock.cpp
+++ b/test/unit/solver/test_cuda_rosenbrock.cpp
@@ -159,11 +159,14 @@ void testAlphaMinusJacobian(std::size_t number_of_grid_cells)
 {
   auto gpu_solver = getSolver<micm::CudaRosenbrockSolver<GPUMatrixPolicy, GPUSparseMatrixPolicy>>(number_of_grid_cells);
   auto gpu_jacobian = gpu_solver.GetState().jacobian_;
-  EXPECT_EQ(gpu_jacobian.Size(), number_of_grid_cells);
-  EXPECT_EQ(gpu_jacobian[0].size(), 5);
-  EXPECT_EQ(gpu_jacobian[0][0].size(), 5);
+  EXPECT_EQ(gpu_jacobian.NumberOfBlocks(), number_of_grid_cells);
+  EXPECT_EQ(gpu_jacobian.NumRows(), 5);
+  EXPECT_EQ(gpu_jacobian.NumColumns(), gpu_jacobian.NumRows());
+  EXPECT_EQ(gpu_jacobian[0].Size(), 5);
+  EXPECT_EQ(gpu_jacobian[0][0].Size(), 5);
   auto& gpu_jacobian_vec = gpu_jacobian.AsVector();
   EXPECT_GE(gpu_jacobian_vec.size(), 13 * number_of_grid_cells);
+
   gpu_jacobian_vec.assign(gpu_jacobian_vec.size(), 100.0);
   for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
   {

--- a/test/unit/solver/test_cuda_rosenbrock.cpp
+++ b/test/unit/solver/test_cuda_rosenbrock.cpp
@@ -126,24 +126,24 @@ RosenbrockPolicy getSolver(std::size_t number_of_grid_cells)
   micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar, baz, quz, quuz } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ foo, baz })
-                         .products({ Yields(bar, 1), Yields(quuz, 2.4) })
-                         .phase(gas_phase)
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
+                         .SetReactants({ foo, baz })
+                         .SetProducts({ Yields(bar, 1), Yields(quuz, 2.4) })
+                         .SetPhase(gas_phase)
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ bar })
-                         .products({ Yields(foo, 1), Yields(quz, 1.4) })
-                         .phase(gas_phase)
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 1.0e-6 }));
+                         .SetReactants({ bar })
+                         .SetProducts({ Yields(foo, 1), Yields(quz, 1.4) })
+                         .SetPhase(gas_phase)
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 1.0e-6 }));
 
-  micm::Process r3 = micm::Process::Create().reactants({ quz }).products({}).phase(gas_phase).rate_constant(
+  micm::Process r3 = micm::Process::Create().SetReactants({ quz }).SetProducts({}).SetPhase(gas_phase).SetRateConstant(
       micm::ArrheniusRateConstant({ .A_ = 3.5e-6 }));
 
   return RosenbrockPolicy(
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }),
       std::vector<micm::Process>{ r1, r2, r3 },
-      micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells, false));
+      micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters(number_of_grid_cells, false));
 }
 
 template<

--- a/test/unit/solver/test_jit_linear_solver.cpp
+++ b/test/unit/solver/test_jit_linear_solver.cpp
@@ -30,7 +30,7 @@ using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorO
 
 TEST(JitLinearSolver, DenseMatrixVectorOrdering)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -51,7 +51,7 @@ TEST(JitLinearSolver, DenseMatrixVectorOrdering)
 
 TEST(JitLinearSolver, RandomMatrixVectorOrdering)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -85,7 +85,7 @@ TEST(JitLinearSolver, RandomMatrixVectorOrdering)
 
 TEST(JitLinearSolver, DiagonalMatrixVectorOrdering)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");

--- a/test/unit/solver/test_jit_lu_decomposition.cpp
+++ b/test/unit/solver/test_jit_lu_decomposition.cpp
@@ -17,7 +17,7 @@ using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorO
 
 TEST(JitLuDecomposition, DenseMatrixVectorOrdering)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -43,7 +43,7 @@ TEST(JitLuDecomposition, DenseMatrixVectorOrdering)
 
 TEST(JitLuDecomposition, SingularMatrixVectorOrdering)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -69,7 +69,7 @@ TEST(JitLuDecomposition, SingularMatrixVectorOrdering)
 
 TEST(JitLuDecomposition, RandomMatrixVectorOrdering)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -99,7 +99,7 @@ TEST(JitLuDecomposition, RandomMatrixVectorOrdering)
 
 TEST(JitLuDecomposition, DiagonalMatrixVectorOrdering)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");

--- a/test/unit/solver/test_jit_rosenbrock.cpp
+++ b/test/unit/solver/test_jit_rosenbrock.cpp
@@ -34,19 +34,22 @@ getSolver(std::shared_ptr<micm::JitCompiler> jit)
   micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar, baz, quz, quuz } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ foo, baz })
-                         .products({ Yields(bar, 1), Yields(quuz, 2.4) })
-                         .phase(gas_phase)
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
+                         .SetReactants({ foo, baz })
+                         .SetProducts({ Yields(bar, 1), Yields(quuz, 2.4) })
+                         .SetPhase(gas_phase)
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ bar })
-                         .products({ Yields(foo, 1), Yields(quz, 1.4) })
-                         .phase(gas_phase)
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 1.0e-6 }));
+                         .SetReactants({ bar })
+                         .SetProducts({ Yields(foo, 1), Yields(quz, 1.4) })
+                         .SetPhase(gas_phase)
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 1.0e-6 }));
 
-  micm::Process r3 = micm::Process::Create().reactants({ quz }).products({}).phase(gas_phase).rate_constant(
-      micm::ArrheniusRateConstant({ .A_ = 3.5e-6 }));
+  micm::Process r3 = micm::Process::Create()
+                         .SetReactants({ quz })
+                         .SetProducts({})
+                         .SetPhase(gas_phase)
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 3.5e-6 }));
 
   return micm::JitRosenbrockSolver<
       MatrixPolicy,
@@ -56,7 +59,7 @@ getSolver(std::shared_ptr<micm::JitCompiler> jit)
       jit,
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }),
       std::vector<micm::Process>{ r1, r2, r3 },
-      micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells, false));
+      micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters(number_of_grid_cells, false));
 }
 
 template<class T>
@@ -69,9 +72,10 @@ void testAlphaMinusJacobian(std::shared_ptr<micm::JitCompiler> jit)
   // return;
   auto jacobian = solver.GetState().jacobian_;
 
-  EXPECT_EQ(jacobian.Size(), number_of_grid_cells);
-  EXPECT_EQ(jacobian[0].size(), 5);
-  EXPECT_EQ(jacobian[0][0].size(), 5);
+  EXPECT_EQ(jacobian.NumRows(), number_of_grid_cells);
+  EXPECT_EQ(jacobian.NumColumns(), jacobian.NumRows());
+  EXPECT_EQ(jacobian[0].Size(), 5);
+  EXPECT_EQ(jacobian[0][0].Size(), 5);
   EXPECT_GE(jacobian.AsVector().size(), 13 * number_of_grid_cells);
 
   // Generate a negative Jacobian matrix
@@ -155,7 +159,7 @@ void run_solver(auto& solver)
 
 TEST(JitRosenbrockSolver, AlphaMinusJacobian)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
   if (auto err = jit.takeError())
   {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs(), "[JIT Error]");
@@ -169,7 +173,7 @@ TEST(JitRosenbrockSolver, AlphaMinusJacobian)
 
 TEST(JitRosenbrockSolver, MultipleInstances)
 {
-  auto jit{ micm::JitCompiler::create() };
+  auto jit{ micm::JitCompiler::Create() };
 
   micm::SolverConfig solverConfig;
   std::string config_path = "./unit_configs/robertson";
@@ -180,7 +184,7 @@ TEST(JitRosenbrockSolver, MultipleInstances)
   auto chemical_system = solver_params.system_;
   auto reactions = solver_params.processes_;
 
-  auto solver_parameters = micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters();
+  auto solver_parameters = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
 
   micm::JitRosenbrockSolver<
       Group1VectorMatrix,

--- a/test/unit/solver/test_jit_rosenbrock.cpp
+++ b/test/unit/solver/test_jit_rosenbrock.cpp
@@ -33,19 +33,19 @@ getSolver(std::shared_ptr<micm::JitCompiler> jit)
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar, baz, quz, quuz } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ foo, baz })
-                         .products({ yields(bar, 1), yields(quuz, 2.4) })
+                         .products({ Yields(bar, 1), Yields(quuz, 2.4) })
                          .phase(gas_phase)
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ bar })
-                         .products({ yields(foo, 1), yields(quz, 1.4) })
+                         .products({ Yields(foo, 1), Yields(quz, 1.4) })
                          .phase(gas_phase)
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 1.0e-6 }));
 
-  micm::Process r3 = micm::Process::create().reactants({ quz }).products({}).phase(gas_phase).rate_constant(
+  micm::Process r3 = micm::Process::Create().reactants({ quz }).products({}).phase(gas_phase).rate_constant(
       micm::ArrheniusRateConstant({ .A_ = 3.5e-6 }));
 
   return micm::JitRosenbrockSolver<

--- a/test/unit/solver/test_jit_rosenbrock.cpp
+++ b/test/unit/solver/test_jit_rosenbrock.cpp
@@ -72,7 +72,8 @@ void testAlphaMinusJacobian(std::shared_ptr<micm::JitCompiler> jit)
   // return;
   auto jacobian = solver.GetState().jacobian_;
 
-  EXPECT_EQ(jacobian.NumRows(), number_of_grid_cells);
+  EXPECT_EQ(jacobian.NumberOfBlocks(), number_of_grid_cells);
+  EXPECT_EQ(jacobian.NumRows(), 5);
   EXPECT_EQ(jacobian.NumColumns(), jacobian.NumRows());
   EXPECT_EQ(jacobian[0].Size(), 5);
   EXPECT_EQ(jacobian[0][0].Size(), 5);

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -104,7 +104,7 @@ void testRandomMatrix(
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::Create(10).NumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())
@@ -141,7 +141,7 @@ void testDiagonalMatrix(
 {
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::Create(6).NumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::Create(6).SetNumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
   for (std::size_t i = 0; i < 6; ++i)
     builder = builder.WithElement(i, i);
 

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -14,14 +14,14 @@ void check_results(
     const std::function<void(const T, const T)> f)
 {
   T result;
-  EXPECT_EQ(A.Size(), b.NumRows());
-  EXPECT_EQ(A.Size(), x.NumRows());
-  for (std::size_t i_block = 0; i_block < A.Size(); ++i_block)
+  EXPECT_EQ(A.NumberOfBlocks(), b.NumRows());
+  EXPECT_EQ(A.NumberOfBlocks(), x.NumRows());
+  for (std::size_t i_block = 0; i_block < A.NumberOfBlocks(); ++i_block)
   {
-    for (std::size_t i = 0; i < A[i_block].size(); ++i)
+    for (std::size_t i = 0; i < A.NumRows(); ++i)
     {
       result = 0.0;
-      for (std::size_t j = 0; j < A[i_block].size(); ++j)
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
         if (!A.IsZero(i, j))
           result += A[i_block][i][j] * x[i_block][j];
       f(b[i_block][i], result);
@@ -32,12 +32,12 @@ void check_results(
 template<typename T, template<class> class SparseMatrixPolicy>
 void print_matrix(const SparseMatrixPolicy<T>& matrix, std::size_t width)
 {
-  for (std::size_t i_block = 0; i_block < matrix.Size(); ++i_block)
+  for (std::size_t i_block = 0; i_block < matrix.NumberOfBlocks(); ++i_block)
   {
     std::cout << "block: " << i_block << std::endl;
-    for (std::size_t i = 0; i < matrix[i_block].size(); ++i)
+    for (std::size_t i = 0; i < matrix.NumRows(); ++i)
     {
-      for (std::size_t j = 0; j < matrix[i_block][i].size(); ++j)
+      for (std::size_t j = 0; j < matrix.NumColumns(); ++j)
       {
         if (matrix.IsZero(i, j))
         {
@@ -58,17 +58,17 @@ void print_matrix(const SparseMatrixPolicy<T>& matrix, std::size_t width)
 template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
 void testDenseMatrix(const std::function<LinearSolverPolicy(const SparseMatrixPolicy<double>, double)> create_linear_solver)
 {
-  SparseMatrixPolicy<double> A = SparseMatrixPolicy<double>(SparseMatrixPolicy<double>::create(3)
-                                                                .initial_value(1.0e-30)
-                                                                .with_element(0, 0)
-                                                                .with_element(0, 1)
-                                                                .with_element(0, 2)
-                                                                .with_element(1, 0)
-                                                                .with_element(1, 1)
-                                                                .with_element(1, 2)
-                                                                .with_element(2, 0)
-                                                                .with_element(2, 1)
-                                                                .with_element(2, 2));
+  SparseMatrixPolicy<double> A = SparseMatrixPolicy<double>(SparseMatrixPolicy<double>::Create(3)
+                                                                .InitialValue(1.0e-30)
+                                                                .WithElement(0, 0)
+                                                                .WithElement(0, 1)
+                                                                .WithElement(0, 2)
+                                                                .WithElement(1, 0)
+                                                                .WithElement(1, 1)
+                                                                .WithElement(1, 2)
+                                                                .WithElement(2, 0)
+                                                                .WithElement(2, 1)
+                                                                .WithElement(2, 2));
   MatrixPolicy<double> b(1, 3, 0.0);
   MatrixPolicy<double> x(1, 3, 100.0);
 
@@ -104,11 +104,11 @@ void testRandomMatrix(
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::create(10).NumberOfBlocks(number_of_blocks).initial_value(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::Create(10).NumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())
-        builder = builder.with_element(i, j);
+        builder = builder.WithElement(i, j);
 
   SparseMatrixPolicy<double> A(builder);
   MatrixPolicy<double> b(number_of_blocks, 10, 0.0);
@@ -141,9 +141,9 @@ void testDiagonalMatrix(
 {
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::create(6).NumberOfBlocks(number_of_blocks).initial_value(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::Create(6).NumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
   for (std::size_t i = 0; i < 6; ++i)
-    builder = builder.with_element(i, i);
+    builder = builder.WithElement(i, i);
 
   SparseMatrixPolicy<double> A(builder);
   MatrixPolicy<double> b(number_of_blocks, 6, 0.0);
@@ -176,18 +176,18 @@ void testMarkowitzReordering()
 
   auto reorder_map = micm::DiagonalMarkowitzReorder<MatrixPolicy>(orig);
 
-  auto builder = SparseMatrixPolicy<double>::create(50);
+  auto builder = SparseMatrixPolicy<double>::Create(50);
   for (std::size_t i = 0; i < order; ++i)
     for (std::size_t j = 0; j < order; ++j)
       if (orig[i][j] != 0)
-        builder = builder.with_element(i, j);
+        builder = builder.WithElement(i, j);
   SparseMatrixPolicy<double> orig_jac{ builder };
 
-  builder = SparseMatrixPolicy<double>::create(50);
+  builder = SparseMatrixPolicy<double>::Create(50);
   for (std::size_t i = 0; i < order; ++i)
     for (std::size_t j = 0; j < order; ++j)
       if (orig[reorder_map[i]][reorder_map[j]] != 0)
-        builder = builder.with_element(i, j);
+        builder = builder.WithElement(i, j);
   SparseMatrixPolicy<double> reordered_jac{ builder };
 
   auto orig_LU_calc = micm::LuDecomposition::Create<double, SparseMatrixPolicy>(orig_jac);

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -104,7 +104,7 @@ void testRandomMatrix(
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::create(10).number_of_blocks(number_of_blocks).initial_value(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::create(10).NumberOfBlocks(number_of_blocks).initial_value(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())
@@ -141,7 +141,7 @@ void testDiagonalMatrix(
 {
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::create(6).number_of_blocks(number_of_blocks).initial_value(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::create(6).NumberOfBlocks(number_of_blocks).initial_value(1.0e-30);
   for (std::size_t i = 0; i < 6; ++i)
     builder = builder.with_element(i, i);
 

--- a/test/unit/solver/test_lu_decomposition_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_policy.hpp
@@ -14,16 +14,16 @@ void check_results(
     const SparseMatrixPolicy<T>& U,
     const std::function<void(const T, const T)> f)
 {
-  EXPECT_EQ(A.Size(), L.Size());
-  EXPECT_EQ(A.Size(), U.Size());
-  for (std::size_t i_block = 0; i_block < A.Size(); ++i_block)
+  EXPECT_EQ(A.NumberOfBlocks(), L.NumberOfBlocks());
+  EXPECT_EQ(A.NumberOfBlocks(), U.NumberOfBlocks());
+  for (std::size_t i_block = 0; i_block < A.NumberOfBlocks(); ++i_block)
   {
-    for (std::size_t i = 0; i < A[i_block].size(); ++i)
+    for (std::size_t i = 0; i < A.NumRows(); ++i)
     {
-      for (std::size_t j = 0; j < A[i_block].size(); ++j)
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
       {
         T result{};
-        for (std::size_t k = 0; k < A[i_block].size(); ++k)
+        for (std::size_t k = 0; k < A.NumRows(); ++k)
         {
           if (!(L.IsZero(i, k) || U.IsZero(k, j)))
           {
@@ -49,12 +49,12 @@ void check_results(
 template<typename T, template<class> class SparseMatrixPolicy>
 void print_matrix(const SparseMatrixPolicy<T>& matrix, std::size_t width)
 {
-  for (std::size_t i_block = 0; i_block < matrix.size(); ++i_block)
+  for (std::size_t i_block = 0; i_block < matrix.NumberOfBlocks(); ++i_block)
   {
     std::cout << "block: " << i_block << std::endl;
-    for (std::size_t i = 0; i < matrix[i_block].size(); ++i)
+    for (std::size_t i = 0; i < matrix.NumRows(); ++i)
     {
-      for (std::size_t j = 0; j < matrix[i_block][i].size(); ++j)
+      for (std::size_t j = 0; j < matrix.NumColumns(); ++j)
       {
         if (matrix.IsZero(i, j))
         {
@@ -76,17 +76,17 @@ void print_matrix(const SparseMatrixPolicy<T>& matrix, std::size_t width)
 template<template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
 void testDenseMatrix(const std::function<LuDecompositionPolicy(const SparseMatrixPolicy<double>&)> create_lu_decomp)
 {
-  SparseMatrixPolicy<double> A = SparseMatrixPolicy<double>(SparseMatrixPolicy<double>::create(3)
-                                                                .initial_value(1.0e-30)
-                                                                .with_element(0, 0)
-                                                                .with_element(0, 1)
-                                                                .with_element(0, 2)
-                                                                .with_element(1, 0)
-                                                                .with_element(1, 1)
-                                                                .with_element(1, 2)
-                                                                .with_element(2, 0)
-                                                                .with_element(2, 1)
-                                                                .with_element(2, 2));
+  SparseMatrixPolicy<double> A = SparseMatrixPolicy<double>(SparseMatrixPolicy<double>::Create(3)
+                                                                .InitialValue(1.0e-30)
+                                                                .WithElement(0, 0)
+                                                                .WithElement(0, 1)
+                                                                .WithElement(0, 2)
+                                                                .WithElement(1, 0)
+                                                                .WithElement(1, 1)
+                                                                .WithElement(1, 2)
+                                                                .WithElement(2, 0)
+                                                                .WithElement(2, 1)
+                                                                .WithElement(2, 2));
 
   A[0][0][0] = 2;
   A[0][0][1] = -1;
@@ -108,12 +108,12 @@ void testDenseMatrix(const std::function<LuDecompositionPolicy(const SparseMatri
 template<template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
 void testSingularMatrix(const std::function<LuDecompositionPolicy(const SparseMatrixPolicy<double>&)> create_lu_decomp)
 {
-  SparseMatrixPolicy<double> A = SparseMatrixPolicy<double>(SparseMatrixPolicy<double>::create(2)
-                                                                .initial_value(1.0e-30)
-                                                                .with_element(0, 0)
-                                                                .with_element(0, 1)
-                                                                .with_element(1, 0)
-                                                                .with_element(1, 1));
+  SparseMatrixPolicy<double> A = SparseMatrixPolicy<double>(SparseMatrixPolicy<double>::Create(2)
+                                                                .InitialValue(1.0e-30)
+                                                                .WithElement(0, 0)
+                                                                .WithElement(0, 1)
+                                                                .WithElement(1, 0)
+                                                                .WithElement(1, 1));
 
   A[0][0][0] = 0;
   A[0][0][1] = 1;
@@ -138,11 +138,11 @@ void testRandomMatrix(
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::create(10).NumberOfBlocks(number_of_blocks).initial_value(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::Create(10).NumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())
-        builder = builder.with_element(i, j);
+        builder = builder.WithElement(i, j);
 
   SparseMatrixPolicy<double> A(builder);
 
@@ -166,9 +166,9 @@ void testDiagonalMatrix(
 {
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::create(6).NumberOfBlocks(number_of_blocks).initial_value(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::Create(6).NumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
   for (std::size_t i = 0; i < 6; ++i)
-    builder = builder.with_element(i, i);
+    builder = builder.WithElement(i, i);
 
   SparseMatrixPolicy<double> A(builder);
 

--- a/test/unit/solver/test_lu_decomposition_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_policy.hpp
@@ -138,7 +138,7 @@ void testRandomMatrix(
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::Create(10).NumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())
@@ -166,7 +166,7 @@ void testDiagonalMatrix(
 {
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::Create(6).NumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::Create(6).SetNumberOfBlocks(number_of_blocks).InitialValue(1.0e-30);
   for (std::size_t i = 0; i < 6; ++i)
     builder = builder.WithElement(i, i);
 

--- a/test/unit/solver/test_lu_decomposition_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_policy.hpp
@@ -138,7 +138,7 @@ void testRandomMatrix(
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::create(10).number_of_blocks(number_of_blocks).initial_value(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::create(10).NumberOfBlocks(number_of_blocks).initial_value(1.0e-30);
   for (std::size_t i = 0; i < 10; ++i)
     for (std::size_t j = 0; j < 10; ++j)
       if (i == j || gen_bool())
@@ -166,7 +166,7 @@ void testDiagonalMatrix(
 {
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
-  auto builder = SparseMatrixPolicy<double>::create(6).number_of_blocks(number_of_blocks).initial_value(1.0e-30);
+  auto builder = SparseMatrixPolicy<double>::create(6).NumberOfBlocks(number_of_blocks).initial_value(1.0e-30);
   for (std::size_t i = 0; i < 6; ++i)
     builder = builder.with_element(i, i);
 

--- a/test/unit/solver/test_rosenbrock.cpp
+++ b/test/unit/solver/test_rosenbrock.cpp
@@ -25,19 +25,19 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> get
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar, baz, quz, quuz } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ foo, baz })
-                         .products({ yields(bar, 1), yields(quuz, 2.4) })
+                         .products({ Yields(bar, 1), Yields(quuz, 2.4) })
                          .phase(gas_phase)
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
 
-  micm::Process r2 = micm::Process::create()
+  micm::Process r2 = micm::Process::Create()
                          .reactants({ bar })
-                         .products({ yields(foo, 1), yields(quz, 1.4) })
+                         .products({ Yields(foo, 1), Yields(quz, 1.4) })
                          .phase(gas_phase)
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 1.0e-6 }));
 
-  micm::Process r3 = micm::Process::create().reactants({ quz }).products({}).phase(gas_phase).rate_constant(
+  micm::Process r3 = micm::Process::Create().reactants({ quz }).products({}).phase(gas_phase).rate_constant(
       micm::ArrheniusRateConstant({ .A_ = 3.5e-6 }));
 
   return micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>(
@@ -201,9 +201,9 @@ TEST(RosenbrockSolver, CanSetTolerances)
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ foo })
-                         .products({ yields(bar, 1) })
+                         .products({ Yields(bar, 1) })
                          .phase(gas_phase)
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
 
@@ -229,9 +229,9 @@ TEST(RosenbrockSolver, CanOverrideTolerancesWithParameters)
 
   micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar } };
 
-  micm::Process r1 = micm::Process::create()
+  micm::Process r1 = micm::Process::Create()
                          .reactants({ foo })
-                         .products({ yields(bar, 1) })
+                         .products({ Yields(bar, 1) })
                          .phase(gas_phase)
                          .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
 

--- a/test/unit/solver/test_rosenbrock.cpp
+++ b/test/unit/solver/test_rosenbrock.cpp
@@ -26,24 +26,27 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> get
   micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar, baz, quz, quuz } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ foo, baz })
-                         .products({ Yields(bar, 1), Yields(quuz, 2.4) })
-                         .phase(gas_phase)
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
+                         .SetReactants({ foo, baz })
+                         .SetProducts({ Yields(bar, 1), Yields(quuz, 2.4) })
+                         .SetPhase(gas_phase)
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
 
   micm::Process r2 = micm::Process::Create()
-                         .reactants({ bar })
-                         .products({ Yields(foo, 1), Yields(quz, 1.4) })
-                         .phase(gas_phase)
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 1.0e-6 }));
+                         .SetReactants({ bar })
+                         .SetProducts({ Yields(foo, 1), Yields(quz, 1.4) })
+                         .SetPhase(gas_phase)
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 1.0e-6 }));
 
-  micm::Process r3 = micm::Process::Create().reactants({ quz }).products({}).phase(gas_phase).rate_constant(
-      micm::ArrheniusRateConstant({ .A_ = 3.5e-6 }));
+  micm::Process r3 = micm::Process::Create()
+                         .SetReactants({ quz })
+                         .SetProducts({})
+                         .SetPhase(gas_phase)
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 3.5e-6 }));
 
   return micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>(
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }),
       std::vector<micm::Process>{ r1, r2, r3 },
-      micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells, false));
+      micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters(number_of_grid_cells, false));
 }
 
 template<class T>
@@ -55,9 +58,11 @@ void testAlphaMinusJacobian(std::size_t number_of_grid_cells)
   auto solver = getSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>(number_of_grid_cells);
   auto jacobian = solver.GetState().jacobian_;
 
-  EXPECT_EQ(jacobian.Size(), number_of_grid_cells);
-  EXPECT_EQ(jacobian[0].size(), 5);
-  EXPECT_EQ(jacobian[0][0].size(), 5);
+  EXPECT_EQ(jacobian.NumberOfBlocks(), number_of_grid_cells);
+  EXPECT_EQ(jacobian.NumRows(), 5);
+  EXPECT_EQ(jacobian.NumColumns(), jacobian.NumRows());
+  EXPECT_EQ(jacobian[0].Size(), 5);
+  EXPECT_EQ(jacobian[0][0].Size(), 5);
   EXPECT_GE(jacobian.AsVector().size(), 13 * number_of_grid_cells);
 
   // Initialize Jacobian matrix
@@ -202,17 +207,17 @@ TEST(RosenbrockSolver, CanSetTolerances)
   micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ foo })
-                         .products({ Yields(bar, 1) })
-                         .phase(gas_phase)
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
+                         .SetReactants({ foo })
+                         .SetProducts({ Yields(bar, 1) })
+                         .SetPhase(gas_phase)
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
 
   for (size_t number_of_grid_cells = 1; number_of_grid_cells <= 10; ++number_of_grid_cells)
   {
     auto solver = micm::RosenbrockSolver<>(
         micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }),
         std::vector<micm::Process>{ r1 },
-        micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells));
+        micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters(number_of_grid_cells));
     EXPECT_EQ(solver.parameters_.absolute_tolerance_.size(), 2);
     EXPECT_EQ(solver.parameters_.absolute_tolerance_[0], 1.0e-07);
     EXPECT_EQ(solver.parameters_.absolute_tolerance_[1], 1.0e-08);
@@ -230,14 +235,14 @@ TEST(RosenbrockSolver, CanOverrideTolerancesWithParameters)
   micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar } };
 
   micm::Process r1 = micm::Process::Create()
-                         .reactants({ foo })
-                         .products({ Yields(bar, 1) })
-                         .phase(gas_phase)
-                         .rate_constant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
+                         .SetReactants({ foo })
+                         .SetProducts({ Yields(bar, 1) })
+                         .SetPhase(gas_phase)
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
 
   for (size_t number_of_grid_cells = 1; number_of_grid_cells <= 10; ++number_of_grid_cells)
   {
-    auto params = micm::RosenbrockSolverParameters::three_stage_rosenbrock_parameters(number_of_grid_cells);
+    auto params = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters(number_of_grid_cells);
     params.absolute_tolerance_ = { 1.0e-01, 1.0e-02 };
     auto solver = micm::RosenbrockSolver<>(
         micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::vector<micm::Process>{ r1 }, params);

--- a/test/unit/solver/test_state.cpp
+++ b/test/unit/solver/test_state.cpp
@@ -17,13 +17,16 @@ TEST(State, Constructor)
   EXPECT_EQ(state.variable_map_["baz"], 2);
   EXPECT_EQ(state.variable_map_["quz"], 3);
   EXPECT_EQ(state.variables_.NumRows(), 3);
-  EXPECT_EQ(state.variables_[0].size(), 4);
+  EXPECT_EQ(state.variables_.NumColumns(), 4);
+  EXPECT_EQ(state.variables_[0].Size(), 4);
   EXPECT_EQ(state.custom_rate_parameter_map_["quux"], 0);
   EXPECT_EQ(state.custom_rate_parameter_map_["corge"], 1);
   EXPECT_EQ(state.custom_rate_parameters_.NumRows(), 3);
-  EXPECT_EQ(state.custom_rate_parameters_[0].size(), 2);
+  EXPECT_EQ(state.custom_rate_parameters_.NumColumns(), 2);
+  EXPECT_EQ(state.custom_rate_parameters_[0].Size(), 2);
   EXPECT_EQ(state.rate_constants_.NumRows(), 3);
-  EXPECT_EQ(state.rate_constants_[0].size(), 10);
+  EXPECT_EQ(state.rate_constants_.NumColumns(), 10);
+  EXPECT_EQ(state.rate_constants_[0].Size(), 10);
 }
 
 TEST(State, SettingSingleConcentrationWithInvalidArgumentsThowsException)

--- a/test/unit/util/test_cuda_dense_matrix.cpp
+++ b/test/unit/util/test_cuda_dense_matrix.cpp
@@ -486,11 +486,11 @@ TEST(CudaDenseMatrix, ConversionFromVector)
 
   EXPECT_EQ(matrix.NumRows(), 2);
   EXPECT_EQ(matrix.NumColumns(), 3);
-  EXPECT_EQ(matrix[0].size(), 3);
+  EXPECT_EQ(matrix[0].Size(), 3);
   EXPECT_EQ(matrix[0][0], 412.3);
   EXPECT_EQ(matrix[0][1], 32.4);
   EXPECT_EQ(matrix[0][2], 41.3);
-  EXPECT_EQ(matrix[1].size(), 3);
+  EXPECT_EQ(matrix[1].Size(), 3);
   EXPECT_EQ(matrix[1][0], 5.33);
   EXPECT_EQ(matrix[1][1], -0.3);
   EXPECT_EQ(matrix[1][2], 31.2);

--- a/test/unit/util/test_cuda_sparse_matrix.cpp
+++ b/test/unit/util/test_cuda_sparse_matrix.cpp
@@ -18,10 +18,10 @@ TEST(CudaSparseMatrix, ConstZeroMatrix)
 
 TEST(CudaSparseMatrix, CopyAssignmentZeroMatrix)
 {
-  auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::create(2)
-                     .with_element(0, 0)
-                     .with_element(1, 1)
-                     .initial_value(0.0);
+  auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::Create(2)
+                     .WithElement(0, 0)
+                     .WithElement(1, 1)
+                     .InitialValue(0.0);
 
   micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>> matrix{ builder };
 
@@ -46,10 +46,10 @@ TEST(CudaSparseMatrix, CopyAssignmentZeroMatrix)
 
 TEST(CudaSparseMatrix, CopyAssignmentConstZeroMatrix)
 {
-  auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::create(2)
-                     .with_element(0, 0)
-                     .with_element(1, 1)
-                     .initial_value(0.0);
+  auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::Create(2)
+                     .WithElement(0, 0)
+                     .WithElement(1, 1)
+                     .InitialValue(0.0);
 
   const micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>> matrix{ builder };
 
@@ -84,10 +84,10 @@ TEST(CudaSparseMatrix, CopyAssignmentConstZeroMatrix)
 
 TEST(CudaSparseMatrix, CopyAssignmentDeSynchedHostZeroMatrix)
 {
-  auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::create(2)
-                     .with_element(0, 0)
-                     .with_element(1, 1)
-                     .initial_value(0.0);
+  auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::Create(2)
+                     .WithElement(0, 0)
+                     .WithElement(1, 1)
+                     .InitialValue(0.0);
 
   micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>> matrix{ builder };
 
@@ -140,10 +140,10 @@ TEST(CudaSparseMatrix, CopyAssignmentDeSynchedHostZeroMatrix)
 
 TEST(CudaSparseMatrix, MoveAssignmentConstZeroMatrix)
 {
-  auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::create(2)
-                     .with_element(0, 0)
-                     .with_element(1, 1)
-                     .initial_value(0.0);
+  auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::Create(2)
+                     .WithElement(0, 0)
+                     .WithElement(1, 1)
+                     .InitialValue(0.0);
 
   const micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>> matrix{ builder };
 
@@ -174,10 +174,10 @@ TEST(CudaSparseMatrix, MoveAssignmentConstZeroMatrix)
 
 TEST(CudaSparseMatrix, MoveAssignmentDeSyncedHostZeroMatrix)
 {
-  auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::create(2)
-                     .with_element(0, 0)
-                     .with_element(1, 1)
-                     .initial_value(0.0);
+  auto builder = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>::Create(2)
+                     .WithElement(0, 0)
+                     .WithElement(1, 1)
+                     .InitialValue(0.0);
 
   micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>> matrix{ builder };
 

--- a/test/unit/util/test_matrix_policy.hpp
+++ b/test/unit/util/test_matrix_policy.hpp
@@ -73,7 +73,7 @@ MatrixPolicy<int> testLoopOverMatrix()
   MatrixPolicy<int> matrix(3, 4, 0);
   for (std::size_t i{}; i < matrix.NumRows(); ++i)
   {
-    for (std::size_t j{}; j < matrix[i].size(); ++j)
+    for (std::size_t j{}; j < matrix.NumColumns(); ++j)
     {
       matrix[i][j] = i * 100 + j;
     }
@@ -93,7 +93,7 @@ const MatrixPolicy<int> testLoopOverConstMatrix()
   MatrixPolicy<int> matrix(3, 4, 0);
   for (std::size_t i{}; i < matrix.NumRows(); ++i)
   {
-    for (std::size_t j{}; j < matrix[i].size(); ++j)
+    for (std::size_t j{}; j < matrix.NumColumns(); ++j)
     {
       matrix[i][j] = i * 100 + j;
     }
@@ -159,11 +159,11 @@ MatrixPolicy<double> testConversionFromVector()
 
   EXPECT_EQ(matrix.NumRows(), 2);
   EXPECT_EQ(matrix.NumColumns(), 3);
-  EXPECT_EQ(matrix[0].size(), 3);
+  EXPECT_EQ(matrix[0].Size(), 3);
   EXPECT_EQ(matrix[0][0], 412.3);
   EXPECT_EQ(matrix[0][1], 32.4);
   EXPECT_EQ(matrix[0][2], 41.3);
-  EXPECT_EQ(matrix[1].size(), 3);
+  EXPECT_EQ(matrix[1].Size(), 3);
   EXPECT_EQ(matrix[1][0], 5.33);
   EXPECT_EQ(matrix[1][1], -0.3);
   EXPECT_EQ(matrix[1][2], 31.2);

--- a/test/unit/util/test_sparse_matrix_policy.hpp
+++ b/test/unit/util/test_sparse_matrix_policy.hpp
@@ -5,7 +5,7 @@
 template<template<class, class> class MatrixPolicy, class OrderingPolicy>
 MatrixPolicy<double, OrderingPolicy> testZeroMatrix()
 {
-  auto builder = MatrixPolicy<double, OrderingPolicy>::create(3);
+  auto builder = MatrixPolicy<double, OrderingPolicy>::Create(3);
   auto row_ids = builder.RowIdsVector();
   auto row_starts = builder.RowStartVector();
 
@@ -93,7 +93,7 @@ MatrixPolicy<double, OrderingPolicy> testZeroMatrix()
 template<template<class, class> class MatrixPolicy, class OrderingPolicy>
 MatrixPolicy<double, OrderingPolicy> testConstZeroMatrix()
 {
-  auto builder = MatrixPolicy<double, OrderingPolicy>::create(3);
+  auto builder = MatrixPolicy<double, OrderingPolicy>::Create(3);
   auto row_ids = builder.RowIdsVector();
   auto row_starts = builder.RowStartVector();
 
@@ -157,12 +157,12 @@ MatrixPolicy<double, OrderingPolicy> testConstZeroMatrix()
 template<template<class, class> class MatrixPolicy, class OrderingPolicy>
 MatrixPolicy<int, OrderingPolicy> testSingleBlockMatrix()
 {
-  auto builder = MatrixPolicy<int, OrderingPolicy>::create(4)
-                     .with_element(0, 1)
-                     .with_element(3, 2)
-                     .with_element(0, 1)
-                     .with_element(2, 3)
-                     .with_element(2, 1);
+  auto builder = MatrixPolicy<int, OrderingPolicy>::Create(4)
+                     .WithElement(0, 1)
+                     .WithElement(3, 2)
+                     .WithElement(0, 1)
+                     .WithElement(2, 3)
+                     .WithElement(2, 1);
   // 0 X 0 0
   // 0 0 0 0
   // 0 X 0 X
@@ -276,12 +276,12 @@ MatrixPolicy<int, OrderingPolicy> testSingleBlockMatrix()
 template<template<class, class> class MatrixPolicy, class OrderingPolicy>
 MatrixPolicy<int, OrderingPolicy> testConstSingleBlockMatrix()
 {
-  auto builder = MatrixPolicy<int, OrderingPolicy>::create(4)
-                     .with_element(0, 1)
-                     .with_element(3, 2)
-                     .with_element(0, 1)
-                     .with_element(2, 3)
-                     .with_element(2, 1);
+  auto builder = MatrixPolicy<int, OrderingPolicy>::Create(4)
+                     .WithElement(0, 1)
+                     .WithElement(3, 2)
+                     .WithElement(0, 1)
+                     .WithElement(2, 3)
+                     .WithElement(2, 1);
   // 0 X 0 0
   // 0 0 0 0
   // 0 X 0 X
@@ -357,13 +357,13 @@ MatrixPolicy<int, OrderingPolicy> testConstSingleBlockMatrix()
 template<template<class, class> class MatrixPolicy, class OrderingPolicy>
 MatrixPolicy<int, OrderingPolicy> testMultiBlockMatrix()
 {
-  auto builder = MatrixPolicy<int, OrderingPolicy>::create(4)
-                     .with_element(0, 1)
-                     .with_element(3, 2)
-                     .with_element(0, 1)
-                     .with_element(2, 3)
-                     .with_element(2, 1)
-                     .initial_value(24)
+  auto builder = MatrixPolicy<int, OrderingPolicy>::Create(4)
+                     .WithElement(0, 1)
+                     .WithElement(3, 2)
+                     .WithElement(0, 1)
+                     .WithElement(2, 3)
+                     .WithElement(2, 1)
+                     .InitialValue(24)
                      .NumberOfBlocks(3);
   // 0 X 0 0
   // 0 0 0 0
@@ -462,7 +462,7 @@ MatrixPolicy<int, OrderingPolicy> testMultiBlockMatrix()
 template<template<class, class> class MatrixPolicy, class OrderingPolicy>
 MatrixPolicy<double, OrderingPolicy> testSetScalar()
 {
-  auto builder = MatrixPolicy<double, OrderingPolicy>::create(3);
+  auto builder = MatrixPolicy<double, OrderingPolicy>::Create(3);
 
   MatrixPolicy<double, OrderingPolicy> matrix{ builder };
 

--- a/test/unit/util/test_sparse_matrix_policy.hpp
+++ b/test/unit/util/test_sparse_matrix_policy.hpp
@@ -364,7 +364,7 @@ MatrixPolicy<int, OrderingPolicy> testMultiBlockMatrix()
                      .WithElement(2, 3)
                      .WithElement(2, 1)
                      .InitialValue(24)
-                     .NumberOfBlocks(3);
+                     .SetNumberOfBlocks(3);
   // 0 X 0 0
   // 0 0 0 0
   // 0 X 0 X

--- a/test/unit/util/test_sparse_matrix_policy.hpp
+++ b/test/unit/util/test_sparse_matrix_policy.hpp
@@ -364,7 +364,7 @@ MatrixPolicy<int, OrderingPolicy> testMultiBlockMatrix()
                      .with_element(2, 3)
                      .with_element(2, 1)
                      .initial_value(24)
-                     .number_of_blocks(3);
+                     .NumberOfBlocks(3);
   // 0 X 0 0
   // 0 0 0 0
   // 0 X 0 X

--- a/test/unit/util/test_sparse_matrix_standard_ordering.cpp
+++ b/test/unit/util/test_sparse_matrix_standard_ordering.cpp
@@ -76,19 +76,19 @@ TEST(SparseMatrix, MultiBlockMatrix)
 TEST(SparseMatrixBuilder, BadConfiguration)
 {
   EXPECT_THROW(
-      try { auto builder = micm::SparseMatrix<double>::create(3).with_element(3, 0); } catch (const std::system_error& e) {
+      try { auto builder = micm::SparseMatrix<double>::Create(3).WithElement(3, 0); } catch (const std::system_error& e) {
         EXPECT_EQ(e.code().value(), static_cast<int>(MicmMatrixErrc::ElementOutOfRange));
         throw;
       },
       std::system_error);
   EXPECT_THROW(
-      try { auto builder = micm::SparseMatrix<double>::create(3).with_element(2, 4); } catch (const std::system_error& e) {
+      try { auto builder = micm::SparseMatrix<double>::Create(3).WithElement(2, 4); } catch (const std::system_error& e) {
         EXPECT_EQ(e.code().value(), static_cast<int>(MicmMatrixErrc::ElementOutOfRange));
         throw;
       },
       std::system_error);
   EXPECT_THROW(
-      try { auto builder = micm::SparseMatrix<double>::create(3).with_element(6, 7); } catch (const std::system_error& e) {
+      try { auto builder = micm::SparseMatrix<double>::Create(3).WithElement(6, 7); } catch (const std::system_error& e) {
         EXPECT_EQ(e.code().value(), static_cast<int>(MicmMatrixErrc::ElementOutOfRange));
         throw;
       },


### PR DESCRIPTION
Closes #480

While working on this issue, some of the suggestions under `readability` check category were applied, considered as easy fix.

- Removed duplicate `public` keywords  (`readability-redundant-access-specifiers`)
- Matched a function parameter name that has different names in declaration and definition(`readability-inconsistent-declaration-parameter-name`)
`void LuDecomposition::Initialize(const SparseMatrixPolicy& A, T initial_value)`
`void LuDecomposition::Initialize(const SparseMatrixPolicy& matrix, T initial_value)`
- Added a `Set` prefix to the functions that have the same `class` name to avoid using `class` tag
e.g.,`ProcessBuilder& Phase(const Phase& phase)` [error] must use class tag to refer to type `Phase` in this scope. 
-> `ProcessBuilder& SetPhase(const Phase& phase)`

The disabled or undecided checks in `readability` category are listed with the comments for the discussion in [`.clang-tidy`](https://github.com/NCAR/micm/blob/480-camel-case/.clang-tidy)

I put aside [an issue](https://github.com/NCAR/micm/issues/129) for updating tutorials to reflect the new names. This task can be done when applying the style and renaming is completed