### PR TITLE
Correct usage of third body species

### DIFF
--- a/examples/configs/TS1/species.json
+++ b/examples/configs/TS1/species.json
@@ -1274,6 +1274,7 @@
     {
       "name": "M",
       "type": "CHEM_SPEC",
+      "tracer type": "THIRD_BODY",
       "__description": "third-body species"
     }
 

--- a/examples/configs/carbon_bond_5/species.json
+++ b/examples/configs/carbon_bond_5/species.json
@@ -130,7 +130,8 @@
     },
     {
       "name": "M",
-      "type": "CHEM_SPEC"
+      "type": "CHEM_SPEC",
+      "tracer type": "THIRD_BODY"
     },
     {
       "name": "MEO2",

--- a/examples/configs/chapman/species.json
+++ b/examples/configs/chapman/species.json
@@ -3,7 +3,7 @@
         {
             "name": "M",
             "type": "CHEM_SPEC",
-            "tracer type": "CONSTANT"
+            "tracer type": "THIRD_BODY"
         },
         {
             "name": "O2",

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -76,6 +76,9 @@ namespace micm
     ///        the solver state.
     std::function<double(const Conditions)> parameterize_{ nullptr };
 
+    /// @brief Default constructor
+    Species() = default;
+
     /// @brief Copy assignment
     /// @param other species to copy
     Species& operator=(const Species& other);

--- a/test/integration/test_chapman_integration.cpp
+++ b/test/integration/test_chapman_integration.cpp
@@ -46,7 +46,6 @@ TEST(ChapmanIntegration, CanBuildChapmanSystemUsingConfig)
 
   for (size_t n_grid_cell = 0; n_grid_cell < state.number_of_grid_cells_; ++n_grid_cell)
   {
-    EXPECT_EQ(solver.solver_.parameters_.absolute_tolerance_[state.variable_map_["M"]], 1.0e-3);
     EXPECT_EQ(solver.solver_.parameters_.absolute_tolerance_[state.variable_map_["Ar"]], 1.0e-12);
     EXPECT_EQ(solver.solver_.parameters_.absolute_tolerance_[state.variable_map_["CO2"]], 1.0e-12);
     EXPECT_EQ(solver.solver_.parameters_.absolute_tolerance_[state.variable_map_["H2O"]], 1.0e-12);
@@ -59,7 +58,7 @@ TEST(ChapmanIntegration, CanBuildChapmanSystemUsingConfig)
 
   // User gives an input of concentrations
   std::unordered_map<std::string, std::vector<double>> concentrations = {
-    { "O", { 0.1 } },  { "O1D", { 0.1 } }, { "O2", { 0.1 } },  { "O3", { 0.2 } }, { "M", { 0.2 } },
+    { "O", { 0.1 } },  { "O1D", { 0.1 } }, { "O2", { 0.1 } },  { "O3", { 0.2 } },
     { "Ar", { 0.2 } }, { "N2", { 0.3 } },  { "H2O", { 0.3 } }, { "CO2", { 0.3 } }
   };
 
@@ -74,6 +73,7 @@ TEST(ChapmanIntegration, CanBuildChapmanSystemUsingConfig)
 
   state.conditions_[0].temperature_ = 2;
   state.conditions_[0].pressure_ = 3;
+  state.conditions_[0].air_density_ = 0.2;
 
   for (double t{}; t < 100; ++t)
   {

--- a/test/unit/configure/test_solver_config.cpp
+++ b/test/unit/configure/test_solver_config.cpp
@@ -117,9 +117,9 @@ TEST(SolverConfig, ReadAndParseSystemObject)
 
   // Check 'name' and 'properties' in 'Species'
   std::vector<std::pair<std::string, short>> species_name_and_num_properties = {
-    std::make_pair("M", 0),   std::make_pair("Ar", 1), std::make_pair("CO2", 1),
-    std::make_pair("H2O", 1), std::make_pair("N2", 2), std::make_pair("O1D", 1),
-    std::make_pair("O", 1),   std::make_pair("O2", 1), std::make_pair("O3", 1)
+    std::make_pair("Ar", 1), std::make_pair("CO2", 1), std::make_pair("H2O", 1),
+    std::make_pair("M", 0), std::make_pair("N2", 2), std::make_pair("O", 1),
+    std::make_pair("O1D", 1), std::make_pair("O2", 1), std::make_pair("O3", 1)
   };
 
   short idx = 0;
@@ -147,9 +147,9 @@ TEST(SolverConfig, ReadAndParseThirdBodySpecies)
   // Get solver parameters ('System', the collection of 'Process')
   micm::SolverParameters solver_params = solverConfig.GetSolverParams();
 
-  EXPECT_EQ(solver_params.system_.gas_phase_.species_[0].name_, "FOO");
-  EXPECT_TRUE(solver_params.system_.gas_phase_.species_[0].IsParameterized());
-  EXPECT_EQ(solver_params.system_.gas_phase_.species_[0].parameterize_({ .air_density_ = 42.4 }), 42.4);
+  EXPECT_EQ(solver_params.system_.gas_phase_.species_[2].name_, "FOO");
+  EXPECT_TRUE(solver_params.system_.gas_phase_.species_[2].IsParameterized());
+  EXPECT_EQ(solver_params.system_.gas_phase_.species_[2].parameterize_({ .air_density_ = 42.4 }), 42.4);
 }
 
 TEST(SolverConfig, ReadAndParseProcessObjects)

--- a/test/unit/unit_configs/small_mechanism/species.json
+++ b/test/unit/unit_configs/small_mechanism/species.json
@@ -7,7 +7,7 @@
     {
       "name" : "M",
       "type" : "CHEM_SPEC",
-      "tracer type" : "CONSTANT"
+      "tracer type" : "THIRD_BODY"
     },
     {
       "name" : "Ar",


### PR DESCRIPTION
Fix #613. The full writeup is in the issue, but ensuring that the species object in the list of products and reactants contains information on whether something is a third body by copying the value from the species array during a read of a configuration file allows the process set to properly detect if a species is a third body or not and fixes our usage of third body species