### PR TITLE
Update the assign function inside both CPU and GPU class

### DIFF
--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -352,7 +352,7 @@ namespace micm
           {
             if (parameters_.new_function_evaluation_[stage])
             {
-              Ynew.AsVector().assign(Y.AsVector().begin(), Y.AsVector().end());
+              Ynew.Copy(Y);
               for (uint64_t j = 0; j < stage; ++j)
               {
                 Ynew.Axpy(parameters_.a_[stage_combinations + j], K[j]);
@@ -361,18 +361,18 @@ namespace micm
               stats.function_calls += 1;
             }
           }
-          K[stage].AsVector().assign(forcing.AsVector().begin(), forcing.AsVector().end());
+          K[stage].Copy(forcing);
           for (uint64_t j = 0; j < stage; ++j)
           {
             K[stage].Axpy(parameters_.c_[stage_combinations + j] / H, K[j]);
           }
-          temp.AsVector().assign(K[stage].AsVector().begin(), K[stage].AsVector().end());
+          temp.Copy(K[stage]);
           linear_solver_.template Solve<MatrixPolicy>(temp, K[stage], state.lower_matrix_, state.upper_matrix_);
           stats.solves += 1;
         }
 
         // Compute the new solution
-        Ynew.AsVector().assign(Y.AsVector().begin(), Y.AsVector().end());
+        Ynew.Copy(Y);
         for (uint64_t stage = 0; stage < parameters_.stages_; ++stage)
           Ynew.Axpy(parameters_.m_[stage], K[stage]);
 
@@ -396,13 +396,13 @@ namespace micm
         // Check the error magnitude and adjust step size
         if (std::isnan(error))
         {
-          Y.AsVector().assign(Ynew.AsVector().begin(), Ynew.AsVector().end());
+          Y.Copy(Ynew);
           result.state_ = SolverState::NaNDetected;
           break;
         }
         else if (std::isinf(error) == 1)
         {
-          Y.AsVector().assign(Ynew.AsVector().begin(), Ynew.AsVector().end());
+          Y.Copy(Ynew);
           result.state_ = SolverState::InfDetected;
           break;
         }
@@ -410,7 +410,7 @@ namespace micm
         {
           stats.accepted += 1;
           present_time = present_time + H;
-          Y.AsVector().assign(Ynew.AsVector().begin(), Ynew.AsVector().end());
+          Y.Copy(Ynew);
           Hnew = std::max(parameters_.h_min_, std::min(Hnew, h_max));
           if (reject_last_h)
           {

--- a/include/micm/util/cuda_dense_matrix.hpp
+++ b/include/micm/util/cuda_dense_matrix.hpp
@@ -34,6 +34,11 @@ namespace micm
    * Copy/Move constructors/assignment operators are non-synchronizing
    * operators/constructors so if device and host data is desynchronized,
    * the copies and moved matrices will remain desynchronized.
+   * 
+   * Copy function only copies the device data from one CUDA dense matrix
+   * to the other (no change of the host data), assuming that the device memory
+   * has been allocated correctly. A check is done before doing the copy
+   * to make sure that both matrices have the same size.
    *
    * CUDA functionality requires T to be of type double, otherwise this
    * behaves similarily to VectorMatrix.

--- a/include/micm/util/cuda_dense_matrix.hpp
+++ b/include/micm/util/cuda_dense_matrix.hpp
@@ -68,7 +68,8 @@ namespace micm
         : VectorMatrix<T, L>()
     {
       this->param_.number_of_grid_cells_ = 0;
-      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), "cudaMalloc");
+      this->param_.number_of_elements_ = this->data_.size();
+      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->param_.number_of_elements_), "cudaMalloc");
     }
     CudaDenseMatrix()
         : VectorMatrix<T, L>()
@@ -78,9 +79,10 @@ namespace micm
     CudaDenseMatrix(std::size_t x_dim, std::size_t y_dim) requires(std::is_same_v<T, double>)
         : VectorMatrix<T, L>(x_dim, y_dim)
     {
-      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), "cudaMalloc");
-      CHECK_CUBLAS_ERROR(cublasCreate(&(this->handle_)), "CUBLAS initialization failed...");
+      this->param_.number_of_elements_ = this->data_.size();
       this->param_.number_of_grid_cells_ = x_dim;
