### PR TITLE
Fix GPU memory leak for the CUDA unit tests

### DIFF
--- a/cmake/test_util.cmake
+++ b/cmake/test_util.cmake
@@ -4,7 +4,7 @@
 if(MICM_ENABLE_MEMCHECK)
   if(MICM_ENABLE_CUDA)
     find_program(MEMORYCHECK_COMMAND "compute-sanitizer")
-    set(MEMORYCHECK_COMMAND_OPTIONS "--error-exitcode=1 --show-backtrace device --tool=memcheck --launch-timeout=0")
+    set(MEMORYCHECK_COMMAND_OPTIONS "--error-exitcode=1 --leak-check full --show-backtrace device --launch-timeout=0")
     set(CUDA_MEMORY_CHECK TRUE)
   else()
     find_program(MEMORYCHECK_COMMAND "valgrind")

--- a/include/micm/cuda/process/cuda_process_set.cuh
+++ b/include/micm/cuda/process/cuda_process_set.cuh
@@ -13,6 +13,10 @@ namespace micm
     ///   for the "jacobian_flat_id" because it is unknown now
     ProcessSetParam CopyConstData(ProcessSetParam& hoststruct);
 
+    /// This is the function that will delete the constant data
+    ///   members of class "CudaProcessSet" on the device
+    void FreeConstData(ProcessSetParam& devstruct);
+
     /// This is the function that will copy the "jacobian_flat_id"
     ///   of class "ProcessSet" to the device, after the matrix
     ///   structure is known

--- a/include/micm/cuda/process/cuda_process_set.hpp
+++ b/include/micm/cuda/process/cuda_process_set.hpp
@@ -19,6 +19,21 @@ namespace micm
     ProcessSetParam devstruct_;
 
     CudaProcessSet() = default;
+
+    CudaProcessSet(const CudaProcessSet&) = delete;
+    CudaProcessSet& operator=(const CudaProcessSet&) = delete;
+    CudaProcessSet(CudaProcessSet&& other)
+        : ProcessSet(std::move(other))
+    {
+      std::swap(this->devstruct_, other.devstruct_); 
+    };
+    CudaProcessSet& operator=(CudaProcessSet&& other)
+    {
+      ProcessSet::operator=(std::move(other));
+      std::swap(this->devstruct_, other.devstruct_); 
+      return *this;
+    };
+
     /// @brief Create a process set calculator for a given set of processes
     /// @param processes Processes to create calculator for
     /// @param variable_map A mapping of species names to concentration index

--- a/include/micm/cuda/process/cuda_process_set.hpp
+++ b/include/micm/cuda/process/cuda_process_set.hpp
@@ -24,6 +24,11 @@ namespace micm
     /// @param variable_map A mapping of species names to concentration index
     CudaProcessSet(const std::vector<Process>& processes, const std::map<std::string, std::size_t>& variable_map);
 
+    ~CudaProcessSet()
+    {
+      micm::cuda::FreeConstData(this->devstruct_);
+    }
+
     /// @brief Set the indexes for the elements of Jacobian matrix before we could copy it to the device;
     /// @brief this will override the "SetJacobianFlatIds" function from the "ProcessSet" class
     /// @param OrderingPolicy
@@ -73,7 +78,6 @@ namespace micm
     hoststruct.number_of_products_ = this->number_of_products_.data();
     hoststruct.product_ids_ = this->product_ids_.data();
     hoststruct.yields_ = this->yields_.data();
-    hoststruct.jacobian_flat_ids_ = nullptr;
 
     hoststruct.number_of_reactants_size_ = this->number_of_reactants_.size();
     hoststruct.reactant_ids_size_ = this->reactant_ids_.size();

--- a/include/micm/cuda/solver/cuda_linear_solver.hpp
+++ b/include/micm/cuda/solver/cuda_linear_solver.hpp
@@ -27,23 +27,15 @@ namespace micm
     CudaLinearSolver(const CudaLinearSolver&) = delete;
     CudaLinearSolver& operator=(const CudaLinearSolver&) = delete;
     CudaLinearSolver(CudaLinearSolver&& other)
