### PR TITLE
514 create a builder class that can make a backward euler solver

### DIFF
--- a/docker/Dockerfile.llvm
+++ b/docker/Dockerfile.llvm
@@ -10,6 +10,7 @@ RUN dnf -y update \
         make \
         zlib-devel \
         llvm-devel \
+        openmpi-devel \
         valgrind \
     && dnf clean all
 
@@ -24,6 +25,7 @@ RUN mkdir /build \
         -D MICM_ENABLE_CLANG_TIDY:BOOL=FALSE \
         -D MICM_ENABLE_LLVM:BOOL=TRUE \
         -D MICM_ENABLE_MEMCHECK:BOOL=TRUE \
+        -D MICM_ENABLE_OPENMP:BOOL=TRUE \
         ../micm \
       && make install -j 8
 

--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -85,11 +85,11 @@ namespace micm
     /// @brief Update the solver state rate constants
     /// @param processes The set of processes being solved
     /// @param state The solver state to update
-    template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+    template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
     requires(!VectorizableDense<MatrixPolicy<double>>) static void UpdateState(
         const std::vector<Process>& processes,
         State<MatrixPolicy, SparseMatrixPolicy>& state);
-    template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+    template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
     requires(VectorizableDense<MatrixPolicy<double>>) static void UpdateState(
         const std::vector<Process>& processes,
         State<MatrixPolicy, SparseMatrixPolicy>& state);
@@ -148,7 +148,7 @@ namespace micm
     ProcessBuilder& SetPhase(const Phase& phase);
   };
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
   requires(!VectorizableDense<MatrixPolicy<double>>) void Process::UpdateState(
       const std::vector<Process>& processes,
       State<MatrixPolicy, SparseMatrixPolicy>& state)
@@ -173,7 +173,7 @@ namespace micm
     }
   }
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
   requires(VectorizableDense<MatrixPolicy<double>>) void Process::UpdateState(
       const std::vector<Process>& processes,
       State<MatrixPolicy, SparseMatrixPolicy>& state)

--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -85,14 +85,14 @@ namespace micm
     /// @brief Update the solver state rate constants
     /// @param processes The set of processes being solved
     /// @param state The solver state to update
-    template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
-    requires(!VectorizableDense<MatrixPolicy<double>>) static void UpdateState(
+    template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+    requires(!VectorizableDense<DenseMatrixPolicy>) static void UpdateState(
         const std::vector<Process>& processes,
-        State<MatrixPolicy, SparseMatrixPolicy>& state);
-    template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
-    requires(VectorizableDense<MatrixPolicy<double>>) static void UpdateState(
+        State<DenseMatrixPolicy, SparseMatrixPolicy>& state);
+    template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+    requires(VectorizableDense<DenseMatrixPolicy>) static void UpdateState(
         const std::vector<Process>& processes,
-        State<MatrixPolicy, SparseMatrixPolicy>& state);
+        State<DenseMatrixPolicy, SparseMatrixPolicy>& state);
 
     friend class ProcessBuilder;
     static ProcessBuilder Create();
@@ -148,10 +148,10 @@ namespace micm
     ProcessBuilder& SetPhase(const Phase& phase);
   };
 
-  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
-  requires(!VectorizableDense<MatrixPolicy<double>>) void Process::UpdateState(
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  requires(!VectorizableDense<DenseMatrixPolicy>) void Process::UpdateState(
       const std::vector<Process>& processes,
-      State<MatrixPolicy, SparseMatrixPolicy>& state)
+      State<DenseMatrixPolicy, SparseMatrixPolicy>& state)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -173,10 +173,10 @@ namespace micm
     }
   }
 
-  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
-  requires(VectorizableDense<MatrixPolicy<double>>) void Process::UpdateState(
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  requires(VectorizableDense<DenseMatrixPolicy>) void Process::UpdateState(
       const std::vector<Process>& processes,
-      State<MatrixPolicy, SparseMatrixPolicy>& state)
+      State<DenseMatrixPolicy, SparseMatrixPolicy>& state)
   {
     MICM_PROFILE_FUNCTION();
     const auto& v_custom_parameters = state.custom_rate_parameters_.AsVector();

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -91,33 +91,32 @@ namespace micm
     /// @param rate_constants Current values for the process rate constants (grid cell, process)
     /// @param state_variables Current state variable values (grid cell, state variable)
     /// @param forcing Forcing terms for each state variable (grid cell, state variable)
-    template<template<class> typename MatrixPolicy>
-    requires(!VectorizableDense<MatrixPolicy<double>>) void AddForcingTerms(
-        const MatrixPolicy<double>& rate_constants,
-        const MatrixPolicy<double>& state_variables,
-        MatrixPolicy<double>& forcing) const;
-    template<template<class> typename MatrixPolicy>
-    requires VectorizableDense<MatrixPolicy<double>>
+    template<typename DenseMatrixPolicy>
+    requires(!VectorizableDense<DenseMatrixPolicy>) void AddForcingTerms(
+        const DenseMatrixPolicy& rate_constants,
+        const DenseMatrixPolicy& state_variables,
+        DenseMatrixPolicy& forcing) const;
+    template<typename DenseMatrixPolicy>
+    requires VectorizableDense<DenseMatrixPolicy>
     void AddForcingTerms(
-        const MatrixPolicy<double>& rate_constants,
-        const MatrixPolicy<double>& state_variables,
-        MatrixPolicy<double>& forcing) const;
+        const DenseMatrixPolicy& rate_constants,
+        const DenseMatrixPolicy& state_variables,
+        DenseMatrixPolicy& forcing) const;
 
     /// @brief Subtract Jacobian terms for the set of processes for the current conditions
     /// @param rate_constants Current values for the process rate constants (grid cell, process)
     /// @param state_variables Current state variable values (grid cell, state variable)
     /// @param jacobian Jacobian matrix for the system (grid cell, dependent variable, independent variable)
-    // template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
-    template<class MatrixPolicy, class SparseMatrixPolicy>
-    requires(!VectorizableDense<MatrixPolicy> || !VectorizableSparse<SparseMatrixPolicy>) void SubtractJacobianTerms(
-        const MatrixPolicy& rate_constants,
-        const MatrixPolicy& state_variables,
+    template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+    requires(!VectorizableDense<DenseMatrixPolicy> || !VectorizableSparse<SparseMatrixPolicy>) void SubtractJacobianTerms(
+        const DenseMatrixPolicy& rate_constants,
+        const DenseMatrixPolicy& state_variables,
         SparseMatrixPolicy& jacobian) const;
     // template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
-    template<class MatrixPolicy, class SparseMatrixPolicy>
-    requires(VectorizableDense<MatrixPolicy>&& VectorizableSparse<SparseMatrixPolicy>) void SubtractJacobianTerms(
-        const MatrixPolicy& rate_constants,
-        const MatrixPolicy& state_variables,
+    template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+    requires(VectorizableDense<DenseMatrixPolicy>&& VectorizableSparse<SparseMatrixPolicy>) void SubtractJacobianTerms(
+        const DenseMatrixPolicy& rate_constants,
+        const DenseMatrixPolicy& state_variables,
         SparseMatrixPolicy& jacobian) const;
 
     /// @brief Returns the set of species used in a set of processes
@@ -217,11 +216,11 @@ namespace micm
     }
   }
 
-  template<template<class> typename MatrixPolicy>
-  requires(!VectorizableDense<MatrixPolicy<double>>) inline void ProcessSet::AddForcingTerms(
-      const MatrixPolicy<double>& rate_constants,
-      const MatrixPolicy<double>& state_variables,
-      MatrixPolicy<double>& forcing) const
+  template<typename DenseMatrixPolicy>
+  requires(!VectorizableDense<DenseMatrixPolicy>) inline void ProcessSet::AddForcingTerms(
+      const DenseMatrixPolicy& rate_constants,
+      const DenseMatrixPolicy& state_variables,
+      DenseMatrixPolicy& forcing) const
   {
     MICM_PROFILE_FUNCTION();
 
@@ -255,12 +254,12 @@ namespace micm
     }
   };
 
-  template<template<class> typename MatrixPolicy>
-  requires VectorizableDense<MatrixPolicy<double>>
+  template<typename DenseMatrixPolicy>
+  requires VectorizableDense<DenseMatrixPolicy>
   inline void ProcessSet::AddForcingTerms(
-      const MatrixPolicy<double>& rate_constants,
-      const MatrixPolicy<double>& state_variables,
-      MatrixPolicy<double>& forcing) const
+      const DenseMatrixPolicy& rate_constants,
+      const DenseMatrixPolicy& state_variables,
+      DenseMatrixPolicy& forcing) const
   {
     MICM_PROFILE_FUNCTION();
 
@@ -300,12 +299,11 @@ namespace micm
   }
 
   // Forming the Jacobian matrix "J" and returning "-J" to be consistent with the CUDA implementation
-  // template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  requires(!VectorizableDense<MatrixPolicy> || !VectorizableSparse<SparseMatrixPolicy>) inline void ProcessSet::
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  requires(!VectorizableDense<DenseMatrixPolicy> || !VectorizableSparse<SparseMatrixPolicy>) inline void ProcessSet::
       SubtractJacobianTerms(
-          const MatrixPolicy& rate_constants,
-          const MatrixPolicy& state_variables,
+          const DenseMatrixPolicy& rate_constants,
+          const DenseMatrixPolicy& state_variables,
           SparseMatrixPolicy& jacobian) const
   {
     MICM_PROFILE_FUNCTION();
@@ -350,12 +348,11 @@ namespace micm
   }
 
   // Forming the Jacobian matrix "J" and returning "-J" to be consistent with the CUDA implementation
