### PR TITLE
Remove redundant variable and optimize the copy assignment for the CUDA matrix

### DIFF
--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -129,10 +129,12 @@ namespace micm
     CudaDenseMatrix& operator=(const CudaDenseMatrix& other)
     {
       VectorMatrix<T, L>::operator=(other);
-      if (this->param_.d_data_ != nullptr)
+      if (this->param_.number_of_elements_ != other.param_.number_of_elements_)
+      {
         CHECK_CUDA_ERROR(micm::cuda::FreeVector(this->param_), "cudaFree");
-      this->param_ = other.param_;
-      CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
+        this->param_ = other.param_;
+        CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
+      }
       CHECK_CUDA_ERROR(micm::cuda::CopyToDeviceFromDevice<T>(this->param_, other.param_), "cudaMemcpyDeviceToDevice");
       return *this;
     }

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -57,11 +57,6 @@ namespace micm
       //  Limit H if necessary to avoid going beyond the specified chemistry time step
       H = std::min(H, std::abs(time_step - present_time));
 
-      // compute the forcing at the beginning of the current time
-      K[0].Fill(0.0);
-      rates_.AddForcingTerms(state.rate_constants_, Y, K[0]);
-      stats.function_calls_ += 1;
-
       // compute the negative jacobian at the beginning of the current time
       state.jacobian_.Fill(0.0);
       rates_.SubtractJacobianTerms(state.rate_constants_, Y, state.jacobian_);
@@ -71,6 +66,11 @@ namespace micm
       //  Repeat step calculation until current step accepted
       while (!accepted)
       {
+        // compute the forcing term; have to do it here if a sub-stepping is needed (or do it outside the while loop and save the initial forcing with a temporary variable)
+        K[0].Fill(0.0);
+        rates_.AddForcingTerms(state.rate_constants_, Y, K[0]);
+        stats.function_calls_ += 1;
+        
         bool is_singular{ false };
         // Form and factor the rosenbrock ode jacobian
         LinearFactor(H, parameters_.gamma_[0], is_singular, Y, stats, state);

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -98,6 +98,10 @@ namespace micm
               stats.function_calls_ += 1;
             }
           }
+          if (stage + 1 < parameters_.stages_ && !parameters_.new_function_evaluation_[stage + 1])
+          {
+            K[stage + 1].Copy(K[stage]);
+          }
           for (uint64_t j = 0; j < stage; ++j)
           {
             K[stage].Axpy(parameters_.c_[stage_combinations + j] / H, K[j]);


### PR DESCRIPTION
This PR:
- removes the usage of `forcing` variable in the `solve` function
- reallocates the device memory in the copy assignment operator only when the matrix size is different

fix #634 
fix #635 