-        : LinearSolver<SparseMatrixPolicy, LuDecompositionPolicy>(std::move(other)),
-          devstruct_(std::move(other.devstruct_))
+        : LinearSolver<SparseMatrixPolicy, LuDecompositionPolicy>(std::move(other))
     {
-      other.devstruct_.nLij_Lii_ = nullptr;
-      other.devstruct_.Lij_yj_ = nullptr;
-      other.devstruct_.nUij_Uii_ = nullptr;
-      other.devstruct_.Uij_xj_ = nullptr;
+      std::swap(this->devstruct_, other.devstruct_);
     };
 
     CudaLinearSolver& operator=(CudaLinearSolver&& other)
     {
       LinearSolver<SparseMatrixPolicy, LuDecompositionPolicy>::operator=(std::move(other));
-      devstruct_ = std::move(other.devstruct_);
-      other.devstruct_.nLij_Lii_ = nullptr;
-      other.devstruct_.Lij_yj_ = nullptr;
-      other.devstruct_.nUij_Uii_ = nullptr;
-      other.devstruct_.Uij_xj_ = nullptr;
+      std::swap(this->devstruct_, other.devstruct_);
       return *this;
     };
 

--- a/include/micm/cuda/solver/cuda_lu_decomposition.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition.hpp
@@ -26,35 +26,15 @@ namespace micm
     CudaLuDecomposition(const CudaLuDecomposition&) = delete;
     CudaLuDecomposition& operator=(const CudaLuDecomposition&) = delete;
     CudaLuDecomposition(CudaLuDecomposition&& other)
-        : LuDecomposition(std::move(other)),
-          devstruct_(std::move(other.devstruct_))
+        : LuDecomposition(std::move(other))
     {
-      other.devstruct_.niLU_ = nullptr;
-      other.devstruct_.do_aik_ = nullptr;
-      other.devstruct_.aik_ = nullptr;
-      other.devstruct_.uik_nkj_ = nullptr;
-      other.devstruct_.lij_ujk_ = nullptr;
-      other.devstruct_.do_aki_ = nullptr;
-      other.devstruct_.aki_ = nullptr;
-      other.devstruct_.lki_nkj_ = nullptr;
-      other.devstruct_.lkj_uji_ = nullptr;
-      other.devstruct_.uii_ = nullptr;
+      std::swap(this->devstruct_, other.devstruct_); 
     };
 
     CudaLuDecomposition& operator=(CudaLuDecomposition&& other)
     {
       LuDecomposition::operator=(std::move(other));
-      devstruct_ = std::move(other.devstruct_);
-      other.devstruct_.niLU_ = nullptr;
-      other.devstruct_.do_aik_ = nullptr;
-      other.devstruct_.aik_ = nullptr;
-      other.devstruct_.uik_nkj_ = nullptr;
-      other.devstruct_.lij_ujk_ = nullptr;
-      other.devstruct_.do_aki_ = nullptr;
-      other.devstruct_.aki_ = nullptr;
-      other.devstruct_.lki_nkj_ = nullptr;
-      other.devstruct_.lkj_uji_ = nullptr;
-      other.devstruct_.uii_ = nullptr;
+      std::swap(this->devstruct_, other.devstruct_); 
       return *this;
     };
 

