### PR TITLE
572 check for singularity when the solver parameters flag is turned on

### DIFF
--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -112,16 +112,6 @@ namespace micm
     /// @param A Sparse matrix to decompose
     /// @param L The lower triangular matrix created by decomposition
     /// @param U The upper triangular matrix created by decomposition
-    template<class SparseMatrixPolicy>
-    requires(SparseMatrixConcept<SparseMatrixPolicy>) void Decompose(
-        const SparseMatrixPolicy& A,
-        SparseMatrixPolicy& L,
-        SparseMatrixPolicy& U) const;
-
-    /// @brief Perform an LU decomposition on a given A matrix
-    /// @param A Sparse matrix to decompose
-    /// @param L The lower triangular matrix created by decomposition
-    /// @param U The upper triangular matrix created by decomposition
     /// @param is_singular Flag that is set to true if A is singular; false otherwise
     template<class SparseMatrixPolicy>
     requires(!VectorizableSparse<SparseMatrixPolicy>) void Decompose(

--- a/include/micm/solver/lu_decomposition.inl
+++ b/include/micm/solver/lu_decomposition.inl
@@ -164,16 +164,6 @@ namespace micm
   }
 
   template<class SparseMatrixPolicy>
-  requires(SparseMatrixConcept<SparseMatrixPolicy>) inline void LuDecomposition::Decompose(
-      const SparseMatrixPolicy& A,
-      SparseMatrixPolicy& L,
-      SparseMatrixPolicy& U) const
-  {
-    bool is_singular = false;
-    Decompose<SparseMatrixPolicy>(A, L, U, is_singular);
-  }
-
-  template<class SparseMatrixPolicy>
   requires(!VectorizableSparse<SparseMatrixPolicy>) inline void LuDecomposition::Decompose(
       const SparseMatrixPolicy& A,
       SparseMatrixPolicy& L,
@@ -328,7 +318,9 @@ namespace micm
       }
 
       auto cell_U_bottom_right = std::next(U.AsVector().begin(), i_group * U_GroupSizeOfFlatBlockSize + U_GroupSizeOfFlatBlockSize - 1);
-      if (*cell_U_bottom_right == 0) is_singular = true;
+        if (*cell_U_bottom_right == 0){
+            is_singular = true;
+        }
     }
   }
 

--- a/include/micm/solver/lu_decomposition.inl
+++ b/include/micm/solver/lu_decomposition.inl
@@ -223,16 +223,19 @@ namespace micm
             L_vector[lki_nkj->first] -= L_vector[lkj_uji->first] * U_vector[lkj_uji->second];
             ++lkj_uji;
           }
+
           if (U_vector[*uii] == 0.0)
           {
             is_singular = true;
-            return;
           }
           L_vector[lki_nkj->first] /= U_vector[*uii];
           ++lki_nkj;
           ++uii;
         }
       }
+      // the singularity check inside the for loop won't detect a zero in the bottom right position
+      auto cell_U_bottom_right = std::next(U.AsVector().begin(), i_block * U.FlatBlockSize() + U.FlatBlockSize() - 1);
+      if (*cell_U_bottom_right == 0) is_singular = true;
     }
   }
 
@@ -316,7 +319,6 @@ namespace micm
             if (U_vector[uii_deref + i_cell] == 0.0)
             {
               is_singular = true;
-              return;
             }
             L_vector[lki_nkj_first + i_cell] /= U_vector[uii_deref + i_cell];
           }
@@ -324,6 +326,9 @@ namespace micm
           ++uii;
         }
       }
+
+      auto cell_U_bottom_right = std::next(U.AsVector().begin(), i_group * U_GroupSizeOfFlatBlockSize + U_GroupSizeOfFlatBlockSize - 1);
+      if (*cell_U_bottom_right == 0) is_singular = true;
     }
   }
 

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -250,13 +250,13 @@ namespace micm
       if (parameters_.check_singularity_)
       {
         linear_solver_.Factor(jacobian, state.lower_matrix_, state.upper_matrix_, singular);
+        std::cout << "singular: " << (singular ? "true" : "false") << std::endl;
       }
       else
       {
         singular = false;
         linear_solver_.Factor(jacobian, state.lower_matrix_, state.upper_matrix_);
       }
