### PR TITLE
Remove local copy of state in solver functions

### DIFF
--- a/include/micm/solver/backward_euler.inl
+++ b/include/micm/solver/backward_euler.inl
@@ -67,7 +67,7 @@ namespace micm
     bool singular = false;
 
     auto Yn = state.variables_;
-    auto Yn1 = state.variables_;
+    auto& Yn1 = state.variables_; // Yn1 will hold the new solution at the end of the solve
     auto forcing = state.variables_;
 
     while (t < time_step)
@@ -162,7 +162,6 @@ namespace micm
       H = std::min(H, time_step - t);
     }
 
-    state.variables_ = Yn1;
     result.final_time_ = t;
     return result;
   }

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -13,7 +13,7 @@ namespace micm
 
     SolverResult result{};
     result.state_ = SolverState::Running;
-    MatrixPolicy Y = state.variables_;
+    MatrixPolicy& Y = state.variables_; // Y will hold the new solution at the end of the solve
     std::size_t num_rows = Y.NumRows();
     std::size_t num_cols = Y.NumColumns();
     MatrixPolicy Ynew(num_rows, num_cols);
@@ -192,7 +192,6 @@ namespace micm
 
     result.final_time_ = present_time;
     result.stats_ = stats;
-    state.variables_ = Y;
 
     return result;
   }


### PR DESCRIPTION
Replaces a local copy of the system state variables in the Rosenbrock and Backward Euler solver functions with a reference to the function argument.