--- a/include/micm/cuda/solver/cuda_rosenbrock.hpp
+++ b/include/micm/cuda/solver/cuda_rosenbrock.hpp
@@ -106,7 +106,6 @@ namespace micm
     ///   the constant data from the class "CudaRosenbrockSolver"
     ~CudaRosenbrockSolver()
     {
-      /// Free the device memory allocated by the members of "devstruct_"
       micm::cuda::FreeConstData(this->devstruct_);
     };
 

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -33,6 +33,7 @@ struct ProcessSetParam
 /// This struct could be allocated on the host or device;
 struct LuDecomposeParam
 {
+  bool* is_singular;
   std::pair<std::size_t, std::size_t>* niLU_;
   char* do_aik_;
   std::size_t* aik_;

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -14,12 +14,12 @@ const std::size_t BLOCK_SIZE = 32;
 /// This struct could be allocated on the host or device;
 struct ProcessSetParam
 {
-  std::size_t* number_of_reactants_;
-  std::size_t* reactant_ids_;
-  std::size_t* number_of_products_;
-  std::size_t* product_ids_;
-  double* yields_;
-  std::size_t* jacobian_flat_ids_;
+  std::size_t* number_of_reactants_ = nullptr;
+  std::size_t* reactant_ids_ = nullptr;
+  std::size_t* number_of_products_ = nullptr;
+  std::size_t* product_ids_ = nullptr;
+  double* yields_ = nullptr;
+  std::size_t* jacobian_flat_ids_ = nullptr;
   std::size_t number_of_reactants_size_;
   std::size_t reactant_ids_size_;
   std::size_t number_of_products_size_;
@@ -33,17 +33,17 @@ struct ProcessSetParam
 /// This struct could be allocated on the host or device;
 struct LuDecomposeParam
 {
-  bool* is_singular;
-  std::pair<std::size_t, std::size_t>* niLU_;
-  char* do_aik_;
-  std::size_t* aik_;
-  std::pair<std::size_t, std::size_t>* uik_nkj_;
-  std::pair<std::size_t, std::size_t>* lij_ujk_;
-  char* do_aki_;
-  std::size_t* aki_;
-  std::pair<std::size_t, std::size_t>* lki_nkj_;
-  std::pair<std::size_t, std::size_t>* lkj_uji_;
-  std::size_t* uii_;
+  bool* is_singular = nullptr;
+  std::pair<std::size_t, std::size_t>* niLU_ = nullptr;
+  char* do_aik_ = nullptr;
+  std::size_t* aik_ = nullptr;
+  std::pair<std::size_t, std::size_t>* uik_nkj_ = nullptr;
+  std::pair<std::size_t, std::size_t>* lij_ujk_ = nullptr;
+  char* do_aki_ = nullptr;
+  std::size_t* aki_ = nullptr;
+  std::pair<std::size_t, std::size_t>* lki_nkj_ = nullptr;
+  std::pair<std::size_t, std::size_t>* lkj_uji_ = nullptr;
+  std::size_t* uii_ = nullptr;
   std::size_t niLU_size_;
   std::size_t do_aik_size_;
   std::size_t aik_size_;
@@ -61,10 +61,10 @@ struct LuDecomposeParam
 /// This struct could be allocated on the host or device;
 struct LinearSolverParam
 {
-  std::pair<std::size_t, std::size_t>* nLij_Lii_;
-  std::pair<std::size_t, std::size_t>* Lij_yj_;
-  std::pair<std::size_t, std::size_t>* nUij_Uii_;
-  std::pair<std::size_t, std::size_t>* Uij_xj_;
+  std::pair<std::size_t, std::size_t>* nLij_Lii_ = nullptr;
+  std::pair<std::size_t, std::size_t>* Lij_yj_ = nullptr;
+  std::pair<std::size_t, std::size_t>* nUij_Uii_ = nullptr;
+  std::pair<std::size_t, std::size_t>* Uij_xj_ = nullptr;
   std::size_t nLij_Lii_size_;
   std::size_t Lij_yj_size_;
   std::size_t nUij_Uii_size_;
@@ -75,7 +75,7 @@ struct LinearSolverParam
 ///   data allocated on a device.
 struct CudaMatrixParam
 {
-  double* d_data_;
+  double* d_data_ = nullptr;
   std::size_t number_of_elements_;
   std::size_t number_of_grid_cells_;
 };
@@ -86,12 +86,12 @@ struct CudaMatrixParam
 struct CudaRosenbrockSolverParam
 {
   // for NormalizedError function
-  double* errors_input_;
-  double* errors_output_;
-  double* absolute_tolerance_;
+  double* errors_input_ = nullptr;
+  double* errors_output_ = nullptr;
+  double* absolute_tolerance_ = nullptr;
   std::size_t absolute_tolerance_size_;
   std::size_t errors_size_;
   // for AlphaMinusJacobian function
-  std::size_t* jacobian_diagonal_elements_;
+  std::size_t* jacobian_diagonal_elements_ = nullptr;
   std::size_t jacobian_diagonal_elements_size_;
 };

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -76,6 +76,8 @@ namespace micm
     /// @param variable_map A mapping of species names to concentration index
     ProcessSet(const std::vector<Process>& processes, const std::map<std::string, std::size_t>& variable_map);
 
+    virtual ~ProcessSet() = default;
+
     /// @brief Return the full set of non-zero Jacobian elements for the set of processes
     /// @return Jacobian elements as a set of index pairs
     std::set<std::pair<std::size_t, std::size_t>> NonZeroJacobianElements() const;

--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -74,6 +74,8 @@ namespace micm
         typename SparseMatrixPolicy::value_type initial_value,
         const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)> create_lu_decomp);
 
+    virtual ~LinearSolver() = default;
+    
     /// @brief Decompose the matrix into upper and lower triangular matrices
     void Factor(const SparseMatrixPolicy& matrix, SparseMatrixPolicy& lower_matrix, SparseMatrixPolicy& upper_matrix);
 

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -95,6 +95,8 @@ namespace micm
     template<class SparseMatrixPolicy>
     requires(SparseMatrixConcept<SparseMatrixPolicy>) LuDecomposition(const SparseMatrixPolicy& matrix);
 
+    ~LuDecomposition() = default;
+    
     /// @brief Create an LU decomposition algorithm for a given sparse matrix policy
     /// @param matrix Sparse matrix
     template<class SparseMatrixPolicy>

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -87,9 +87,10 @@ namespace micm
 
     LuDecomposition(const LuDecomposition&) = delete;
     LuDecomposition& operator=(const LuDecomposition&) = delete;
-    LuDecomposition(LuDecomposition&&) = default;
+ 
+    LuDecomposition(LuDecomposition&& other) = default;
     LuDecomposition& operator=(LuDecomposition&&) = default;
-
+    
     /// @brief Construct an LU decomposition algorithm for a given sparse matrix
     /// @param matrix Sparse matrix
     template<class SparseMatrixPolicy>

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -153,7 +153,6 @@ namespace micm
               jacobian)
     {
     }
-
     RosenbrockSolver(const RosenbrockSolver&) = delete;
     RosenbrockSolver& operator=(const RosenbrockSolver&) = delete;
     RosenbrockSolver(RosenbrockSolver&&) = default;

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -36,6 +36,29 @@ namespace micm
     {
     }
 
+    Solver(const Solver&) = delete;
+    Solver& operator=(const Solver&) = delete;
+
+    Solver(Solver&& other)
+        : solver_(std::swap(other.solver_)),
+          number_of_grid_cells_(other.number_of_grid_cells_),
+          number_of_species_(other.number_of_species_),
+          number_of_reactions_(other.number_of_reactions_),
+          state_parameters_(other.state_parameters_),
+          processes_(std::swap(other.processes_))
+    {
+    }
+    Solver& operator=(Solver&& other)
+    {
+      solver_ = std::swap(other.solver_);
+      number_of_grid_cells_ = other.number_of_grid_cells_;
+      number_of_species_ = other.number_of_species_;
+      number_of_reactions_ = other.number_of_reactions_;
+      state_parameters_ = other.state_parameters_;
+      processes_ = std::swap(other.processes_);
+      return *this;
+    }
+
     SolverResult Solve(double time_step, StatePolicy& state)
     {
       return solver_.Solve(time_step, state);

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -40,13 +40,13 @@ namespace micm
     Solver& operator=(const Solver&) = delete;
 
     Solver(Solver&& other)
-        : solver_(std::swap(other.solver_)),
-          number_of_grid_cells_(other.number_of_grid_cells_),
+        : number_of_grid_cells_(other.number_of_grid_cells_),
           number_of_species_(other.number_of_species_),
           number_of_reactions_(other.number_of_reactions_),
-          state_parameters_(other.state_parameters_),
-          processes_(std::swap(other.processes_))
+          state_parameters_(other.state_parameters_)
     {
+      std::swap(this->solver_,other.solver_);
+      std::swap(this->processes_,other.processes_); 
     }
     Solver& operator=(Solver&& other)
     {

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -50,12 +50,12 @@ namespace micm
     }
     Solver& operator=(Solver&& other)
     {
-      solver_ = std::swap(other.solver_);
+      std::swap(this->solver_,other.solver_);
       number_of_grid_cells_ = other.number_of_grid_cells_;
       number_of_species_ = other.number_of_species_;
       number_of_reactions_ = other.number_of_reactions_;
       state_parameters_ = other.state_parameters_;
-      processes_ = std::swap(other.processes_);
+      std::swap(this->solver_,other.processes_);
       return *this;
     }
 

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -172,6 +172,9 @@ namespace micm
       devstruct.product_ids_size_ = hoststruct.product_ids_size_;
       devstruct.yields_size_ = hoststruct.yields_size_;
 
+      // Initialize the jacobian_flat_ids_ to nullptr to avoid unnecessary cudaFree
+      devstruct.jacobian_flat_ids_ = nullptr;
+      
       return devstruct;
     }
 

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -202,11 +202,11 @@ namespace micm
     ///   members of class "CudaProcessSet" on the device
     void FreeConstData(ProcessSetParam& devstruct)
     {
-      CHECK_CUDA_ERROR(cudaFree(devstruct.number_of_reactants_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.reactant_ids_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.number_of_products_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.product_ids_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.yields_), "cudaFree");
+      if (devstruct.number_of_reactants_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.number_of_reactants_), "cudaFree");
+      if (devstruct.reactant_ids_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.reactant_ids_), "cudaFree");
+      if (devstruct.number_of_products_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.number_of_products_), "cudaFree");
+      if (devstruct.product_ids_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.product_ids_), "cudaFree");
+      if (devstruct.yields_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.yields_), "cudaFree");
       if (devstruct.jacobian_flat_ids_ != nullptr)
       {
         CHECK_CUDA_ERROR(cudaFree(devstruct.jacobian_flat_ids_), "cudaFree");

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -171,9 +171,6 @@ namespace micm
       devstruct.number_of_products_size_ = hoststruct.number_of_products_size_;
       devstruct.product_ids_size_ = hoststruct.product_ids_size_;
       devstruct.yields_size_ = hoststruct.yields_size_;
-
-      // Initialize the jacobian_flat_ids_ to nullptr to avoid unnecessary cudaFree
-      devstruct.jacobian_flat_ids_ = nullptr;
       
       return devstruct;
     }