-  // template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  requires(VectorizableDense<MatrixPolicy>&& VectorizableSparse<SparseMatrixPolicy>) inline void ProcessSet::
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  requires(VectorizableDense<DenseMatrixPolicy>&& VectorizableSparse<SparseMatrixPolicy>) inline void ProcessSet::
       SubtractJacobianTerms(
-          const MatrixPolicy& rate_constants,
-          const MatrixPolicy& state_variables,
+          const DenseMatrixPolicy& rate_constants,
+          const DenseMatrixPolicy& state_variables,
           SparseMatrixPolicy& jacobian) const
   {
     MICM_PROFILE_FUNCTION();

--- a/include/micm/solver/backward_euler.hpp
+++ b/include/micm/solver/backward_euler.hpp
@@ -9,6 +9,7 @@
 #include <micm/profiler/instrumentation.hpp>
 #include <micm/solver/linear_solver.hpp>
 #include <micm/solver/state.hpp>
+#include <micm/solver/backward_euler_solver_parameters.hpp>
 #include <micm/system/system.hpp>
 #include <micm/util/jacobian.hpp>
 
@@ -52,6 +53,7 @@ namespace micm
     void Solve(
         double time_step,
         auto& state,
+        BackwardEulerSolverParameters parameters,
         auto linear_solver,
         auto process_set,
         const std::vector<micm::Process>& processes,

--- a/include/micm/solver/backward_euler.hpp
+++ b/include/micm/solver/backward_euler.hpp
@@ -35,11 +35,6 @@ namespace micm
     /// @brief Default constructor
     BackwardEuler();
 
-    /// @brief Builds a backward eulder solver for the given system and processes
-    /// @param system The chemical system to create the solver for
-    /// @param processes The collection of chemical processes that will be applied during solving
-    BackwardEuler(const System& system, const std::vector<Process>& processes);
-
     virtual ~BackwardEuler() = default;
 
     /// @brief Advances the given step over the specified time step

--- a/include/micm/solver/backward_euler.hpp
+++ b/include/micm/solver/backward_euler.hpp
@@ -7,9 +7,9 @@
 #include <micm/process/process.hpp>
 #include <micm/process/process_set.hpp>
 #include <micm/profiler/instrumentation.hpp>
+#include <micm/solver/backward_euler_solver_parameters.hpp>
 #include <micm/solver/linear_solver.hpp>
 #include <micm/solver/state.hpp>
-#include <micm/solver/backward_euler_solver_parameters.hpp>
 #include <micm/system/system.hpp>
 #include <micm/util/jacobian.hpp>
 
@@ -29,30 +29,40 @@ namespace micm
 {
 
   /// @brief An implementation of the fully implicit backward euler method
+  template <class LinearSolverPolicy, class ProcessSetPolicy> 
   class BackwardEuler
   {
+    BackwardEulerSolverParameters parameters_;
+    LinearSolverPolicy linear_solver_;
+    ProcessSetPolicy process_set_;
+    std::vector<std::size_t> jacobian_diagonal_elements_;
+    std::vector<micm::Process> processes_;
+
    public:
     /// @brief Default constructor
-    BackwardEuler();
+    BackwardEuler(
+      BackwardEulerSolverParameters parameters, 
+      LinearSolverPolicy linear_solver, 
+      ProcessSetPolicy process_set,
+      std::vector<std::size_t> jacobian_diagonal_elements,
+      std::vector<micm::Process>& processes
+      ) : parameters_(parameters),
+          linear_solver_(linear_solver),
+          process_set_(process_set),
+          jacobian_diagonal_elements_(jacobian_diagonal_elements),
+          processes_(processes)
+    {
+    }
 
     virtual ~BackwardEuler() = default;
 
     /// @brief Advances the given step over the specified time step
     /// @param time_step Time [s] to advance the state by
     /// @param state The state to advance
-    /// @param linear_solver The linear solver to use
-    /// @param process_set The process set to use
-    /// @param processes The collection of chemical processes that will be applied during solving
-    /// @param jacobian_diagonal_elements The diagonal elements of the jacobian matrix
     /// @return A struct containing results and a status code
     void Solve(
         double time_step,
-        auto& state,
-        BackwardEulerSolverParameters parameters,
-        auto linear_solver,
-        auto process_set,
-        const std::vector<micm::Process>& processes,
-        auto jacobian_diagonal_elements);
+        auto& state);
   };
 
 }  // namespace micm

--- a/include/micm/solver/backward_euler.inl
+++ b/include/micm/solver/backward_euler.inl
@@ -51,6 +51,7 @@ namespace micm
   inline void BackwardEuler::Solve(
       double time_step,
       auto& state,
+      BackwardEulerSolverParameters parameters,
       auto linear_solver,
       auto process_set,
       const std::vector<micm::Process>& processes,
@@ -67,15 +68,17 @@ namespace micm
     // if that fails, try H = H/10 once
     // if that fails, accept the current H but do not update the Yn vector
 
+    double tolerance = parameters.absolute_tolerance_[0];
+    double small = parameters.small;
+    std::size_t max_iter = parameters.max_number_of_steps_;
+    const auto time_step_reductions = parameters.time_step_reductions;
+
     double H = time_step;
     double t = 0.0;
-    double tol = 1e-4;
-    double small = 1.0e-40;
-    bool singular = false;
-    std::size_t max_iter = 11;
     std::size_t n_successful_integrations = 0;
     std::size_t n_convergence_failures = 0;
-    const std::array<double, 5> time_step_reductions{ 0.5, 0.5, 0.5, 0.5, 0.1 };
+
+    bool singular = false;
 
     auto Yn = state.variables_;
     auto Yn1 = state.variables_;
@@ -160,7 +163,7 @@ namespace micm
         do
         {
           // changes that are much smaller than the tolerance are negligible and we assume can be accepted
-          converged = (std::abs(*forcing_iter) <= small) || (std::abs(*forcing_iter) <= tol * std::abs(*yn1_iter));
+          converged = (std::abs(*forcing_iter) <= small) || (std::abs(*forcing_iter) <= tolerance * std::abs(*yn1_iter));
           ++forcing_iter, ++yn1_iter;
         } while (converged && forcing_iter != forcing.end());
 

--- a/include/micm/solver/backward_euler.inl
+++ b/include/micm/solver/backward_euler.inl
@@ -44,18 +44,10 @@ inline std::error_code make_error_code(MicmBackwardEulerErrc e)
 
 namespace micm
 {
-  inline BackwardEuler::BackwardEuler()
-  {
-  }
-
-  inline void BackwardEuler::Solve(
+  template <class LinearSolverPolicy, class ProcessSetPolicy> 
+  inline void BackwardEuler<LinearSolverPolicy, ProcessSetPolicy>::Solve(
       double time_step,
-      auto& state,
-      BackwardEulerSolverParameters parameters,
-      auto linear_solver,
-      auto process_set,
-      const std::vector<micm::Process>& processes,
-      auto jacobian_diagonal_elements)
+      auto& state)
   {
     // A fully implicit euler implementation is given by the following equation:
     // y_{n+1} = y_n + H * f(t_{n+1}, y_{n+1})
@@ -68,10 +60,11 @@ namespace micm
     // if that fails, try H = H/10 once
     // if that fails, accept the current H but do not update the Yn vector
 
-    double tolerance = parameters.absolute_tolerance_[0];
-    double small = parameters.small;
-    std::size_t max_iter = parameters.max_number_of_steps_;
-    const auto time_step_reductions = parameters.time_step_reductions;
+
+    double tolerance = parameters_.absolute_tolerance_[0];
+    double small = parameters_.small;
+    std::size_t max_iter = parameters_.max_number_of_steps_;
+    const auto time_step_reductions = parameters_.time_step_reductions;
 
     double H = time_step;
     double t = 0.0;
@@ -84,7 +77,7 @@ namespace micm
     auto Yn1 = state.variables_;
     auto forcing = state.variables_;
 
-    Process::UpdateState(processes, state);
+    Process::UpdateState(processes_, state);
 
     while (t < time_step)
     {
@@ -100,11 +93,11 @@ namespace micm
         // so we can use Yn1 to calculate the forcing and jacobian
         // calculate forcing
         std::fill(forcing.AsVector().begin(), forcing.AsVector().end(), 0.0);
-        process_set.AddForcingTerms(state.rate_constants_, Yn1, forcing);
+        process_set_.AddForcingTerms(state.rate_constants_, Yn1, forcing);
 
         // calculate jacobian
         std::fill(state.jacobian_.AsVector().begin(), state.jacobian_.AsVector().end(), 0.0);
-        process_set.SubtractJacobianTerms(state.rate_constants_, Yn1, state.jacobian_);
+        process_set_.SubtractJacobianTerms(state.rate_constants_, Yn1, state.jacobian_);
 
         // subtract the inverse of the time step from the diagonal
         // TODO: handle vectorized jacobian matrix
@@ -115,7 +108,7 @@ namespace micm
         for (std::size_t i_block = 0; i_block < state.jacobian_.NumberOfBlocks(); ++i_block)
         {
           auto jacobian_vector = std::next(state.jacobian_.AsVector().begin(), i_block * state.jacobian_.FlatBlockSize());
-          for (const auto& i_elem : jacobian_diagonal_elements)
+          for (const auto& i_elem : jacobian_diagonal_elements_)
             jacobian_vector[i_elem] -= 1 / H;
         }
 
@@ -123,7 +116,7 @@ namespace micm
         // (y_{n+1} - y_n) / H = f(t_{n+1}, y_{n+1})
 
         // try to find the root by factoring and solving the linear system
-        linear_solver.Factor(state.jacobian_, state.lower_matrix_, state.upper_matrix_, singular);
+        linear_solver_.Factor(state.jacobian_, state.lower_matrix_, state.upper_matrix_, singular);
 
         auto yn1_iter = Yn1.begin();
         auto yn_iter = Yn.begin();
@@ -138,7 +131,7 @@ namespace micm
 
         // the result of the linear solver will be stored in forcing
         // this represents the change in the solution
-        linear_solver.Solve(forcing, forcing, state.lower_matrix_, state.upper_matrix_);
+        linear_solver_.Solve(forcing, forcing, state.lower_matrix_, state.upper_matrix_);
 
         // solution_blk in camchem
         // Yn1 = Yn1 + residual;

--- a/include/micm/solver/backward_euler_solver_parameters.hpp
+++ b/include/micm/solver/backward_euler_solver_parameters.hpp
@@ -1,0 +1,24 @@
+/* Copyright (C) 2023-2024 National Center for Atmospheric Research
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <cstddef>
+#include <iostream>
+#include <vector>
+#include <array>
+
+namespace micm
+{
+
+  /// @brief BackwardEuler solver parameters
+  struct BackwardEulerSolverParameters
+  {
+    std::vector<double> absolute_tolerance_;
+    double small { 1.0e-40 };
+    size_t max_number_of_steps_{ 11 };
+    const std::array<double, 5> time_step_reductions{ 0.5, 0.5, 0.5, 0.5, 0.1 };
+  };
+
+}  // namespace micm

--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -24,7 +24,7 @@ namespace micm
   /// @brief A general-use block-diagonal sparse-matrix linear solver
   ///
   /// The sparsity pattern of each block in the block diagonal matrix is the same.
-  template<typename T, template<class> class SparseMatrixPolicy, class LuDecompositionPolicy = LuDecomposition>
+  template<typename T, class SparseMatrixPolicy, class LuDecompositionPolicy = LuDecomposition>
   class LinearSolver
   {
    protected:
@@ -60,43 +60,43 @@ namespace micm
     /// @brief Constructs a linear solver for the sparsity structure of the given matrix
     /// @param matrix Sparse matrix
     /// @param initial_value Initial value for matrix elements
-    LinearSolver(const SparseMatrixPolicy<T>& matrix, T initial_value);
+    LinearSolver(const SparseMatrixPolicy& matrix, T initial_value);
 
     /// @brief Constructs a linear solver for the sparsity structure of the given matrix
     /// @param matrix Sparse matrix
     /// @param initial_value Initial value for matrix elements
     /// @param create_lu_decomp Function to create an LU Decomposition object that adheres to LuDecompositionPolicy
     LinearSolver(
-        const SparseMatrixPolicy<T>& matrix,
+        const SparseMatrixPolicy& matrix,
         T initial_value,
-        const std::function<LuDecompositionPolicy(const SparseMatrixPolicy<T>&)> create_lu_decomp);
+        const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)> create_lu_decomp);
 
     /// @brief Decompose the matrix into upper and lower triangular matrices
     void
-    Factor(const SparseMatrixPolicy<T>& matrix, SparseMatrixPolicy<T>& lower_matrix, SparseMatrixPolicy<T>& upper_matrix);
+    Factor(const SparseMatrixPolicy& matrix, SparseMatrixPolicy& lower_matrix, SparseMatrixPolicy& upper_matrix);
 
     /// @brief Decompose the matrix into upper and lower triangular matrices
     /// @param matrix Matrix to decompose into lower and upper triangular matrices
     /// @param is_singular Flag that is set to true if matrix is singular; false otherwise
     void Factor(
-        const SparseMatrixPolicy<T>& matrix,
-        SparseMatrixPolicy<T>& lower_matrix,
-        SparseMatrixPolicy<T>& upper_matrix,
+        const SparseMatrixPolicy& matrix,
+        SparseMatrixPolicy& lower_matrix,
+        SparseMatrixPolicy& upper_matrix,
         bool& is_singular);
 
     /// @brief Solve for x in Ax = b
-    template<template<class> class MatrixPolicy>
-    requires(!VectorizableDense<MatrixPolicy<T>> || !VectorizableSparse<SparseMatrixPolicy<T>>) void Solve(
-        const MatrixPolicy<T>& b,
-        MatrixPolicy<T>& x,
-        const SparseMatrixPolicy<T>& lower_matrix,
-        const SparseMatrixPolicy<T>& upper_matrix) const;
-    template<template<class> class MatrixPolicy>
-    requires(VectorizableDense<MatrixPolicy<T>>&& VectorizableSparse<SparseMatrixPolicy<T>>) void Solve(
-        const MatrixPolicy<T>& b,
-        MatrixPolicy<T>& x,
-        const SparseMatrixPolicy<T>& lower_matrix,
-        const SparseMatrixPolicy<T>& upper_matrix) const;
+    template<class MatrixPolicy>
+    requires(!VectorizableDense<MatrixPolicy> || !VectorizableSparse<SparseMatrixPolicy>) void Solve(
+        const MatrixPolicy& b,
+        MatrixPolicy& x,
+        const SparseMatrixPolicy& lower_matrix,
+        const SparseMatrixPolicy& upper_matrix) const;
+    template<class MatrixPolicy>
+    requires(VectorizableDense<MatrixPolicy>&& VectorizableSparse<SparseMatrixPolicy>) void Solve(
+        const MatrixPolicy& b,
+        MatrixPolicy& x,
+        const SparseMatrixPolicy& lower_matrix,
+        const SparseMatrixPolicy& upper_matrix) const;
   };
 
 }  // namespace micm

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -2,17 +2,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 namespace micm
 {
-  template<template<class> class MatrixPolicy>
-  inline std::vector<std::size_t> DiagonalMarkowitzReorder(const MatrixPolicy<int>& matrix)
+  template<class MatrixPolicy>
+  inline std::vector<std::size_t> DiagonalMarkowitzReorder(const MatrixPolicy& matrix)
   {
     MICM_PROFILE_FUNCTION();
     const std::size_t order = matrix.NumRows();
     std::vector<std::size_t> perm(order);
     for (std::size_t i = 0; i < order; ++i)
       perm[i] = i;
-    MatrixPolicy<int> pattern = matrix;
+    MatrixPolicy pattern = matrix;
     for (std::size_t row = 0; row < (order - 1); ++row)
     {
       std::size_t beta = std::pow((order - 1), 2);
@@ -50,23 +51,23 @@ namespace micm
     return perm;
   }
 
-  template<typename T, template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
+  template<typename T, class SparseMatrixPolicy, class LuDecompositionPolicy>
   inline LinearSolver<T, SparseMatrixPolicy, LuDecompositionPolicy>::LinearSolver(
-      const SparseMatrixPolicy<T>& matrix,
+      const SparseMatrixPolicy& matrix,
       T initial_value)
       : LinearSolver<T, SparseMatrixPolicy, LuDecompositionPolicy>(
             matrix,
             initial_value,
-            [](const SparseMatrixPolicy<T>& m) -> LuDecompositionPolicy
-            { return LuDecomposition::Create<T, SparseMatrixPolicy>(m); })
+            [](const SparseMatrixPolicy& m) -> LuDecompositionPolicy
+            { return LuDecomposition::Create<SparseMatrixPolicy>(m); })
   {
   }
 
-  template<typename T, template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
+  template<typename T, class SparseMatrixPolicy, class LuDecompositionPolicy>
   inline LinearSolver<T, SparseMatrixPolicy, LuDecompositionPolicy>::LinearSolver(
-      const SparseMatrixPolicy<T>& matrix,
+      const SparseMatrixPolicy& matrix,
       T initial_value,
-      const std::function<LuDecompositionPolicy(const SparseMatrixPolicy<T>&)> create_lu_decomp)
+      const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)> create_lu_decomp)
       : nLij_Lii_(),
         Lij_yj_(),
         nUij_Uii_(),
@@ -75,7 +76,7 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    auto lu = lu_decomp_.template GetLUMatrices<T, SparseMatrixPolicy>(matrix, initial_value);
+    auto lu = lu_decomp_.template GetLUMatrices<SparseMatrixPolicy>(matrix, initial_value);
     auto lower_matrix = std::move(lu.first);
     auto upper_matrix = std::move(lu.second);
     for (std::size_t i = 0; i < lower_matrix.NumRows(); ++i)
@@ -108,22 +109,22 @@ namespace micm
     }
   };
 
-  template<typename T, template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
+  template<typename T, class SparseMatrixPolicy, class LuDecompositionPolicy>
   inline void LinearSolver<T, SparseMatrixPolicy, LuDecompositionPolicy>::Factor(
-      const SparseMatrixPolicy<T>& matrix,
-      SparseMatrixPolicy<T>& lower_matrix,
-      SparseMatrixPolicy<T>& upper_matrix)
+      const SparseMatrixPolicy& matrix,
+      SparseMatrixPolicy& lower_matrix,
+      SparseMatrixPolicy& upper_matrix)
   {
     MICM_PROFILE_FUNCTION();
 
     lu_decomp_.template Decompose<T, SparseMatrixPolicy>(matrix, lower_matrix, upper_matrix);
   }
 
-  template<typename T, template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
+  template<typename T, class SparseMatrixPolicy, class LuDecompositionPolicy>
   inline void LinearSolver<T, SparseMatrixPolicy, LuDecompositionPolicy>::Factor(
-      const SparseMatrixPolicy<T>& matrix,
-      SparseMatrixPolicy<T>& lower_matrix,
-      SparseMatrixPolicy<T>& upper_matrix,
+      const SparseMatrixPolicy& matrix,
+      SparseMatrixPolicy& lower_matrix,
+      SparseMatrixPolicy& upper_matrix,
       bool& is_singular)
   {
     MICM_PROFILE_FUNCTION();
@@ -131,16 +132,15 @@ namespace micm
     lu_decomp_.template Decompose<T, SparseMatrixPolicy>(matrix, lower_matrix, upper_matrix, is_singular);
   }
 
-  template<typename T, template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
-  template<template<class> class MatrixPolicy>
+  template<typename T, class SparseMatrixPolicy, class LuDecompositionPolicy>
+  template<class MatrixPolicy>
   requires(
-      !VectorizableDense<MatrixPolicy<T>> ||
-      !VectorizableSparse<SparseMatrixPolicy<T>>) inline void LinearSolver<T, SparseMatrixPolicy, LuDecompositionPolicy>::
-      Solve(
-          const MatrixPolicy<T>& b,
-          MatrixPolicy<T>& x,
-          const SparseMatrixPolicy<T>& lower_matrix,
-          const SparseMatrixPolicy<T>& upper_matrix) const
+      !VectorizableDense<MatrixPolicy> ||
+      !VectorizableSparse<SparseMatrixPolicy>) inline void LinearSolver<T, SparseMatrixPolicy, LuDecompositionPolicy>::Solve(
+          const MatrixPolicy& b,
+          MatrixPolicy& x,
+          const SparseMatrixPolicy& lower_matrix,
+          const SparseMatrixPolicy& upper_matrix) const
   {
     MICM_PROFILE_FUNCTION();
 
@@ -189,15 +189,15 @@ namespace micm
     }
   }
 
-  template<typename T, template<class> class SparseMatrixPolicy, class LuDecompositionPolicy>
-  template<template<class> class MatrixPolicy>
-  requires(VectorizableDense<MatrixPolicy<T>>&& VectorizableSparse<
-           SparseMatrixPolicy<T>>) inline void LinearSolver<T, SparseMatrixPolicy, LuDecompositionPolicy>::
+  template<typename T, class SparseMatrixPolicy, class LuDecompositionPolicy>
+  template<class MatrixPolicy>
+  requires(VectorizableDense<MatrixPolicy>&& VectorizableSparse<
+           SparseMatrixPolicy>) inline void LinearSolver<T, SparseMatrixPolicy, LuDecompositionPolicy>::
       Solve(
-          const MatrixPolicy<T>& b,
-          MatrixPolicy<T>& x,
-          const SparseMatrixPolicy<T>& lower_matrix,
-          const SparseMatrixPolicy<T>& upper_matrix) const
+          const MatrixPolicy& b,
+          MatrixPolicy& x,
+          const SparseMatrixPolicy& lower_matrix,
+          const SparseMatrixPolicy& upper_matrix) const
   {
     MICM_PROFILE_FUNCTION();
     const std::size_t n_cells = b.GroupVectorSize();

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -78,56 +78,50 @@ namespace micm
 
     /// @brief Construct an LU decomposition algorithm for a given sparse matrix
     /// @param matrix Sparse matrix
-    template<typename T>
-    LuDecomposition(const SparseMatrix<T>& matrix);
+    template<class SparseMatrixPolicy>
+    LuDecomposition(const SparseMatrixPolicy& matrix);
 
     /// @brief Create an LU decomposition algorithm for a given sparse matrix policy
     /// @param matrix Sparse matrix
-    template<typename T, template<class> class SparseMatrixPolicy>
-    static LuDecomposition Create(const SparseMatrixPolicy<T>& matrix);
-    template<typename T, class SparseMatrixPolicy>
+    template<class SparseMatrixPolicy>
     static LuDecomposition Create(const SparseMatrixPolicy& matrix);
 
     /// @brief Create sparse L and U matrices for a given A matrix
     /// @param A Sparse matrix that will be decomposed
     /// @return L and U Sparse matrices
-    template<typename T, template<class> class SparseMatrixPolicy>
-    static std::pair<SparseMatrixPolicy<T>, SparseMatrixPolicy<T>> GetLUMatrices(
-        const SparseMatrixPolicy<T>& A,
-        T initial_value);
-    template<typename T, class SparseMatrixPolicy>
-    static std::pair<SparseMatrixPolicy, SparseMatrixPolicy> GetLUMatrices(const SparseMatrixPolicy& A, T initial_value);
+    template<class SparseMatrixPolicy>
+    static std::pair<SparseMatrixPolicy, SparseMatrixPolicy> GetLUMatrices(const SparseMatrixPolicy& A, typename SparseMatrixPolicy::value_type initial_value);
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose
     /// @param L The lower triangular matrix created by decomposition
     /// @param U The upper triangular matrix created by decomposition
-    template<typename T, template<class> class SparseMatrixPolicy>
-    void Decompose(const SparseMatrixPolicy<T>& A, SparseMatrixPolicy<T>& L, SparseMatrixPolicy<T>& U) const;
+    template<typename T, class SparseMatrixPolicy>
+    void Decompose(const SparseMatrixPolicy& A, SparseMatrixPolicy& L, SparseMatrixPolicy& U) const;
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose
     /// @param L The lower triangular matrix created by decomposition
     /// @param U The upper triangular matrix created by decomposition
     /// @param is_singular Flag that is set to true if A is singular; false otherwise
-    template<typename T, template<class> class SparseMatrixPolicy>
-    requires(!VectorizableSparse<SparseMatrixPolicy<T>>) void Decompose(
-        const SparseMatrixPolicy<T>& A,
-        SparseMatrixPolicy<T>& L,
-        SparseMatrixPolicy<T>& U,
+    template<typename T, class SparseMatrixPolicy>
+    requires(!VectorizableSparse<SparseMatrixPolicy>) void Decompose(
+        const SparseMatrixPolicy& A,
+        SparseMatrixPolicy& L,
+        SparseMatrixPolicy& U,
         bool& is_singular) const;
-    template<typename T, template<class> class SparseMatrixPolicy>
-    requires(VectorizableSparse<SparseMatrixPolicy<T>>) void Decompose(
-        const SparseMatrixPolicy<T>& A,
-        SparseMatrixPolicy<T>& L,
-        SparseMatrixPolicy<T>& U,
+    template<typename T, class SparseMatrixPolicy>
+    requires(VectorizableSparse<SparseMatrixPolicy>) void Decompose(
+        const SparseMatrixPolicy& A,
+        SparseMatrixPolicy& L,
+        SparseMatrixPolicy& U,
         bool& is_singular) const;
 
    private:
     /// @brief Initialize arrays for the LU decomposition
     /// @param A Sparse matrix to decompose
-    template<typename T, class SparseMatrixPolicy>
-    void Initialize(const SparseMatrixPolicy& matrix, T initial_value);
+    template<class SparseMatrixPolicy>
+    void Initialize(const SparseMatrixPolicy& matrix, auto initial_value);
   };
 
 }  // namespace micm

--- a/include/micm/solver/lu_decomposition.inl
+++ b/include/micm/solver/lu_decomposition.inl
@@ -9,35 +9,27 @@ namespace micm
   {
   }
 
-  template<typename T>
-  inline LuDecomposition::LuDecomposition(const SparseMatrix<T>& matrix)
+  template<class SparseMatrixPolicy>
+  inline LuDecomposition::LuDecomposition(const SparseMatrixPolicy& matrix)
   {
-    Initialize<T, SparseMatrix>(matrix);
+    Initialize<SparseMatrixPolicy>(matrix, typename SparseMatrixPolicy::value_type());
   }
 
-  template<typename T, template<class> class SparseMatrixPolicy>
-  inline LuDecomposition LuDecomposition::Create(const SparseMatrixPolicy<T>& matrix)
-  {
-    LuDecomposition lu_decomp{};
-    lu_decomp.Initialize<T, SparseMatrixPolicy<T>>(matrix, T{});
-    return lu_decomp;
-  }
-
-  template<typename T, class SparseMatrixPolicy>
+  template<class SparseMatrixPolicy>
   inline LuDecomposition LuDecomposition::Create(const SparseMatrixPolicy& matrix)
   {
     LuDecomposition lu_decomp{};
-    lu_decomp.Initialize<T, SparseMatrixPolicy>(matrix, T{});
+    lu_decomp.Initialize<SparseMatrixPolicy>(matrix, typename SparseMatrixPolicy::value_type());
     return lu_decomp;
   }
 
-  template<typename T, class SparseMatrixPolicy>
-  inline void LuDecomposition::Initialize(const SparseMatrixPolicy& matrix, T initial_value)
+  template<class SparseMatrixPolicy>
+  inline void LuDecomposition::Initialize(const SparseMatrixPolicy& matrix, auto initial_value)
   {
     MICM_PROFILE_FUNCTION();
 
     std::size_t n = matrix.NumRows();
-    auto LU = GetLUMatrices<T, SparseMatrixPolicy>(matrix, initial_value);
+    auto LU = GetLUMatrices<SparseMatrixPolicy>(matrix, initial_value);
     const auto& L_row_start = LU.first.RowStartVector();
     const auto& L_row_ids = LU.first.RowIdsVector();
     const auto& U_row_start = LU.second.RowStartVector();
@@ -107,18 +99,10 @@ namespace micm
     }
   }
 
-  template<typename T, template<class> class SparseMatrixPolicy>
-  inline std::pair<SparseMatrixPolicy<T>, SparseMatrixPolicy<T>> LuDecomposition::GetLUMatrices(
-      const SparseMatrixPolicy<T>& A,
-      T initial_value)
-  {
-    return GetLUMatrices<T, SparseMatrixPolicy<T>>(A, initial_value);
-  }
-
-  template<typename T, class SparseMatrixPolicy>
+  template<class SparseMatrixPolicy>
   inline std::pair<SparseMatrixPolicy, SparseMatrixPolicy> LuDecomposition::GetLUMatrices(
       const SparseMatrixPolicy& A,
-      T initial_value)
+      typename SparseMatrixPolicy::value_type initial_value)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -177,19 +161,19 @@ namespace micm
     return LU;
   }
 
-  template<typename T, template<class> class SparseMatrixPolicy>
-  inline void LuDecomposition::Decompose(const SparseMatrixPolicy<T>& A, SparseMatrixPolicy<T>& L, SparseMatrixPolicy<T>& U)
+  template<typename T, class SparseMatrixPolicy>
+  inline void LuDecomposition::Decompose(const SparseMatrixPolicy& A, SparseMatrixPolicy& L, SparseMatrixPolicy& U)
       const
   {
     bool is_singular = false;
     Decompose<T, SparseMatrixPolicy>(A, L, U, is_singular);
   }
 
-  template<typename T, template<class> class SparseMatrixPolicy>
-  requires(!VectorizableSparse<SparseMatrixPolicy<T>>) inline void LuDecomposition::Decompose(
-      const SparseMatrixPolicy<T>& A,
-      SparseMatrixPolicy<T>& L,
-      SparseMatrixPolicy<T>& U,
+  template<typename T, class SparseMatrixPolicy>
+  requires(!VectorizableSparse<SparseMatrixPolicy>) inline void LuDecomposition::Decompose(
+      const SparseMatrixPolicy& A,
+      SparseMatrixPolicy& L,
+      SparseMatrixPolicy& U,
       bool& is_singular) const
   {
     MICM_PROFILE_FUNCTION();
@@ -248,11 +232,11 @@ namespace micm
     }
   }
 
-  template<typename T, template<class> class SparseMatrixPolicy>
-  requires(VectorizableSparse<SparseMatrixPolicy<T>>) inline void LuDecomposition::Decompose(
-      const SparseMatrixPolicy<T>& A,
-      SparseMatrixPolicy<T>& L,
-      SparseMatrixPolicy<T>& U,
+  template<typename T, class SparseMatrixPolicy>
+  requires(VectorizableSparse<SparseMatrixPolicy>) inline void LuDecomposition::Decompose(
+      const SparseMatrixPolicy& A,
+      SparseMatrixPolicy& L,
+      SparseMatrixPolicy& U,
       bool& is_singular) const
   {
     MICM_PROFILE_FUNCTION();

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -92,7 +92,7 @@ namespace micm
   /// The template parameter is the type of matrix to use
   template<
       template<class> class MatrixPolicy = Matrix,
-      template<class> class SparseMatrixPolicy = StandardSparseMatrix,
+      class SparseMatrixPolicy = StandardSparseMatrix,
       class LinearSolverPolicy = LinearSolver<double, SparseMatrixPolicy>,
       class ProcessSetPolicy = ProcessSet>
   class RosenbrockSolver
@@ -141,7 +141,7 @@ namespace micm
         const System& system,
         const std::vector<Process>& processes,
         const RosenbrockSolverParameters& parameters,
-        const std::function<LinearSolverPolicy(const SparseMatrixPolicy<double>, double)> create_linear_solver,
+        const std::function<LinearSolverPolicy(const SparseMatrixPolicy, double)> create_linear_solver,
         const std::function<ProcessSetPolicy(const std::vector<Process>&, const std::map<std::string, std::size_t>&)>
             create_process_set);
 
@@ -168,10 +168,10 @@ namespace micm
     /// @brief compute [alpha * I - dforce_dy]
     /// @param jacobian Jacobian matrix (dforce_dy)
     /// @param alpha
-    void AlphaMinusJacobian(SparseMatrixPolicy<double>& jacobian, const double& alpha) const
-        requires(!VectorizableSparse<SparseMatrixPolicy<double>>);
-    void AlphaMinusJacobian(SparseMatrixPolicy<double>& jacobian, const double& alpha) const
-        requires(VectorizableSparse<SparseMatrixPolicy<double>>);
+    void AlphaMinusJacobian(SparseMatrixPolicy& jacobian, const double& alpha) const
+        requires(!VectorizableSparse<SparseMatrixPolicy>);
+    void AlphaMinusJacobian(SparseMatrixPolicy& jacobian, const double& alpha) const
+        requires(VectorizableSparse<SparseMatrixPolicy>);
 
     /// @brief Update the rate constants for the environment state
     /// @param state The current state of the chemical system
@@ -184,7 +184,7 @@ namespace micm
     virtual void CalculateNegativeJacobian(
         const MatrixPolicy<double>& rate_constants,
         const MatrixPolicy<double>& number_densities,
-        SparseMatrixPolicy<double>& jacobian);
+        SparseMatrixPolicy& jacobian);
 
     /// @brief Prepare the linear solver
     /// @param H time step (seconds)

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -149,12 +149,12 @@ namespace micm
 
     /// @brief Returns a state object for use with the solver
     /// @return A object that can hold the full state of the chemical system
-    virtual State<MatrixPolicy, SparseMatrixPolicy> GetState() const;
+    virtual State<MatrixPolicy<double>, SparseMatrixPolicy> GetState() const;
 
     /// @brief Advances the given step over the specified time step
     /// @param time_step Time [s] to advance the state by
     /// @return A struct containing results and a status code
-    SolverResult Solve(double time_step, State<MatrixPolicy, SparseMatrixPolicy>& state) noexcept;
+    SolverResult Solve(double time_step, State<MatrixPolicy<double>, SparseMatrixPolicy>& state) noexcept;
 
     /// @brief Calculate a chemical forcing
     /// @param rate_constants List of rate constants for each needed species
@@ -175,7 +175,7 @@ namespace micm
 
     /// @brief Update the rate constants for the environment state
     /// @param state The current state of the chemical system
-    void UpdateState(State<MatrixPolicy, SparseMatrixPolicy>& state);
+    void UpdateState(State<MatrixPolicy<double>, SparseMatrixPolicy>& state);
 
     /// @brief Compute the derivative of the forcing w.r.t. each chemical, and return the negative jacobian
     /// @param rate_constants List of rate constants for each needed species
@@ -198,7 +198,7 @@ namespace micm
         bool& singular,
         const MatrixPolicy<double>& number_densities,
         SolverStats& stats,
-        State<MatrixPolicy, SparseMatrixPolicy>& state);
+        State<MatrixPolicy<double>, SparseMatrixPolicy>& state);
 
     /// @brief Computes the scaled norm of the vector errors
     /// @param y the original vector

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -237,10 +237,10 @@ namespace micm
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
-  inline State<MatrixPolicy, SparseMatrixPolicy>
+  inline State<MatrixPolicy<double>, SparseMatrixPolicy>
   RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy, ProcessSetPolicy>::GetState() const
   {
-    return State<MatrixPolicy, SparseMatrixPolicy>{ state_parameters_ };
+    return State<MatrixPolicy<double>, SparseMatrixPolicy>{ state_parameters_ };
   }
 
   template<
@@ -252,7 +252,7 @@ namespace micm
   inline typename RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy, ProcessSetPolicy>::SolverResult
   RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy, ProcessSetPolicy>::Solve(
       double time_step,
-      State<MatrixPolicy, SparseMatrixPolicy>& state) noexcept
+      State<MatrixPolicy<double>, SparseMatrixPolicy>& state) noexcept
   {
     MICM_PROFILE_FUNCTION();
 
@@ -460,7 +460,7 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
     std::fill(forcing.AsVector().begin(), forcing.AsVector().end(), 0.0);
-    process_set_.template AddForcingTerms<MatrixPolicy>(rate_constants, number_densities, forcing);
+    process_set_.template AddForcingTerms<MatrixPolicy<double>>(rate_constants, number_densities, forcing);
   }
 
   template<
@@ -530,7 +530,7 @@ namespace micm
       class LinearSolverPolicy,
       class ProcessSetPolicy>
   inline void RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy, ProcessSetPolicy>::UpdateState(
-      State<MatrixPolicy, SparseMatrixPolicy>& state)
+      State<MatrixPolicy<double>, SparseMatrixPolicy>& state)
   {
     Process::UpdateState(processes_, state);
   }
@@ -547,7 +547,7 @@ namespace micm
       bool& singular,
       const MatrixPolicy<double>& number_densities,
       SolverStats& stats,
-      State<MatrixPolicy, SparseMatrixPolicy>& state)
+      State<MatrixPolicy<double>, SparseMatrixPolicy>& state)
   {
     MICM_PROFILE_FUNCTION();
 

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -78,7 +78,6 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
@@ -94,7 +93,6 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
@@ -106,7 +104,7 @@ namespace micm
             system,
             processes,
             parameters,
-            [](const SparseMatrixPolicy<double>& matrix, double initial_value) -> LinearSolverPolicy {
+            [](const SparseMatrixPolicy& matrix, double initial_value) -> LinearSolverPolicy {
               return LinearSolverPolicy{ matrix, initial_value };
             },
             [](const std::vector<Process>& processes,
@@ -119,7 +117,6 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
@@ -127,7 +124,7 @@ namespace micm
       const System& system,
       const std::vector<Process>& processes,
       const RosenbrockSolverParameters& parameters,
-      const std::function<LinearSolverPolicy(const SparseMatrixPolicy<double>, double)> create_linear_solver,
+      const std::function<LinearSolverPolicy(const SparseMatrixPolicy, double)> create_linear_solver,
       const std::function<ProcessSetPolicy(const std::vector<Process>&, const std::map<std::string, std::size_t>&)>
           create_process_set)
       : processes_(processes),
@@ -172,7 +169,7 @@ namespace micm
       MatrixPolicy<int> unsorted_jac_non_zeros(system.StateSize(), system.StateSize(), 0);
       for (auto& elem : unsorted_jac_elements)
         unsorted_jac_non_zeros[elem.first][elem.second] = 1;
-      auto reorder_map = DiagonalMarkowitzReorder<MatrixPolicy>(unsorted_jac_non_zeros);
+      auto reorder_map = DiagonalMarkowitzReorder<MatrixPolicy<int>>(unsorted_jac_non_zeros);
       state_reordering = [=](const std::vector<std::string>& variables, const std::size_t i)
       { return variables[reorder_map[i]]; };
 
@@ -237,7 +234,6 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
@@ -250,7 +246,6 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
@@ -455,7 +450,6 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
@@ -472,13 +466,12 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
   inline void RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy, ProcessSetPolicy>::AlphaMinusJacobian(
-      SparseMatrixPolicy<double>& jacobian,
-      const double& alpha) const requires(!VectorizableSparse<SparseMatrixPolicy<double>>)
+      SparseMatrixPolicy& jacobian,
+      const double& alpha) const requires(!VectorizableSparse<SparseMatrixPolicy>)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -493,13 +486,12 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
   inline void RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy, ProcessSetPolicy>::AlphaMinusJacobian(
-      SparseMatrixPolicy<double>& jacobian,
-      const double& alpha) const requires(VectorizableSparse<SparseMatrixPolicy<double>>)
+      SparseMatrixPolicy& jacobian,
+      const double& alpha) const requires(VectorizableSparse<SparseMatrixPolicy>)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -516,7 +508,6 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
@@ -524,7 +515,7 @@ namespace micm
   RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy, ProcessSetPolicy>::CalculateNegativeJacobian(
       const MatrixPolicy<double>& rate_constants,
       const MatrixPolicy<double>& number_densities,
-      SparseMatrixPolicy<double>& jacobian)
+      SparseMatrixPolicy& jacobian)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -535,7 +526,6 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
@@ -548,7 +538,6 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
@@ -592,7 +581,6 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>
@@ -632,7 +620,6 @@ namespace micm
   template<
       template<class>
       class MatrixPolicy,
-      template<class>
       class SparseMatrixPolicy,
       class LinearSolverPolicy,
       class ProcessSetPolicy>

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -362,7 +362,7 @@ namespace micm
             K[stage].Axpy(parameters_.c_[stage_combinations + j] / H, K[j]);
           }
           temp.Copy(K[stage]);
-          linear_solver_.template Solve<MatrixPolicy>(temp, K[stage], state.lower_matrix_, state.upper_matrix_);
+          linear_solver_.template Solve<MatrixPolicy<double>>(temp, K[stage], state.lower_matrix_, state.upper_matrix_);
           stats.solves += 1;
         }
 

--- a/include/micm/solver/rosenbrock_solver_parameters.hpp
+++ b/include/micm/solver/rosenbrock_solver_parameters.hpp
@@ -17,9 +17,9 @@ namespace micm
   /// @brief Rosenbrock solver parameters
   struct RosenbrockSolverParameters
   {
-    size_t stages_{};
-    size_t upper_limit_tolerance_{};
-    size_t max_number_of_steps_{ 1000 };
+    std::size_t stages_{};
+    std::size_t upper_limit_tolerance_{};
+    std::size_t max_number_of_steps_{ 1000 };
 
     double round_off_{ std::numeric_limits<double>::epsilon() };  // Unit roundoff (1+round_off)>1
     double factor_min_{ 0.2 };                                    // solver step size minimum boundary
@@ -59,7 +59,7 @@ namespace micm
     std::vector<double> absolute_tolerance_;
     double relative_tolerance_{ 1e-4 };
 
-    size_t number_of_grid_cells_{ 1 };     // Number of grid cells to solve simultaneously
+    std::size_t number_of_grid_cells_{ 1 };     // Number of grid cells to solve simultaneously
     bool reorder_state_{ true };           // Reorder state during solver construction to minimize LU fill-in
     bool check_singularity_{ false };      // Check for singular A matrix in linear solve of A x = b
     bool ignore_unused_species_{ false };  // Allow unused species to be included in state and solve
@@ -72,35 +72,35 @@ namespace micm
     /// @param reorder_state
     /// @return
     static RosenbrockSolverParameters TwoStageRosenbrockParameters(
-        size_t number_of_grid_cells = 1,
+        std::size_t number_of_grid_cells = 1,
         bool reorder_state = true);
     /// @brief an L-stable method, 3 stages, order 3, 2 function evaluations
     /// @param number_of_grid_cells
     /// @param reorder_state
     /// @return
     static RosenbrockSolverParameters ThreeStageRosenbrockParameters(
-        size_t number_of_grid_cells = 1,
+        std::size_t number_of_grid_cells = 1,
         bool reorder_state = true);
     /// @brief L-stable rosenbrock method of order 4, with 4 stages
     /// @param number_of_grid_cells
     /// @param reorder_state
     /// @return
     static RosenbrockSolverParameters FourStageRosenbrockParameters(
-        size_t number_of_grid_cells = 1,
+        std::size_t number_of_grid_cells = 1,
         bool reorder_state = true);
     /// @brief A stiffly-stable method, 4 stages, order 3
     /// @param number_of_grid_cells
     /// @param reorder_state
     /// @return
     static RosenbrockSolverParameters FourStageDifferentialAlgebraicRosenbrockParameters(
-        size_t number_of_grid_cells = 1,
+        std::size_t number_of_grid_cells = 1,
         bool reorder_state = true);
     /// @brief stiffly-stable rosenbrock method of order 4, with 6 stages
     /// @param number_of_grid_cells
     /// @param reorder_state
     /// @return
     static RosenbrockSolverParameters SixStageDifferentialAlgebraicRosenbrockParameters(
-        size_t number_of_grid_cells = 1,
+        std::size_t number_of_grid_cells = 1,
         bool reorder_state = true);
 
    private:
@@ -160,7 +160,7 @@ namespace micm
   }
 
   inline RosenbrockSolverParameters RosenbrockSolverParameters::TwoStageRosenbrockParameters(
-      size_t number_of_grid_cells,
+      std::size_t number_of_grid_cells,
       bool reorder_state)
   {
     // an L-stable method, 2 stages, order 2
@@ -204,7 +204,7 @@ namespace micm
   }
 
   inline RosenbrockSolverParameters RosenbrockSolverParameters::ThreeStageRosenbrockParameters(
-      size_t number_of_grid_cells,
+      std::size_t number_of_grid_cells,
       bool reorder_state)
   {
     // an L-stable method, 3 stages, order 3, 2 function evaluations
@@ -260,7 +260,7 @@ namespace micm
   }
 
   inline RosenbrockSolverParameters RosenbrockSolverParameters::FourStageRosenbrockParameters(
-      size_t number_of_grid_cells,
+      std::size_t number_of_grid_cells,
       bool reorder_state)
   {
     // L-STABLE ROSENBROCK METHOD OF ORDER 4, WITH 4 STAGES
@@ -329,7 +329,7 @@ namespace micm
   }
 
   inline RosenbrockSolverParameters RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters(
-      size_t number_of_grid_cells,
+      std::size_t number_of_grid_cells,
       bool reorder_state)
   {
     // A STIFFLY-STABLE METHOD, 4 stages, order 3
@@ -384,7 +384,7 @@ namespace micm
   }
 
   inline RosenbrockSolverParameters RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters(
-      size_t number_of_grid_cells,
+      std::size_t number_of_grid_cells,
       bool reorder_state)
   {
     // STIFFLY-STABLE ROSENBROCK METHOD OF ORDER 4, WITH 6 STAGES

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -1,0 +1,81 @@
+/* Copyright (C) 2023-2024 National Center for Atmospheric Research
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <micm/solver/backward_euler.hpp>
+#include <micm/solver/backward_euler_solver_parameters.hpp>
+#include <micm/solver/rosenbrock_solver_parameters.hpp>
+
+#include <variant>
+
+namespace micm
+{
+  class Solver
+  {
+   private:
+    using SolverParameters =
+        std::variant<std::monostate, micm::RosenbrockSolverParameters, micm::BackwardEulerSolverParameters>;
+
+    SolverParameters parameters_;
+    std::size_t number_of_grid_cells_;
+    std::size_t number_of_species_;
+    std::size_t number_of_reactions_;
+
+   public:
+    Solver()
+        : parameters_(std::monostate{}),
+          number_of_grid_cells_(0),
+          number_of_species_(0),
+          number_of_reactions_(0)
+    {
+    }
+
+    Solver(
+        SolverParameters parameters,
+        std::size_t number_of_grid_cells,
+        std::size_t number_of_species,
+        std::size_t number_of_reactions)
+        : parameters_(parameters),
+          number_of_grid_cells_(number_of_grid_cells),
+          number_of_species_(number_of_species),
+          number_of_reactions_(number_of_reactions)
+    {
+    }
+
+    void Solve()
+    {
+      if (std::holds_alternative<micm::RosenbrockSolverParameters>(parameters_))
+      {
+        // call Rosenbrock solver
+      }
+      else if (std::holds_alternative<micm::BackwardEulerSolverParameters>(parameters_))
+      {
+        micm::BackwardEuler be;
+        // be.solve()
+      }
+    }
+
+    /// @brief Returns the number of grid cells
+    /// @return
+    std::size_t GetNumberOfGridCells() const
+    {
+      return number_of_grid_cells_;
+    }
+
+    /// @brief Returns the number of species
+    /// @return
+    std::size_t GetNumberOfSpecies() const
+    {
+      return number_of_species_;
+    }
+
+    /// @brief Returns the number of reactions
+    /// @return
+    std::size_t GetNumberOfReactions() const
+    {
+      return number_of_reactions_;
+    }
+  };
+}  // namespace micm

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -8,10 +8,22 @@
 #include <micm/solver/backward_euler_solver_parameters.hpp>
 #include <micm/solver/rosenbrock_solver_parameters.hpp>
 
+#include <memory>
 #include <variant>
 
 namespace micm
 {
+  class SolverImplBase {
+  public:
+    virtual ~SolverImplBase() = default;
+  };
+
+  template<class LinearSolverPolicy, class ProcessSetPolicy>
+  struct SolverImpl : public SolverImplBase {
+    ProcessSetPolicy process_set_;
+    LinearSolverPolicy linear_solver_;
+  };
+
   class Solver
   {
    private:
@@ -22,6 +34,7 @@ namespace micm
     std::size_t number_of_grid_cells_;
     std::size_t number_of_species_;
     std::size_t number_of_reactions_;
+    std::unique_ptr<SolverImplBase> solver_impl_;
 
    public:
     Solver()
@@ -33,11 +46,13 @@ namespace micm
     }
 
     Solver(
+        SolverImplBase* solver_impl,
         SolverParameters parameters,
         std::size_t number_of_grid_cells,
         std::size_t number_of_species,
         std::size_t number_of_reactions)
-        : parameters_(parameters),
+        : solver_impl_(solver_impl),
+          parameters_(parameters),
           number_of_grid_cells_(number_of_grid_cells),
           number_of_species_(number_of_species),
           number_of_reactions_(number_of_reactions)

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -13,13 +13,17 @@
 
 namespace micm
 {
-  class SolverImplBase {
-  public:
+  using SolverParameters = std::variant<std::monostate, micm::RosenbrockSolverParameters, micm::BackwardEulerSolverParameters>;
+
+  class SolverImplBase
+  {
+   public:
     virtual ~SolverImplBase() = default;
   };
 
   template<class LinearSolverPolicy, class ProcessSetPolicy>
-  struct SolverImpl : public SolverImplBase {
+  struct SolverImpl : public SolverImplBase
+  {
     ProcessSetPolicy process_set_;
     LinearSolverPolicy linear_solver_;
   };
@@ -27,9 +31,6 @@ namespace micm
   class Solver
   {
    private:
-    using SolverParameters =
-        std::variant<std::monostate, micm::RosenbrockSolverParameters, micm::BackwardEulerSolverParameters>;
-
     SolverParameters parameters_;
     std::size_t number_of_grid_cells_;
     std::size_t number_of_species_;

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -28,6 +28,7 @@ namespace micm
     LinearSolverPolicy linear_solver_;
   };
 
+  template<class StatePolicy>
   class Solver
   {
    private:
@@ -36,6 +37,7 @@ namespace micm
     std::size_t number_of_species_;
     std::size_t number_of_reactions_;
     std::unique_ptr<SolverImplBase> solver_impl_;
+    StateParameters state_parameters_;
 
    public:
     Solver()
@@ -60,7 +62,7 @@ namespace micm
     {
     }
 
-    void Solve()
+    void Solve(double timestep, StatePolicy& state)
     {
       if (std::holds_alternative<micm::RosenbrockSolverParameters>(parameters_))
       {

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -58,7 +58,8 @@ namespace micm
 
     /// @brief
     /// @return
-    Solver Build();
+    template<class MatrixPolicy, class SparseMatrixPolicy>
+    Solver<State<MatrixPolicy, SparseMatrixPolicy>> Build();
 
    protected:
     /// @brief

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -20,6 +20,7 @@
 
 namespace micm
 {
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
   class SolverBuilder
   {
    protected:
@@ -58,13 +59,12 @@ namespace micm
 
     /// @brief
     /// @return
-    template<class MatrixPolicy, class SparseMatrixPolicy>
-    Solver<State<MatrixPolicy, SparseMatrixPolicy>> Build();
+    Solver<State<DenseMatrixPolicy, SparseMatrixPolicy>> Build();
 
    protected:
     /// @brief
     /// @return
-    virtual Solver BuildBackwardEulerSolver() = 0;
+    virtual Solver<State<DenseMatrixPolicy, SparseMatrixPolicy>> BuildBackwardEulerSolver() = 0;
     virtual ~SolverBuilder() = default;
 
     /// @brief
@@ -75,7 +75,7 @@ namespace micm
 
     /// @brief Get a species map properly ordered
     /// @return
-    template<class MatrixPolicy, class ProcessSetPolicy>
+    template<class ProcessSetPolicy>
     std::map<std::string, std::size_t> GetSpeciesMap() const;
 
     /// @brief Set the absolute tolerances per species
@@ -91,18 +91,18 @@ namespace micm
     std::vector<std::size_t> GetJacobianDiagonalElements(auto jacobian) const;
   };
 
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  class CpuSolverBuilder : public SolverBuilder
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  class CpuSolverBuilder : public SolverBuilder<DenseMatrixPolicy, SparseMatrixPolicy>
   {
    public:
-    Solver BuildBackwardEulerSolver() override;
+    Solver<State<DenseMatrixPolicy, SparseMatrixPolicy>> BuildBackwardEulerSolver() override;
   };
 
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  class GpuSolverBuilder : public SolverBuilder
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  class GpuSolverBuilder : public SolverBuilder<DenseMatrixPolicy, SparseMatrixPolicy>
   {
    public:
-    Solver BuildBackwardEulerSolver() override;
+    Solver<State<DenseMatrixPolicy, SparseMatrixPolicy>> BuildBackwardEulerSolver() override;
   };
 
 }  // namespace micm

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -64,7 +64,8 @@ namespace micm
 
     /// @brief  
     /// @return 
-    virtual Solver BuildBackwardEulerSolver();
+    virtual Solver BuildBackwardEulerSolver() = 0;
+    virtual ~SolverBuilder() = default;
 
     /// @brief 
     /// @tparam ProcessSetPolicy 
@@ -74,7 +75,7 @@ namespace micm
 
     /// @brief Get a species map properly ordered
     /// @return 
-    template<template<class> class MatrixPolicy, class ProcessSetPolicy>
+    template<class MatrixPolicy, class ProcessSetPolicy>
     std::map<std::string, std::size_t> GetSpeciesMap() const;
 
     /// @brief Set the absolute tolerances per species
@@ -91,14 +92,14 @@ namespace micm
 
   };
 
-  template<class MatrixPolicy = Matrix<double>, class SparseMatrixPolicy = StandardSparseMatrix>
+  template<class MatrixPolicy, class SparseMatrixPolicy>
   class CpuSolverBuilder : public SolverBuilder
   {
    public:
     Solver BuildBackwardEulerSolver() override;
   };
 
-  template<class MatrixPolicy = Matrix<double>, class SparseMatrixPolicy = StandardSparseMatrix>
+  template<class MatrixPolicy, class SparseMatrixPolicy>
   class GpuSolverBuilder : public SolverBuilder
   {
    public:

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -1,0 +1,91 @@
+/* Copyright (C) 2023-2024 National Center for Atmospheric Research
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <micm/process/process.hpp>
+#include <micm/solver/backward_euler_solver_parameters.hpp>
+#include <micm/solver/linear_solver.hpp>
+#include <micm/solver/lu_decomposition.hpp>
+#include <micm/solver/rosenbrock_solver_parameters.hpp>
+#include <micm/solver/solver.hpp>
+#include <micm/system/conditions.hpp>
+#include <micm/system/system.hpp>
+#include <micm/util/jacobian.hpp>
+#include <micm/util/matrix.hpp>
+#include <micm/util/sparse_matrix.hpp>
+
+#include <system_error>
+
+namespace micm
+{
+  class SolverBuilder
+  {
+   private:
+    micm::System system_;
+    std::size_t number_of_grid_cells_;
+    std::vector<micm::Process> reactions_;
+    std::variant<std::monostate, micm::RosenbrockSolverParameters, micm::BackwardEulerSolverParameters> options_;
+    bool ignore_unused_species_ = true;
+    bool reorder_state_ = true;
+
+   public:
+    /// @brief Set the chemical system
+    /// @param system 
+    /// @return 
+    SolverBuilder& SetSystem(micm::System system);
+
+    /// @brief Set the reactions
+    /// @param reactions 
+    /// @return 
+    SolverBuilder& SetReactions(std::vector<micm::Process> reactions);
+
+    /// @brief Set the number of grid cells
+    /// @param number_of_grid_cells 
+    /// @return 
+    SolverBuilder& SetNumberOfGridCells(int number_of_grid_cells);
+
+    /// @brief Choose a rosenbrock solver
+    /// @param options 
+    /// @return 
+    SolverBuilder& Rosenbrock(const RosenbrockSolverParameters& options);
+
+    /// @brief Choose a backward euler solver
+    /// @param options 
+    /// @return 
+    SolverBuilder& BackwardEuler(const BackwardEulerSolverParameters& options);
+
+    /// @brief  
+    /// @return 
+    template<template<class> class MatrixPolicy = Matrix, template<class> class SparseMatrixPolicy = StandardSparseMatrix>
+    Solver Build();
+
+   private:
+
+    /// @brief  
+    /// @return 
+    template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+    Solver BuildBackwardEulerSolver();
+
+    /// @brief 
+    /// @tparam ProcessSetPolicy 
+    /// @return 
+    template<class ProcessSetPolicy>
+    void UnusedSpeciesCheck();
+
+    /// @brief Get a species map properly ordered
+    /// @return 
+    template<template<class> class MatrixPolicy, class ProcessSetPolicy>
+    std::map<std::string, std::size_t> GetSpeciesMap() const;
+
+    /// @brief Set the absolute tolerances per species
+    /// @param parameters 
+    /// @param species_map 
+    /// @return 
+    void SetAbsoluteTolerances(std::vector<double>& tolerances, const std::map<std::string, std::size_t>& species_map) const;
+
+  };
+}  // namespace micm
+
+#include "solver_builder.inl"

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -85,6 +85,12 @@ namespace micm
     /// @return 
     void SetAbsoluteTolerances(std::vector<double>& tolerances, const std::map<std::string, std::size_t>& species_map) const;
 
+    /// @brief Return the labels of the custom parameters
+    /// @return 
+    std::vector<std::string> GetCustomParameterLabels() const;
+
+    std::vector<std::size_t> GetJacobianDiagonalElements(auto jacobian) const;
+
   };
 }  // namespace micm
 

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -22,7 +22,7 @@ namespace micm
 {
   class SolverBuilder
   {
-   private:
+   protected:
     micm::System system_;
     std::size_t number_of_grid_cells_;
     std::vector<micm::Process> reactions_;
@@ -49,24 +49,22 @@ namespace micm
     /// @brief Choose a rosenbrock solver
     /// @param options 
     /// @return 
-    SolverBuilder& Rosenbrock(const RosenbrockSolverParameters& options);
+    SolverBuilder& SolverParameters(const RosenbrockSolverParameters& options);
 
     /// @brief Choose a backward euler solver
     /// @param options 
     /// @return 
-    SolverBuilder& BackwardEuler(const BackwardEulerSolverParameters& options);
+    SolverBuilder& SolverParameters(const BackwardEulerSolverParameters& options);
 
     /// @brief  
     /// @return 
-    template<template<class> class MatrixPolicy = Matrix, template<class> class SparseMatrixPolicy = StandardSparseMatrix>
     Solver Build();
 
-   private:
+   protected:
 
     /// @brief  
     /// @return 
-    template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
-    Solver BuildBackwardEulerSolver();
+    virtual Solver BuildBackwardEulerSolver();
 
     /// @brief 
     /// @tparam ProcessSetPolicy 
@@ -92,6 +90,21 @@ namespace micm
     std::vector<std::size_t> GetJacobianDiagonalElements(auto jacobian) const;
 
   };
+
+  template<class MatrixPolicy = Matrix<double>, class SparseMatrixPolicy = StandardSparseMatrix>
+  class CpuSolverBuilder : public SolverBuilder
+  {
+   public:
+    Solver BuildBackwardEulerSolver() override;
+  };
+
+  template<class MatrixPolicy = Matrix<double>, class SparseMatrixPolicy = StandardSparseMatrix>
+  class GpuSolverBuilder : public SolverBuilder
+  {
+   public:
+    Solver BuildBackwardEulerSolver() override;
+  };
+
 }  // namespace micm
 
 #include "solver_builder.inl"

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -26,70 +26,68 @@ namespace micm
     micm::System system_;
     std::size_t number_of_grid_cells_;
     std::vector<micm::Process> reactions_;
-    std::variant<std::monostate, micm::RosenbrockSolverParameters, micm::BackwardEulerSolverParameters> options_;
+    SolverParameters options_;
     bool ignore_unused_species_ = true;
     bool reorder_state_ = true;
 
    public:
     /// @brief Set the chemical system
-    /// @param system 
-    /// @return 
+    /// @param system
+    /// @return
     SolverBuilder& SetSystem(micm::System system);
 
     /// @brief Set the reactions
-    /// @param reactions 
-    /// @return 
+    /// @param reactions
+    /// @return
     SolverBuilder& SetReactions(std::vector<micm::Process> reactions);
 
     /// @brief Set the number of grid cells
-    /// @param number_of_grid_cells 
-    /// @return 
+    /// @param number_of_grid_cells
+    /// @return
     SolverBuilder& SetNumberOfGridCells(int number_of_grid_cells);
 
     /// @brief Choose a rosenbrock solver
-    /// @param options 
-    /// @return 
-    SolverBuilder& SolverParameters(const RosenbrockSolverParameters& options);
+    /// @param options
+    /// @return
+    SolverBuilder& SetSolverParameters(const RosenbrockSolverParameters& options);
 
     /// @brief Choose a backward euler solver
-    /// @param options 
-    /// @return 
-    SolverBuilder& SolverParameters(const BackwardEulerSolverParameters& options);
+    /// @param options
+    /// @return
+    SolverBuilder& SetSolverParameters(const BackwardEulerSolverParameters& options);
 
-    /// @brief  
-    /// @return 
+    /// @brief
+    /// @return
     Solver Build();
 
    protected:
-
-    /// @brief  
-    /// @return 
+    /// @brief
+    /// @return
     virtual Solver BuildBackwardEulerSolver() = 0;
     virtual ~SolverBuilder() = default;
 
-    /// @brief 
-    /// @tparam ProcessSetPolicy 
-    /// @return 
+    /// @brief
+    /// @tparam ProcessSetPolicy
+    /// @return
     template<class ProcessSetPolicy>
     void UnusedSpeciesCheck();
 
     /// @brief Get a species map properly ordered
-    /// @return 
+    /// @return
     template<class MatrixPolicy, class ProcessSetPolicy>
     std::map<std::string, std::size_t> GetSpeciesMap() const;
 
     /// @brief Set the absolute tolerances per species
-    /// @param parameters 
-    /// @param species_map 
-    /// @return 
+    /// @param parameters
+    /// @param species_map
+    /// @return
     void SetAbsoluteTolerances(std::vector<double>& tolerances, const std::map<std::string, std::size_t>& species_map) const;
 
     /// @brief Return the labels of the custom parameters
-    /// @return 
+    /// @return
     std::vector<std::string> GetCustomParameterLabels() const;
 
     std::vector<std::size_t> GetJacobianDiagonalElements(auto jacobian) const;
-
   };
 
   template<class MatrixPolicy, class SparseMatrixPolicy>

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <micm/process/process.hpp>
+#include <micm/process/process_set.hpp>
+#include <micm/solver/backward_euler.hpp>
 #include <micm/solver/backward_euler_solver_parameters.hpp>
 #include <micm/solver/linear_solver.hpp>
 #include <micm/solver/lu_decomposition.hpp>
@@ -20,6 +22,8 @@
 
 namespace micm
 {
+  using SolverParameters = std::variant<std::monostate, micm::RosenbrockSolverParameters, micm::BackwardEulerSolverParameters>;
+
   template<class DenseMatrixPolicy, class SparseMatrixPolicy>
   class SolverBuilder
   {
@@ -59,12 +63,13 @@ namespace micm
 
     /// @brief
     /// @return
-    Solver<State<DenseMatrixPolicy, SparseMatrixPolicy>> Build();
+    auto Build();
 
    protected:
     /// @brief
     /// @return
-    virtual Solver<State<DenseMatrixPolicy, SparseMatrixPolicy>> BuildBackwardEulerSolver() = 0;
+    virtual Solver<BackwardEuler<LinearSolver<typename DenseMatrixPolicy::value_type, SparseMatrixPolicy>, ProcessSet>, State<DenseMatrixPolicy, SparseMatrixPolicy>> BuildBackwardEulerSolver() = 0;
+
     virtual ~SolverBuilder() = default;
 
     /// @brief
@@ -95,14 +100,14 @@ namespace micm
   class CpuSolverBuilder : public SolverBuilder<DenseMatrixPolicy, SparseMatrixPolicy>
   {
    public:
-    Solver<State<DenseMatrixPolicy, SparseMatrixPolicy>> BuildBackwardEulerSolver() override;
+    Solver<BackwardEuler<LinearSolver<typename DenseMatrixPolicy::value_type, SparseMatrixPolicy>, ProcessSet>, State<DenseMatrixPolicy, SparseMatrixPolicy>> BuildBackwardEulerSolver() override;
   };
 
   template<class DenseMatrixPolicy, class SparseMatrixPolicy>
   class GpuSolverBuilder : public SolverBuilder<DenseMatrixPolicy, SparseMatrixPolicy>
   {
    public:
-    Solver<State<DenseMatrixPolicy, SparseMatrixPolicy>> BuildBackwardEulerSolver() override;
+    Solver<BackwardEuler<LinearSolver<typename DenseMatrixPolicy::value_type, SparseMatrixPolicy>, ProcessSet>, State<DenseMatrixPolicy, SparseMatrixPolicy>> BuildBackwardEulerSolver() override;
   };
 
 }  // namespace micm

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -65,7 +65,7 @@ namespace micm
     return *this;
   }
 
-  inline SolverBuilder& SolverBuilder::SolverParameters(const RosenbrockSolverParameters& options)
+  inline SolverBuilder& SolverBuilder::SetSolverParameters(const RosenbrockSolverParameters& options)
   {
     if (!std::holds_alternative<std::monostate>(options_))
     {
@@ -75,7 +75,7 @@ namespace micm
     return *this;
   }
 
-  inline SolverBuilder& SolverBuilder::SolverParameters(const BackwardEulerSolverParameters& options)
+  inline SolverBuilder& SolverBuilder::SetSolverParameters(const BackwardEulerSolverParameters& options)
   {
     if (!std::holds_alternative<std::monostate>(options_))
     {
@@ -137,7 +137,6 @@ namespace micm
     for (auto& name : system_.UniqueNames())
       species_map[name] = index++;
 
-
     if (reorder_state_)
     {
       // get unsorted Jacobian non-zero elements
@@ -189,7 +188,8 @@ namespace micm
     }
   }
 
-  inline std::vector<std::string> SolverBuilder::GetCustomParameterLabels() const {
+  inline std::vector<std::string> SolverBuilder::GetCustomParameterLabels() const
+  {
     std::vector<std::string> param_labels{};
     for (const auto& reaction : reactions_)
       if (reaction.rate_constant_)
@@ -198,7 +198,8 @@ namespace micm
     return param_labels;
   }
 
-  inline std::vector<std::size_t> SolverBuilder::GetJacobianDiagonalElements(auto jacobian) const {
+  inline std::vector<std::size_t> SolverBuilder::GetJacobianDiagonalElements(auto jacobian) const
+  {
     std::vector<std::size_t> jacobian_diagonal_elements;
 
     jacobian_diagonal_elements.reserve(jacobian.NumRows());
@@ -221,19 +222,23 @@ namespace micm
     auto labels = GetCustomParameterLabels();
     std::size_t number_of_species = system_.StateSize();
 
-
     UnusedSpeciesCheck<ProcessSetPolicy>();
     SetAbsoluteTolerances(parameters.absolute_tolerance_, species_map);
 
     ProcessSetPolicy process_set(reactions_, species_map);
-    auto jacobian = BuildJacobian<SparseMatrixPolicy>(process_set.NonZeroJacobianElements(), number_of_grid_cells_, number_of_species);
+    auto jacobian =
+        BuildJacobian<SparseMatrixPolicy>(process_set.NonZeroJacobianElements(), number_of_grid_cells_, number_of_species);
     auto diagonal_elements = GetJacobianDiagonalElements(jacobian);
+
     process_set.SetJacobianFlatIds(jacobian);
-    micm::LinearSolver<double, SparseMatrixPolicy> linear_solver(jacobian, 1e-30);
+    micm::LinearSolver<typename MatrixPolicy::value_type, SparseMatrixPolicy> linear_solver(jacobian, 1e-30);
 
     return Solver(
-      new SolverImpl<decltype(linear_solver), decltype(process_set)>(), 
-      parameters, number_of_grid_cells_, number_of_species, reactions_.size());
+        new SolverImpl<decltype(linear_solver), decltype(process_set)>(),
+        parameters,
+        number_of_grid_cells_,
+        number_of_species,
+        reactions_.size());
   }
 
 }  // namespace micm

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -1,0 +1,206 @@
+/* Copyright (C) 2023-2024 National Center for Atmospheric Research
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+enum class MicmSolverBuilderErrc
+{
+  UnusedSpecies = 1,  // Unused species present in the chemical system
+};
+
+namespace std
+{
+  template<>
+  struct is_error_condition_enum<MicmSolverBuilderErrc> : true_type
+  {
+  };
+}  // namespace std
+
+namespace
+{
+  class SolverBuilderErrorCategory : public std::error_category
+  {
+   public:
+    const char* name() const noexcept override
+    {
+      return "MICM Solver Builder";
+    }
+    std::string message(int ev) const override
+    {
+      switch (static_cast<MicmSolverBuilderErrc>(ev))
+      {
+        case MicmSolverBuilderErrc::UnusedSpecies:
+          return "Unused species present in the chemical system. Use the ignore_unused_species_ parameter to allow unused "
+                 "species in the solve.";
+        default: return "Unknown error";
+      }
+    }
+  };
+
+  const SolverBuilderErrorCategory solverBuilderErrorCategory{};
+}  // namespace
+
+inline std::error_code make_error_code(MicmSolverBuilderErrc e)
+{
+  return { static_cast<int>(e), solverBuilderErrorCategory };
+}
+
+namespace micm
+{
+  SolverBuilder& SolverBuilder::SetSystem(micm::System system)
+  {
+    system_ = system;
+    return *this;
+  }
+
+  SolverBuilder& SolverBuilder::SetReactions(std::vector<micm::Process> reactions)
+  {
+    reactions_ = reactions;
+    return *this;
+  }
+
+  SolverBuilder& SolverBuilder::SetNumberOfGridCells(int number_of_grid_cells)
+  {
+    number_of_grid_cells_ = number_of_grid_cells;
+    return *this;
+  }
+
+  SolverBuilder& SolverBuilder::Rosenbrock(const RosenbrockSolverParameters& options)
+  {
+    if (!std::holds_alternative<std::monostate>(options_))
+    {
+      throw std::runtime_error("Solver type already set");
+    }
+    options_.emplace<RosenbrockSolverParameters>(options);
+    return *this;
+  }
+
+  SolverBuilder& SolverBuilder::BackwardEuler(const BackwardEulerSolverParameters& options)
+  {
+    if (!std::holds_alternative<std::monostate>(options_))
+    {
+      throw std::runtime_error("Solver type already set");
+    }
+    options_.emplace<BackwardEulerSolverParameters>(options);
+    return *this;
+  }
+
+  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  Solver SolverBuilder::Build()
+  {
+    if (std::holds_alternative<micm::RosenbrockSolverParameters>(options_))
+    {
+      throw std::runtime_error("Not implemented yet");
+    }
+    if (std::holds_alternative<micm::BackwardEulerSolverParameters>(options_))
+    {
+      return BuildBackwardEulerSolver<MatrixPolicy, SparseMatrixPolicy>();
+    }
+
+    throw std::runtime_error("No solver type set");
+  }
+
+  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  Solver SolverBuilder::BuildBackwardEulerSolver()
+  {
+    auto parameters = std::get<BackwardEulerSolverParameters>(options_);
+    UnusedSpeciesCheck<micm::ProcessSet>();
+    auto species_map = GetSpeciesMap<MatrixPolicy, micm::ProcessSet>();
+    SetAbsoluteTolerances(parameters.absolute_tolerance_, species_map);
+    std::size_t number_of_species = system_.StateSize();
+
+    micm::ProcessSet process_set(reactions_, species_map);
+    auto jacobian = BuildJacobian<SparseMatrixPolicy>(process_set.NonZeroJacobianElements(), number_of_grid_cells_, number_of_species);
+
+    return Solver(parameters, number_of_grid_cells_, number_of_species, reactions_.size());
+  }
+
+  template<class ProcessSetPolicy>
+  void SolverBuilder::UnusedSpeciesCheck()
+  {
+    if (ignore_unused_species_)
+    {
+      return;
+    }
+
+    std::size_t index = 0;
+    auto used_species = ProcessSetPolicy::SpeciesUsed(reactions_);
+    auto available_species = system_.UniqueNames();
+    std::sort(available_species.begin(), available_species.end());
+    std::set<std::string> unused_species;
+    std::set_difference(
+        available_species.begin(),
+        available_species.end(),
+        used_species.begin(),
+        used_species.end(),
+        std::inserter(unused_species, unused_species.begin()));
+    if (unused_species.size() > 0)
+    {
+      std::string err_msg = "Unused species in chemical system:";
+      for (auto& species : unused_species)
+        err_msg += " '" + species + "'";
+      err_msg += ".";
+      throw std::system_error(make_error_code(MicmSolverBuilderErrc::UnusedSpecies), err_msg);
+    }
+  }
+
+  template<template<class> class MatrixPolicy, class ProcessSetPolicy>
+  std::map<std::string, std::size_t> SolverBuilder::GetSpeciesMap() const
+  {
+    std::map<std::string, std::size_t> species_map;
+    std::function<std::string(const std::vector<std::string>& variables, const std::size_t i)> state_reordering;
+    std::size_t index = 0;
+
+    if (!reorder_state_)
+    {
+      for (auto& name : system_.UniqueNames())
+        species_map[name] = index++;
+    }
+    else
+    {
+      // get unsorted Jacobian non-zero elements
+      auto unsorted_process_set = ProcessSetPolicy(reactions_, species_map);
+      auto unsorted_jac_elements = unsorted_process_set.NonZeroJacobianElements();
+      MatrixPolicy<int> unsorted_jac_non_zeros(system_.StateSize(), system_.StateSize(), 0);
+      for (auto& elem : unsorted_jac_elements)
+        unsorted_jac_non_zeros[elem.first][elem.second] = 1;
+      auto reorder_map = DiagonalMarkowitzReorder<MatrixPolicy>(unsorted_jac_non_zeros);
+      state_reordering = [=](const std::vector<std::string>& variables, const std::size_t i)
+      { return variables[reorder_map[i]]; };
+
+      std::size_t index = 0;
+      for (auto& name : system_.UniqueNames(state_reordering))
+        species_map[name] = index++;
+    }
+
+    return species_map;
+  }
+
+  void SolverBuilder::SetAbsoluteTolerances(
+      std::vector<double>& tolerances,
+      const std::map<std::string, std::size_t>& species_map) const
+  {
+    // if the tolerances aren't already set, initialize them and then set based off of information in the system
+    if (tolerances.size() != species_map.size())
+    {
+      tolerances = std::vector<double>(species_map.size(), 1e-3);
+      for (auto& species : system_.gas_phase_.species_)
+      {
+        if (species.HasProperty("absolute tolerance"))
+        {
+          tolerances[species_map.at(species.name_)] = species.GetProperty<double>("absolute tolerance");
+        }
+      }
+      for (auto& phase : system_.phases_)
+      {
+        for (auto& species : phase.second.species_)
+        {
+          if (species.HasProperty("absolute tolerance"))
+          {
+            tolerances[species_map.at(species.name_)] = species.GetProperty<double>("absolute tolerance");
+          }
+        }
+      }
+    }
+  }
+}  // namespace micm

--- a/include/micm/solver/state.hpp
+++ b/include/micm/solver/state.hpp
@@ -35,15 +35,15 @@ namespace micm
     std::set<std::pair<std::size_t, std::size_t>> nonzero_jacobian_elements_{};
   };
 
-  template<template<class> class MatrixPolicy = Matrix, class SparseMatrixPolicy = StandardSparseMatrix>
+  template<class MatrixPolicy = StandardDenseMatrix, class SparseMatrixPolicy = StandardSparseMatrix>
   struct State
   {
     /// @brief The concentration of chemicals, varies through time
-    MatrixPolicy<double> variables_;
+    MatrixPolicy variables_;
     /// @brief Rate paramters particular to user-defined rate constants, may vary in time
-    MatrixPolicy<double> custom_rate_parameters_;
+    MatrixPolicy custom_rate_parameters_;
     /// @brief The reaction rates, may vary in time
-    MatrixPolicy<double> rate_constants_;
+    MatrixPolicy rate_constants_;
     /// @brief Atmospheric conditions, varies in time
     std::vector<Conditions> conditions_;
     /// @brief The jacobian structure, varies for each solve

--- a/include/micm/solver/state.hpp
+++ b/include/micm/solver/state.hpp
@@ -35,15 +35,15 @@ namespace micm
     std::set<std::pair<std::size_t, std::size_t>> nonzero_jacobian_elements_{};
   };
 
-  template<class MatrixPolicy = StandardDenseMatrix, class SparseMatrixPolicy = StandardSparseMatrix>
+  template<class DenseMatrixPolicy = StandardDenseMatrix, class SparseMatrixPolicy = StandardSparseMatrix>
   struct State
   {
     /// @brief The concentration of chemicals, varies through time
-    MatrixPolicy variables_;
+    DenseMatrixPolicy variables_;
     /// @brief Rate paramters particular to user-defined rate constants, may vary in time
-    MatrixPolicy custom_rate_parameters_;
+    DenseMatrixPolicy custom_rate_parameters_;
     /// @brief The reaction rates, may vary in time
-    MatrixPolicy rate_constants_;
+    DenseMatrixPolicy rate_constants_;
     /// @brief Atmospheric conditions, varies in time
     std::vector<Conditions> conditions_;
     /// @brief The jacobian structure, varies for each solve

--- a/include/micm/solver/state.hpp
+++ b/include/micm/solver/state.hpp
@@ -35,7 +35,7 @@ namespace micm
     std::set<std::pair<std::size_t, std::size_t>> nonzero_jacobian_elements_{};
   };
 
-  template<template<class> class MatrixPolicy = Matrix, template<class> class SparseMatrixPolicy = StandardSparseMatrix>
+  template<template<class> class MatrixPolicy = Matrix, class SparseMatrixPolicy = StandardSparseMatrix>
   struct State
   {
     /// @brief The concentration of chemicals, varies through time
@@ -47,13 +47,13 @@ namespace micm
     /// @brief Atmospheric conditions, varies in time
     std::vector<Conditions> conditions_;
     /// @brief The jacobian structure, varies for each solve
-    SparseMatrixPolicy<double> jacobian_;
+    SparseMatrixPolicy jacobian_;
     /// @brief Immutable data required for the state
     std::map<std::string, std::size_t> variable_map_;
     std::map<std::string, std::size_t> custom_rate_parameter_map_;
     std::vector<std::string> variable_names_{};
-    SparseMatrixPolicy<double> lower_matrix_;
-    SparseMatrixPolicy<double> upper_matrix_;
+    SparseMatrixPolicy lower_matrix_;
+    SparseMatrixPolicy upper_matrix_;
     std::size_t state_size_;
     std::size_t number_of_grid_cells_;
 

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -58,8 +58,8 @@ inline std::error_code make_error_code(MicmStateErrc e)
 namespace micm
 {
 
-  template<class MatrixPolicy,class SparseMatrixPolicy>
-  inline State<MatrixPolicy, SparseMatrixPolicy>::State()
+  template<class DenseMatrixPolicy,class SparseMatrixPolicy>
+  inline State<DenseMatrixPolicy, SparseMatrixPolicy>::State()
       : conditions_(),
         variables_(),
         custom_rate_parameters_(),
@@ -68,8 +68,8 @@ namespace micm
   {
   }
 
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  inline State<MatrixPolicy, SparseMatrixPolicy>::State(const StateParameters& parameters)
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  inline State<DenseMatrixPolicy, SparseMatrixPolicy>::State(const StateParameters& parameters)
       : conditions_(parameters.number_of_grid_cells_),
         variables_(parameters.number_of_grid_cells_, parameters.variable_names_.size(), 0.0),
         custom_rate_parameters_(parameters.number_of_grid_cells_, parameters.custom_rate_parameter_labels_.size(), 0.0),
@@ -100,8 +100,8 @@ namespace micm
     upper_matrix_ = upper_matrix;
   }
 
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  inline void State<MatrixPolicy, SparseMatrixPolicy>::SetConcentrations(
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  inline void State<DenseMatrixPolicy, SparseMatrixPolicy>::SetConcentrations(
       const std::unordered_map<std::string, std::vector<double>>& species_to_concentration)
   {
     const std::size_t num_grid_cells = conditions_.size();
@@ -109,8 +109,8 @@ namespace micm
       SetConcentration({ pair.first }, pair.second);
   }
 
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  inline void State<MatrixPolicy, SparseMatrixPolicy>::SetConcentration(const Species& species, double concentration)
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  inline void State<DenseMatrixPolicy, SparseMatrixPolicy>::SetConcentration(const Species& species, double concentration)
   {
     auto var = variable_map_.find(species.name_);
     if (var == variable_map_.end())
@@ -120,8 +120,8 @@ namespace micm
     variables_[0][variable_map_[species.name_]] = concentration;
   }
 
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  inline void State<MatrixPolicy, SparseMatrixPolicy>::SetConcentration(
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  inline void State<DenseMatrixPolicy, SparseMatrixPolicy>::SetConcentration(
       const Species& species,
       const std::vector<double>& concentration)
   {
@@ -135,8 +135,8 @@ namespace micm
       variables_[i][i_species] = concentration[i];
   }
 
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  inline void State<MatrixPolicy, SparseMatrixPolicy>::UnsafelySetCustomRateParameters(
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  inline void State<DenseMatrixPolicy, SparseMatrixPolicy>::UnsafelySetCustomRateParameters(
       const std::vector<std::vector<double>>& parameters)
   {
     if (parameters.size() != variables_.NumRows())
@@ -152,16 +152,16 @@ namespace micm
     }
   }
 
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  inline void State<MatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameters(
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  inline void State<DenseMatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameters(
       const std::unordered_map<std::string, std::vector<double>>& parameters)
   {
     for (auto& pair : parameters)
       SetCustomRateParameter(pair.first, pair.second);
   }
 
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  inline void State<MatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameter(const std::string& label, double value)
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  inline void State<DenseMatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameter(const std::string& label, double value)
   {
     auto param = custom_rate_parameter_map_.find(label);
     if (param == custom_rate_parameter_map_.end())
@@ -172,8 +172,8 @@ namespace micm
     custom_rate_parameters_[0][param->second] = value;
   }
 
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  inline void State<MatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameter(
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  inline void State<DenseMatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameter(
       const std::string& label,
       const std::vector<double>& values)
   {
@@ -187,8 +187,8 @@ namespace micm
       custom_rate_parameters_[i][param->second] = values[i];
   }
 
-  template<class MatrixPolicy, class SparseMatrixPolicy>
-  inline void State<MatrixPolicy, SparseMatrixPolicy>::PrintHeader()
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  inline void State<DenseMatrixPolicy, SparseMatrixPolicy>::PrintHeader()
   {
     auto largest_str_iter = std::max_element(
         variable_names_.begin(), variable_names_.end(), [](const auto& a, const auto& b) { return a.size() < b.size(); });
@@ -208,8 +208,8 @@ namespace micm
     std::cout << std::endl;
   }
 
-  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
-  inline void State<MatrixPolicy, SparseMatrixPolicy>::PrintState(double time)
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  inline void State<DenseMatrixPolicy, SparseMatrixPolicy>::PrintState(double time)
   {
     std::ios oldState(nullptr);
     oldState.copyfmt(std::cout);

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -58,7 +58,7 @@ inline std::error_code make_error_code(MicmStateErrc e)
 namespace micm
 {
 
-  template<template<class> class MatrixPolicy,class SparseMatrixPolicy>
+  template<class MatrixPolicy,class SparseMatrixPolicy>
   inline State<MatrixPolicy, SparseMatrixPolicy>::State()
       : conditions_(),
         variables_(),
@@ -68,7 +68,7 @@ namespace micm
   {
   }
 
-  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
+  template<class MatrixPolicy, class SparseMatrixPolicy>
   inline State<MatrixPolicy, SparseMatrixPolicy>::State(const StateParameters& parameters)
       : conditions_(parameters.number_of_grid_cells_),
         variables_(parameters.number_of_grid_cells_, parameters.variable_names_.size(), 0.0),
@@ -100,7 +100,7 @@ namespace micm
     upper_matrix_ = upper_matrix;
   }
 
-  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
+  template<class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetConcentrations(
       const std::unordered_map<std::string, std::vector<double>>& species_to_concentration)
   {
@@ -109,7 +109,7 @@ namespace micm
       SetConcentration({ pair.first }, pair.second);
   }
 
-  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
+  template<class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetConcentration(const Species& species, double concentration)
   {
     auto var = variable_map_.find(species.name_);
@@ -120,7 +120,7 @@ namespace micm
     variables_[0][variable_map_[species.name_]] = concentration;
   }
 
-  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
+  template<class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetConcentration(
       const Species& species,
       const std::vector<double>& concentration)
@@ -135,7 +135,7 @@ namespace micm
       variables_[i][i_species] = concentration[i];
   }
 
-  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
+  template<class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::UnsafelySetCustomRateParameters(
       const std::vector<std::vector<double>>& parameters)
   {
@@ -152,7 +152,7 @@ namespace micm
     }
   }
 
-  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
+  template<class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameters(
       const std::unordered_map<std::string, std::vector<double>>& parameters)
   {
@@ -160,7 +160,7 @@ namespace micm
       SetCustomRateParameter(pair.first, pair.second);
   }
 
-  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
+  template<class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameter(const std::string& label, double value)
   {
     auto param = custom_rate_parameter_map_.find(label);
@@ -172,7 +172,7 @@ namespace micm
     custom_rate_parameters_[0][param->second] = value;
   }
 
-  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
+  template<class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameter(
       const std::string& label,
       const std::vector<double>& values)
@@ -187,7 +187,7 @@ namespace micm
       custom_rate_parameters_[i][param->second] = values[i];
   }
 
-  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
+  template<class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::PrintHeader()
   {
     auto largest_str_iter = std::max_element(

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -58,7 +58,7 @@ inline std::error_code make_error_code(MicmStateErrc e)
 namespace micm
 {
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy,class SparseMatrixPolicy>
   inline State<MatrixPolicy, SparseMatrixPolicy>::State()
       : conditions_(),
         variables_(),
@@ -68,7 +68,7 @@ namespace micm
   {
   }
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
   inline State<MatrixPolicy, SparseMatrixPolicy>::State(const StateParameters& parameters)
       : conditions_(parameters.number_of_grid_cells_),
         variables_(parameters.number_of_grid_cells_, parameters.variable_names_.size(), 0.0),
@@ -93,14 +93,14 @@ namespace micm
     jacobian_ = BuildJacobian<SparseMatrixPolicy>(
         parameters.nonzero_jacobian_elements_, parameters.number_of_grid_cells_, state_size_);
 
-    auto lu = LuDecomposition::GetLUMatrices<double, SparseMatrixPolicy>(jacobian_, 1.0e-30);
+    auto lu = LuDecomposition::GetLUMatrices<SparseMatrixPolicy>(jacobian_, 1.0e-30);
     auto lower_matrix = std::move(lu.first);
     auto upper_matrix = std::move(lu.second);
     lower_matrix_ = lower_matrix;
     upper_matrix_ = upper_matrix;
   }
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetConcentrations(
       const std::unordered_map<std::string, std::vector<double>>& species_to_concentration)
   {
@@ -109,7 +109,7 @@ namespace micm
       SetConcentration({ pair.first }, pair.second);
   }
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetConcentration(const Species& species, double concentration)
   {
     auto var = variable_map_.find(species.name_);
@@ -120,7 +120,7 @@ namespace micm
     variables_[0][variable_map_[species.name_]] = concentration;
   }
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetConcentration(
       const Species& species,
       const std::vector<double>& concentration)
@@ -135,7 +135,7 @@ namespace micm
       variables_[i][i_species] = concentration[i];
   }
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::UnsafelySetCustomRateParameters(
       const std::vector<std::vector<double>>& parameters)
   {
@@ -152,7 +152,7 @@ namespace micm
     }
   }
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameters(
       const std::unordered_map<std::string, std::vector<double>>& parameters)
   {
@@ -160,7 +160,7 @@ namespace micm
       SetCustomRateParameter(pair.first, pair.second);
   }
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameter(const std::string& label, double value)
   {
     auto param = custom_rate_parameter_map_.find(label);
@@ -172,7 +172,7 @@ namespace micm
     custom_rate_parameters_[0][param->second] = value;
   }
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::SetCustomRateParameter(
       const std::string& label,
       const std::vector<double>& values)
@@ -187,7 +187,7 @@ namespace micm
       custom_rate_parameters_[i][param->second] = values[i];
   }
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::PrintHeader()
   {
     auto largest_str_iter = std::max_element(
@@ -208,7 +208,7 @@ namespace micm
     std::cout << std::endl;
   }
 
-  template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy>
+  template<template<class> class MatrixPolicy, class SparseMatrixPolicy>
   inline void State<MatrixPolicy, SparseMatrixPolicy>::PrintState(double time)
   {
     std::ios oldState(nullptr);

--- a/include/micm/util/jacobian.hpp
+++ b/include/micm/util/jacobian.hpp
@@ -13,21 +13,21 @@
 namespace micm
 {
   // annonymous namespace to hide jacobian builder
-  template<template<class> class SparseMatrixPolicy>
-  SparseMatrixPolicy<double> BuildJacobian(
+  template<class SparseMatrixPolicy>
+  SparseMatrixPolicy BuildJacobian(
       const std::set<std::pair<std::size_t, std::size_t>>& nonzero_jacobian_elements,
       std::size_t number_of_grid_cells,
       std::size_t state_size)
   {
     MICM_PROFILE_FUNCTION();
 
-    auto builder = SparseMatrixPolicy<double>::Create(state_size).SetNumberOfBlocks(number_of_grid_cells);
+    auto builder = SparseMatrixPolicy::Create(state_size).SetNumberOfBlocks(number_of_grid_cells);
     for (auto& elem : nonzero_jacobian_elements)
       builder = builder.WithElement(elem.first, elem.second);
     // Always include diagonal elements
     for (std::size_t i = 0; i < state_size; ++i)
       builder = builder.WithElement(i, i);
 
-    return SparseMatrixPolicy<double>(builder);
+    return SparseMatrixPolicy(builder);
   }
 }  // namespace micm

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -28,6 +28,12 @@ namespace micm
   template<class T = double>
   class Matrix
   {
+    public:
+    // Diagonal markowitz reordering requires an int argument, make sure one is always accessible
+    using IntMatrix = Matrix<int>;
+    using value_type = T;
+
+    private:
     std::vector<T> data_;
     std::size_t x_dim_;
     std::size_t y_dim_;

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -25,7 +25,7 @@ namespace micm
   };
 
   /// @brief A 2D array class with contiguous memory
-  template<class T>
+  template<class T = double>
   class Matrix
   {
     std::vector<T> data_;

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -24,6 +24,11 @@ namespace micm
     t.NumberOfGroups();
   };
 
+  template<class>
+  class Matrix;
+
+  using StandardDenseMatrix = Matrix<double>;
+
   /// @brief A 2D array class with contiguous memory
   template<class T = double>
   class Matrix

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -46,6 +46,8 @@ namespace micm
   class SparseMatrix : public OrderingPolicy
   {
    public:
+    // Diagonal markowitz reordering requires an int argument, make sure one is always accessible
+    using IntMatrix = SparseMatrix<int, OrderingPolicy>;
     using value_type = T;
 
    protected:

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -32,8 +32,7 @@ namespace micm
   template<class T, class OrderingPolicy = SparseMatrixStandardOrdering>
   class SparseMatrix;
 
-  template<class T>
-  using StandardSparseMatrix = SparseMatrix<T, SparseMatrixStandardOrdering>;
+  using StandardSparseMatrix = SparseMatrix<double, SparseMatrixStandardOrdering>;
 
   /// @brief A sparse block-diagonal 2D matrix class with contiguous memory
   ///
@@ -43,9 +42,12 @@ namespace micm
   ///
   /// The template parameters are the type of the matrix elements and a class that
   /// defines the sizing and ordering of the data elements
-  template<class T, class OrderingPolicy>
+  template<class T = double, class OrderingPolicy>
   class SparseMatrix : public OrderingPolicy
   {
+   public:
+    using value_type = T;
+
    protected:
     std::size_t number_of_blocks_;        // Number of block sub-matrices in the overall matrix
     std::vector<std::size_t> row_ids_;    // Row indices of each non-zero element in a block

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -31,6 +31,12 @@ namespace micm
   template<class T, std::size_t L = MICM_DEFAULT_VECTOR_SIZE>
   class VectorMatrix
   {
+    public:
+    // Diagonal markowitz reordering requires an int argument, make sure one is always accessible
+    using IntMatrix = VectorMatrix<int>;
+    using value_type = T;
+
+    private:
    protected:
     std::vector<T> data_;
     std::size_t x_dim_;  // number of rows

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -162,12 +162,12 @@ void test_analytical_troe(
     times.push_back(time_step);
     // Model results
     auto result = solver.Solve(time_step, state);
-    if constexpr (std::is_same_v<OdeSolverPolicy, micm::RosenbrockSolver<>>)
+    if constexpr (std::is_same_v<decltype(solver.process_set_), micm::ProcessSet>)
     {
       auto linear_solver = solver.linear_solver_;
       auto process_set = solver.process_set_;
       be.Solve(
-          time_step, be_state, linear_solver, process_set, processes, solver.state_parameters_.jacobian_diagonal_elements_);
+        time_step, be_state, micm::BackwardEulerSolverParameters(), linear_solver, process_set, processes, solver.state_parameters_.jacobian_diagonal_elements_);
     }
     EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     EXPECT_NEAR(k1, state.rate_constants_.AsVector()[0], 1e-8);

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -112,7 +112,6 @@ void test_analytical_troe(
   auto processes = std::vector<micm::Process>{ r1, r2 };
   OdeSolverPolicy solver = create_solver(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), processes);
 
-  micm::BackwardEuler be;
   auto be_state = solver.GetState();
 
   double temperature = 272.5;

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -71,8 +71,7 @@ void writeCSV(
 
 using yields = std::pair<micm::Species, double>;
 
-template<class T>
-using SparseMatrixTest = micm::SparseMatrix<T>;
+using SparseMatrixTest = micm::SparseMatrix<double>;
 
 template<class OdeSolverPolicy>
 void test_analytical_troe(
@@ -162,18 +161,18 @@ void test_analytical_troe(
     times.push_back(time_step);
     // Model results
     auto result = solver.Solve(time_step, state);
-    if constexpr (std::is_same_v<decltype(solver.process_set_), micm::ProcessSet>)
-    {
-      auto linear_solver = solver.linear_solver_;
-      auto process_set = solver.process_set_;
-      be.Solve(
-        time_step, be_state, micm::BackwardEulerSolverParameters(), linear_solver, process_set, processes, solver.state_parameters_.jacobian_diagonal_elements_);
-    }
+    // if constexpr (std::is_same_v<decltype(solver.process_set_), micm::ProcessSet>)
+    // {
+    //   auto linear_solver = solver.linear_solver_;
+    //   auto process_set = solver.process_set_;
+    //   be.Solve(
+    //     time_step, be_state, micm::BackwardEulerSolverParameters(), linear_solver, process_set, processes, solver.state_parameters_.jacobian_diagonal_elements_);
+    // }
     EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     EXPECT_NEAR(k1, state.rate_constants_.AsVector()[0], 1e-8);
     EXPECT_NEAR(k2, state.rate_constants_.AsVector()[1], 1e-8);
     model_concentrations[i_time] = result.result_.AsVector();
-    be_model_concentrations[i_time] = be_state.variables_[0];
+    // be_model_concentrations[i_time] = be_state.variables_[0];
     state.variables_[0] = result.result_.AsVector();
 
     // Analytical results
@@ -206,15 +205,15 @@ void test_analytical_troe(
     EXPECT_NEAR(model_concentrations[i][_c], analytical_concentrations[i][2], 1e-8)
         << "Arrays differ at index (" << i << ", " << 2 << ")";
 
-    if constexpr (std::is_same_v<OdeSolverPolicy, micm::RosenbrockSolver<>>)
-    {
-      EXPECT_NEAR(be_model_concentrations[i][_a], analytical_concentrations[i][0], 1e-4)
-          << "Arrays differ at index (" << i << ", " << 0 << ")";
-      EXPECT_NEAR(be_model_concentrations[i][_b], analytical_concentrations[i][1], 1e-4)
-          << "Arrays differ at index (" << i << ", " << 1 << ")";
-      EXPECT_NEAR(be_model_concentrations[i][_c], analytical_concentrations[i][2], 1e-4)
-          << "Arrays differ at index (" << i << ", " << 2 << ")";
-    }
+    // if constexpr (std::is_same_v<OdeSolverPolicy, micm::RosenbrockSolver<>>)
+    // {
+    //   EXPECT_NEAR(be_model_concentrations[i][_a], analytical_concentrations[i][0], 1e-4)
+    //       << "Arrays differ at index (" << i << ", " << 0 << ")";
+    //   EXPECT_NEAR(be_model_concentrations[i][_b], analytical_concentrations[i][1], 1e-4)
+    //       << "Arrays differ at index (" << i << ", " << 1 << ")";
+    //   EXPECT_NEAR(be_model_concentrations[i][_c], analytical_concentrations[i][2], 1e-4)
+    //       << "Arrays differ at index (" << i << ", " << 2 << ")";
+    // }
   }
 }
 

--- a/test/integration/analytical_rosenbrock.cpp
+++ b/test/integration/analytical_rosenbrock.cpp
@@ -9,8 +9,7 @@
 
 #include <gtest/gtest.h>
 
-template<class T>
-using SparseMatrixTest = micm::SparseMatrix<T>;
+using SparseMatrixTest = micm::SparseMatrix<double>;
 
 TEST(AnalyticalExamples, Troe)
 {

--- a/test/integration/chapman.cpp
+++ b/test/integration/chapman.cpp
@@ -14,8 +14,7 @@
 
 using yields = std::pair<micm::Species, double>;
 
-template<class T>
-using SparseMatrixTest = micm::SparseMatrix<T>;
+using SparseMatrixTest = micm::SparseMatrix<double>;
 
 #ifdef USE_JSON
 #  include <micm/configure/solver_config.hpp>

--- a/test/integration/cmake/test_micm.cpp
+++ b/test/integration/cmake/test_micm.cpp
@@ -11,8 +11,8 @@ void print_header()
             << "," << std::setw(10) << "C" << std::endl;
 }
 
-template<template<class> class T>
-void print_state(double time, State<T>& state)
+template<class StatePolicy>
+void print_state(double time, StatePolicy& state)
 {
   std::ios oldState(nullptr);
   oldState.copyfmt(std::cout);
@@ -42,7 +42,7 @@ int main()
   auto reactions = solver_params.processes_;
 
   RosenbrockSolver<> solver{ chemical_system, reactions, params };
-  State<Matrix> state = solver.GetState();
+  auto state = solver.GetState();
 
   // mol m-3
   state.variables_[0] = { 1, 0, 0 };

--- a/test/integration/e5.hpp
+++ b/test/integration/e5.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <micm/solver/rosenbrock.hpp>
+#include <micm/util/sparse_matrix.hpp>
 
 template<
     template<class> class MatrixPolicy = micm::Matrix,
-    template<class> class SparseMatrixPolicy = micm::SparseMatrix,
+    class SparseMatrixPolicy = micm::StandardSparseMatrix,
     class LinearSolverPolicy = micm::LinearSolver<double, SparseMatrixPolicy>>
 class E5 : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>
 {
@@ -22,7 +23,7 @@ class E5 : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Linea
     this->processes_ = processes;
     this->parameters_ = parameters;
 
-    auto builder = SparseMatrixPolicy<double>::Create(4).SetNumberOfBlocks(1).InitialValue(0.0);
+    auto builder = SparseMatrixPolicy::Create(4).SetNumberOfBlocks(1).InitialValue(0.0);
     for (int i = 0; i < 4; ++i)
     {
       for (int j = 0; j < 4; ++j)
@@ -31,7 +32,7 @@ class E5 : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Linea
         nonzero_jacobian_elements_.insert(std::make_pair(i, j));
       }
     }
-    SparseMatrixPolicy<double> jacobian = SparseMatrixPolicy<double>(builder);
+    SparseMatrixPolicy jacobian = SparseMatrixPolicy(builder);
 
     std::vector<std::size_t> jacobian_diagonal_elements;
     for (std::size_t i = 0; i < jacobian.NumRows(); ++i)
@@ -108,7 +109,7 @@ class E5 : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Linea
   void CalculateNegativeJacobian(
       const MatrixPolicy<double>& rate_constants,
       const MatrixPolicy<double>& number_densities,
-      SparseMatrixPolicy<double>& jacobian) override
+      SparseMatrixPolicy& jacobian) override
   {
     std::fill(jacobian.AsVector().begin(), jacobian.AsVector().end(), 0.0);
     auto data = number_densities.AsVector();

--- a/test/integration/e5.hpp
+++ b/test/integration/e5.hpp
@@ -61,9 +61,9 @@ class E5 : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Linea
   {
   }
 
-  micm::State<MatrixPolicy, SparseMatrixPolicy> GetState() const override
+  micm::State<MatrixPolicy<double>, SparseMatrixPolicy> GetState() const override
   {
-    auto state = micm::State<MatrixPolicy, SparseMatrixPolicy>{ this->state_parameters_ };
+    auto state = micm::State<MatrixPolicy<double>, SparseMatrixPolicy>{ this->state_parameters_ };
 
     state.jacobian_ = micm::BuildJacobian<SparseMatrixPolicy>(
         nonzero_jacobian_elements_,

--- a/test/integration/hires.hpp
+++ b/test/integration/hires.hpp
@@ -4,7 +4,7 @@
 
 template<
     template<class> class MatrixPolicy = micm::Matrix,
-    template<class> class SparseMatrixPolicy = micm::SparseMatrix,
+    class SparseMatrixPolicy = micm::StandardSparseMatrix,
     class LinearSolverPolicy = micm::LinearSolver<double, SparseMatrixPolicy>>
 class HIRES : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>
 {
@@ -23,7 +23,7 @@ class HIRES : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Li
     this->processes_ = processes;
     this->parameters_ = parameters;
 
-    auto builder = SparseMatrixPolicy<double>::Create(8).SetNumberOfBlocks(1).InitialValue(0.0);
+    auto builder = SparseMatrixPolicy::Create(8).SetNumberOfBlocks(1).InitialValue(0.0);
     for (int i = 0; i < 8; ++i)
     {
       for (int j = 0; j < 8; ++j)
@@ -32,7 +32,7 @@ class HIRES : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Li
         nonzero_jacobian_elements_.insert(std::make_pair(i, j));
       }
     }
-    SparseMatrixPolicy<double> jacobian = SparseMatrixPolicy<double>(builder);
+    SparseMatrixPolicy jacobian = SparseMatrixPolicy(builder);
 
     std::vector<std::size_t> jacobian_diagonal_elements;
     for (std::size_t i = 0; i < jacobian.NumRows(); ++i)
@@ -109,7 +109,7 @@ class HIRES : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Li
   void CalculateNegativeJacobian(
       const MatrixPolicy<double>& rate_constants,
       const MatrixPolicy<double>& number_densities,
-      SparseMatrixPolicy<double>& jacobian) override
+      SparseMatrixPolicy& jacobian) override
   {
     std::fill(jacobian.AsVector().begin(), jacobian.AsVector().end(), 0.0);
     auto data = number_densities.AsVector();

--- a/test/integration/hires.hpp
+++ b/test/integration/hires.hpp
@@ -61,9 +61,9 @@ class HIRES : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, Li
   {
   }
 
-  micm::State<MatrixPolicy, SparseMatrixPolicy> GetState() const override
+  micm::State<MatrixPolicy<double>, SparseMatrixPolicy> GetState() const override
   {
-    auto state = micm::State<MatrixPolicy, SparseMatrixPolicy>{ this->state_parameters_ };
+    auto state = micm::State<MatrixPolicy<double>, SparseMatrixPolicy>{ this->state_parameters_ };
 
     state.jacobian_ = micm::BuildJacobian<SparseMatrixPolicy>(
         nonzero_jacobian_elements_,

--- a/test/integration/integrated_reaction_rates.cpp
+++ b/test/integration/integrated_reaction_rates.cpp
@@ -14,8 +14,7 @@
 
 using yields = std::pair<micm::Species, double>;
 
-template<class T>
-using SparseMatrixTest = micm::SparseMatrix<T>;
+using SparseMatrixTest = micm::SparseMatrix<double>;
 
 TEST(ChapmanIntegration, CanBuildChapmanSystem)
 {

--- a/test/integration/oregonator.hpp
+++ b/test/integration/oregonator.hpp
@@ -4,7 +4,7 @@
 
 template<
     template<class> class MatrixPolicy = micm::Matrix,
-    template<class> class SparseMatrixPolicy = micm::SparseMatrix,
+    class SparseMatrixPolicy = micm::StandardSparseMatrix,
     class LinearSolverPolicy = micm::LinearSolver<double, SparseMatrixPolicy>>
 class Oregonator : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>
 {
@@ -24,7 +24,7 @@ class Oregonator : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolic
     this->parameters_ = parameters;
     this->parameters_.absolute_tolerance_ = std::vector<double>(3, 1.0e-3);
 
-    auto builder = SparseMatrixPolicy<double>::Create(3).SetNumberOfBlocks(1).InitialValue(0.0);
+    auto builder = SparseMatrixPolicy::Create(3).SetNumberOfBlocks(1).InitialValue(0.0);
     for (int i = 0; i < 3; ++i)
     {
       for (int j = 0; j < 3; ++j)
@@ -33,7 +33,7 @@ class Oregonator : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolic
         nonzero_jacobian_elements_.insert(std::make_pair(i, j));
       }
     }
-    SparseMatrixPolicy<double> jacobian = SparseMatrixPolicy<double>(builder);
+    SparseMatrixPolicy jacobian = SparseMatrixPolicy(builder);
 
     std::vector<std::size_t> jacobian_diagonal_elements;
     for (std::size_t i = 0; i < jacobian.NumRows(); ++i)
@@ -105,7 +105,7 @@ class Oregonator : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolic
   void CalculateNegativeJacobian(
       const MatrixPolicy<double>& rate_constants,
       const MatrixPolicy<double>& number_densities,
-      SparseMatrixPolicy<double>& jacobian) override
+      SparseMatrixPolicy& jacobian) override
   {
     auto data = number_densities.AsVector();
 

--- a/test/integration/oregonator.hpp
+++ b/test/integration/oregonator.hpp
@@ -62,9 +62,9 @@ class Oregonator : public micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolic
   {
   }
 
-  micm::State<MatrixPolicy, SparseMatrixPolicy> GetState() const override
+  micm::State<MatrixPolicy<double>, SparseMatrixPolicy> GetState() const override
   {
-    auto state = micm::State<MatrixPolicy, SparseMatrixPolicy>{ this->state_parameters_ };
+    auto state = micm::State<MatrixPolicy<double>, SparseMatrixPolicy>{ this->state_parameters_ };
 
     state.jacobian_ = micm::BuildJacobian<SparseMatrixPolicy>(
         nonzero_jacobian_elements_,

--- a/test/integration/terminator.cpp
+++ b/test/integration/terminator.cpp
@@ -10,10 +10,9 @@
 
 #include <gtest/gtest.h>
 
-template<class T>
-using SparseMatrixTest = micm::SparseMatrix<T>;
+using SparseMatrixTest = micm::SparseMatrix<double>;
 
-template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
+template<template<class> class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
 void RunTerminatorTest(std::size_t number_of_grid_cells)
 {
   TestTerminator<MatrixPolicy, micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>>(
@@ -56,14 +55,10 @@ using Group3VectorMatrix = micm::VectorMatrix<T, 3>;
 template<class T>
 using Group4VectorMatrix = micm::VectorMatrix<T, 4>;
 
-template<class T>
-using Group1SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
-template<class T>
-using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
-template<class T>
-using Group3SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
-template<class T>
-using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+using Group1SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>;
+using Group2SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<2>>;
+using Group3SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
+using Group4SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<4>>;
 
 TEST(RosenbrockSolver, VectorTerminator)
 {

--- a/test/regression/RosenbrockChapman/regression_test_dforce_dy_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_dforce_dy_policy.hpp
@@ -51,8 +51,7 @@ void testJacobian(OdeSolverPolicy& solver)
 
 template<class T>
 using DenseMatrix = micm::Matrix<T>;
-template<class T>
-using SparseMatrix = micm::SparseMatrix<T>;
+using SparseMatrix = micm::SparseMatrix<double>;
 
 template<class T>
 using Group1VectorMatrix = micm::VectorMatrix<T, 1>;
@@ -63,11 +62,7 @@ using Group3VectorMatrix = micm::VectorMatrix<T, 3>;
 template<class T>
 using Group4VectorMatrix = micm::VectorMatrix<T, 4>;
 
-template<class T>
-using Group1SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
-template<class T>
-using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
-template<class T>
-using Group3SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
-template<class T>
-using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+using Group1SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>;
+using Group2SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<2>>;
+using Group3SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
+using Group4SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<4>>;

--- a/test/regression/RosenbrockChapman/regression_test_p_force_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_p_force_policy.hpp
@@ -85,8 +85,7 @@ void testForcing(OdeSolverPolicy& solver)
 
 template<class T>
 using DenseMatrix = micm::Matrix<T>;
-template<class T>
-using SparseMatrix = micm::SparseMatrix<T>;
+using SparseMatrix = micm::SparseMatrix<double>;
 
 template<class T>
 using Group1VectorMatrix = micm::VectorMatrix<T, 1>;
@@ -97,11 +96,7 @@ using Group3VectorMatrix = micm::VectorMatrix<T, 3>;
 template<class T>
 using Group4VectorMatrix = micm::VectorMatrix<T, 4>;
 
-template<class T>
-using Group1SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
-template<class T>
-using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
-template<class T>
-using Group3SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
-template<class T>
-using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+using Group1SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>;
+using Group2SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<2>>;
+using Group3SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
+using Group4SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<4>>;

--- a/test/regression/RosenbrockChapman/regression_test_solve_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_solve_policy.hpp
@@ -66,8 +66,8 @@ void testSolve(OdeSolverPolicy& solver, double relative_tolerance = 1.0e-8)
 
 template<class T>
 using DenseMatrix = micm::Matrix<T>;
-template<class T>
-using SparseMatrix = micm::SparseMatrix<T>;
+
+using SparseMatrix = micm::SparseMatrix<double>;
 
 template<class T>
 using Group1VectorMatrix = micm::VectorMatrix<T, 1>;
@@ -78,11 +78,7 @@ using Group3VectorMatrix = micm::VectorMatrix<T, 3>;
 template<class T>
 using Group4VectorMatrix = micm::VectorMatrix<T, 4>;
 
-template<class T>
-using Group1SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
-template<class T>
-using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
-template<class T>
-using Group3SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
-template<class T>
-using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+using Group1SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>;
+using Group2SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<2>>;
+using Group3SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
+using Group4SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<4>>;

--- a/test/regression/RosenbrockChapman/util.hpp
+++ b/test/regression/RosenbrockChapman/util.hpp
@@ -83,7 +83,7 @@ std::vector<micm::Process> createProcesses(const micm::Phase& gas_phase)
   return { photo_1, photo_2, photo_3, r1, r2, r3, r4 };
 }
 
-template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
+template<template<class> class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
 micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> getTwoStageMultiCellChapmanSolver(
     const size_t number_of_grid_cells)
 {
@@ -97,7 +97,7 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> get
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::move(processes), options);
 }
 
-template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
+template<template<class> class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
 micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> getThreeStageMultiCellChapmanSolver(
     const size_t number_of_grid_cells)
 {
@@ -111,7 +111,7 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> get
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::move(processes), options);
 }
 
-template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
+template<template<class> class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
 micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> getFourStageMultiCellChapmanSolver(
     const size_t number_of_grid_cells)
 {
@@ -125,7 +125,7 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> get
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::move(processes), options);
 }
 
-template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
+template<template<class> class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
 micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> getFourStageDAMultiCellChapmanSolver(
     const size_t number_of_grid_cells)
 {
@@ -139,7 +139,7 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> get
       micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }), std::move(processes), options);
 }
 
-template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
+template<template<class> class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
 micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> getSixStageDAMultiCellChapmanSolver(
     const size_t number_of_grid_cells)
 {

--- a/test/tutorial/test_README_example.cpp
+++ b/test/tutorial/test_README_example.cpp
@@ -30,21 +30,52 @@ int main(const int argc, const char *argv[])
 
   std::vector<Process> reactions{ r1, r2 };
 
-  RosenbrockSolver<> solver{ chemical_system, reactions, RosenbrockSolverParameters::ThreeStageRosenbrockParameters() };
+#if 0
+  auto rosenbrock_solver = Solver::Create()
+                    .SetSystem(chemical_system)
+                    .SetReactions(reactions)
+                    .SetNumberOfGridCells(19)
+                    .Rosenbrock<MatrixPolicy, SparseMatrixPolicy>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
 
-  State state = solver.GetState();
+  auto backward_euler_solver = Solver::Create()
+                    .SetSystem(chemical_system)
+                    .SetReactions(reactions)
+                    .SetNumberOfGridCells(19)
+                    .BackwardEuler(BackwardEulerParameters::CamChemParameters());
 
-  state.conditions_[0].temperature_ = 287.45;  // K
-  state.conditions_[0].pressure_ = 101319.9;   // Pa
-  state.SetConcentration(foo, 20.0);           // mol m-3
+  auto cuda_solver = Solver::Create()
+                    .SetSystem(chemical_system)
+                    .SetReactions(reactions)
+                    .SetNumberOfGridCells(19)
+                    .Rosenbrock<CudaDenseMatrixPolicy, CudaSparseMatrixPolicy>(RosenbrockSolverParameters::ThreeStageRosenbrockParameter());
+  
 
-  state.PrintHeader();
+  auto rosenbrock_state = rosenbrock_solver.GetState();
+  auto backward_euler_state = backward_euler_solver.GetState();
+  auto cuda_state = cuda_solver.GetState();
+
+  rosenbrock_state.conditions_[0].temperature_ = 287.45;  // K
+  rosenbrock_state.conditions_[0].pressure_ = 101319.9;   // Pa
+  rosenbrock_state.SetConcentration(foo, 20.0);           // mol m-3
+
+  backward_euler_state.conditions_[0].temperature_ = 287.45;  // K
+  backward_euler_state.conditions_[0].pressure_ = 101319.9;   // Pa
+  backward_euler_state.SetConcentration(foo, 20.0);           // mol m-3
+
+  cuda_state.conditions_[0].temperature_ = 287.45;  // K
+  cuda_state.conditions_[0].pressure_ = 101319.9;   // Pa
+  cuda_state.SetConcentration(foo, 20.0);           // mol m-3
+
+  cuda_state.PrintHeader();
   for (int i = 0; i < 10; ++i)
   {
-    auto result = solver.Solve(500.0, state);
-    state.variables_ = result.result_;
-    state.PrintState(i * 500);
+    cuda_state.CalculateRateConstants(); // calculate rate constants on the host
+    cuda_state.SyncToDevice();
+    auto result = cuda_solver.Solve(500.0, cuda_state); // solve on the device
+    cuda_state.variables_ = result.result_; // device to device copy with overloaded operator=
+    cuda_state.SyncToHost();
+    cuda_state.PrintState(i * 500);
   }
-
+#endif
   return 0;
 }

--- a/test/tutorial/test_vectorized_matrix_solver.cpp
+++ b/test/tutorial/test_vectorized_matrix_solver.cpp
@@ -15,8 +15,7 @@ using namespace micm;
 template<typename T>
 using Group3Matrix = micm::VectorMatrix<T, 3>;
 
-template<typename T>
-using Group3SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
+using Group3SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
 
 void solve(auto& solver, auto& state)
 {

--- a/test/unit/process/test_jit_process_set.cpp
+++ b/test/unit/process/test_jit_process_set.cpp
@@ -9,17 +9,12 @@
 
 #include <random>
 
-template<class T>
-using Group2VectorMatrix = micm::VectorMatrix<T, 2>;
-template<class T>
-using Group200VectorMatrix = micm::VectorMatrix<T, 200>;
-template<class T>
-using Group300VectorMatrix = micm::VectorMatrix<T, 300>;
-template<class T>
-using Group400VectorMatrix = micm::VectorMatrix<T, 400>;
+using Group2VectorMatrix = micm::VectorMatrix<double, 2>;
+using Group200VectorMatrix = micm::VectorMatrix<double, 200>;
+using Group300VectorMatrix = micm::VectorMatrix<double, 300>;
+using Group400VectorMatrix = micm::VectorMatrix<double, 400>;
 
-template<class T>
-using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
+using Group2SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<2>>;
 
 TEST(JitProcessSet, VectorMatrix)
 {

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -9,7 +9,7 @@
 
 #include <random>
 
-template<template<class> class MatrixPolicy>
+template<class DenseMatrixPolicy>
 void testProcessUpdateState(const std::size_t number_of_grid_cells)
 {
   micm::Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }, { "diffusion coefficient [m2 s-1]", 2.3e2 } });
@@ -29,14 +29,14 @@ void testProcessUpdateState(const std::size_t number_of_grid_cells)
   for (const auto& process : processes)
     for (auto& label : process.rate_constant_->CustomParameters())
       param_labels.push_back(label);
-  micm::State<MatrixPolicy> state{ micm::StateParameters{
+  micm::State<DenseMatrixPolicy> state{ micm::StateParameters{
       .number_of_grid_cells_ = number_of_grid_cells,
       .number_of_rate_constants_ = processes.size(),
       .variable_names_ = { "foo", "bar'" },
       .custom_rate_parameter_labels_ = param_labels,
   } };
 
-  MatrixPolicy<double> expected_rate_constants(number_of_grid_cells, 3, 0.0);
+  DenseMatrixPolicy expected_rate_constants(number_of_grid_cells, 3, 0.0);
   std::vector<double> params = { 0.0, 0.0, 0.0 };
   auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
 
@@ -82,15 +82,15 @@ using Group4VectorMatrix = micm::VectorMatrix<T, 4>;
 
 TEST(Process, Matrix)
 {
-  testProcessUpdateState<micm::Matrix>(5);
+  testProcessUpdateState<micm::Matrix<double>>(5);
 }
 
 TEST(Process, VectorMatrix)
 {
-  testProcessUpdateState<Group1VectorMatrix>(5);
-  testProcessUpdateState<Group2VectorMatrix>(5);
-  testProcessUpdateState<Group3VectorMatrix>(5);
-  testProcessUpdateState<Group4VectorMatrix>(5);
+  testProcessUpdateState<Group1VectorMatrix<double>>(5);
+  testProcessUpdateState<Group2VectorMatrix<double>>(5);
+  testProcessUpdateState<Group3VectorMatrix<double>>(5);
+  testProcessUpdateState<Group4VectorMatrix<double>>(5);
 }
 
 TEST(Process, SurfaceRateConstantOnlyHasOneReactant)

--- a/test/unit/process/test_process_set.cpp
+++ b/test/unit/process/test_process_set.cpp
@@ -11,8 +11,7 @@
 
 #include <random>
 
-template<class T>
-using SparseMatrixTest = micm::SparseMatrix<T>;
+using SparseMatrixTest = micm::SparseMatrix<double>;
 
 template<class T>
 using Group1VectorMatrix = micm::VectorMatrix<T, 1>;
@@ -23,46 +22,22 @@ using Group3VectorMatrix = micm::VectorMatrix<T, 3>;
 template<class T>
 using Group4VectorMatrix = micm::VectorMatrix<T, 4>;
 
-template<class T>
-using Group1SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
-template<class T>
-using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
-template<class T>
-using Group3SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
-template<class T>
-using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+using Group1SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>;
+using Group2SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<2>>;
+using Group3SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
+using Group4SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<4>>;
 
 TEST(ProcessSet, Matrix)
 {
-  testProcessSet<micm::Matrix, SparseMatrixTest, micm::ProcessSet>(
-      [](const std::vector<micm::Process>& processes,
-         const micm::State<micm::Matrix, SparseMatrixTest>& state) -> micm::ProcessSet {
-        return micm::ProcessSet{ processes, state.variable_map_ };
-      });
+  testProcessSet<micm::Matrix, SparseMatrixTest, micm::ProcessSet>();
 }
 
 TEST(ProcessSet, VectorMatrix)
 {
-  testProcessSet<Group1VectorMatrix, Group1SparseVectorMatrix, micm::ProcessSet>(
-      [](const std::vector<micm::Process>& processes,
-         const micm::State<Group1VectorMatrix, Group1SparseVectorMatrix>& state) -> micm::ProcessSet {
-        return micm::ProcessSet{ processes, state.variable_map_ };
-      });
-  testProcessSet<Group2VectorMatrix, Group2SparseVectorMatrix, micm::ProcessSet>(
-      [](const std::vector<micm::Process>& processes,
-         const micm::State<Group2VectorMatrix, Group2SparseVectorMatrix>& state) -> micm::ProcessSet {
-        return micm::ProcessSet{ processes, state.variable_map_ };
-      });
-  testProcessSet<Group3VectorMatrix, Group3SparseVectorMatrix, micm::ProcessSet>(
-      [](const std::vector<micm::Process>& processes,
-         const micm::State<Group3VectorMatrix, Group3SparseVectorMatrix>& state) -> micm::ProcessSet {
-        return micm::ProcessSet{ processes, state.variable_map_ };
-      });
-  testProcessSet<Group4VectorMatrix, Group4SparseVectorMatrix, micm::ProcessSet>(
-      [](const std::vector<micm::Process>& processes,
-         const micm::State<Group4VectorMatrix, Group4SparseVectorMatrix>& state) -> micm::ProcessSet {
-        return micm::ProcessSet{ processes, state.variable_map_ };
-      });
+  testProcessSet<Group1VectorMatrix, Group1SparseVectorMatrix, micm::ProcessSet>();
+  testProcessSet<Group2VectorMatrix, Group2SparseVectorMatrix, micm::ProcessSet>();
+  testProcessSet<Group3VectorMatrix, Group3SparseVectorMatrix, micm::ProcessSet>();
+  testProcessSet<Group4VectorMatrix, Group4SparseVectorMatrix, micm::ProcessSet>();
 }
 
 TEST(RandomProcessSet, Matrix)

--- a/test/unit/process/test_process_set.cpp
+++ b/test/unit/process/test_process_set.cpp
@@ -13,14 +13,10 @@
 
 using SparseMatrixTest = micm::SparseMatrix<double>;
 
-template<class T>
-using Group1VectorMatrix = micm::VectorMatrix<T, 1>;
-template<class T>
-using Group2VectorMatrix = micm::VectorMatrix<T, 2>;
-template<class T>
-using Group3VectorMatrix = micm::VectorMatrix<T, 3>;
-template<class T>
-using Group4VectorMatrix = micm::VectorMatrix<T, 4>;
+using Group1VectorMatrix = micm::VectorMatrix<double, 1>;
+using Group2VectorMatrix = micm::VectorMatrix<double, 2>;
+using Group3VectorMatrix = micm::VectorMatrix<double, 3>;
+using Group4VectorMatrix = micm::VectorMatrix<double, 4>;
 
 using Group1SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>;
 using Group2SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<2>>;
@@ -29,7 +25,7 @@ using Group4SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVe
 
 TEST(ProcessSet, Matrix)
 {
-  testProcessSet<micm::Matrix, SparseMatrixTest, micm::ProcessSet>();
+  testProcessSet<micm::Matrix<double>, SparseMatrixTest, micm::ProcessSet>();
 }
 
 TEST(ProcessSet, VectorMatrix)
@@ -42,28 +38,28 @@ TEST(ProcessSet, VectorMatrix)
 
 TEST(RandomProcessSet, Matrix)
 {
-  testRandomSystem<micm::Matrix, SparseMatrixTest, micm::ProcessSet>(
+  testRandomSystem<micm::Matrix<double>, SparseMatrixTest, micm::ProcessSet>(
       200,
       50,
       40,
       [](const std::vector<micm::Process>& processes,
-         const micm::State<micm::Matrix, SparseMatrixTest>& state) -> micm::ProcessSet {
+         const micm::State<micm::Matrix<double>, SparseMatrixTest>& state) -> micm::ProcessSet {
         return micm::ProcessSet{ processes, state.variable_map_ };
       });
-  testRandomSystem<micm::Matrix, SparseMatrixTest, micm::ProcessSet>(
+  testRandomSystem<micm::Matrix<double>, SparseMatrixTest, micm::ProcessSet>(
       300,
       30,
       20,
       [](const std::vector<micm::Process>& processes,
-         const micm::State<micm::Matrix, SparseMatrixTest>& state) -> micm::ProcessSet {
+         const micm::State<micm::Matrix<double>, SparseMatrixTest>& state) -> micm::ProcessSet {
         return micm::ProcessSet{ processes, state.variable_map_ };
       });
-  testRandomSystem<micm::Matrix, SparseMatrixTest, micm::ProcessSet>(
+  testRandomSystem<micm::Matrix<double>, SparseMatrixTest, micm::ProcessSet>(
       400,
       100,
       80,
       [](const std::vector<micm::Process>& processes,
-         const micm::State<micm::Matrix, SparseMatrixTest>& state) -> micm::ProcessSet {
+         const micm::State<micm::Matrix<double>, SparseMatrixTest>& state) -> micm::ProcessSet {
         return micm::ProcessSet{ processes, state.variable_map_ };
       });
 }

--- a/test/unit/solver/CMakeLists.txt
+++ b/test/unit/solver/CMakeLists.txt
@@ -12,6 +12,7 @@ create_standard_test(NAME lu_decomposition SOURCES test_lu_decomposition.cpp)
 create_standard_test(NAME rosenbrock SOURCES test_rosenbrock.cpp)
 create_standard_test(NAME state SOURCES test_state.cpp)
 create_standard_test(NAME backward_euler SOURCES test_backward_euler.cpp)
+create_standard_test(NAME solver_builder SOURCES test_solver_builder.cpp)
 
 # GPU tests
 if(MICM_ENABLE_CUDA)

--- a/test/unit/solver/test_backward_euler.cpp
+++ b/test/unit/solver/test_backward_euler.cpp
@@ -53,6 +53,9 @@ TEST(BackwardEuler, CanCallSolve)
   auto process_set = rosenbrock.process_set_;
   auto processes = std::vector<micm::Process>{ r1, r2 };
 
+  auto params = micm::BackwardEulerSolverParameters();
+  params.absolute_tolerance_ = { 1e-6, 1e-6, 1e-6 };
+
   EXPECT_NO_THROW(be.Solve(
-      time_step, state, micm::BackwardEulerSolverParameters(), linear_solver, process_set, processes, rosenbrock.state_parameters_.jacobian_diagonal_elements_));
+      time_step, state, params, linear_solver, process_set, processes, rosenbrock.state_parameters_.jacobian_diagonal_elements_));
 }

--- a/test/unit/solver/test_backward_euler.cpp
+++ b/test/unit/solver/test_backward_euler.cpp
@@ -54,5 +54,5 @@ TEST(BackwardEuler, CanCallSolve)
   auto processes = std::vector<micm::Process>{ r1, r2 };
 
   EXPECT_NO_THROW(be.Solve(
-      time_step, state, linear_solver, process_set, processes, rosenbrock.state_parameters_.jacobian_diagonal_elements_));
+      time_step, state, micm::BackwardEulerSolverParameters(), linear_solver, process_set, processes, rosenbrock.state_parameters_.jacobian_diagonal_elements_));
 }

--- a/test/unit/solver/test_backward_euler.cpp
+++ b/test/unit/solver/test_backward_euler.cpp
@@ -1,21 +1,11 @@
-#include <micm/solver/backward_euler.hpp>
-#include <micm/solver/rosenbrock.hpp>
+#include <micm/solver/solver_builder.hpp>
 
 #include <gtest/gtest.h>
 
 #include <algorithm>
 #include <random>
 
-TEST(BackwardEuler, DefaultConstructor)
-{
-  EXPECT_NO_THROW(micm::BackwardEuler be);
-}
-
-TEST(BackwardEuler, CanCallSolve)
-{
-  micm::BackwardEuler be;
-  double time_step = 1.0;
-
+namespace {
   auto a = micm::Species("A");
   auto b = micm::Species("B");
   auto c = micm::Species("C");
@@ -35,27 +25,29 @@ TEST(BackwardEuler, CanCallSolve)
                              micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .B_ = 0, .C_ = 55 }))
                          .SetPhase(gas_phase);
 
-  auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
-  options.ignore_unused_species_ = true;
+  auto the_system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+  std::vector<micm::Process> reactions = { r1, r2 };
+}
 
-  micm::RosenbrockSolver<> rosenbrock{ micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }),
-                                       std::vector<micm::Process>{ r1, r2 },
-                                       options };
+TEST(BackwardEuler, CanCallSolve)
+{
+  auto params = micm::BackwardEulerSolverParameters();
+  params.absolute_tolerance_ = { 1e-6, 1e-6, 1e-6 };
 
-  auto state = rosenbrock.GetState();
+  auto be = micm::CpuSolverBuilder<micm::Matrix<double>, micm::SparseMatrix<double>>()
+                            .SetSystem(the_system)
+                            .SetReactions(reactions)
+                            .SetNumberOfGridCells(1)
+                            .SetSolverParameters(params)
+                            .Build();
+  double time_step = 1.0;
+
+  auto state = be.GetState();
 
   state.variables_[0] = { 1.0, 0.0, 0.0 };
   state.conditions_[0].temperature_ = 272.5;
   state.conditions_[0].pressure_ = 101253.3;
   state.conditions_[0].air_density_ = 1e6;
 
-  auto linear_solver = rosenbrock.linear_solver_;
-  auto process_set = rosenbrock.process_set_;
-  auto processes = std::vector<micm::Process>{ r1, r2 };
-
-  auto params = micm::BackwardEulerSolverParameters();
-  params.absolute_tolerance_ = { 1e-6, 1e-6, 1e-6 };
-
-  EXPECT_NO_THROW(be.Solve(
-      time_step, state, params, linear_solver, process_set, processes, rosenbrock.state_parameters_.jacobian_diagonal_elements_));
+  EXPECT_NO_THROW(be.Solve(time_step, state));
 }

--- a/test/unit/solver/test_chapman_ode_solver.cpp
+++ b/test/unit/solver/test_chapman_ode_solver.cpp
@@ -210,7 +210,7 @@ TEST(ChapmanMechanismHardCodedAndGeneral, dforce_dy_times_vector)
 
 void TestSolve(micm::ChapmanODESolver& solver)
 {
-  micm::State<micm::Matrix> state = solver.GetState();
+  micm::State<micm::Matrix<double>> state = solver.GetState();
   state.variables_[0] = { 1, 3.92e-1, 1.69e-2, 0, 3.29e1, 0, 0, 8.84, 0 };
   //"M"   "Ar"     "CO2",   "H2O", "N2",   "O1D", "O", "O2", "O3",
   state.conditions_[0].temperature_ = 273.15;
@@ -245,7 +245,7 @@ TEST(ChapmanMechanismHardCodedAndGeneral, Solve)
 
 void TestSolve10TimesLarger(micm::ChapmanODESolver& solver)
 {
-  micm::State<micm::Matrix> state = solver.GetState();
+  micm::State<micm::Matrix<double>> state = solver.GetState();
   state.variables_[0] = { 1, 3.92e-1, 1.69e-2, 0, 3.29e1, 0, 0, 8.84, 0 };
   //"M"   "Ar"     "CO2",   "H2O", "N2",   "O1D", "O", "O2", "O3",
   state.conditions_[0].temperature_ = 273.15;
@@ -283,7 +283,7 @@ TEST(ChapmanMechanismHardCodedAndGeneral, solve_10_times_larger)
 
 void TestSolve10TimesSmaller(micm::ChapmanODESolver& solver)
 {
-  micm::State<micm::Matrix> state = solver.GetState();
+  micm::State<micm::Matrix<double>> state = solver.GetState();
   state.variables_[0] = { 1, 3.92e-1, 1.69e-2, 0, 3.29e1, 0, 0, 8.84, 0 };
   //"M"   "Ar"     "CO2",   "H2O", "N2",   "O1D", "O", "O2", "O3",
   state.conditions_[0].temperature_ = 273.15;
@@ -321,7 +321,7 @@ TEST(RegressionChapmanODESolver, solve_10_times_smaller)
 
 void TestSolveWithRandomNumberDensities(micm::ChapmanODESolver& solver)
 {
-  micm::State<micm::Matrix> state = solver.GetState();
+  micm::State<micm::Matrix<double>> state = solver.GetState();
   state.conditions_[0].temperature_ = 273.15;
   state.conditions_[0].pressure_ = 1000 * 100;  // 1000 hPa
   state.conditions_[0].air_density_ = 2.7e19;

--- a/test/unit/solver/test_linear_solver.cpp
+++ b/test/unit/solver/test_linear_solver.cpp
@@ -10,22 +10,24 @@
 
 #include <functional>
 
-using DenseMatrixTest = micm::Matrix<double>;
-using SparseMatrixTest = micm::SparseMatrix<double>;
+using FloatingPointType = double;
+
+using DenseMatrixTest = micm::Matrix<FloatingPointType>;
+using SparseMatrixTest = micm::SparseMatrix<FloatingPointType>;
 
 TEST(LinearSolver, DenseMatrixStandardOrdering)
 {
-  testDenseMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<double, micm::SparseMatrix<>>>();
+  testDenseMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<FloatingPointType, SparseMatrixTest>>();
 }
 
 TEST(LinearSolver, RandomMatrixStandardOrdering)
 {
-  testRandomMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<double, micm::SparseMatrix<>>>(5);
+  testRandomMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<FloatingPointType, SparseMatrixTest>>(5);
 }
 
 TEST(LinearSolver, DiagonalMatrixStandardOrdering)
 {
-  testDiagonalMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<double, micm::SparseMatrix<>>>(5);
+  testDiagonalMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<FloatingPointType, SparseMatrixTest>>(5);
 }
 
 TEST(LinearSolver, DiagonalMarkowitzReorder)
@@ -33,38 +35,38 @@ TEST(LinearSolver, DiagonalMarkowitzReorder)
   testMarkowitzReordering<micm::Matrix<int>, SparseMatrixTest>();
 }
 
-using Group1VectorMatrix = micm::VectorMatrix<double, 1>;
-using Group2VectorMatrix = micm::VectorMatrix<double, 2>;
-using Group3VectorMatrix = micm::VectorMatrix<double, 3>;
-using Group4VectorMatrix = micm::VectorMatrix<double, 4>;
+using Group1VectorMatrix = micm::VectorMatrix<FloatingPointType, 1>;
+using Group2VectorMatrix = micm::VectorMatrix<FloatingPointType, 2>;
+using Group3VectorMatrix = micm::VectorMatrix<FloatingPointType, 3>;
+using Group4VectorMatrix = micm::VectorMatrix<FloatingPointType, 4>;
 
-using Group1SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>;
-using Group2SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<2>>;
-using Group3SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
-using Group4SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<4>>;
+using Group1SparseVectorMatrix = micm::SparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<1>>;
+using Group2SparseVectorMatrix = micm::SparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<2>>;
+using Group3SparseVectorMatrix = micm::SparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<3>>;
+using Group4SparseVectorMatrix = micm::SparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<4>>;
 
 TEST(LinearSolver, DenseMatrixVectorOrdering)
 {
-  testDenseMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<double, Group1SparseVectorMatrix>>();
-  testDenseMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<double, Group2SparseVectorMatrix>>();
-  testDenseMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<double, Group3SparseVectorMatrix>>();
-  testDenseMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<double, Group4SparseVectorMatrix>>();
+  testDenseMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<FloatingPointType, Group1SparseVectorMatrix>>();
+  testDenseMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<FloatingPointType, Group2SparseVectorMatrix>>();
+  testDenseMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<FloatingPointType, Group3SparseVectorMatrix>>();
+  testDenseMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<FloatingPointType, Group4SparseVectorMatrix>>();
 }
 
 TEST(LinearSolver, RandomMatrixVectorOrdering)
 {
-  testRandomMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<double, Group1SparseVectorMatrix>>(5);
-  testRandomMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<double, Group2SparseVectorMatrix>>(5);
-  testRandomMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<double, Group3SparseVectorMatrix>>(5);
-  testRandomMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<double, Group4SparseVectorMatrix>>(5);
+  testRandomMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<FloatingPointType, Group1SparseVectorMatrix>>(5);
+  testRandomMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<FloatingPointType, Group2SparseVectorMatrix>>(5);
+  testRandomMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<FloatingPointType, Group3SparseVectorMatrix>>(5);
+  testRandomMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<FloatingPointType, Group4SparseVectorMatrix>>(5);
 }
 
 TEST(LinearSolver, DiagonalMatrixVectorOrdering)
 {
-  testDiagonalMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<double, Group1SparseVectorMatrix>>(5);
-  testDiagonalMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<double, Group2SparseVectorMatrix>>(5);
-  testDiagonalMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<double, Group3SparseVectorMatrix>>(5);
-  testDiagonalMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<double, Group4SparseVectorMatrix>>(5);
+  testDiagonalMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<FloatingPointType, Group1SparseVectorMatrix>>(5);
+  testDiagonalMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<FloatingPointType, Group2SparseVectorMatrix>>(5);
+  testDiagonalMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<FloatingPointType, Group3SparseVectorMatrix>>(5);
+  testDiagonalMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<FloatingPointType, Group4SparseVectorMatrix>>(5);
 }
 
 TEST(LinearSolver, VectorDiagonalMarkowitzReordering)

--- a/test/unit/solver/test_linear_solver.cpp
+++ b/test/unit/solver/test_linear_solver.cpp
@@ -10,136 +10,61 @@
 
 #include <functional>
 
-template<class T>
-using SparseMatrixTest = micm::SparseMatrix<T>;
+using DenseMatrixTest = micm::Matrix<double>;
+using SparseMatrixTest = micm::SparseMatrix<double>;
 
 TEST(LinearSolver, DenseMatrixStandardOrdering)
 {
-  testDenseMatrix<micm::Matrix, SparseMatrixTest, micm::LinearSolver<double, SparseMatrixTest>>(
-      [](const SparseMatrixTest<double>& matrix, double initial_value) -> micm::LinearSolver<double, SparseMatrixTest> {
-        return micm::LinearSolver<double, SparseMatrixTest>{ matrix, initial_value };
-      });
+  testDenseMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<double, micm::SparseMatrix<>>>();
 }
 
 TEST(LinearSolver, RandomMatrixStandardOrdering)
 {
-  testRandomMatrix<micm::Matrix, SparseMatrixTest, micm::LinearSolver<double, SparseMatrixTest>>(
-      [](const SparseMatrixTest<double>& matrix, double initial_value) -> micm::LinearSolver<double, SparseMatrixTest> {
-        return micm::LinearSolver<double, SparseMatrixTest>{ matrix, initial_value };
-      },
-      5);
+  testRandomMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<double, micm::SparseMatrix<>>>(5);
 }
 
 TEST(LinearSolver, DiagonalMatrixStandardOrdering)
 {
-  testDiagonalMatrix<micm::Matrix, SparseMatrixTest, micm::LinearSolver<double, SparseMatrixTest>>(
-      [](const SparseMatrixTest<double>& matrix, double initial_value) -> micm::LinearSolver<double, SparseMatrixTest> {
-        return micm::LinearSolver<double, SparseMatrixTest>{ matrix, initial_value };
-      },
-      5);
+  testDiagonalMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<double, micm::SparseMatrix<>>>(5);
 }
 
 TEST(LinearSolver, DiagonalMarkowitzReorder)
 {
-  testMarkowitzReordering<micm::Matrix, SparseMatrixTest>();
+  testMarkowitzReordering<micm::Matrix<int>, SparseMatrixTest>();
 }
 
-template<class T>
-using Group1VectorMatrix = micm::VectorMatrix<T, 1>;
-template<class T>
-using Group2VectorMatrix = micm::VectorMatrix<T, 2>;
-template<class T>
-using Group3VectorMatrix = micm::VectorMatrix<T, 3>;
-template<class T>
-using Group4VectorMatrix = micm::VectorMatrix<T, 4>;
+using Group1VectorMatrix = micm::VectorMatrix<double, 1>;
+using Group2VectorMatrix = micm::VectorMatrix<double, 2>;
+using Group3VectorMatrix = micm::VectorMatrix<double, 3>;
+using Group4VectorMatrix = micm::VectorMatrix<double, 4>;
 
-template<class T>
-using Group1SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
-template<class T>
-using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
-template<class T>
-using Group3SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
-template<class T>
-using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+using Group1SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>;
+using Group2SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<2>>;
+using Group3SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
+using Group4SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<4>>;
 
 TEST(LinearSolver, DenseMatrixVectorOrdering)
 {
-  testDenseMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<double, Group1SparseVectorMatrix>>(
-      [](const Group1SparseVectorMatrix<double>& matrix,
-         double initial_value) -> micm::LinearSolver<double, Group1SparseVectorMatrix> {
-        return micm::LinearSolver<double, Group1SparseVectorMatrix>{ matrix, initial_value };
-      });
-  testDenseMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<double, Group2SparseVectorMatrix>>(
-      [](const Group2SparseVectorMatrix<double>& matrix,
-         double initial_value) -> micm::LinearSolver<double, Group2SparseVectorMatrix> {
-        return micm::LinearSolver<double, Group2SparseVectorMatrix>{ matrix, initial_value };
-      });
-  testDenseMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<double, Group3SparseVectorMatrix>>(
-      [](const Group3SparseVectorMatrix<double>& matrix,
-         double initial_value) -> micm::LinearSolver<double, Group3SparseVectorMatrix> {
-        return micm::LinearSolver<double, Group3SparseVectorMatrix>{ matrix, initial_value };
-      });
-  testDenseMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<double, Group4SparseVectorMatrix>>(
-      [](const Group4SparseVectorMatrix<double>& matrix,
-         double initial_value) -> micm::LinearSolver<double, Group4SparseVectorMatrix> {
-        return micm::LinearSolver<double, Group4SparseVectorMatrix>{ matrix, initial_value };
-      });
+  testDenseMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<double, Group1SparseVectorMatrix>>();
+  testDenseMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<double, Group2SparseVectorMatrix>>();
+  testDenseMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<double, Group3SparseVectorMatrix>>();
+  testDenseMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<double, Group4SparseVectorMatrix>>();
 }
 
 TEST(LinearSolver, RandomMatrixVectorOrdering)
 {
-  testRandomMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<double, Group1SparseVectorMatrix>>(
-      [](const Group1SparseVectorMatrix<double>& matrix,
-         double initial_value) -> micm::LinearSolver<double, Group1SparseVectorMatrix> {
-        return micm::LinearSolver<double, Group1SparseVectorMatrix>{ matrix, initial_value };
-      },
-      5);
-  testRandomMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<double, Group2SparseVectorMatrix>>(
-      [](const Group2SparseVectorMatrix<double>& matrix,
-         double initial_value) -> micm::LinearSolver<double, Group2SparseVectorMatrix> {
-        return micm::LinearSolver<double, Group2SparseVectorMatrix>{ matrix, initial_value };
-      },
-      5);
-  testRandomMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<double, Group3SparseVectorMatrix>>(
-      [](const Group3SparseVectorMatrix<double>& matrix,
-         double initial_value) -> micm::LinearSolver<double, Group3SparseVectorMatrix> {
-        return micm::LinearSolver<double, Group3SparseVectorMatrix>{ matrix, initial_value };
-      },
-      5);
-  testRandomMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<double, Group4SparseVectorMatrix>>(
-      [](const Group4SparseVectorMatrix<double>& matrix,
-         double initial_value) -> micm::LinearSolver<double, Group4SparseVectorMatrix> {
-        return micm::LinearSolver<double, Group4SparseVectorMatrix>{ matrix, initial_value };
-      },
-      5);
+  testRandomMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<double, Group1SparseVectorMatrix>>(5);
+  testRandomMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<double, Group2SparseVectorMatrix>>(5);
+  testRandomMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<double, Group3SparseVectorMatrix>>(5);
+  testRandomMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<double, Group4SparseVectorMatrix>>(5);
 }
 
 TEST(LinearSolver, DiagonalMatrixVectorOrdering)
 {
-  testDiagonalMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<double, Group1SparseVectorMatrix>>(
-      [](const Group1SparseVectorMatrix<double>& matrix,
-         double initial_value) -> micm::LinearSolver<double, Group1SparseVectorMatrix> {
-        return micm::LinearSolver<double, Group1SparseVectorMatrix>{ matrix, initial_value };
-      },
-      5);
-  testDiagonalMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<double, Group2SparseVectorMatrix>>(
-      [](const Group2SparseVectorMatrix<double>& matrix,
-         double initial_value) -> micm::LinearSolver<double, Group2SparseVectorMatrix> {
-        return micm::LinearSolver<double, Group2SparseVectorMatrix>{ matrix, initial_value };
-      },
-      5);
-  testDiagonalMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<double, Group3SparseVectorMatrix>>(
-      [](const Group3SparseVectorMatrix<double>& matrix,
-         double initial_value) -> micm::LinearSolver<double, Group3SparseVectorMatrix> {
-        return micm::LinearSolver<double, Group3SparseVectorMatrix>{ matrix, initial_value };
-      },
-      5);
-  testDiagonalMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<double, Group4SparseVectorMatrix>>(
-      [](const Group4SparseVectorMatrix<double>& matrix,
-         double initial_value) -> micm::LinearSolver<double, Group4SparseVectorMatrix> {
-        return micm::LinearSolver<double, Group4SparseVectorMatrix>{ matrix, initial_value };
-      },
-      5);
+  testDiagonalMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<double, Group1SparseVectorMatrix>>(5);
+  testDiagonalMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<double, Group2SparseVectorMatrix>>(5);
+  testDiagonalMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<double, Group3SparseVectorMatrix>>(5);
+  testDiagonalMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<double, Group4SparseVectorMatrix>>(5);
 }
 
 TEST(LinearSolver, VectorDiagonalMarkowitzReordering)

--- a/test/unit/solver/test_lu_decomposition.cpp
+++ b/test/unit/solver/test_lu_decomposition.cpp
@@ -6,116 +6,61 @@
 
 #include <gtest/gtest.h>
 
-template<class T>
-using SparseMatrixTest = micm::SparseMatrix<T>;
+using SparseMatrixTest = micm::SparseMatrix<double>;
 
-template<class T>
-using Group1SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
-template<class T>
-using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
-template<class T>
-using Group3SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
-template<class T>
-using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
+using Group1SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>;
+using Group2SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<2>>;
+using Group3SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
+using Group4SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<4>>;
 
 TEST(LuDecomposition, DenseMatrixStandardOrdering)
 {
-  testDenseMatrix<SparseMatrixTest, micm::LuDecomposition>(
-      [](const SparseMatrixTest<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, SparseMatrixTest>(matrix); });
+  testDenseMatrix<SparseMatrixTest, micm::LuDecomposition>();
 }
 
 TEST(LuDecomposition, SingularMatrixStandardOrdering)
 {
-  testSingularMatrix<SparseMatrixTest, micm::LuDecomposition>(
-      [](const SparseMatrixTest<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, SparseMatrixTest>(matrix); });
+  testSingularMatrix<SparseMatrixTest, micm::LuDecomposition>();
 }
 
 TEST(LuDecomposition, RandomMatrixStandardOrdering)
 {
-  testRandomMatrix<SparseMatrixTest, micm::LuDecomposition>(
-      [](const SparseMatrixTest<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, SparseMatrixTest>(matrix); },
-      5);
+  testRandomMatrix<SparseMatrixTest, micm::LuDecomposition>(5);
 }
 
 TEST(LuDecomposition, DiagonalMatrixStandardOrdering)
 {
-  testDiagonalMatrix<SparseMatrixTest, micm::LuDecomposition>(
-      [](const SparseMatrixTest<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, SparseMatrixTest>(matrix); },
-      5);
+  testDiagonalMatrix<SparseMatrixTest, micm::LuDecomposition>(5);
 }
 
 TEST(LuDecomposition, DenseMatrixVectorOrdering)
 {
-  testDenseMatrix<Group1SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group1SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group1SparseVectorMatrix>(matrix); });
-  testDenseMatrix<Group2SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group2SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group2SparseVectorMatrix>(matrix); });
-  testDenseMatrix<Group3SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group3SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group3SparseVectorMatrix>(matrix); });
-  testDenseMatrix<Group4SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group4SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group4SparseVectorMatrix>(matrix); });
+  testDenseMatrix<Group1SparseVectorMatrix, micm::LuDecomposition>();
+  testDenseMatrix<Group2SparseVectorMatrix, micm::LuDecomposition>();
+  testDenseMatrix<Group3SparseVectorMatrix, micm::LuDecomposition>();
+  testDenseMatrix<Group4SparseVectorMatrix, micm::LuDecomposition>();
 }
 
 TEST(LuDecomposition, SingluarMatrixVectorOrdering)
 {
-  testSingularMatrix<Group1SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group1SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group1SparseVectorMatrix>(matrix); });
-  testSingularMatrix<Group2SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group2SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group2SparseVectorMatrix>(matrix); });
-  testSingularMatrix<Group3SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group3SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group3SparseVectorMatrix>(matrix); });
-  testSingularMatrix<Group4SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group4SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group4SparseVectorMatrix>(matrix); });
+  testSingularMatrix<Group1SparseVectorMatrix, micm::LuDecomposition>();
+  testSingularMatrix<Group2SparseVectorMatrix, micm::LuDecomposition>();
+  testSingularMatrix<Group3SparseVectorMatrix, micm::LuDecomposition>();
+  testSingularMatrix<Group4SparseVectorMatrix, micm::LuDecomposition>();
 }
 
 TEST(LuDecomposition, RandomMatrixVectorOrdering)
 {
-  testRandomMatrix<Group1SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group1SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group1SparseVectorMatrix>(matrix); },
-      5);
-  testRandomMatrix<Group2SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group2SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group2SparseVectorMatrix>(matrix); },
-      5);
-  testRandomMatrix<Group3SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group3SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group3SparseVectorMatrix>(matrix); },
-      5);
-  testRandomMatrix<Group4SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group4SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group4SparseVectorMatrix>(matrix); },
-      5);
+  testRandomMatrix<Group1SparseVectorMatrix, micm::LuDecomposition>(5);
+  testRandomMatrix<Group2SparseVectorMatrix, micm::LuDecomposition>(5);
+  testRandomMatrix<Group3SparseVectorMatrix, micm::LuDecomposition>(5);
+  testRandomMatrix<Group4SparseVectorMatrix, micm::LuDecomposition>(5);
 }
 
 TEST(LuDecomposition, DiagonalMatrixVectorOrdering)
 {
-  testDiagonalMatrix<Group1SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group1SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group1SparseVectorMatrix>(matrix); },
-      5);
-  testDiagonalMatrix<Group2SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group2SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group2SparseVectorMatrix>(matrix); },
-      5);
-  testDiagonalMatrix<Group3SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group3SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group3SparseVectorMatrix>(matrix); },
-      5);
-  testDiagonalMatrix<Group4SparseVectorMatrix, micm::LuDecomposition>(
-      [](const Group4SparseVectorMatrix<double>& matrix) -> micm::LuDecomposition
-      { return micm::LuDecomposition::Create<double, Group4SparseVectorMatrix>(matrix); },
-      5);
+  testDiagonalMatrix<Group1SparseVectorMatrix, micm::LuDecomposition>(5);
+  testDiagonalMatrix<Group2SparseVectorMatrix, micm::LuDecomposition>(5);
+  testDiagonalMatrix<Group3SparseVectorMatrix, micm::LuDecomposition>(5);
+  testDiagonalMatrix<Group4SparseVectorMatrix, micm::LuDecomposition>(5);
 }

--- a/test/unit/solver/test_rosenbrock.cpp
+++ b/test/unit/solver/test_rosenbrock.cpp
@@ -7,7 +7,7 @@
 
 #include <gtest/gtest.h>
 
-template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
+template<template<class> class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
 micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> getSolver(std::size_t number_of_grid_cells)
 {
   // ---- foo  bar  baz  quz  quuz
@@ -46,10 +46,9 @@ micm::RosenbrockSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy> get
       micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters(number_of_grid_cells, false));
 }
 
-template<class T>
-using SparseMatrix = micm::SparseMatrix<T>;
+using SparseMatrix = micm::SparseMatrix<double>;
 
-template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
+template<template<class> class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
 void testAlphaMinusJacobian(std::size_t number_of_grid_cells)
 {
   auto solver = getSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>(number_of_grid_cells);
@@ -105,7 +104,7 @@ void testAlphaMinusJacobian(std::size_t number_of_grid_cells)
 
 // In this test, the elements in the same array are different;
 // thus the calculated RMSE will change when the size of the array changes.
-template<template<class> class MatrixPolicy, template<class> class SparseMatrixPolicy, class LinearSolverPolicy>
+template<template<class> class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
 void testNormalizedErrorDiff(const size_t number_of_grid_cells)
 {
   auto solver = getSolver<MatrixPolicy, SparseMatrixPolicy, LinearSolverPolicy>(number_of_grid_cells);
@@ -168,18 +167,12 @@ using Group8VectorMatrix = micm::VectorMatrix<T, 8>;
 template<class T>
 using Group10VectorMatrix = micm::VectorMatrix<T, 10>;
 
-template<class T>
-using Group1SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<1>>;
-template<class T>
-using Group2SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<2>>;
-template<class T>
-using Group3SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<3>>;
-template<class T>
-using Group4SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<4>>;
-template<class T>
-using Group8SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<8>>;
-template<class T>
-using Group10SparseVectorMatrix = micm::SparseMatrix<T, micm::SparseMatrixVectorOrdering<10>>;
+using Group1SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>;
+using Group2SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<2>>;
+using Group3SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
+using Group4SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<4>>;
+using Group8SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<8>>;
+using Group10SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<10>>;
 
 TEST(RosenbrockSolver, DenseAlphaMinusJacobian)
 {

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -1,0 +1,40 @@
+#include <micm/solver/backward_euler.hpp>
+#include <micm/solver/solver_builder.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <random>
+
+namespace {
+  auto a = micm::Species("A");
+  auto b = micm::Species("B");
+  auto c = micm::Species("C");
+
+  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+
+  micm::Process r1 = micm::Process::Create()
+                         .SetReactants({ a })
+                         .SetProducts({ micm::Yields(b, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
+                         .SetPhase(gas_phase);
+
+  micm::Process r2 = micm::Process::Create()
+                         .SetReactants({ b })
+                         .SetProducts({ micm::Yields(c, 1) })
+                         .SetRateConstant(micm::ArrheniusRateConstant(
+                             micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .B_ = 0, .C_ = 55 }))
+                         .SetPhase(gas_phase);
+  micm::System the_system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+  std::vector<micm::Process> reactions = { r1, r2 };
+}
+
+TEST(SolverBuilder, CanBuildBackwardEuler)
+{
+  auto backward_euler = micm::SolverBuilder()
+                            .SetSystem(the_system)
+                            .SetReactions(reactions)
+                            .SetNumberOfGridCells(1)
+                            .BackwardEuler(micm::BackwardEulerSolverParameters{})
+                            .Build();
+}

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -1,5 +1,8 @@
 #include <micm/solver/backward_euler.hpp>
 #include <micm/solver/solver_builder.hpp>
+#include <micm/util/matrix.hpp>
+#include <micm/util/sparse_matrix.hpp>
+#include <micm/util/vector_matrix.hpp>
 
 #include <gtest/gtest.h>
 
@@ -31,10 +34,62 @@ namespace {
 
 TEST(SolverBuilder, CanBuildBackwardEuler)
 {
-  auto backward_euler = micm::SolverBuilder()
+  auto backward_euler = micm::CpuSolverBuilder<micm::Matrix<double>, micm::SparseMatrix<double>>()
                             .SetSystem(the_system)
                             .SetReactions(reactions)
                             .SetNumberOfGridCells(1)
-                            .BackwardEuler(micm::BackwardEulerSolverParameters{})
+                            .SolverParameters(micm::BackwardEulerSolverParameters{})
                             .Build();
+
+  constexpr std::size_t L = 4;
+  auto backward_euler_vector = micm::CpuSolverBuilder<micm::VectorMatrix<double, L>, micm::SparseMatrix<double>>()
+                            .SetSystem(the_system)
+                            .SetReactions(reactions)
+                            .SetNumberOfGridCells(1)
+                            .SolverParameters(micm::BackwardEulerSolverParameters{})
+                            .Build();
+}
+
+TEST(SolverBuilder, CanBuildRosenbrock)
+{
+  // auto rosenbrock = micm::CpuSolverBuilder<Matrix<double>, SparseMatrix<double>>()
+  //                           .SetSystem(the_system)
+  //                           .SetReactions(reactions)
+  //                           .SetNumberOfGridCells(1)
+  //                           .SolverParameters(micm::ThreeStageRosenbockSolverParameters{})
+  //                           .Build();
+
+  // auto rosenbrock_vector = micm::CpuSolverBuilder<VectorMatrix<double, L>, SparseVectorMatrix<double, L>>()
+  //                           .SetSystem(the_system)
+  //                           .SetReactions(reactions)
+  //                           .SetNumberOfGridCells(1)
+  //                           .SolverParameters(micm::ThreeStageRosenbockSolverParameters{})
+  //                           .Build();
+}
+
+TEST(SolverBuilder, CanBuildJitRosenbrock)
+{
+  // auto jit_rosenbrock = micm::JitSolverBuilder<L>()
+  //                           .SetSystem(the_system)
+  //                           .SetReactions(reactions)
+  //                           .SetNumberOfGridCells(1)
+  //                           .SolverParameters(micm::ThreeStageRosenbockSolverParameters{})
+  //                           .Build();
+}
+
+TEST(SolverBuilder, CanBuildCudaSolvers)
+{
+  // auto cuda_rosenbrock = micm::CudaSolverBuilder<L>()
+  //                           .SetSystem(the_system)
+  //                           .SetReactions(reactions)
+  //                           .SetNumberOfGridCells(1)
+  //                           .SolverParameters(micm::ThreeStageRosenbockSolverParameters{})
+  //                           .Build();
+
+  // auto cuda_rosenbrock = micm::CudaSolverBuilder<L>()
+  //                           .SetSystem(the_system)
+  //                           .SetReactions(reactions)
+  //                           .SetNumberOfGridCells(1)
+  //                           .SolverParameters(micm::ThreeStageRosenbockSolverParameters{})
+  //                           .Build();
 }

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -9,7 +9,8 @@
 #include <algorithm>
 #include <random>
 
-namespace {
+namespace
+{
   auto a = micm::Species("A");
   auto b = micm::Species("B");
   auto c = micm::Species("C");
@@ -30,7 +31,7 @@ namespace {
                          .SetPhase(gas_phase);
   micm::System the_system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });
   std::vector<micm::Process> reactions = { r1, r2 };
-}
+}  // namespace
 
 TEST(SolverBuilder, CanBuildBackwardEuler)
 {
@@ -38,16 +39,16 @@ TEST(SolverBuilder, CanBuildBackwardEuler)
                             .SetSystem(the_system)
                             .SetReactions(reactions)
                             .SetNumberOfGridCells(1)
-                            .SolverParameters(micm::BackwardEulerSolverParameters{})
+                            .SetSolverParameters(micm::BackwardEulerSolverParameters{})
                             .Build();
 
   constexpr std::size_t L = 4;
   auto backward_euler_vector = micm::CpuSolverBuilder<micm::VectorMatrix<double, L>, micm::SparseMatrix<double>>()
-                            .SetSystem(the_system)
-                            .SetReactions(reactions)
-                            .SetNumberOfGridCells(1)
-                            .SolverParameters(micm::BackwardEulerSolverParameters{})
-                            .Build();
+                                   .SetSystem(the_system)
+                                   .SetReactions(reactions)
+                                   .SetNumberOfGridCells(1)
+                                   .SetSolverParameters(micm::BackwardEulerSolverParameters{})
+                                   .Build();
 }
 
 TEST(SolverBuilder, CanBuildRosenbrock)


### PR DESCRIPTION
Closes #514 

- Temporarily removes backward euler from running in the analytical policy test until we finish implementing the builder such that any solver could be run with those tests
- Adds a solver builder, which has options to build different solvers, right now only BackwardEuler is supported
- Adds a solver class which wraps any solver (backward euler, rosenbrock). This may be a useless class
- Removes template template parameters from many different places