### PR TITLE
throwing error on mismatched size

### DIFF
--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -6,7 +6,8 @@ enum class MicmSolverBuilderErrc
   UnusedSpecies = 1,          // Unused species present in the chemical system
   MissingChemicalSystem = 2,  // Missing chemical system
   MissingReactions = 3,       // Missing processes
-  MissingChemicalSpecies = 4  // Missing chemical species
+  MissingChemicalSpecies = 4, // Missing chemical species
+  InvalidToleranceSize = 5    // Invalid tolerance size
 };
 
 namespace std
@@ -37,7 +38,10 @@ namespace
           return "Missing chemical system. Use the SetSystem function to set the chemical system.";
         case MicmSolverBuilderErrc::MissingReactions:
           return "Missing reactions. Use the SetReactions function to set the processes.";
-        case MicmSolverBuilderErrc::MissingChemicalSpecies: return "Provided chemical system contains no species.";
+        case MicmSolverBuilderErrc::MissingChemicalSpecies:
+          return "Provided chemical system contains no species.";
+        case MicmSolverBuilderErrc::InvalidToleranceSize:
+          return "Provided tolerances do not match the number of species in the chemical system.";
         default: return "Unknown error";
       }
     }
@@ -285,6 +289,12 @@ namespace micm
       StatePolicy>::
       SetAbsoluteTolerances(std::vector<double>& tolerances, const std::map<std::string, std::size_t>& species_map) const
   {
+    if (tolerances.size() > 0 && tolerances.size() != species_map.size())
+    {
+      throw std::system_error(
+          make_error_code(MicmSolverBuilderErrc::InvalidToleranceSize),
+          "You provided a list tolerances that does not match the number of species in the chemical system. Either provide the correct length or pass none in and a default value will be set for all species.");
+    }
     // if the tolerances aren't already set, initialize them and then set based off of information in the system
     if (tolerances.size() != species_map.size())
     {

--- a/test/unit/cuda/solver/test_cuda_solver_builder.cpp
+++ b/test/unit/cuda/solver/test_cuda_solver_builder.cpp
@@ -48,3 +48,31 @@ TEST(SolverBuilder, CanBuildCudaSolvers)
                              .SetNumberOfGridCells(L)
                              .Build();
 }
+
+TEST(SolverBuilder, MismatchedToleranceSizeIsCaught)
+{
+  auto params = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
+  // too many
+  params.absolute_tolerance_ = { 1e-6, 1e-6, 1e-6, 1e-6, 1e-6 };
+
+  constexpr std::size_t L = 4;
+  using cuda_builder = micm::CudaSolverBuilder<micm::CudaRosenbrockSolverParameters, L>;
+
+  EXPECT_ANY_THROW(
+    cuda_builder(params)
+      .SetSystem(the_system)
+      .SetReactions(reactions)
+      .SetNumberOfGridCells(L)
+      .Build();
+  );
+
+  // too few
+  params.absolute_tolerance_ = { 1e-6, 1e-6 };
+  EXPECT_ANY_THROW(
+    cuda_builder(params)
+      .SetSystem(the_system)
+      .SetReactions(reactions)
+      .SetNumberOfGridCells(L)
+      .Build();
+  );
+}

--- a/test/unit/jit/solver/test_jit_solver_builder.cpp
+++ b/test/unit/jit/solver/test_jit_solver_builder.cpp
@@ -48,3 +48,31 @@ TEST(SolverBuilder, CanBuildJitRosenbrock)
                             .SetNumberOfGridCells(L)
                             .Build();
 }
+
+TEST(SolverBuilder, MismatchedToleranceSizeIsCaught)
+{
+  auto params = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
+  // too many
+  params.absolute_tolerance_ = { 1e-6, 1e-6, 1e-6, 1e-6, 1e-6 };
+
+  constexpr std::size_t L = 4;
+  using jit_builder = micm::JitSolverBuilder<micm::JitRosenbrockSolverParameters, L>;
+
+  EXPECT_ANY_THROW(
+    jit_builder(params)
+      .SetSystem(the_system)
+      .SetReactions(reactions)
+      .SetNumberOfGridCells(L)
+      .Build();
+  );
+
+  // too few
+  params.absolute_tolerance_ = { 1e-6, 1e-6 };
+  EXPECT_ANY_THROW(
+    jit_builder(params)
+      .SetSystem(the_system)
+      .SetReactions(reactions)
+      .SetNumberOfGridCells(L)
+      .Build();
+  );
+}

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -105,3 +105,35 @@ TEST(SolverBuilder, CanBuildRosenbrock)
                                .SetNumberOfGridCells(1)
                                .Build();
 }
+
+TEST(SolverBuilder, MismatchedToleranceSizeIsCaught)
+{
+  auto params = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
+  // too many
+  params.absolute_tolerance_ = { 1e-6, 1e-6, 1e-6, 1e-6, 1e-6 };
+  EXPECT_ANY_THROW(
+    micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(params)
+      .SetSystem(the_system)
+      .SetReactions(reactions)
+      .SetNumberOfGridCells(1)
+      .Build();
+  );
+
+  constexpr std::size_t L = 4;
+  // too few
+  params.absolute_tolerance_ = { 1e-6, 1e-6 };
+ 
+ auto builder = micm::CpuSolverBuilder<
+  micm::RosenbrockSolverParameters, 
+  micm::VectorMatrix<double, L>, 
+  micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<L>> 
+>(params);
+ 
+  EXPECT_ANY_THROW(
+    builder
+      .SetSystem(the_system)
+      .SetReactions(reactions)
+      .SetNumberOfGridCells(1)
+      .Build();
+  );
+}


### PR DESCRIPTION
Closees #599 

Throws an error when a mismatched size of absolute tolerances is passed to the builder