--- a/src/solver/linear_solver.cu
+++ b/src/solver/linear_solver.cu
@@ -116,10 +116,10 @@ namespace micm
     ///   members of class "CudaLinearSolver" on the device
     void FreeConstData(LinearSolverParam& devstruct)
     {
-      CHECK_CUDA_ERROR(cudaFree(devstruct.nLij_Lii_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.Lij_yj_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.nUij_Uii_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.Uij_xj_), "cudaFree");
+      if (devstruct.nLij_Lii_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.nLij_Lii_), "cudaFree");
+      if (devstruct.Lij_yj_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.Lij_yj_), "cudaFree");
+      if (devstruct.nUij_Uii_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.nUij_Uii_), "cudaFree");
+      if (devstruct.Uij_xj_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.Uij_xj_), "cudaFree");
     }
 
     void SolveKernelDriver(

--- a/src/solver/lu_decomposition.cu
+++ b/src/solver/lu_decomposition.cu
@@ -161,17 +161,17 @@ namespace micm
     ///   members of class "CudaLuDecomposition" on the device
     void FreeConstData(LuDecomposeParam& devstruct)
     {
-      CHECK_CUDA_ERROR(cudaFree(devstruct.is_singular), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.niLU_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.do_aik_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.aik_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.uik_nkj_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.lij_ujk_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.do_aki_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.aki_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.lki_nkj_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.lkj_uji_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.uii_), "cudaFree");
+      if (devstruct.is_singular != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.is_singular), "cudaFree");
+      if (devstruct.niLU_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.niLU_), "cudaFree");
+      if (devstruct.do_aik_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.do_aik_), "cudaFree");
+      if (devstruct.aik_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.aik_), "cudaFree");
+      if (devstruct.uik_nkj_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.uik_nkj_), "cudaFree");
+      if (devstruct.lij_ujk_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.lij_ujk_), "cudaFree");
+      if (devstruct.do_aki_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.do_aki_), "cudaFree");
+      if (devstruct.aki_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.aki_), "cudaFree");
+      if (devstruct.lki_nkj_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.lki_nkj_), "cudaFree");
+      if (devstruct.lkj_uji_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.lkj_uji_), "cudaFree");
+      if (devstruct.uii_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.uii_), "cudaFree");
     }
 
     void DecomposeKernelDriver(

--- a/src/solver/lu_decomposition.cu
+++ b/src/solver/lu_decomposition.cu
@@ -181,8 +181,6 @@ namespace micm
         const LuDecomposeParam& devstruct,
         bool& is_singular)
     {
-      // Copy the boolean result from host to device
-      cudaMemcpy(devstruct.is_singular, &is_singular, sizeof(bool), cudaMemcpyHostToDevice);
       // Launch the CUDA kernel for LU decomposition
       size_t number_of_blocks = (A_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
       DecomposeKernel<<<number_of_blocks, BLOCK_SIZE>>>(A_param, L_param, U_param, devstruct);

--- a/src/solver/lu_decomposition.cu
+++ b/src/solver/lu_decomposition.cu
@@ -189,6 +189,7 @@ namespace micm
       DecomposeKernel<<<number_of_blocks, BLOCK_SIZE>>>(A_param, L_param, U_param, devstruct, d_is_singular);
       // Copy the boolean result from device back to host
       cudaMemcpy(&is_singular, d_is_singular, sizeof(bool), cudaMemcpyDeviceToHost);
+      cudaFree(d_is_singular);
     }  // end of DecomposeKernelDriver
   }    // end of namespace cuda
 }  // end of namespace micm

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -74,10 +74,10 @@ namespace micm
     ///   members and temporary variables of class "CudaLuDecomposition" on the device
     void FreeConstData(CudaRosenbrockSolverParam& devstruct)
     {
-      CHECK_CUDA_ERROR(cudaFree(devstruct.errors_input_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.errors_output_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.jacobian_diagonal_elements_), "cudaFree");
-      CHECK_CUDA_ERROR(cudaFree(devstruct.absolute_tolerance_), "cudaFree");
+      if (devstruct.errors_input_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.errors_input_), "cudaFree");
+      if (devstruct.errors_output_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.errors_output_), "cudaFree");
+      if (devstruct.jacobian_diagonal_elements_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.jacobian_diagonal_elements_), "cudaFree");
+      if (devstruct.absolute_tolerance_ != nullptr) CHECK_CUDA_ERROR(cudaFree(devstruct.absolute_tolerance_), "cudaFree");
     }
 
     // Specific CUDA device function to do reduction within a warp


### PR DESCRIPTION
This PR:
- use the correct option `--leak-check full` for `compute-sanitizer` to check the memory leak on the GPU.
- fix a GPU memory leak due to the missing of `cudaFree` for a bool pointer on the GPU.
- fix multiple GPU memory leaks by using `std::swap` rather than `std::move` in the move constructor and assignment in a CUDA class.

All the GPU unit tests are now passed for GPU memory check on Derecho's A100 GPU. The integration test is not checked for GPU memory leak because it takes too long.

fix #598 