### PR TITLE
Add error checks for all the CUDA APIs

### DIFF
--- a/include/micm/util/cuda_dense_matrix.hpp
+++ b/include/micm/util/cuda_dense_matrix.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <micm/util/cuda_matrix.cuh>
+#include <micm/util/cuda_util.cuh>
 #include <micm/util/error.hpp>
 #include <micm/util/vector_matrix.hpp>
 

--- a/include/micm/util/cuda_dense_matrix.hpp
+++ b/include/micm/util/cuda_dense_matrix.hpp
@@ -13,9 +13,6 @@
 
 #include <type_traits>
 
-#define CHECK_CUDA_ERROR(err, msg)   micm::cuda::CheckCudaError(err, __FILE__, __LINE__, msg)
-#define CHECK_CUBLAS_ERROR(err, msg) micm::cuda::CheckCublasError(err, __FILE__, __LINE__, msg)
-
 namespace micm
 {
   /**

--- a/include/micm/util/cuda_matrix.cuh
+++ b/include/micm/util/cuda_matrix.cuh
@@ -12,6 +12,9 @@
 #include <string>
 #include <vector>
 
+#define CHECK_CUDA_ERROR(err, msg)   micm::cuda::CheckCudaError(err, __FILE__, __LINE__, msg)
+#define CHECK_CUBLAS_ERROR(err, msg) micm::cuda::CheckCublasError(err, __FILE__, __LINE__, msg)
+
 namespace micm
 {
   namespace cuda

--- a/include/micm/util/cuda_matrix.cuh
+++ b/include/micm/util/cuda_matrix.cuh
@@ -5,15 +5,8 @@
 #pragma once
 
 #include <micm/util/cuda_param.hpp>
-
-#include <cublas_v2.h>
 #include <cuda_runtime.h>
-
-#include <string>
 #include <vector>
-
-#define CHECK_CUDA_ERROR(err, msg)   micm::cuda::CheckCudaError(err, __FILE__, __LINE__, msg)
-#define CHECK_CUBLAS_ERROR(err, msg) micm::cuda::CheckCublasError(err, __FILE__, __LINE__, msg)
 
 namespace micm
 {
@@ -47,19 +40,5 @@ namespace micm
     /// @param vectorMatrixSrc Struct containing allocated source device memory to copy from
     /// @returns Error code from copying to destination device memory from source device memory, if any
     cudaError_t CopyToDeviceFromDevice(CudaMatrixParam& vectorMatrixDest, const CudaMatrixParam& vectorMatrixSrc);
-
-    /// @brief Checks for CUDA errors and prints error message if any
-    /// @param err Error code to check
-    /// @param file File where error occurred
-    /// @param line Line number where error occurred
-    /// @param str Additional string to print with error message
-    void CheckCudaError(cudaError_t err, const char* file, int line, std::string str);
-
-    /// @brief Checks for cuBLAS errors and prints error message if any
-    /// @param err Error code to check
-    /// @param file File where error occurred
-    /// @param line Line number where error occurred
-    /// @param str Additional string to print with error message
-    void CheckCublasError(cublasStatus_t err, const char* file, int line, std::string str);
   }  // namespace cuda
 }  // namespace micm

--- a/include/micm/util/cuda_sparse_matrix.hpp
+++ b/include/micm/util/cuda_sparse_matrix.hpp
@@ -6,6 +6,7 @@
 
 #include <micm/util/cuda_dense_matrix.hpp>  // include this for CudaMatrix concept
 #include <micm/util/cuda_matrix.cuh>
+#include <micm/util/cuda_util.cuh>
 #include <micm/util/cuda_param.hpp>
 #include <micm/util/sparse_matrix.hpp>
 

--- a/include/micm/util/cuda_sparse_matrix.hpp
+++ b/include/micm/util/cuda_sparse_matrix.hpp
@@ -13,8 +13,6 @@
 
 #include <type_traits>
 
-#define CHECK_CUDA_ERROR(err, msg) micm::cuda::CheckCudaError(err, __FILE__, __LINE__, msg)
-
 namespace micm
 {
   template<class T, class OrderingPolicy>

--- a/include/micm/util/cuda_util.cuh
+++ b/include/micm/util/cuda_util.cuh
@@ -1,0 +1,32 @@
+/* Copyright (C) 2023-2024 National Center for Atmospheric Research
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+ 
+#include <cublas_v2.h>
+#include <cuda_runtime.h> 
+#include <string>
+
+#define CHECK_CUDA_ERROR(err, msg)   micm::cuda::CheckCudaError(err, __FILE__, __LINE__, msg)
+#define CHECK_CUBLAS_ERROR(err, msg) micm::cuda::CheckCublasError(err, __FILE__, __LINE__, msg)
+
+namespace micm
+{
+  namespace cuda
+  {
+    /// @brief Checks for CUDA errors and prints error message if any
+    /// @param err Error code to check
+    /// @param file File where error occurred
+    /// @param line Line number where error occurred
+    /// @param str Additional string to print with error message
+    void CheckCudaError(cudaError_t err, const char* file, int line, std::string str);
+
+    /// @brief Checks for cuBLAS errors and prints error message if any
+    /// @param err Error code to check
+    /// @param file File where error occurred
+    /// @param line Line number where error occurred
+    /// @param str Additional string to print with error message
+    void CheckCublasError(cublasStatus_t err, const char* file, int line, std::string str);
+  }  // namespace cuda
+}  // namespace micm

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <micm/util/cuda_param.hpp>
+#include <micm/util/cuda_matrix.cuh>
 
 namespace micm
 {
@@ -137,23 +138,23 @@ namespace micm
       ProcessSetParam devstruct;
 
       /// Allocate memory space on the device
-      cudaMalloc(&(devstruct.number_of_reactants_), number_of_reactants_bytes);
-      cudaMalloc(&(devstruct.reactant_ids_), reactant_ids_bytes);
-      cudaMalloc(&(devstruct.number_of_products_), number_of_products_bytes);
-      cudaMalloc(&(devstruct.product_ids_), product_ids_bytes);
-      cudaMalloc(&(devstruct.yields_), yields_bytes);
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.number_of_reactants_), number_of_reactants_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.reactant_ids_), reactant_ids_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.number_of_products_), number_of_products_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.product_ids_), product_ids_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.yields_), yields_bytes), "cudaMalloc");
 
       /// Copy the data from host to device
-      cudaMemcpy(
+      CHECK_CUDA_ERROR(cudaMemcpy(
           devstruct.number_of_reactants_,
           hoststruct.number_of_reactants_,
           number_of_reactants_bytes,
-          cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.reactant_ids_, hoststruct.reactant_ids_, reactant_ids_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(
-          devstruct.number_of_products_, hoststruct.number_of_products_, number_of_products_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.product_ids_, hoststruct.product_ids_, product_ids_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.yields_, hoststruct.yields_, yields_bytes, cudaMemcpyHostToDevice);
+          cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.reactant_ids_, hoststruct.reactant_ids_, reactant_ids_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(
+          devstruct.number_of_products_, hoststruct.number_of_products_, number_of_products_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.product_ids_, hoststruct.product_ids_, product_ids_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.yields_, hoststruct.yields_, yields_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
 
       devstruct.number_of_reactants_size_ = hoststruct.number_of_reactants_size_;
       devstruct.reactant_ids_size_ = hoststruct.reactant_ids_size_;
@@ -173,11 +174,11 @@ namespace micm
       size_t jacobian_flat_ids_bytes = sizeof(size_t) * hoststruct.jacobian_flat_ids_size_;
 
       /// Allocate memory space on the device
-      cudaMalloc(&(devstruct.jacobian_flat_ids_), jacobian_flat_ids_bytes);
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.jacobian_flat_ids_), jacobian_flat_ids_bytes), "cudaMalloc");
 
       /// Copy the data from host to device
-      cudaMemcpy(
-          devstruct.jacobian_flat_ids_, hoststruct.jacobian_flat_ids_, jacobian_flat_ids_bytes, cudaMemcpyHostToDevice);
+      CHECK_CUDA_ERROR(cudaMemcpy(
+          devstruct.jacobian_flat_ids_, hoststruct.jacobian_flat_ids_, jacobian_flat_ids_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
 
       devstruct.jacobian_flat_ids_size_ = hoststruct.jacobian_flat_ids_size_;
     }
@@ -186,14 +187,14 @@ namespace micm
     ///   members of class "CudaProcessSet" on the device
     void FreeConstData(ProcessSetParam& devstruct)
     {
-      cudaFree(devstruct.number_of_reactants_);
-      cudaFree(devstruct.reactant_ids_);
-      cudaFree(devstruct.number_of_products_);
-      cudaFree(devstruct.product_ids_);
-      cudaFree(devstruct.yields_);
+      CHECK_CUDA_ERROR(cudaFree(devstruct.number_of_reactants_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.reactant_ids_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.number_of_products_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.product_ids_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.yields_), "cudaFree");
       if (devstruct.jacobian_flat_ids_ != nullptr)
       {
-        cudaFree(devstruct.jacobian_flat_ids_);
+        CHECK_CUDA_ERROR(cudaFree(devstruct.jacobian_flat_ids_), "cudaFree");
       }
     }
 

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <micm/util/cuda_param.hpp>
-#include <micm/util/cuda_matrix.cuh>
+#include <micm/util/cuda_util.cuh>
 
 namespace micm
 {

--- a/src/solver/linear_solver.cu
+++ b/src/solver/linear_solver.cu
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <micm/util/cuda_param.hpp>
-#include <micm/util/cuda_matrix.cuh>
+#include <micm/util/cuda_util.cuh>
 
 #include <chrono>
 

--- a/src/solver/linear_solver.cu
+++ b/src/solver/linear_solver.cu
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <micm/util/cuda_param.hpp>
+#include <micm/util/cuda_matrix.cuh>
 
 #include <chrono>
 
@@ -92,16 +93,16 @@ namespace micm
 
       /// Create a struct whose members contain the addresses in the device memory.
       LinearSolverParam devstruct;
-      cudaMalloc(&(devstruct.nLij_Lii_), nLij_Lii_bytes);
-      cudaMalloc(&(devstruct.Lij_yj_), Lij_yj_bytes);
-      cudaMalloc(&(devstruct.nUij_Uii_), nUij_Uii_bytes);
-      cudaMalloc(&(devstruct.Uij_xj_), Uij_xj_bytes);
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.nLij_Lii_), nLij_Lii_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.Lij_yj_), Lij_yj_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.nUij_Uii_), nUij_Uii_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.Uij_xj_), Uij_xj_bytes), "cudaMalloc");
 
       /// Copy the data from host to device
-      cudaMemcpy(devstruct.nLij_Lii_, hoststruct.nLij_Lii_, nLij_Lii_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.Lij_yj_, hoststruct.Lij_yj_, Lij_yj_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.nUij_Uii_, hoststruct.nUij_Uii_, nUij_Uii_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.Uij_xj_, hoststruct.Uij_xj_, Uij_xj_bytes, cudaMemcpyHostToDevice);
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.nLij_Lii_, hoststruct.nLij_Lii_, nLij_Lii_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.Lij_yj_, hoststruct.Lij_yj_, Lij_yj_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.nUij_Uii_, hoststruct.nUij_Uii_, nUij_Uii_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.Uij_xj_, hoststruct.Uij_xj_, Uij_xj_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
 
       devstruct.nLij_Lii_size_ = hoststruct.nLij_Lii_size_;
       devstruct.Lij_yj_size_ = hoststruct.Lij_yj_size_;
@@ -115,10 +116,10 @@ namespace micm
     ///   members of class "CudaLinearSolver" on the device
     void FreeConstData(LinearSolverParam& devstruct)
     {
-      cudaFree(devstruct.nLij_Lii_);
-      cudaFree(devstruct.Lij_yj_);
-      cudaFree(devstruct.nUij_Uii_);
-      cudaFree(devstruct.Uij_xj_);
+      CHECK_CUDA_ERROR(cudaFree(devstruct.nLij_Lii_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.Lij_yj_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.nUij_Uii_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.Uij_xj_), "cudaFree");
     }
 
     void SolveKernelDriver(

--- a/src/solver/lu_decomposition.cu
+++ b/src/solver/lu_decomposition.cu
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <micm/util/cuda_param.hpp>
-#include <micm/util/cuda_matrix.cuh>
+#include <micm/util/cuda_util.cuh>
 
 namespace micm
 {

--- a/src/solver/lu_decomposition.cu
+++ b/src/solver/lu_decomposition.cu
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <micm/util/cuda_param.hpp>
-
-#include <chrono>
-#include <iostream>
+#include <micm/util/cuda_matrix.cuh>
 
 namespace micm
 {
@@ -121,28 +119,28 @@ namespace micm
 
       /// Create a struct whose members contain the addresses in the device memory.
       LuDecomposeParam devstruct;
-      cudaMalloc(&(devstruct.niLU_), niLU_bytes);
-      cudaMalloc(&(devstruct.do_aik_), do_aik_bytes);
-      cudaMalloc(&(devstruct.aik_), aik_bytes);
-      cudaMalloc(&(devstruct.uik_nkj_), uik_nkj_bytes);
-      cudaMalloc(&(devstruct.lij_ujk_), lij_ujk_bytes);
-      cudaMalloc(&(devstruct.do_aki_), do_aki_bytes);
-      cudaMalloc(&(devstruct.aki_), aki_bytes);
-      cudaMalloc(&(devstruct.lki_nkj_), lki_nkj_bytes);
-      cudaMalloc(&(devstruct.lkj_uji_), lkj_uji_bytes);
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.niLU_), niLU_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.do_aik_), do_aik_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.aik_), aik_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.uik_nkj_), uik_nkj_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.lij_ujk_), lij_ujk_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.do_aki_), do_aki_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.aki_), aki_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.lki_nkj_), lki_nkj_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.lkj_uji_), lkj_uji_bytes), "cudaMalloc");
       cudaMalloc(&(devstruct.uii_), uii_bytes);
 
       /// Copy the data from host to device
-      cudaMemcpy(devstruct.niLU_, hoststruct.niLU_, niLU_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.do_aik_, hoststruct.do_aik_, do_aik_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.aik_, hoststruct.aik_, aik_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.uik_nkj_, hoststruct.uik_nkj_, uik_nkj_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.lij_ujk_, hoststruct.lij_ujk_, lij_ujk_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.do_aki_, hoststruct.do_aki_, do_aki_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.aki_, hoststruct.aki_, aki_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.lki_nkj_, hoststruct.lki_nkj_, lki_nkj_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.lkj_uji_, hoststruct.lkj_uji_, lkj_uji_bytes, cudaMemcpyHostToDevice);
-      cudaMemcpy(devstruct.uii_, hoststruct.uii_, uii_bytes, cudaMemcpyHostToDevice);
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.niLU_, hoststruct.niLU_, niLU_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.do_aik_, hoststruct.do_aik_, do_aik_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.aik_, hoststruct.aik_, aik_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.uik_nkj_, hoststruct.uik_nkj_, uik_nkj_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.lij_ujk_, hoststruct.lij_ujk_, lij_ujk_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.do_aki_, hoststruct.do_aki_, do_aki_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.aki_, hoststruct.aki_, aki_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.lki_nkj_, hoststruct.lki_nkj_, lki_nkj_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.lkj_uji_, hoststruct.lkj_uji_, lkj_uji_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.uii_, hoststruct.uii_, uii_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
       devstruct.niLU_size_ = hoststruct.niLU_size_;
 
       return devstruct;
@@ -152,16 +150,16 @@ namespace micm
     ///   members of class "CudaLuDecomposition" on the device
     void FreeConstData(LuDecomposeParam& devstruct)
     {
-      cudaFree(devstruct.niLU_);
-      cudaFree(devstruct.do_aik_);
-      cudaFree(devstruct.aik_);
-      cudaFree(devstruct.uik_nkj_);
-      cudaFree(devstruct.lij_ujk_);
-      cudaFree(devstruct.do_aki_);
-      cudaFree(devstruct.aki_);
-      cudaFree(devstruct.lki_nkj_);
-      cudaFree(devstruct.lkj_uji_);
-      cudaFree(devstruct.uii_);
+      CHECK_CUDA_ERROR(cudaFree(devstruct.niLU_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.do_aik_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.aik_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.uik_nkj_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.lij_ujk_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.do_aki_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.aki_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.lki_nkj_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.lkj_uji_), "cudaFree");
+      CHECK_CUDA_ERROR(cudaFree(devstruct.uii_), "cudaFree");
     }
 
     void DecomposeKernelDriver(

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -5,7 +5,7 @@
 #include <micm/solver/rosenbrock_solver_parameters.hpp>
 #include <micm/util/cuda_param.hpp>
 #include <micm/util/internal_error.hpp>
-#include <micm/util/cuda_matrix.cuh>
+#include <micm/util/cuda_util.cuh>
 #include <cublas_v2.h>
 
 namespace micm

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -2,5 +2,6 @@ if(MICM_ENABLE_CUDA)
   target_sources(micm_cuda
        PRIVATE
        cuda_matrix.cu
+       cuda_util.cu
   )
 endif()

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -55,23 +55,5 @@ namespace micm
           cudaMemcpyDeviceToDevice);
       return err;
     }
-
-    void CheckCudaError(cudaError_t err, const char* file, int line, std::string str)
-    {
-      if (err != cudaSuccess)
-      {
-        std::string msg = std::string(cudaGetErrorString(err)) + " : " + str;
-        ThrowInternalError(MicmInternalErrc::Cuda, file, line, msg.c_str());
-      }
-    }
-
-    void CheckCublasError(cublasStatus_t err, const char* file, int line, std::string str)
-    {
-      if (err != CUBLAS_STATUS_SUCCESS)
-      {
-        std::string msg = std::to_string(err) + " : " + str;
-        ThrowInternalError(MicmInternalErrc::Cublas, file, line, msg.c_str());
-      }
-    }
   }  // namespace cuda
 }  // namespace micm

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -4,10 +4,7 @@
  */
 #include <micm/util/cuda_matrix.cuh>
 #include <micm/util/internal_error.hpp>
-
 #include <cuda_runtime.h>
-
-#include <iostream>
 #include <vector>
 
 namespace micm

--- a/src/util/cuda_util.cu
+++ b/src/util/cuda_util.cu
@@ -1,0 +1,32 @@
+/* Copyright (C) 2023-2024 National Center for Atmospheric Research
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ #include <micm/util/cuda_util.cuh>
+ #include <micm/util/internal_error.hpp>
+ #include <cuda_runtime.h>
+ 
+ namespace micm
+ {
+   namespace cuda
+   {
+     void CheckCudaError(cudaError_t err, const char* file, int line, std::string str)
+     {
+       if (err != cudaSuccess)
+       {
+         std::string msg = std::string(cudaGetErrorString(err)) + " : " + str;
+         ThrowInternalError(MicmInternalErrc::Cuda, file, line, msg.c_str());
+       }
+     }
+
+     void CheckCublasError(cublasStatus_t err, const char* file, int line, std::string str)
+     {
+       if (err != CUBLAS_STATUS_SUCCESS)
+       {
+         std::string msg = std::to_string(err) + " : " + str;
+         ThrowInternalError(MicmInternalErrc::Cublas, file, line, msg.c_str());
+       }
+     }
+   }  // namespace cuda
+ }  // namespace micm
+ 


### PR DESCRIPTION
This PR adds the error checks for all the CUDA APIs used in the MICM CUDA code.

With this change, we find a potential GPU memory issue in the `test_cuda_rosenbrock` test. After discussing with @mattldawson , we will update the solver builder in the `test_cuda_rosenbrock` and hopefully the test will pass later.

fix #550 