+      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->param_.number_of_elements_), "cudaMalloc");
+      CHECK_CUBLAS_ERROR(cublasCreate(&(this->handle_)), "CUBLAS initialization failed...");
     }
     CudaDenseMatrix(std::size_t x_dim, std::size_t y_dim)
         : VectorMatrix<T, L>(x_dim, y_dim)
@@ -90,8 +92,9 @@ namespace micm
     CudaDenseMatrix(std::size_t x_dim, std::size_t y_dim, T initial_value) requires(std::is_same_v<T, double>)
         : VectorMatrix<T, L>(x_dim, y_dim, initial_value)
     {
-      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), "cudaMalloc");
+      this->param_.number_of_elements_ = this->data_.size();
       this->param_.number_of_grid_cells_ = x_dim;
+      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->param_.number_of_elements_), "cudaMalloc");
       CHECK_CUBLAS_ERROR(cublasCreate(&(this->handle_)), "CUBLAS initialization failed...");
     }
     CudaDenseMatrix(std::size_t x_dim, std::size_t y_dim, T initial_value)
@@ -103,7 +106,8 @@ namespace micm
         : VectorMatrix<T, L>(other)
     {
       this->param_.number_of_grid_cells_ = 0;
-      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), "cudaMalloc");
+      this->param_.number_of_elements_ = this->data_.size();
+      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->param_.number_of_elements_), "cudaMalloc");
       CHECK_CUBLAS_ERROR(cublasCreate(&(this->handle_)), "CUBLAS initialization failed...");
     }
 
@@ -117,7 +121,9 @@ namespace micm
     {
       this->param_ = other.param_;
       this->param_.d_data_ = nullptr;
-      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), "cudaMalloc");
+      this->param_.number_of_elements_ = other.param_.number_of_elements_;
+      this->param_.number_of_grid_cells_ = other.param_.number_of_grid_cells_;
+      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->param_.number_of_elements_), "cudaMalloc");
       CHECK_CUDA_ERROR(micm::cuda::CopyToDeviceFromDevice(this->param_, other.param_), "cudaMemcpyDeviceToDevice");
       CHECK_CUBLAS_ERROR(cublasCreate(&(this->handle_)), "CUBLAS initialization failed...");
     }
@@ -138,9 +144,9 @@ namespace micm
     CudaDenseMatrix& operator=(const CudaDenseMatrix& other)
     {
       VectorMatrix<T, L>::operator=(other);
+      if (this->param_.d_data_ != nullptr) CHECK_CUDA_ERROR(micm::cuda::FreeVector(this->param_), "cudaFree");
       this->param_ = other.param_;
-      this->param_.d_data_ = nullptr;
-      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->data_.size()), "cudaMalloc");
+      CHECK_CUDA_ERROR(micm::cuda::MallocVector(this->param_, this->param_.number_of_elements_), "cudaMalloc");
       CHECK_CUDA_ERROR(micm::cuda::CopyToDeviceFromDevice(this->param_, other.param_), "cudaMemcpyDeviceToDevice");
       CHECK_CUBLAS_ERROR(cublasCreate(&(this->handle_)), "CUBLAS initialization failed...");
       return *this;
@@ -207,5 +213,11 @@ namespace micm
               this->handle_, x.param_.number_of_elements_, &alpha, x.param_.d_data_, incx, this->param_.d_data_, incy),
           "CUBLAS Daxpy operation failed...");
     }
-  };
+
+    void Copy(const CudaDenseMatrix& other)
+    {
+      static_assert(other.param_.number_of_elements_ == this->param_.number_of_elements_, "Both CUDA dense matrices must have the same size.");
+      CHECK_CUDA_ERROR(micm::cuda::CopyToDeviceFromDevice(this->param_, other.param_), "cudaMemcpyDeviceToDevice");
+    }
+  }; // class CudaDenseMatrix
 }  // namespace micm

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -234,6 +234,13 @@ namespace micm
         f(elem, *(a_iter++), *(b_iter++));
     }
 
