### PR TITLE
Add exiting error code for compute-sanitizer

### DIFF
--- a/cmake/test_util.cmake
+++ b/cmake/test_util.cmake
@@ -4,7 +4,7 @@
 if(MICM_ENABLE_MEMCHECK)
   if(MICM_ENABLE_CUDA)
     find_program(MEMORYCHECK_COMMAND "compute-sanitizer")
-    set(MEMORYCHECK_COMMAND_OPTIONS "--show-backtrace device --tool=memcheck --launch-timeout=0")
+    set(MEMORYCHECK_COMMAND_OPTIONS "--error-exitcode=1 --show-backtrace device --tool=memcheck --launch-timeout=0")
     set(CUDA_MEMORY_CHECK TRUE)
   else()
     find_program(MEMORYCHECK_COMMAND "valgrind")


### PR DESCRIPTION
This PR adds a non-zero exiting code for `compute-santizer` when it finishes a run and detects a memory leak. Therefore, a test with memory leak will fail as expected.

fix #552 