### PR TITLE
520 clang tidy cert additions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -48,6 +48,7 @@ Checks: >
   -bugprone-signal-handler,
   cert-*,
   -cert-err58-cpp,
+  -cert-msc32-c,
 
 WarningsAsErrors: '*'
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,6 +46,7 @@ Checks: >
   -readability-isolate-declaration,
   bugprone-*,
   -bugprone-signal-handler,
+  cert-*,
 
 WarningsAsErrors: '*'
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -48,7 +48,7 @@ Checks: >
   -bugprone-signal-handler,
   cert-*,
   -cert-err58-cpp,
-  -cert-msc32-c,
+  -cert-msc51-cpp,
 
 WarningsAsErrors: '*'
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -47,6 +47,7 @@ Checks: >
   bugprone-*,
   -bugprone-signal-handler,
   cert-*,
+  -cert-err58-cpp,
 
 WarningsAsErrors: '*'
 


### PR DESCRIPTION
Added the `cert-*` checks to .clang-tidy.  Removed two relating to the random number generators as they were used primarily in the tests and those instance need to be reproducible.  Also removed cert-err58-cpp as this would require changing `static const std::string`'s to `const char*`.

Closes #520 