+    // Copy the values from the other matrix into this one 
+    void Copy(const Matrix &other)
+    {
+      if (other.AsVector().size() != this->data_.size()) throw std::runtime_error("Both vector matrices must have the same size.");
+      this->data_.assign(other.AsVector().begin(), other.AsVector().end());
+    }
+
     std::vector<T> &AsVector()
     {
       return data_;

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -290,6 +290,13 @@ namespace micm
       }
     }
 
+    // Copy the values from the other VectorMatrix into this one 
+    void Copy(const VectorMatrix &other)
+    {
+      static_assert(other.AsVector().size() == this->data_.size(), "Both vector matrices must have the same size.");
+      this->data_.assign(other.AsVector().begin(), other.AsVector().end());
+    }
+
     std::vector<T> &AsVector()
     {
       return data_;

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -293,7 +293,7 @@ namespace micm
     // Copy the values from the other VectorMatrix into this one 
     void Copy(const VectorMatrix &other)
     {
-      static_assert(other.AsVector().size() == this->data_.size(), "Both vector matrices must have the same size.");
+      if (other.AsVector().size() != this->data_.size()) throw std::runtime_error("Both vector matrices must have the same size.");
       this->data_.assign(other.AsVector().begin(), other.AsVector().end());
     }
 

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -23,6 +23,8 @@ namespace micm
 
     cudaError_t FreeVector(CudaMatrixParam& param)
     {
+      param.number_of_elements_ = 0;
+      param.number_of_grid_cells_ = 0;
       if (param.d_data_ == nullptr)
       {
         return cudaError_t::cudaSuccess;

--- a/test/unit/util/test_cuda_dense_matrix.cpp
+++ b/test/unit/util/test_cuda_dense_matrix.cpp
@@ -535,3 +535,39 @@ TEST(CudaDenseMatrix, Axpy)
   double sum = std::accumulate(gpu_y.AsVector().begin(), gpu_y.AsVector().end(), 0);
   EXPECT_EQ(sum, (10 * 2.0 + 20.0) * 198 + 20.0 * 2.0 + 20.0 + 30.0 * 2.0 + 20.0);
 }
+
+TEST(CudaDenseMatrix, CopyFunction)
+{
+  std::vector<std::vector<double>> h_vector{ { 0.1, 2.9 }, { 7.3, 4.5 } };
+  auto matrix = micm::CudaDenseMatrix<double, 2>(h_vector);
+
+  std::vector<std::vector<double>> h_vector2{ { 2.1, 5.9 }, { 6.3, 4.8 } };
+  auto matrix2 = micm::CudaDenseMatrix<double, 2>(h_vector2);
+
+  matrix[0][0] = 8.5;
+
+  EXPECT_EQ(matrix[0][0], 8.5);
+  EXPECT_EQ(matrix[0][1], 2.9);
+  EXPECT_EQ(matrix[1][0], 7.3);
+  EXPECT_EQ(matrix[1][1], 4.5);
+  EXPECT_EQ(matrix2[0][0], 2.1);
+  EXPECT_EQ(matrix2[0][1], 5.9);
+  EXPECT_EQ(matrix2[1][0], 6.3);
+  EXPECT_EQ(matrix2[1][1], 4.8);
+
+  ModifyAndSyncToHost(matrix);
+  matrix2.Copy(matrix);
+  matrix2.CopyToHost();
+
+  EXPECT_EQ(matrix[0][0], 72.25);
+  EXPECT_EQ(matrix[0][1], 8.41);
+  EXPECT_EQ(matrix[1][0], 53.29);
+  EXPECT_EQ(matrix[1][1], 20.25);
+  for(int i = 0; i < 2; i++)
+  {
+    for(int j = 0; j < 2; j++)
+    {
+      EXPECT_EQ(matrix2[i][j], matrix[i][j]);
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a new `Copy` function in both the CPU and GPU matrix class.

In the CPU matrix class, it simply calls the `assign` function.

In the GPU matrix class, it only copies the device data.

All the 42 tests all passed on Derecho's A100 GPU by using `nvhpc/23.7`.

fix #471 