-      singular = false;  // TODO This should be evaluated in some way
       stats.decompositions_ += 1;
       if (!singular)
         break;

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -247,17 +247,14 @@ namespace micm
       auto jacobian = state.jacobian_;
       double alpha = 1 / (H * gamma);
       static_cast<Derived*>(this)->AlphaMinusJacobian(jacobian, alpha);
-      if (parameters_.check_singularity_)
-      {
-        linear_solver_.Factor(jacobian, state.lower_matrix_, state.upper_matrix_, singular);
-      }
-      else
-      {
-        linear_solver_.Factor(jacobian, state.lower_matrix_, state.upper_matrix_);
-      }
+      linear_solver_.Factor(jacobian, state.lower_matrix_, state.upper_matrix_, singular);
       stats.decompositions_ += 1;
-      if (!singular)
+
+      // if we are checking for singularity and the matrix is not singular, we can break the loop
+      // if we are not checking for singularity, we always break the loop
+      if (!singular || !parameters_.check_singularity_)
         break;
+
       stats.singular_ += 1;
       if (++n_consecutive > 5)
         break;

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -240,21 +240,19 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    auto jacobian = state.jacobian_;
     uint64_t n_consecutive = 0;
     singular = false;
     while (true)
     {
+      auto jacobian = state.jacobian_;
       double alpha = 1 / (H * gamma);
       static_cast<Derived*>(this)->AlphaMinusJacobian(jacobian, alpha);
       if (parameters_.check_singularity_)
       {
         linear_solver_.Factor(jacobian, state.lower_matrix_, state.upper_matrix_, singular);
-        std::cout << "singular: " << (singular ? "true" : "false") << std::endl;
       }
       else
       {
-        singular = false;
         linear_solver_.Factor(jacobian, state.lower_matrix_, state.upper_matrix_);
       }
       stats.decompositions_ += 1;

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -92,7 +92,7 @@ namespace micm
     jacobian_ = BuildJacobian<SparseMatrixPolicy>(
         parameters.nonzero_jacobian_elements_, parameters.number_of_grid_cells_, state_size_);
 
-    auto lu = LuDecomposition::GetLUMatrices<SparseMatrixPolicy>(jacobian_, 1.0e-30);
+    auto lu = LuDecomposition::GetLUMatrices<SparseMatrixPolicy>(jacobian_, 0);
     auto lower_matrix = std::move(lu.first);
     auto upper_matrix = std::move(lu.second);
     lower_matrix_ = lower_matrix;

--- a/test/integration/test_analytical_rosenbrock.cpp
+++ b/test/integration/test_analytical_rosenbrock.cpp
@@ -220,7 +220,7 @@ TEST(AnalyticalExamples, SurfaceRxn)
   test_analytical_surface_rxn(rosenbrock_6stage_da, 1e-7);
 }
 
-TEST(AnalyticalExamples, HIRESConfig)
+TEST(AnalyticalExamples, HIRES)
 {
   auto rosenbrock_solver = [](auto params)
   {

--- a/test/unit/solver/test_rosenbrock.cpp
+++ b/test/unit/solver/test_rosenbrock.cpp
@@ -281,9 +281,14 @@ TEST(RosenbrockSolver, SingularSystem)
   vector_state.variables_[0] = { 1.0, 1.0, 1.0 };
 
   // to get a jacobian with an LU factorization that contains a zero on the diagonal
-  // of U, we need alpha * I - jacobian to have an alpha value that is either 0 (useless) or - k1
-  // alpha is 1 / (H * gamma), where H is the time step and gamma is the gamma value
-  // so H needs to be 1 / ( - k1 * gamma)
+  // of U, we need det(alpha * I - jacobian) = 0
+  // for the system above, that means we have to have alpha + k1 + k2 = 0
+  // in this case, one of the reaction rates will be negative but it's good enough to 
+  // test the singularity check
+  // alpha is 1 / (H * gamma), where H is the time step and gamma is the gamma value from 
+  // the rosenbrock paramters
+  // so H needs to be 1 / ( (-k1 - k2) * gamma)
+  // since H is positive we need -k1 -k2 to be positive, hence the smaller, negative value for k1
   double H = 1 / ( (-k1 - k2) * params.gamma_[0]);
   standard_solver.solver_.parameters_.h_start_ = H;
     


### PR DESCRIPTION
Closes #572 

This PR fixes an unknown bug where a zero in the bottom right position of the U matrix (which leads to a singular matrix) was not detected by always checking for zero in the bottom right element. Additionally, two tests are added to check for singular matrices when running rosenbrock