### PR TITLE
Removing 2019 msvc github actions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -36,7 +36,6 @@ jobs:
           ctest -C ${{ matrix.build_type }} --rerun-failed --output-on-failure . --verbose -j 10
 
   clang:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,25 +37,6 @@ jobs:
           cd build
           ctest -C Debug --rerun-failed --output-on-failure . --verbose
 
-  msvc2019:
-    runs-on: windows-2019
-    strategy:
-      matrix:
-        build_type: [Release]
-        architecture: [Win32, x64]
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Run CMake
-      run: cmake -S . -B build -D MICM_ENABLE_PROFILE=ON -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -G "Visual Studio 16 2019" -A ${{ matrix.architecture }}
-
-    - name: Build
-      run: cmake --build build --config ${{ matrix.build_type }} --parallel 10
-
-    - name: Test
-      run: cd build ; ctest -j 10 -C ${{ matrix.build_type }} --output-on-failure
-
   msvc2022:
     runs-on: windows-2022
     strategy:


### PR DESCRIPTION
Closes #563 

The ICE for msvc will likely not be simple to find and fix and we aren't required to compile with that compiler at this time. I vote we drop support for it in the github actions rather than burning time on fixing this