### PR TITLE
Add GPU memory check for CUDA code

### DIFF
--- a/cmake/test_util.cmake
+++ b/cmake/test_util.cmake
@@ -2,7 +2,13 @@
 # Utility functions for creating tests
 
 if(MICM_ENABLE_MEMCHECK)
-  find_program(MEMORYCHECK_COMMAND "valgrind")
+  if(MICM_ENABLE_CUDA)
+    find_program(MEMORYCHECK_COMMAND "compute-sanitizer")
+    set(MEMORYCHECK_COMMAND_OPTIONS "--show-backtrace device --tool=memcheck --launch-timeout=0")
+  else()
+    find_program(MEMORYCHECK_COMMAND "valgrind")
+    set(MEMORYCHECK_COMMAND_OPTIONS "--error-exitcode=1 --trace-children=yes --leak-check=full --gen-suppressions=all ${MEMCHECK_SUPPRESS}")
+  endif()
 endif()
 
 ################################################################################
@@ -46,7 +52,6 @@ function(add_micm_test test_name test_binary test_args working_dir test_skip_mem
              COMMAND ${test_binary} ${test_args}
              WORKING_DIRECTORY ${working_dir})
   endif()
-  set(MEMORYCHECK_COMMAND_OPTIONS "--error-exitcode=1 --trace-children=yes --leak-check=full --gen-suppressions=all ${MEMCHECK_SUPPRESS}")
   set(memcheck "${MEMORYCHECK_COMMAND} ${MEMORYCHECK_COMMAND_OPTIONS}")
   separate_arguments(memcheck)
   if(MICM_ENABLE_MPI AND MEMORYCHECK_COMMAND AND MICM_ENABLE_MEMCHECK AND NOT test_skip_memcheck)

--- a/test/unit/process/CMakeLists.txt
+++ b/test/unit/process/CMakeLists.txt
@@ -18,11 +18,7 @@ create_standard_test(NAME user_defined_rate_constant SOURCES test_user_defined_r
 
 # GPU tests
 if(MICM_ENABLE_CUDA)
-  create_standard_test(NAME cuda_process_set SOURCES test_cuda_process_set.cpp LIBRARIES musica::micm_cuda)
-endif()
-
-if(MICM_ENABLE_OPENACC)
-  create_standard_test(NAME openacc_process_set SOURCES test_openacc_process_set.cpp LIBRARIES musica::micm_openacc)
+  create_standard_test(NAME cuda_process_set SOURCES test_cuda_process_set.cpp LIBRARIES musica::micm_cuda IS_CUDA_TEST)
 endif()
 
 if(MICM_ENABLE_LLVM)

--- a/test/unit/solver/CMakeLists.txt
+++ b/test/unit/solver/CMakeLists.txt
@@ -16,9 +16,9 @@ create_standard_test(NAME solver_builder SOURCES test_solver_builder.cpp)
 
 # GPU tests
 if(MICM_ENABLE_CUDA)
-  create_standard_test(NAME cuda_lu_decomposition SOURCES test_cuda_lu_decomposition.cpp LIBRARIES musica::micm_cuda)
-  create_standard_test(NAME cuda_linear_solver SOURCES test_cuda_linear_solver.cpp LIBRARIES musica::micm_cuda)
-  create_standard_test(NAME cuda_rosenbrock SOURCES test_cuda_rosenbrock.cpp LIBRARIES musica::micm_cuda)
+  create_standard_test(NAME cuda_lu_decomposition SOURCES test_cuda_lu_decomposition.cpp LIBRARIES musica::micm_cuda IS_CUDA_TEST)
+  create_standard_test(NAME cuda_linear_solver SOURCES test_cuda_linear_solver.cpp LIBRARIES musica::micm_cuda IS_CUDA_TEST)
+  create_standard_test(NAME cuda_rosenbrock SOURCES test_cuda_rosenbrock.cpp LIBRARIES musica::micm_cuda IS_CUDA_TEST)
 endif()
 
 if(MICM_ENABLE_LLVM)

--- a/test/unit/util/CMakeLists.txt
+++ b/test/unit/util/CMakeLists.txt
@@ -17,6 +17,6 @@ if(MICM_ENABLE_CUDA)
   target_sources(micm_cuda_test_utils PRIVATE cuda_matrix_utils.cu)
   set_target_properties(micm_cuda_test_utils PROPERTIES LINKER_LANGUAGE CXX)
   
-  create_standard_test(NAME cuda_dense_matrix SOURCES test_cuda_dense_matrix.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils)
-  create_standard_test(NAME cuda_sparse_matrix SOURCES test_cuda_sparse_matrix.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils)
+  create_standard_test(NAME cuda_dense_matrix SOURCES test_cuda_dense_matrix.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils IS_CUDA_TEST)
+  create_standard_test(NAME cuda_sparse_matrix SOURCES test_cuda_sparse_matrix.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils IS_CUDA_TEST)
 endif()


### PR DESCRIPTION
This PR adds `compute-sanitizer` to check the GPU memory leak for all the CUDA tests.

Note that the `compute-sanitizer` looks for CUDA APIs in a code and will issue an error when applied to a CPU test. This error could not be suppressed unfortunately (https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html#error-suppression). Therefore, we add new internal options to apply the `compute-sanitizer` check to the CUDA tests only.

All the 50 tests (including GPU memory check) are passed on Derecho's A100 GPU, using the `nvhpc/23.7`.

fix #415 
