### PR TITLE
Initial attempt for supporting presets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ option(MICM_ENABLE_TESTS "Build the tests" ON)
 option(MICM_ENABLE_EXAMPLES "Build the examples" ON)
 option(MICM_ENABLE_PROFILE "Profile MICM Solver" OFF)
 set(MICM_DEFAULT_VECTOR_MATRIX_SIZE "4" CACHE STRING "Default size for vectorizable matrix types")
+set(MICM_MODULE_LOADS "" CACHE STRING "Modules to load")
+set(MICM_MODULE_UNLOADS "" CACHE STRING "Modules to unload")
 
 include(CMakeDependentOption)
 # Option to collect custom OpenACC flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,16 +2,18 @@
 # Preamble
 cmake_minimum_required(VERSION 3.21)
 
-find_package(EnvModules REQUIRED)
 
-foreach(NEEDED_MODULE IN LISTS MICM_MODULE_LOADS)
-  env_module(load "${NEEDED_MODULE}")
-endforeach()
-foreach(UNNEEDED_MODULE IN LISTS MICM_MODULE_UNLOADS)
-  env_module(unload "${UNNEEDED_MODULE}")
-endforeach()
-env_module_list(MICM_CURRENT_MODULES)
-message(STATUS "Currently loaded modules: ${MICM_CURRENT_MODULES}")
+if(DEFINED MICM_MODULE_LOADS OR DEFINED MICM_MODULE_UNLOADS)
+  find_package(EnvModules REQUIRED)
+  foreach(NEEDED_MODULE IN LISTS MICM_MODULE_LOADS)
+    env_module(load "${NEEDED_MODULE}")
+  endforeach()
+  foreach(UNNEEDED_MODULE IN LISTS MICM_MODULE_UNLOADS)
+    env_module(unload "${UNNEEDED_MODULE}")
+  endforeach()
+  env_module_list(MICM_CURRENT_MODULES)
+  message(STATUS "Currently loaded modules: ${MICM_CURRENT_MODULES}")
+endif()
 
 project(
   micm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,17 @@
 # Preamble
 cmake_minimum_required(VERSION 3.21)
 
+find_package(EnvModules REQUIRED)
+
+foreach(NEEDED_MODULE IN LISTS MICM_MODULE_LOADS)
+  env_module(load "${NEEDED_MODULE}")
+endforeach()
+foreach(UNNEEDED_MODULE IN LISTS MICM_MODULE_UNLOADS)
+  env_module(unload "${UNNEEDED_MODULE}")
+endforeach()
+env_module_list(MICM_CURRENT_MODULES)
+message(STATUS "Currently loaded modules: ${MICM_CURRENT_MODULES}")
+
 project(
   micm
   VERSION 3.5.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ if(DEFINED MICM_MODULE_LOADS OR DEFINED MICM_MODULE_UNLOADS)
   endforeach()
   env_module_list(MICM_CURRENT_MODULES)
   message(STATUS "Currently loaded modules: ${MICM_CURRENT_MODULES}")
+  message(STATUS "Currently using $ENV{SHELL}.")
+  # set(MACHINE_MODULE_PATH "$ENV{MODULESHOME}")
+  # add_custom_target(enable-module-command
+  #   ALL COMMAND "." "${MACHINE_MODULE_PATH}/init/bash"
+  #   COMMAND "ml" "${MICM_MODULE_LOADS}"
+  #   COMMAND_EXPAND_LISTS)
 endif()
 
 project(

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,28 @@
+{
+    "version" : 6,
+    "cmakeMinimumRequired": {
+      "major": 3,
+      "minor": 26
+    },
+    "configurePresets": [
+        {
+            "name": "derecho-gpu",
+            "displayName": "Derecho",
+            "description": "Presets for the Derecho cluster",
+            "cacheVariables": {
+                "MICM_MODULE_LOADS": {
+                    "type": "STRING",
+                    "value": "nvhpc/23.7;gcc-toolchain/12.2.0;cmake"
+                },
+                "MICM_MODULE_UNLOADS": {
+                    "type": "STRING",
+                    "value": "openmpi"
+                },
+                "MICM_ENABLE_GPU_TYPE": {
+                    "type": "STRING",
+                    "value": "a100"
+                }
+            }
+        }
+    ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,17 +6,17 @@
     },
     "configurePresets": [
         {
-            "name": "derecho-gpu",
+            "name": "derecho-gpu-configure",
             "displayName": "Derecho",
             "description": "Presets for the Derecho cluster",
             "cacheVariables": {
                 "MICM_MODULE_LOADS": {
                     "type": "STRING",
-                    "value": "nvhpc/23.7;gcc-toolchain/12.2.0;cmake"
+                    "value": "nvhpc/23.7;gcc-toolchain/12.2.0;cuda/12.2.1"
                 },
                 "MICM_MODULE_UNLOADS": {
                     "type": "STRING",
-                    "value": "openmpi"
+                    "value": "cray-mpich"
                 },
                 "MICM_GPU_TYPE": {
                     "type": "STRING",
@@ -26,7 +26,30 @@
                     "type": "BOOL",
                     "value": "ON"
                 }
-            }
+            },
+            "binaryDir": "nvhpc-test"
         }
+    ],
+    "buildPresets": [
+      {
+        "name": "derecho-gpu-build",
+        "configurePreset" : "derecho-gpu-configure",
+        "inheritConfigureEnvironment": true
+      }
+    ],
+    "workflowPresets": [
+      {
+        "name" : "derecho-gpu-workflow",
+        "steps": [
+          {
+            "type": "configure",
+            "name" : "derecho-gpu-configure"
+          },
+          {
+            "type": "build",
+            "name": "derecho-gpu-build"
+          }
+        ]
+      }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,9 +18,13 @@
                     "type": "STRING",
                     "value": "openmpi"
                 },
-                "MICM_ENABLE_GPU_TYPE": {
+                "MICM_GPU_TYPE": {
                     "type": "STRING",
                     "value": "a100"
+                },
+                "MICM_ENABLE_CUDA": {
+                    "type": "BOOL",
+                    "value": "ON"
                 }
             }
         }

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,14 +1,4 @@
 include(FetchContent)
-find_package(EnvModules REQUIRED)
-
-foreach(NEEDED_MODULE IN LISTS MICM_MODULE_LOADS)
-  env_module(load "${NEEDED_MODULE}")
-endforeach()
-foreach(UNNEEDED_MODULE IN LISTS MICM_MODULE_UNLOADS)
-  env_module(unload "${UNNEEDED_MODULE}")
-endforeach()
-env_module_list(MICM_CURRENT_MODULES)
-message(STATUS "Currently loaded modules: ${MICM_CURRENT_MODULES}")
 
 ################################################################################
 # Memory check

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,4 +1,14 @@
 include(FetchContent)
+find_package(EnvModules REQUIRED)
+
+foreach(NEEDED_MODULE IN LISTS MICM_MODULE_LOADS)
+  env_module(load "${NEEDED_MODULE}")
+endforeach()
+foreach(UNNEEDED_MODULE IN LISTS MICM_MODULE_UNLOADS)
+  env_module(unload "${UNNEEDED_MODULE}")
+endforeach()
+env_module_list(MICM_CURRENT_MODULES)
+message(STATUS "Currently loaded modules: ${MICM_CURRENT_MODULES}")
 
 ################################################################################
 # Memory check


### PR DESCRIPTION
Adds preset file and now to target derecho a100 gpu, we can simply run `cmake --preset=derecho-gpu` with the following output:
```
-- CMake build configuration for micm(Release) 3.5.0
-- Found EnvModules: /glade/u/apps/casper/23.10/spack/opt/spack/lmod/8.7.24/gcc/7.5.0/m4jx/lmod/lmod/libexec/lmod  

Lmod is automatically replacing "intel/2023.2.1" with "nvhpc/23.7".


Due to MODULEPATH changes, the following have been reloaded:
  1) hdf5/1.12.2     2) ncarcompilers/1.0.0     3) netcdf/4.9.2     4) openmpi/4.1.6

-- Currently loaded modules: ncarenv/23.10;nvhpc/23.7;ncarcompilers/1.0.0;hdf5/1.12.2;netcdf/4.9.2;gcc-toolchain/12.2.0;cmake/3.26.3
-- The C compiler identification is NVHPC 23.7.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /glade/u/apps/casper/23.10/spack/opt/spack/ncarcompilers/1.0.0/nvhpc/23.7/pw2i/bin/nvc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
```