### PR TITLE
Add CUDA stream for asynchronous kernel launch

### DIFF
--- a/cmake/test_util.cmake
+++ b/cmake/test_util.cmake
@@ -26,7 +26,11 @@ function(create_standard_test)
 
   add_executable(test_${TEST_NAME} ${TEST_SOURCES})
 
-  target_link_libraries(test_${TEST_NAME} PUBLIC musica::micm GTest::gtest_main)
+  if(TEST_IS_CUDA_TEST)
+    target_link_libraries(test_${TEST_NAME} PUBLIC musica::micm cuda_gtest_main)
+  else()
+    target_link_libraries(test_${TEST_NAME} PUBLIC musica::micm GTest::gtest_main)
+  endif()
 
   # link additional libraries
   foreach(library ${TEST_LIBRARIES})

--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -151,10 +151,6 @@ namespace micm
 
     ~CudaDenseMatrix()
     {
-    }
-
-    ~CudaDenseMatrix() requires(std::is_same_v<T, double>)
-    {
       CHECK_CUDA_ERROR(micm::cuda::FreeVector(this->param_), "cudaFree");
       this->param_.d_data_ = nullptr;
     }

--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -210,7 +210,7 @@ namespace micm
       {
         // the cudaMemset function only works for integer types and is an asynchronous function:
         // https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html#group__CUDART__MEMORY_1gf7338650f7683c51ee26aadc6973c63a
-        CHECK_CUDA_ERROR(cudaMemset(this->param_.d_data_, val, sizeof(T) * this->param_.number_of_elements_), "cudaMemset");
+        CHECK_CUDA_ERROR(cudaMemsetAsync(this->param_.d_data_, val, sizeof(T) * this->param_.number_of_elements_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemset");
       }
       else
       {

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -4,10 +4,12 @@
 
 #include <cstddef>
 #include <utility>
+#include <micm/cuda/util/cuda_util.cuh>
 
 // To make the NormalizedError function works properly on GPU,
 // make sure to choose the BLOCK_SIZE from [32, 64, 128, 256, 512, 1024]
 const std::size_t BLOCK_SIZE = 32;
+micm::cuda::CudaStreamSingleton cudastreams;
 
 /// This struct holds the (1) pointer to, and (2) size of
 ///   each constatnt data member from the class "ProcessSet";

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -9,7 +9,6 @@
 // To make the NormalizedError function works properly on GPU,
 // make sure to choose the BLOCK_SIZE from [32, 64, 128, 256, 512, 1024]
 const std::size_t BLOCK_SIZE = 32;
-micm::cuda::CudaStreamSingleton cudastreams;
 
 /// This struct holds the (1) pointer to, and (2) size of
 ///   each constatnt data member from the class "ProcessSet";

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -4,7 +4,6 @@
 
 #include <cstddef>
 #include <utility>
-#include <micm/cuda/util/cuda_util.cuh>
 
 // To make the NormalizedError function works properly on GPU,
 // make sure to choose the BLOCK_SIZE from [32, 64, 128, 256, 512, 1024]

--- a/include/micm/cuda/util/cuda_util.cuh
+++ b/include/micm/cuda/util/cuda_util.cuh
@@ -55,8 +55,6 @@ namespace micm
     class CudaStreamSingleton
     {
     public:
-
-      CudaStreamSingleton() = default;
       
       ~CudaStreamSingleton() = default;
       
@@ -74,6 +72,8 @@ namespace micm
       void CleanUp();
       
     private:
+      // Private constructor to prevent direct instantiation
+      CudaStreamSingleton() = default;
 
       // Create a CUDA stream and return a unique pointer to it
       CudaStreamPtr CreateCudaStream();

--- a/include/micm/cuda/util/cuda_util.cuh
+++ b/include/micm/cuda/util/cuda_util.cuh
@@ -30,5 +30,8 @@ namespace micm
 
     /// @brief Get the cuBLAS handle for the current device
     cublasHandle_t& GetCublasHandle();
+
+    /// @brief Get the CUDA stream give a stream ID
+    cudaStream_t& GetCudaStream(std::size_t stream_id);
   }  // namespace cuda
 }  // namespace micm

--- a/include/micm/cuda/util/cuda_util.cuh
+++ b/include/micm/cuda/util/cuda_util.cuh
@@ -41,9 +41,9 @@ namespace micm
       {
         if (cuda_stream != nullptr)
         {
-          cudaStreamSynchronize(*cuda_stream);
           CHECK_CUDA_ERROR(cudaStreamDestroy(*cuda_stream), "CUDA stream finalization failed");
           delete cuda_stream;
+          cuda_stream = nullptr;
         }
       }
     };
@@ -58,22 +58,25 @@ namespace micm
 
       CudaStreamSingleton() = default;
       
-      ~CudaStreamSingleton(){ CleanUp(); }
+      ~CudaStreamSingleton() = default;
       
       CudaStreamSingleton(const CudaStreamSingleton&) = delete;
 
       CudaStreamSingleton& operator=(const CudaStreamSingleton&) = delete;
 
+      // Get the only one instance of the singleton class
+      static CudaStreamSingleton& GetInstance();
+      
       // Get the CUDA stream given a stream ID
       cudaStream_t& GetCudaStream(std::size_t stream_id);
 
+      // Empty the map variable to clean up all CUDA streams
+      void CleanUp();
+      
     private:
 
       // Create a CUDA stream and return a unique pointer to it
       CudaStreamPtr CreateCudaStream();
-
-      // Empty the map variable to clean up all CUDA streams
-      void CleanUp();
 
       std::map<int, CudaStreamPtr> cuda_streams_map_;
 

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -136,11 +136,11 @@ namespace micm
       ProcessSetParam devstruct;
 
       /// Allocate memory space on the device
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.number_of_reactants_), number_of_reactants_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.reactant_ids_), reactant_ids_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.number_of_products_), number_of_products_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.product_ids_), product_ids_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.yields_), yields_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.number_of_reactants_), number_of_reactants_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.reactant_ids_), reactant_ids_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.number_of_products_), number_of_products_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.product_ids_), product_ids_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.yields_), yields_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
       CHECK_CUDA_ERROR(
@@ -149,10 +149,10 @@ namespace micm
               hoststruct.number_of_reactants_,
               number_of_reactants_bytes,
               cudaMemcpyHostToDevice,
-              micm::cuda::GetCudaStream(0)),
+              cudastreams.GetCudaStream(0)),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.reactant_ids_, hoststruct.reactant_ids_, reactant_ids_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)),
+          cudaMemcpyAsync(devstruct.reactant_ids_, hoststruct.reactant_ids_, reactant_ids_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
           cudaMemcpyAsync(
@@ -160,13 +160,13 @@ namespace micm
               hoststruct.number_of_products_,
               number_of_products_bytes,
               cudaMemcpyHostToDevice,
-              micm::cuda::GetCudaStream(0)),
+              cudastreams.GetCudaStream(0)),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.product_ids_, hoststruct.product_ids_, product_ids_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)),
+          cudaMemcpyAsync(devstruct.product_ids_, hoststruct.product_ids_, product_ids_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.yields_, hoststruct.yields_, yields_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.yields_, hoststruct.yields_, yields_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
 
       devstruct.number_of_reactants_size_ = hoststruct.number_of_reactants_size_;
       devstruct.reactant_ids_size_ = hoststruct.reactant_ids_size_;
@@ -186,12 +186,12 @@ namespace micm
       size_t jacobian_flat_ids_bytes = sizeof(size_t) * hoststruct.jacobian_flat_ids_size_;
 
       /// Allocate memory space on the device
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.jacobian_flat_ids_), jacobian_flat_ids_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.jacobian_flat_ids_), jacobian_flat_ids_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
       CHECK_CUDA_ERROR(
           cudaMemcpyAsync(
-              devstruct.jacobian_flat_ids_, hoststruct.jacobian_flat_ids_, jacobian_flat_ids_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)),
+              devstruct.jacobian_flat_ids_, hoststruct.jacobian_flat_ids_, jacobian_flat_ids_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)),
           "cudaMemcpy");
 
       devstruct.jacobian_flat_ids_size_ = hoststruct.jacobian_flat_ids_size_;
@@ -202,18 +202,18 @@ namespace micm
     void FreeConstData(ProcessSetParam& devstruct)
     {
       if (devstruct.number_of_reactants_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_reactants_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_reactants_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.reactant_ids_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.reactant_ids_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.reactant_ids_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.number_of_products_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_products_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_products_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.product_ids_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.product_ids_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.product_ids_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.yields_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.yields_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.yields_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.jacobian_flat_ids_ != nullptr)
       {
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_flat_ids_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_flat_ids_, cudastreams.GetCudaStream(0)), "cudaFree");
       }
     }
 
@@ -224,7 +224,7 @@ namespace micm
         const ProcessSetParam& devstruct)
     {
       size_t number_of_blocks = (rate_constants_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      SubtractJacobianTermsKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(
+      SubtractJacobianTermsKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(
           rate_constants_param, state_variables_param, jacobian_param, devstruct);
     }  // end of SubtractJacobianTermsKernelDriver
 
@@ -235,7 +235,7 @@ namespace micm
         const ProcessSetParam& devstruct)
     {
       size_t number_of_blocks = (rate_constants_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      AddForcingTermsKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(
+      AddForcingTermsKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(
           rate_constants_param, state_variables_param, forcing_param, devstruct);
     }  // end of AddForcingTermsKernelDriver
   }    // namespace cuda

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -136,11 +136,11 @@ namespace micm
       ProcessSetParam devstruct;
 
       /// Allocate memory space on the device
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.number_of_reactants_), number_of_reactants_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.reactant_ids_), reactant_ids_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.number_of_products_), number_of_products_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.product_ids_), product_ids_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.yields_), yields_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.number_of_reactants_), number_of_reactants_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.reactant_ids_), reactant_ids_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.number_of_products_), number_of_products_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.product_ids_), product_ids_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.yields_), yields_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
       CHECK_CUDA_ERROR(
@@ -149,10 +149,10 @@ namespace micm
               hoststruct.number_of_reactants_,
               number_of_reactants_bytes,
               cudaMemcpyHostToDevice,
-              cudastreams.GetCudaStream(0)),
+              micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.reactant_ids_, hoststruct.reactant_ids_, reactant_ids_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)),
+          cudaMemcpyAsync(devstruct.reactant_ids_, hoststruct.reactant_ids_, reactant_ids_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
           cudaMemcpyAsync(
@@ -160,13 +160,13 @@ namespace micm
               hoststruct.number_of_products_,
               number_of_products_bytes,
               cudaMemcpyHostToDevice,
-              cudastreams.GetCudaStream(0)),
+              micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.product_ids_, hoststruct.product_ids_, product_ids_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)),
+          cudaMemcpyAsync(devstruct.product_ids_, hoststruct.product_ids_, product_ids_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.yields_, hoststruct.yields_, yields_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.yields_, hoststruct.yields_, yields_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
 
       devstruct.number_of_reactants_size_ = hoststruct.number_of_reactants_size_;
       devstruct.reactant_ids_size_ = hoststruct.reactant_ids_size_;
@@ -186,12 +186,12 @@ namespace micm
       size_t jacobian_flat_ids_bytes = sizeof(size_t) * hoststruct.jacobian_flat_ids_size_;
 
       /// Allocate memory space on the device
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.jacobian_flat_ids_), jacobian_flat_ids_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.jacobian_flat_ids_), jacobian_flat_ids_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
       CHECK_CUDA_ERROR(
           cudaMemcpyAsync(
-              devstruct.jacobian_flat_ids_, hoststruct.jacobian_flat_ids_, jacobian_flat_ids_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)),
+              devstruct.jacobian_flat_ids_, hoststruct.jacobian_flat_ids_, jacobian_flat_ids_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)),
           "cudaMemcpy");
 
       devstruct.jacobian_flat_ids_size_ = hoststruct.jacobian_flat_ids_size_;
@@ -202,18 +202,18 @@ namespace micm
     void FreeConstData(ProcessSetParam& devstruct)
     {
       if (devstruct.number_of_reactants_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_reactants_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_reactants_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.reactant_ids_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.reactant_ids_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.reactant_ids_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.number_of_products_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_products_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_products_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.product_ids_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.product_ids_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.product_ids_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.yields_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.yields_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.yields_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.jacobian_flat_ids_ != nullptr)
       {
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_flat_ids_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_flat_ids_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       }
     }
 
@@ -224,7 +224,7 @@ namespace micm
         const ProcessSetParam& devstruct)
     {
       size_t number_of_blocks = (rate_constants_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      SubtractJacobianTermsKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(
+      SubtractJacobianTermsKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(
           rate_constants_param, state_variables_param, jacobian_param, devstruct);
     }  // end of SubtractJacobianTermsKernelDriver
 
@@ -235,7 +235,7 @@ namespace micm
         const ProcessSetParam& devstruct)
     {
       size_t number_of_blocks = (rate_constants_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      AddForcingTermsKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(
+      AddForcingTermsKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(
           rate_constants_param, state_variables_param, forcing_param, devstruct);
     }  // end of AddForcingTermsKernelDriver
   }    // namespace cuda

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -136,35 +136,37 @@ namespace micm
       ProcessSetParam devstruct;
 
       /// Allocate memory space on the device
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.number_of_reactants_), number_of_reactants_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.reactant_ids_), reactant_ids_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.number_of_products_), number_of_products_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.product_ids_), product_ids_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.yields_), yields_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.number_of_reactants_), number_of_reactants_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.reactant_ids_), reactant_ids_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.number_of_products_), number_of_products_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.product_ids_), product_ids_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.yields_), yields_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
       CHECK_CUDA_ERROR(
-          cudaMemcpy(
+          cudaMemcpyAsync(
               devstruct.number_of_reactants_,
               hoststruct.number_of_reactants_,
               number_of_reactants_bytes,
-              cudaMemcpyHostToDevice),
+              cudaMemcpyHostToDevice,
+              micm::cuda::GetCudaStream(0)),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.reactant_ids_, hoststruct.reactant_ids_, reactant_ids_bytes, cudaMemcpyHostToDevice),
+          cudaMemcpyAsync(devstruct.reactant_ids_, hoststruct.reactant_ids_, reactant_ids_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(
+          cudaMemcpyAsync(
               devstruct.number_of_products_,
               hoststruct.number_of_products_,
               number_of_products_bytes,
-              cudaMemcpyHostToDevice),
+              cudaMemcpyHostToDevice,
+              micm::cuda::GetCudaStream(0)),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.product_ids_, hoststruct.product_ids_, product_ids_bytes, cudaMemcpyHostToDevice),
+          cudaMemcpyAsync(devstruct.product_ids_, hoststruct.product_ids_, product_ids_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.yields_, hoststruct.yields_, yields_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.yields_, hoststruct.yields_, yields_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
 
       devstruct.number_of_reactants_size_ = hoststruct.number_of_reactants_size_;
       devstruct.reactant_ids_size_ = hoststruct.reactant_ids_size_;
@@ -184,12 +186,12 @@ namespace micm
       size_t jacobian_flat_ids_bytes = sizeof(size_t) * hoststruct.jacobian_flat_ids_size_;
 
       /// Allocate memory space on the device
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.jacobian_flat_ids_), jacobian_flat_ids_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.jacobian_flat_ids_), jacobian_flat_ids_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
       CHECK_CUDA_ERROR(
-          cudaMemcpy(
-              devstruct.jacobian_flat_ids_, hoststruct.jacobian_flat_ids_, jacobian_flat_ids_bytes, cudaMemcpyHostToDevice),
+          cudaMemcpyAsync(
+              devstruct.jacobian_flat_ids_, hoststruct.jacobian_flat_ids_, jacobian_flat_ids_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)),
           "cudaMemcpy");
 
       devstruct.jacobian_flat_ids_size_ = hoststruct.jacobian_flat_ids_size_;
@@ -200,18 +202,18 @@ namespace micm
     void FreeConstData(ProcessSetParam& devstruct)
     {
       if (devstruct.number_of_reactants_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.number_of_reactants_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_reactants_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.reactant_ids_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.reactant_ids_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.reactant_ids_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.number_of_products_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.number_of_products_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_products_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.product_ids_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.product_ids_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.product_ids_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.yields_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.yields_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.yields_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.jacobian_flat_ids_ != nullptr)
       {
-        CHECK_CUDA_ERROR(cudaFree(devstruct.jacobian_flat_ids_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_flat_ids_, micm::cuda::GetCudaStream(0)), "cudaFree");
       }
     }
 
@@ -222,7 +224,7 @@ namespace micm
         const ProcessSetParam& devstruct)
     {
       size_t number_of_blocks = (rate_constants_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      SubtractJacobianTermsKernel<<<number_of_blocks, BLOCK_SIZE>>>(
+      SubtractJacobianTermsKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(
           rate_constants_param, state_variables_param, jacobian_param, devstruct);
     }  // end of SubtractJacobianTermsKernelDriver
 
@@ -233,7 +235,7 @@ namespace micm
         const ProcessSetParam& devstruct)
     {
       size_t number_of_blocks = (rate_constants_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      AddForcingTermsKernel<<<number_of_blocks, BLOCK_SIZE>>>(
+      AddForcingTermsKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(
           rate_constants_param, state_variables_param, forcing_param, devstruct);
     }  // end of AddForcingTermsKernelDriver
   }    // namespace cuda

--- a/src/solver/linear_solver.cu
+++ b/src/solver/linear_solver.cu
@@ -89,20 +89,20 @@ namespace micm
 
       /// Create a struct whose members contain the addresses in the device memory.
       LinearSolverParam devstruct;
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.nLij_Lii_), nLij_Lii_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.Lij_yj_), Lij_yj_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.nUij_Uii_), nUij_Uii_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.Uij_xj_), Uij_xj_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.nLij_Lii_), nLij_Lii_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.Lij_yj_), Lij_yj_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.nUij_Uii_), nUij_Uii_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.Uij_xj_), Uij_xj_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.nLij_Lii_, hoststruct.nLij_Lii_, nLij_Lii_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.nLij_Lii_, hoststruct.nLij_Lii_, nLij_Lii_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.Lij_yj_, hoststruct.Lij_yj_, Lij_yj_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.Lij_yj_, hoststruct.Lij_yj_, Lij_yj_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.nUij_Uii_, hoststruct.nUij_Uii_, nUij_Uii_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.nUij_Uii_, hoststruct.nUij_Uii_, nUij_Uii_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.Uij_xj_, hoststruct.Uij_xj_, Uij_xj_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.Uij_xj_, hoststruct.Uij_xj_, Uij_xj_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
 
       devstruct.nLij_Lii_size_ = hoststruct.nLij_Lii_size_;
       devstruct.Lij_yj_size_ = hoststruct.Lij_yj_size_;
@@ -117,13 +117,13 @@ namespace micm
     void FreeConstData(LinearSolverParam& devstruct)
     {
       if (devstruct.nLij_Lii_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.nLij_Lii_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.nLij_Lii_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.Lij_yj_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.Lij_yj_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.Lij_yj_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.nUij_Uii_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.nUij_Uii_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.nUij_Uii_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.Uij_xj_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.Uij_xj_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.Uij_xj_, cudastreams.GetCudaStream(0)), "cudaFree");
     }
 
     void SolveKernelDriver(
@@ -133,7 +133,7 @@ namespace micm
         const LinearSolverParam& devstruct)
     {
       size_t number_of_blocks = (x_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      SolveKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(x_param, L_param, U_param, devstruct);
+      SolveKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(x_param, L_param, U_param, devstruct);
     }
   }  // namespace cuda
 }  // namespace micm

--- a/src/solver/linear_solver.cu
+++ b/src/solver/linear_solver.cu
@@ -89,20 +89,20 @@ namespace micm
 
       /// Create a struct whose members contain the addresses in the device memory.
       LinearSolverParam devstruct;
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.nLij_Lii_), nLij_Lii_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.Lij_yj_), Lij_yj_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.nUij_Uii_), nUij_Uii_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.Uij_xj_), Uij_xj_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.nLij_Lii_), nLij_Lii_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.Lij_yj_), Lij_yj_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.nUij_Uii_), nUij_Uii_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.Uij_xj_), Uij_xj_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.nLij_Lii_, hoststruct.nLij_Lii_, nLij_Lii_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.nLij_Lii_, hoststruct.nLij_Lii_, nLij_Lii_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.Lij_yj_, hoststruct.Lij_yj_, Lij_yj_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.Lij_yj_, hoststruct.Lij_yj_, Lij_yj_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.nUij_Uii_, hoststruct.nUij_Uii_, nUij_Uii_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.nUij_Uii_, hoststruct.nUij_Uii_, nUij_Uii_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.Uij_xj_, hoststruct.Uij_xj_, Uij_xj_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.Uij_xj_, hoststruct.Uij_xj_, Uij_xj_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
 
       devstruct.nLij_Lii_size_ = hoststruct.nLij_Lii_size_;
       devstruct.Lij_yj_size_ = hoststruct.Lij_yj_size_;
@@ -117,13 +117,13 @@ namespace micm
     void FreeConstData(LinearSolverParam& devstruct)
     {
       if (devstruct.nLij_Lii_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.nLij_Lii_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.nLij_Lii_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.Lij_yj_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.Lij_yj_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.Lij_yj_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.nUij_Uii_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.nUij_Uii_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.nUij_Uii_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.Uij_xj_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.Uij_xj_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.Uij_xj_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
     }
 
     void SolveKernelDriver(
@@ -133,7 +133,7 @@ namespace micm
         const LinearSolverParam& devstruct)
     {
       size_t number_of_blocks = (x_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      SolveKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(x_param, L_param, U_param, devstruct);
+      SolveKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(x_param, L_param, U_param, devstruct);
     }
   }  // namespace cuda
 }  // namespace micm

--- a/src/solver/linear_solver.cu
+++ b/src/solver/linear_solver.cu
@@ -89,20 +89,20 @@ namespace micm
 
       /// Create a struct whose members contain the addresses in the device memory.
       LinearSolverParam devstruct;
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.nLij_Lii_), nLij_Lii_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.Lij_yj_), Lij_yj_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.nUij_Uii_), nUij_Uii_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.Uij_xj_), Uij_xj_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.nLij_Lii_), nLij_Lii_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.Lij_yj_), Lij_yj_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.nUij_Uii_), nUij_Uii_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.Uij_xj_), Uij_xj_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.nLij_Lii_, hoststruct.nLij_Lii_, nLij_Lii_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.nLij_Lii_, hoststruct.nLij_Lii_, nLij_Lii_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.Lij_yj_, hoststruct.Lij_yj_, Lij_yj_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.Lij_yj_, hoststruct.Lij_yj_, Lij_yj_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.nUij_Uii_, hoststruct.nUij_Uii_, nUij_Uii_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.nUij_Uii_, hoststruct.nUij_Uii_, nUij_Uii_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.Uij_xj_, hoststruct.Uij_xj_, Uij_xj_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.Uij_xj_, hoststruct.Uij_xj_, Uij_xj_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
 
       devstruct.nLij_Lii_size_ = hoststruct.nLij_Lii_size_;
       devstruct.Lij_yj_size_ = hoststruct.Lij_yj_size_;
@@ -117,13 +117,13 @@ namespace micm
     void FreeConstData(LinearSolverParam& devstruct)
     {
       if (devstruct.nLij_Lii_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.nLij_Lii_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.nLij_Lii_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.Lij_yj_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.Lij_yj_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.Lij_yj_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.nUij_Uii_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.nUij_Uii_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.nUij_Uii_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.Uij_xj_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.Uij_xj_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.Uij_xj_, micm::cuda::GetCudaStream(0)), "cudaFree");
     }
 
     void SolveKernelDriver(
@@ -133,7 +133,7 @@ namespace micm
         const LinearSolverParam& devstruct)
     {
       size_t number_of_blocks = (x_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      SolveKernel<<<number_of_blocks, BLOCK_SIZE>>>(x_param, L_param, U_param, devstruct);
+      SolveKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(x_param, L_param, U_param, devstruct);
     }
   }  // namespace cuda
 }  // namespace micm

--- a/src/solver/lu_decomposition.cu
+++ b/src/solver/lu_decomposition.cu
@@ -128,35 +128,35 @@ namespace micm
 
       /// Create a struct whose members contain the addresses in the device memory.
       LuDecomposeParam devstruct;
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.niLU_), niLU_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.do_aik_), do_aik_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.aik_), aik_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.uik_nkj_), uik_nkj_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lij_ujk_), lij_ujk_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.do_aki_), do_aki_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.aki_), aki_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lki_nkj_), lki_nkj_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lkj_uji_), lkj_uji_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.uii_), uii_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&devstruct.is_singular, sizeof(bool), cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.niLU_), niLU_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.do_aik_), do_aik_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.aik_), aik_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.uik_nkj_), uik_nkj_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lij_ujk_), lij_ujk_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.do_aki_), do_aki_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.aki_), aki_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lki_nkj_), lki_nkj_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lkj_uji_), lkj_uji_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.uii_), uii_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&devstruct.is_singular, sizeof(bool), micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
-      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.niLU_, hoststruct.niLU_, niLU_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.niLU_, hoststruct.niLU_, niLU_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.do_aik_, hoststruct.do_aik_, do_aik_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
-      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.aik_, hoststruct.aik_, aik_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.do_aik_, hoststruct.do_aik_, do_aik_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.aik_, hoststruct.aik_, aik_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.uik_nkj_, hoststruct.uik_nkj_, uik_nkj_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.uik_nkj_, hoststruct.uik_nkj_, uik_nkj_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.lij_ujk_, hoststruct.lij_ujk_, lij_ujk_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.lij_ujk_, hoststruct.lij_ujk_, lij_ujk_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.do_aki_, hoststruct.do_aki_, do_aki_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
-      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.aki_, hoststruct.aki_, aki_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.do_aki_, hoststruct.do_aki_, do_aki_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.aki_, hoststruct.aki_, aki_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.lki_nkj_, hoststruct.lki_nkj_, lki_nkj_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.lki_nkj_, hoststruct.lki_nkj_, lki_nkj_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.lkj_uji_, hoststruct.lkj_uji_, lkj_uji_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
-      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.uii_, hoststruct.uii_, uii_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.lkj_uji_, hoststruct.lkj_uji_, lkj_uji_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.uii_, hoststruct.uii_, uii_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMemcpy");
       devstruct.niLU_size_ = hoststruct.niLU_size_;
 
       return devstruct;
@@ -167,27 +167,27 @@ namespace micm
     void FreeConstData(LuDecomposeParam& devstruct)
     {
       if (devstruct.is_singular != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.is_singular, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.is_singular, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.niLU_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.niLU_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.niLU_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.do_aik_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.do_aik_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.do_aik_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.aik_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.aik_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.aik_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.uik_nkj_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.uik_nkj_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.uik_nkj_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.lij_ujk_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lij_ujk_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lij_ujk_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.do_aki_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.do_aki_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.do_aki_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.aki_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.aki_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.aki_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.lki_nkj_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lki_nkj_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lki_nkj_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.lkj_uji_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lkj_uji_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lkj_uji_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.uii_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.uii_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.uii_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
     }
 
     void DecomposeKernelDriver(
@@ -199,9 +199,9 @@ namespace micm
     {
       // Launch the CUDA kernel for LU decomposition
       size_t number_of_blocks = (A_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      DecomposeKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(A_param, L_param, U_param, devstruct);
+      DecomposeKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(A_param, L_param, U_param, devstruct);
       // Copy the boolean result from device back to host
-      cudaMemcpyAsync(&is_singular, devstruct.is_singular, sizeof(bool), cudaMemcpyDeviceToHost, cudastreams.GetCudaStream(0));
+      cudaMemcpyAsync(&is_singular, devstruct.is_singular, sizeof(bool), cudaMemcpyDeviceToHost, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0));
     }  // end of DecomposeKernelDriver
   }    // end of namespace cuda
 }  // end of namespace micm

--- a/src/solver/lu_decomposition.cu
+++ b/src/solver/lu_decomposition.cu
@@ -128,35 +128,35 @@ namespace micm
 
       /// Create a struct whose members contain the addresses in the device memory.
       LuDecomposeParam devstruct;
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.niLU_), niLU_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.do_aik_), do_aik_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.aik_), aik_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.uik_nkj_), uik_nkj_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.lij_ujk_), lij_ujk_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.do_aki_), do_aki_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.aki_), aki_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.lki_nkj_), lki_nkj_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.lkj_uji_), lkj_uji_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.uii_), uii_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&devstruct.is_singular, sizeof(bool)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.niLU_), niLU_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.do_aik_), do_aik_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.aik_), aik_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.uik_nkj_), uik_nkj_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lij_ujk_), lij_ujk_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.do_aki_), do_aki_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.aki_), aki_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lki_nkj_), lki_nkj_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lkj_uji_), lkj_uji_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.uii_), uii_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&devstruct.is_singular, sizeof(bool), micm::cuda::GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
-      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.niLU_, hoststruct.niLU_, niLU_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.niLU_, hoststruct.niLU_, niLU_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.do_aik_, hoststruct.do_aik_, do_aik_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
-      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.aik_, hoststruct.aik_, aik_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.do_aik_, hoststruct.do_aik_, do_aik_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.aik_, hoststruct.aik_, aik_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.uik_nkj_, hoststruct.uik_nkj_, uik_nkj_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.uik_nkj_, hoststruct.uik_nkj_, uik_nkj_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.lij_ujk_, hoststruct.lij_ujk_, lij_ujk_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.lij_ujk_, hoststruct.lij_ujk_, lij_ujk_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.do_aki_, hoststruct.do_aki_, do_aki_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
-      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.aki_, hoststruct.aki_, aki_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.do_aki_, hoststruct.do_aki_, do_aki_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.aki_, hoststruct.aki_, aki_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.lki_nkj_, hoststruct.lki_nkj_, lki_nkj_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.lki_nkj_, hoststruct.lki_nkj_, lki_nkj_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.lkj_uji_, hoststruct.lkj_uji_, lkj_uji_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
-      CHECK_CUDA_ERROR(cudaMemcpy(devstruct.uii_, hoststruct.uii_, uii_bytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.lkj_uji_, hoststruct.lkj_uji_, lkj_uji_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.uii_, hoststruct.uii_, uii_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
       devstruct.niLU_size_ = hoststruct.niLU_size_;
 
       return devstruct;
@@ -167,27 +167,27 @@ namespace micm
     void FreeConstData(LuDecomposeParam& devstruct)
     {
       if (devstruct.is_singular != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.is_singular), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.is_singular, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.niLU_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.niLU_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.niLU_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.do_aik_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.do_aik_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.do_aik_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.aik_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.aik_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.aik_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.uik_nkj_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.uik_nkj_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.uik_nkj_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.lij_ujk_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.lij_ujk_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lij_ujk_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.do_aki_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.do_aki_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.do_aki_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.aki_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.aki_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.aki_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.lki_nkj_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.lki_nkj_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lki_nkj_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.lkj_uji_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.lkj_uji_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lkj_uji_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.uii_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.uii_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.uii_, micm::cuda::GetCudaStream(0)), "cudaFree");
     }
 
     void DecomposeKernelDriver(
@@ -199,9 +199,9 @@ namespace micm
     {
       // Launch the CUDA kernel for LU decomposition
       size_t number_of_blocks = (A_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      DecomposeKernel<<<number_of_blocks, BLOCK_SIZE>>>(A_param, L_param, U_param, devstruct);
+      DecomposeKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(A_param, L_param, U_param, devstruct);
       // Copy the boolean result from device back to host
-      cudaMemcpy(&is_singular, devstruct.is_singular, sizeof(bool), cudaMemcpyDeviceToHost);
+      cudaMemcpyAsync(&is_singular, devstruct.is_singular, sizeof(bool), cudaMemcpyDeviceToHost, micm::cuda::GetCudaStream(0));
     }  // end of DecomposeKernelDriver
   }    // end of namespace cuda
 }  // end of namespace micm

--- a/src/solver/lu_decomposition.cu
+++ b/src/solver/lu_decomposition.cu
@@ -128,35 +128,35 @@ namespace micm
 
       /// Create a struct whose members contain the addresses in the device memory.
       LuDecomposeParam devstruct;
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.niLU_), niLU_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.do_aik_), do_aik_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.aik_), aik_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.uik_nkj_), uik_nkj_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lij_ujk_), lij_ujk_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.do_aki_), do_aki_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.aki_), aki_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lki_nkj_), lki_nkj_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lkj_uji_), lkj_uji_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.uii_), uii_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&devstruct.is_singular, sizeof(bool), micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.niLU_), niLU_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.do_aik_), do_aik_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.aik_), aik_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.uik_nkj_), uik_nkj_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lij_ujk_), lij_ujk_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.do_aki_), do_aki_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.aki_), aki_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lki_nkj_), lki_nkj_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.lkj_uji_), lkj_uji_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.uii_), uii_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&devstruct.is_singular, sizeof(bool), cudastreams.GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
-      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.niLU_, hoststruct.niLU_, niLU_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.niLU_, hoststruct.niLU_, niLU_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.do_aik_, hoststruct.do_aik_, do_aik_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
-      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.aik_, hoststruct.aik_, aik_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.do_aik_, hoststruct.do_aik_, do_aik_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.aik_, hoststruct.aik_, aik_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.uik_nkj_, hoststruct.uik_nkj_, uik_nkj_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.uik_nkj_, hoststruct.uik_nkj_, uik_nkj_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.lij_ujk_, hoststruct.lij_ujk_, lij_ujk_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.lij_ujk_, hoststruct.lij_ujk_, lij_ujk_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.do_aki_, hoststruct.do_aki_, do_aki_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
-      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.aki_, hoststruct.aki_, aki_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.do_aki_, hoststruct.do_aki_, do_aki_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.aki_, hoststruct.aki_, aki_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.lki_nkj_, hoststruct.lki_nkj_, lki_nkj_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.lki_nkj_, hoststruct.lki_nkj_, lki_nkj_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.lkj_uji_, hoststruct.lkj_uji_, lkj_uji_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
-      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.uii_, hoststruct.uii_, uii_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)), "cudaMemcpy");
+          cudaMemcpyAsync(devstruct.lkj_uji_, hoststruct.lkj_uji_, lkj_uji_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(devstruct.uii_, hoststruct.uii_, uii_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)), "cudaMemcpy");
       devstruct.niLU_size_ = hoststruct.niLU_size_;
 
       return devstruct;
@@ -167,27 +167,27 @@ namespace micm
     void FreeConstData(LuDecomposeParam& devstruct)
     {
       if (devstruct.is_singular != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.is_singular, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.is_singular, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.niLU_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.niLU_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.niLU_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.do_aik_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.do_aik_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.do_aik_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.aik_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.aik_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.aik_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.uik_nkj_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.uik_nkj_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.uik_nkj_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.lij_ujk_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lij_ujk_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lij_ujk_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.do_aki_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.do_aki_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.do_aki_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.aki_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.aki_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.aki_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.lki_nkj_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lki_nkj_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lki_nkj_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.lkj_uji_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lkj_uji_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.lkj_uji_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.uii_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.uii_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.uii_, cudastreams.GetCudaStream(0)), "cudaFree");
     }
 
     void DecomposeKernelDriver(
@@ -199,9 +199,9 @@ namespace micm
     {
       // Launch the CUDA kernel for LU decomposition
       size_t number_of_blocks = (A_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      DecomposeKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(A_param, L_param, U_param, devstruct);
+      DecomposeKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(A_param, L_param, U_param, devstruct);
       // Copy the boolean result from device back to host
-      cudaMemcpyAsync(&is_singular, devstruct.is_singular, sizeof(bool), cudaMemcpyDeviceToHost, micm::cuda::GetCudaStream(0));
+      cudaMemcpyAsync(&is_singular, devstruct.is_singular, sizeof(bool), cudaMemcpyDeviceToHost, cudastreams.GetCudaStream(0));
     }  // end of DecomposeKernelDriver
   }    // end of namespace cuda
 }  // end of namespace micm

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -45,22 +45,23 @@ namespace micm
 
       /// Create a struct whose members contain the addresses in the device memory.
       CudaRosenbrockSolverParam devstruct;
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.errors_input_), errors_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.errors_output_), errors_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.jacobian_diagonal_elements_), jacobian_diagonal_elements_bytes), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMalloc(&(devstruct.absolute_tolerance_), tolerance_bytes), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.errors_input_), errors_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.errors_output_), errors_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.jacobian_diagonal_elements_), jacobian_diagonal_elements_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.absolute_tolerance_), tolerance_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
       CHECK_CUDA_ERROR(
-          cudaMemcpy(
+          cudaMemcpyAsync(
               devstruct.jacobian_diagonal_elements_,
               hoststruct.jacobian_diagonal_elements_,
               jacobian_diagonal_elements_bytes,
-              cudaMemcpyHostToDevice),
+              cudaMemcpyHostToDevice,
+              micm::cuda::GetCudaStream(0)),
           "cudaMemcpy");
 
       CHECK_CUDA_ERROR(
-          cudaMemcpy(devstruct.absolute_tolerance_, hoststruct.absolute_tolerance_, tolerance_bytes, cudaMemcpyHostToDevice),
+          cudaMemcpyAsync(devstruct.absolute_tolerance_, hoststruct.absolute_tolerance_, tolerance_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)),
           "cudaMemcpy");
 
       devstruct.errors_size_ = hoststruct.errors_size_;
@@ -75,13 +76,13 @@ namespace micm
     void FreeConstData(CudaRosenbrockSolverParam& devstruct)
     {
       if (devstruct.errors_input_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.errors_input_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.errors_input_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.errors_output_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.errors_output_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.errors_output_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.jacobian_diagonal_elements_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.jacobian_diagonal_elements_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_diagonal_elements_, micm::cuda::GetCudaStream(0)), "cudaFree");
       if (devstruct.absolute_tolerance_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFree(devstruct.absolute_tolerance_), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.absolute_tolerance_, micm::cuda::GetCudaStream(0)), "cudaFree");
     }
 
     // Specific CUDA device function to do reduction within a warp
@@ -245,7 +246,7 @@ namespace micm
     {
       size_t number_of_blocks =
           (devstruct.jacobian_diagonal_elements_size_ * jacobian_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      AlphaMinusJacobianKernel<<<number_of_blocks, BLOCK_SIZE>>>(jacobian_param, alpha, devstruct);
+      AlphaMinusJacobianKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(jacobian_param, alpha, devstruct);
     }
 
     // Host code that will launch the NormalizedError CUDA kernel
@@ -266,20 +267,21 @@ namespace micm
         INTERNAL_ERROR(msg.c_str());
       }
       CHECK_CUDA_ERROR(
-          cudaMemcpy(
-              devstruct.errors_input_, errors_param.d_data_, sizeof(double) * number_of_elements, cudaMemcpyDeviceToDevice),
+          cudaMemcpyAsync(
+              devstruct.errors_input_, errors_param.d_data_, sizeof(double) * number_of_elements, cudaMemcpyDeviceToDevice, micm::cuda::GetCudaStream(0)),
           "cudaMemcpy");
 
       if (number_of_elements > 1000000)
       {
         // call cublas APIs
         size_t number_of_blocks = (number_of_elements + BLOCK_SIZE - 1) / BLOCK_SIZE;
-        ScaledErrorKernel<<<number_of_blocks, BLOCK_SIZE>>>(y_old_param, y_new_param, ros_param, devstruct);
+        ScaledErrorKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(y_old_param, y_new_param, ros_param, devstruct);
         // call cublas function to perform the norm:
         // https://docs.nvidia.com/cuda/cublas/index.html?highlight=dnrm2#cublas-t-nrm2
         CHECK_CUBLAS_ERROR(
             cublasDnrm2(micm::cuda::GetCublasHandle(), number_of_elements, devstruct.errors_input_, 1, &normalized_error),
             "cublasDnrm2");
+        cudaStreamSynchronize(micm::cuda::GetCudaStream(0));
         normalized_error = normalized_error * std::sqrt(1.0 / number_of_elements);
       }
       else
@@ -291,7 +293,7 @@ namespace micm
         bool is_first_call = true;
 
         // Kernel call
-        NormalizedErrorKernel<<<number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double)>>>(
+        NormalizedErrorKernel<<<number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), micm::cuda::GetCudaStream(0)>>>(
             y_old_param, y_new_param, ros_param, devstruct, number_of_elements, is_first_call);
         is_first_call = false;
         while (number_of_blocks > 1)
@@ -301,18 +303,19 @@ namespace micm
           new_number_of_blocks = std::ceil(std::ceil(number_of_blocks * 1.0 / BLOCK_SIZE) / 2.0);
           if (new_number_of_blocks <= 1)
           {
-            NormalizedErrorKernel<<<1, BLOCK_SIZE, BLOCK_SIZE * sizeof(double)>>>(
+            NormalizedErrorKernel<<<1, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), micm::cuda::GetCudaStream(0)>>>(
                 y_old_param, y_new_param, ros_param, devstruct, number_of_blocks, is_first_call);
             break;
           }
-          NormalizedErrorKernel<<<new_number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double)>>>(
+          NormalizedErrorKernel<<<new_number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), micm::cuda::GetCudaStream(0)>>>(
               y_old_param, y_new_param, ros_param, devstruct, number_of_blocks, is_first_call);
           number_of_blocks = new_number_of_blocks;
         }
 
         CHECK_CUDA_ERROR(
-            cudaMemcpy(&normalized_error, &devstruct.errors_output_[0], sizeof(double), cudaMemcpyDeviceToHost),
+            cudaMemcpyAsync(&normalized_error, &devstruct.errors_output_[0], sizeof(double), cudaMemcpyDeviceToHost, micm::cuda::GetCudaStream(0)),
             "cudaMemcpy");
+        cudaStreamSynchronize(micm::cuda::GetCudaStream(0));
         normalized_error = std::sqrt(normalized_error / number_of_elements);
       }  // end of if-else for CUDA/CUBLAS implementation
       return std::max(normalized_error, 1.0e-10);

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -45,10 +45,10 @@ namespace micm
 
       /// Create a struct whose members contain the addresses in the device memory.
       CudaRosenbrockSolverParam devstruct;
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.errors_input_), errors_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.errors_output_), errors_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.jacobian_diagonal_elements_), jacobian_diagonal_elements_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.absolute_tolerance_), tolerance_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.errors_input_), errors_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.errors_output_), errors_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.jacobian_diagonal_elements_), jacobian_diagonal_elements_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.absolute_tolerance_), tolerance_bytes, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
       CHECK_CUDA_ERROR(
@@ -57,11 +57,11 @@ namespace micm
               hoststruct.jacobian_diagonal_elements_,
               jacobian_diagonal_elements_bytes,
               cudaMemcpyHostToDevice,
-              cudastreams.GetCudaStream(0)),
+              micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)),
           "cudaMemcpy");
 
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.absolute_tolerance_, hoststruct.absolute_tolerance_, tolerance_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)),
+          cudaMemcpyAsync(devstruct.absolute_tolerance_, hoststruct.absolute_tolerance_, tolerance_bytes, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)),
           "cudaMemcpy");
 
       devstruct.errors_size_ = hoststruct.errors_size_;
@@ -76,13 +76,13 @@ namespace micm
     void FreeConstData(CudaRosenbrockSolverParam& devstruct)
     {
       if (devstruct.errors_input_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.errors_input_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.errors_input_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.errors_output_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.errors_output_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.errors_output_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.jacobian_diagonal_elements_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_diagonal_elements_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_diagonal_elements_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
       if (devstruct.absolute_tolerance_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.absolute_tolerance_, cudastreams.GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.absolute_tolerance_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
     }
 
     // Specific CUDA device function to do reduction within a warp
@@ -246,7 +246,7 @@ namespace micm
     {
       size_t number_of_blocks =
           (devstruct.jacobian_diagonal_elements_size_ * jacobian_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      AlphaMinusJacobianKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(jacobian_param, alpha, devstruct);
+      AlphaMinusJacobianKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(jacobian_param, alpha, devstruct);
     }
 
     // Host code that will launch the NormalizedError CUDA kernel
@@ -268,20 +268,20 @@ namespace micm
       }
       CHECK_CUDA_ERROR(
           cudaMemcpyAsync(
-              devstruct.errors_input_, errors_param.d_data_, sizeof(double) * number_of_elements, cudaMemcpyDeviceToDevice, cudastreams.GetCudaStream(0)),
+              devstruct.errors_input_, errors_param.d_data_, sizeof(double) * number_of_elements, cudaMemcpyDeviceToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)),
           "cudaMemcpy");
 
       if (number_of_elements > 1000000)
       {
         // call cublas APIs
         size_t number_of_blocks = (number_of_elements + BLOCK_SIZE - 1) / BLOCK_SIZE;
-        ScaledErrorKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(y_old_param, y_new_param, ros_param, devstruct);
+        ScaledErrorKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(y_old_param, y_new_param, ros_param, devstruct);
         // call cublas function to perform the norm:
         // https://docs.nvidia.com/cuda/cublas/index.html?highlight=dnrm2#cublas-t-nrm2
         CHECK_CUBLAS_ERROR(
             cublasDnrm2(micm::cuda::GetCublasHandle(), number_of_elements, devstruct.errors_input_, 1, &normalized_error),
             "cublasDnrm2");
-        cudaStreamSynchronize(cudastreams.GetCudaStream(0));
+        cudaStreamSynchronize(micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0));
         normalized_error = normalized_error * std::sqrt(1.0 / number_of_elements);
       }
       else
@@ -293,7 +293,7 @@ namespace micm
         bool is_first_call = true;
 
         // Kernel call
-        NormalizedErrorKernel<<<number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), cudastreams.GetCudaStream(0)>>>(
+        NormalizedErrorKernel<<<number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(
             y_old_param, y_new_param, ros_param, devstruct, number_of_elements, is_first_call);
         is_first_call = false;
         while (number_of_blocks > 1)
@@ -303,19 +303,19 @@ namespace micm
           new_number_of_blocks = std::ceil(std::ceil(number_of_blocks * 1.0 / BLOCK_SIZE) / 2.0);
           if (new_number_of_blocks <= 1)
           {
-            NormalizedErrorKernel<<<1, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), cudastreams.GetCudaStream(0)>>>(
+            NormalizedErrorKernel<<<1, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(
                 y_old_param, y_new_param, ros_param, devstruct, number_of_blocks, is_first_call);
             break;
           }
-          NormalizedErrorKernel<<<new_number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), cudastreams.GetCudaStream(0)>>>(
+          NormalizedErrorKernel<<<new_number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(
               y_old_param, y_new_param, ros_param, devstruct, number_of_blocks, is_first_call);
           number_of_blocks = new_number_of_blocks;
         }
 
         CHECK_CUDA_ERROR(
-            cudaMemcpyAsync(&normalized_error, &devstruct.errors_output_[0], sizeof(double), cudaMemcpyDeviceToHost, cudastreams.GetCudaStream(0)),
+            cudaMemcpyAsync(&normalized_error, &devstruct.errors_output_[0], sizeof(double), cudaMemcpyDeviceToHost, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)),
             "cudaMemcpy");
-        cudaStreamSynchronize(cudastreams.GetCudaStream(0));
+        cudaStreamSynchronize(micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0));
         normalized_error = std::sqrt(normalized_error / number_of_elements);
       }  // end of if-else for CUDA/CUBLAS implementation
       return std::max(normalized_error, 1.0e-10);

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -45,10 +45,10 @@ namespace micm
 
       /// Create a struct whose members contain the addresses in the device memory.
       CudaRosenbrockSolverParam devstruct;
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.errors_input_), errors_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.errors_output_), errors_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.jacobian_diagonal_elements_), jacobian_diagonal_elements_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
-      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.absolute_tolerance_), tolerance_bytes, micm::cuda::GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.errors_input_), errors_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.errors_output_), errors_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.jacobian_diagonal_elements_), jacobian_diagonal_elements_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.absolute_tolerance_), tolerance_bytes, cudastreams.GetCudaStream(0)), "cudaMalloc");
 
       /// Copy the data from host to device
       CHECK_CUDA_ERROR(
@@ -57,11 +57,11 @@ namespace micm
               hoststruct.jacobian_diagonal_elements_,
               jacobian_diagonal_elements_bytes,
               cudaMemcpyHostToDevice,
-              micm::cuda::GetCudaStream(0)),
+              cudastreams.GetCudaStream(0)),
           "cudaMemcpy");
 
       CHECK_CUDA_ERROR(
-          cudaMemcpyAsync(devstruct.absolute_tolerance_, hoststruct.absolute_tolerance_, tolerance_bytes, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0)),
+          cudaMemcpyAsync(devstruct.absolute_tolerance_, hoststruct.absolute_tolerance_, tolerance_bytes, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0)),
           "cudaMemcpy");
 
       devstruct.errors_size_ = hoststruct.errors_size_;
@@ -76,13 +76,13 @@ namespace micm
     void FreeConstData(CudaRosenbrockSolverParam& devstruct)
     {
       if (devstruct.errors_input_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.errors_input_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.errors_input_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.errors_output_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.errors_output_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.errors_output_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.jacobian_diagonal_elements_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_diagonal_elements_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_diagonal_elements_, cudastreams.GetCudaStream(0)), "cudaFree");
       if (devstruct.absolute_tolerance_ != nullptr)
-        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.absolute_tolerance_, micm::cuda::GetCudaStream(0)), "cudaFree");
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.absolute_tolerance_, cudastreams.GetCudaStream(0)), "cudaFree");
     }
 
     // Specific CUDA device function to do reduction within a warp
@@ -246,7 +246,7 @@ namespace micm
     {
       size_t number_of_blocks =
           (devstruct.jacobian_diagonal_elements_size_ * jacobian_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      AlphaMinusJacobianKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(jacobian_param, alpha, devstruct);
+      AlphaMinusJacobianKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(jacobian_param, alpha, devstruct);
     }
 
     // Host code that will launch the NormalizedError CUDA kernel
@@ -268,20 +268,20 @@ namespace micm
       }
       CHECK_CUDA_ERROR(
           cudaMemcpyAsync(
-              devstruct.errors_input_, errors_param.d_data_, sizeof(double) * number_of_elements, cudaMemcpyDeviceToDevice, micm::cuda::GetCudaStream(0)),
+              devstruct.errors_input_, errors_param.d_data_, sizeof(double) * number_of_elements, cudaMemcpyDeviceToDevice, cudastreams.GetCudaStream(0)),
           "cudaMemcpy");
 
       if (number_of_elements > 1000000)
       {
         // call cublas APIs
         size_t number_of_blocks = (number_of_elements + BLOCK_SIZE - 1) / BLOCK_SIZE;
-        ScaledErrorKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(y_old_param, y_new_param, ros_param, devstruct);
+        ScaledErrorKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(y_old_param, y_new_param, ros_param, devstruct);
         // call cublas function to perform the norm:
         // https://docs.nvidia.com/cuda/cublas/index.html?highlight=dnrm2#cublas-t-nrm2
         CHECK_CUBLAS_ERROR(
             cublasDnrm2(micm::cuda::GetCublasHandle(), number_of_elements, devstruct.errors_input_, 1, &normalized_error),
             "cublasDnrm2");
-        cudaStreamSynchronize(micm::cuda::GetCudaStream(0));
+        cudaStreamSynchronize(cudastreams.GetCudaStream(0));
         normalized_error = normalized_error * std::sqrt(1.0 / number_of_elements);
       }
       else
@@ -293,7 +293,7 @@ namespace micm
         bool is_first_call = true;
 
         // Kernel call
-        NormalizedErrorKernel<<<number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), micm::cuda::GetCudaStream(0)>>>(
+        NormalizedErrorKernel<<<number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), cudastreams.GetCudaStream(0)>>>(
             y_old_param, y_new_param, ros_param, devstruct, number_of_elements, is_first_call);
         is_first_call = false;
         while (number_of_blocks > 1)
@@ -303,19 +303,19 @@ namespace micm
           new_number_of_blocks = std::ceil(std::ceil(number_of_blocks * 1.0 / BLOCK_SIZE) / 2.0);
           if (new_number_of_blocks <= 1)
           {
-            NormalizedErrorKernel<<<1, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), micm::cuda::GetCudaStream(0)>>>(
+            NormalizedErrorKernel<<<1, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), cudastreams.GetCudaStream(0)>>>(
                 y_old_param, y_new_param, ros_param, devstruct, number_of_blocks, is_first_call);
             break;
           }
-          NormalizedErrorKernel<<<new_number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), micm::cuda::GetCudaStream(0)>>>(
+          NormalizedErrorKernel<<<new_number_of_blocks, BLOCK_SIZE, BLOCK_SIZE * sizeof(double), cudastreams.GetCudaStream(0)>>>(
               y_old_param, y_new_param, ros_param, devstruct, number_of_blocks, is_first_call);
           number_of_blocks = new_number_of_blocks;
         }
 
         CHECK_CUDA_ERROR(
-            cudaMemcpyAsync(&normalized_error, &devstruct.errors_output_[0], sizeof(double), cudaMemcpyDeviceToHost, micm::cuda::GetCudaStream(0)),
+            cudaMemcpyAsync(&normalized_error, &devstruct.errors_output_[0], sizeof(double), cudaMemcpyDeviceToHost, cudastreams.GetCudaStream(0)),
             "cudaMemcpy");
-        cudaStreamSynchronize(micm::cuda::GetCudaStream(0));
+        cudaStreamSynchronize(cudastreams.GetCudaStream(0));
         normalized_error = std::sqrt(normalized_error / number_of_elements);
       }  // end of if-else for CUDA/CUBLAS implementation
       return std::max(normalized_error, 1.0e-10);

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -17,7 +17,7 @@ namespace micm
     cudaError_t MallocVector(CudaMatrixParam& param, std::size_t number_of_elements)
     {
       param.number_of_elements_ = number_of_elements;
-      cudaError_t err = cudaMallocAsync(&(param.d_data_), sizeof(T) * number_of_elements, micm::cuda::GetCudaStream(0));
+      cudaError_t err = cudaMallocAsync(&(param.d_data_), sizeof(T) * number_of_elements, cudastreams.GetCudaStream(0));
       return err;
     }
 
@@ -29,7 +29,7 @@ namespace micm
       {
         return cudaError_t::cudaSuccess;
       }
-      cudaError_t err = cudaFreeAsync(param.d_data_, micm::cuda::GetCudaStream(0));
+      cudaError_t err = cudaFreeAsync(param.d_data_, cudastreams.GetCudaStream(0));
       param.d_data_ = nullptr;
       return err;
     }
@@ -38,7 +38,7 @@ namespace micm
     cudaError_t CopyToDevice(CudaMatrixParam& param, std::vector<T>& h_data)
     {
       cudaError_t err =
-      cudaMemcpyAsync(param.d_data_, h_data.data(), sizeof(T) * param.number_of_elements_, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0));
+      cudaMemcpyAsync(param.d_data_, h_data.data(), sizeof(T) * param.number_of_elements_, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0));
       return err;
     }
 
@@ -46,8 +46,8 @@ namespace micm
     cudaError_t CopyToHost(CudaMatrixParam& param, std::vector<T>& h_data)
     {
       cudaError_t err =
-        cudaMemcpyAsync(h_data.data(), param.d_data_, sizeof(T) * param.number_of_elements_, cudaMemcpyDeviceToHost, micm::cuda::GetCudaStream(0));
-      cudaStreamSynchronize(micm::cuda::GetCudaStream(0));
+        cudaMemcpyAsync(h_data.data(), param.d_data_, sizeof(T) * param.number_of_elements_, cudaMemcpyDeviceToHost, cudastreams.GetCudaStream(0));
+      cudaStreamSynchronize(cudastreams.GetCudaStream(0));
       return err;
     }
 
@@ -59,7 +59,7 @@ namespace micm
           vectorMatrixSrc.d_data_,
           sizeof(T) * vectorMatrixSrc.number_of_elements_,
           cudaMemcpyDeviceToDevice,
-          micm::cuda::GetCudaStream(0));
+          cudastreams.GetCudaStream(0));
       return err;
     }
 
@@ -77,7 +77,7 @@ namespace micm
     cudaError_t FillCudaMatrix(CudaMatrixParam& param, T val)
     {
       std::size_t number_of_blocks = (param.number_of_elements_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      FillCudaMatrixKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(param.d_data_, param.number_of_elements_, val);
+      FillCudaMatrixKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(param.d_data_, param.number_of_elements_, val);
       cudaError_t err = cudaGetLastError();
       return err;
     }

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -17,7 +17,7 @@ namespace micm
     cudaError_t MallocVector(CudaMatrixParam& param, std::size_t number_of_elements)
     {
       param.number_of_elements_ = number_of_elements;
-      cudaError_t err = cudaMallocAsync(&(param.d_data_), sizeof(T) * number_of_elements, cudastreams.GetCudaStream(0));
+      cudaError_t err = cudaMallocAsync(&(param.d_data_), sizeof(T) * number_of_elements, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0));
       return err;
     }
 
@@ -29,7 +29,7 @@ namespace micm
       {
         return cudaError_t::cudaSuccess;
       }
-      cudaError_t err = cudaFreeAsync(param.d_data_, cudastreams.GetCudaStream(0));
+      cudaError_t err = cudaFreeAsync(param.d_data_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0));
       param.d_data_ = nullptr;
       return err;
     }
@@ -38,7 +38,7 @@ namespace micm
     cudaError_t CopyToDevice(CudaMatrixParam& param, std::vector<T>& h_data)
     {
       cudaError_t err =
-      cudaMemcpyAsync(param.d_data_, h_data.data(), sizeof(T) * param.number_of_elements_, cudaMemcpyHostToDevice, cudastreams.GetCudaStream(0));
+      cudaMemcpyAsync(param.d_data_, h_data.data(), sizeof(T) * param.number_of_elements_, cudaMemcpyHostToDevice, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0));
       return err;
     }
 
@@ -46,8 +46,8 @@ namespace micm
     cudaError_t CopyToHost(CudaMatrixParam& param, std::vector<T>& h_data)
     {
       cudaError_t err =
-        cudaMemcpyAsync(h_data.data(), param.d_data_, sizeof(T) * param.number_of_elements_, cudaMemcpyDeviceToHost, cudastreams.GetCudaStream(0));
-      cudaStreamSynchronize(cudastreams.GetCudaStream(0));
+        cudaMemcpyAsync(h_data.data(), param.d_data_, sizeof(T) * param.number_of_elements_, cudaMemcpyDeviceToHost, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0));
+      cudaStreamSynchronize(micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0));
       return err;
     }
 
@@ -59,7 +59,7 @@ namespace micm
           vectorMatrixSrc.d_data_,
           sizeof(T) * vectorMatrixSrc.number_of_elements_,
           cudaMemcpyDeviceToDevice,
-          cudastreams.GetCudaStream(0));
+          micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0));
       return err;
     }
 
@@ -77,7 +77,7 @@ namespace micm
     cudaError_t FillCudaMatrix(CudaMatrixParam& param, T val)
     {
       std::size_t number_of_blocks = (param.number_of_elements_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      FillCudaMatrixKernel<<<number_of_blocks, BLOCK_SIZE, 0, cudastreams.GetCudaStream(0)>>>(param.d_data_, param.number_of_elements_, val);
+      FillCudaMatrixKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(param.d_data_, param.number_of_elements_, val);
       cudaError_t err = cudaGetLastError();
       return err;
     }

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_matrix.cuh>
 #include <micm/cuda/util/cuda_param.hpp>
+#include <micm/cuda/util/cuda_util.cuh>
 #include <micm/util/internal_error.hpp>
 
 #include <cuda_runtime.h>
@@ -16,7 +17,7 @@ namespace micm
     cudaError_t MallocVector(CudaMatrixParam& param, std::size_t number_of_elements)
     {
       param.number_of_elements_ = number_of_elements;
-      cudaError_t err = cudaMalloc(&(param.d_data_), sizeof(T) * number_of_elements);
+      cudaError_t err = cudaMallocAsync(&(param.d_data_), sizeof(T) * number_of_elements, micm::cuda::GetCudaStream(0));
       return err;
     }
 
@@ -28,7 +29,7 @@ namespace micm
       {
         return cudaError_t::cudaSuccess;
       }
-      cudaError_t err = cudaFree(param.d_data_);
+      cudaError_t err = cudaFreeAsync(param.d_data_, micm::cuda::GetCudaStream(0));
       param.d_data_ = nullptr;
       return err;
     }
@@ -37,27 +38,28 @@ namespace micm
     cudaError_t CopyToDevice(CudaMatrixParam& param, std::vector<T>& h_data)
     {
       cudaError_t err =
-          cudaMemcpy(param.d_data_, h_data.data(), sizeof(T) * param.number_of_elements_, cudaMemcpyHostToDevice);
+      cudaMemcpyAsync(param.d_data_, h_data.data(), sizeof(T) * param.number_of_elements_, cudaMemcpyHostToDevice, micm::cuda::GetCudaStream(0));
       return err;
     }
 
     template<typename T>
     cudaError_t CopyToHost(CudaMatrixParam& param, std::vector<T>& h_data)
     {
-      cudaDeviceSynchronize();
       cudaError_t err =
-          cudaMemcpy(h_data.data(), param.d_data_, sizeof(T) * param.number_of_elements_, cudaMemcpyDeviceToHost);
+        cudaMemcpyAsync(h_data.data(), param.d_data_, sizeof(T) * param.number_of_elements_, cudaMemcpyDeviceToHost, micm::cuda::GetCudaStream(0));
+      cudaStreamSynchronize(micm::cuda::GetCudaStream(0));
       return err;
     }
 
     template<typename T>
     cudaError_t CopyToDeviceFromDevice(CudaMatrixParam& vectorMatrixDest, const CudaMatrixParam& vectorMatrixSrc)
     {
-      cudaError_t err = cudaMemcpy(
+      cudaError_t err = cudaMemcpyAsync(
           vectorMatrixDest.d_data_,
           vectorMatrixSrc.d_data_,
           sizeof(T) * vectorMatrixSrc.number_of_elements_,
-          cudaMemcpyDeviceToDevice);
+          cudaMemcpyDeviceToDevice,
+          micm::cuda::GetCudaStream(0));
       return err;
     }
 
@@ -75,7 +77,7 @@ namespace micm
     cudaError_t FillCudaMatrix(CudaMatrixParam& param, T val)
     {
       std::size_t number_of_blocks = (param.number_of_elements_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      FillCudaMatrixKernel<<<number_of_blocks, BLOCK_SIZE>>>(param.d_data_, param.number_of_elements_, val);
+      FillCudaMatrixKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::GetCudaStream(0)>>>(param.d_data_, param.number_of_elements_, val);
       cudaError_t err = cudaGetLastError();
       return err;
     }

--- a/src/util/cuda_util.cu
+++ b/src/util/cuda_util.cu
@@ -82,12 +82,13 @@ namespace micm
     // Define a functor for the cudaStream unique pointer deleter
     struct CudaStreamDeleter
     {
-      void operator()(cudaStream_t* cuda_streams) const
+      void operator()(cudaStream_t* cuda_stream) const
       {
-        if (cuda_streams != nullptr)
+        if (cuda_stream != nullptr)
         {
-          CHECK_CUDA_ERROR(cudaStreamDestroy(*cuda_streams), "CUDA stream finalization failed");
-          delete cuda_streams;
+          cudaStreamSynchronize(*cuda_stream);
+          CHECK_CUDA_ERROR(cudaStreamDestroy(*cuda_stream), "CUDA stream finalization failed");
+          delete cuda_stream;
         }
       }
     };
@@ -98,9 +99,9 @@ namespace micm
     // Create a CUDA stream and return a unique pointer to it
     CudaStreamPtr CreateCudaStream()
     {
-      cudaStream_t* cuda_streams = new cudaStream_t;
-      CHECK_CUDA_ERROR(cudaStreamCreate(cuda_streams), "CUDA stream initialization failed...");
-      return CudaStreamPtr(cuda_streams, CudaStreamDeleter());
+      cudaStream_t* cuda_stream = new cudaStream_t;
+      CHECK_CUDA_ERROR(cudaStreamCreate(cuda_stream), "CUDA stream initialization failed...");
+      return CudaStreamPtr(cuda_stream, CudaStreamDeleter());
     }
 
     // Get the CUDA stream given a stream ID

--- a/src/util/cuda_util.cu
+++ b/src/util/cuda_util.cu
@@ -1,6 +1,5 @@
 // Copyright (C) 2023-2024 National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
-#include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>
 #include <micm/util/internal_error.hpp>
 

--- a/src/util/cuda_util.cu
+++ b/src/util/cuda_util.cu
@@ -71,6 +71,7 @@ namespace micm
       if (auto search = cublas_handles_map.find(device_id); search == cublas_handles_map.end())
       {
         cublas_handles_map[device_id] = std::move(CreateCublasHandle());
+        cublasSetStream(*cublas_handles_map[device_id], micm::cuda::GetCudaStream(0));
       }
       return *cublas_handles_map[device_id];
     }

--- a/src/util/cuda_util.cu
+++ b/src/util/cuda_util.cu
@@ -1,14 +1,8 @@
 // Copyright (C) 2023-2024 National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
+#include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>
 #include <micm/util/internal_error.hpp>
-
-#include <cublas_v2.h>
-#include <cuda_runtime.h>
-
-#include <map>
-#include <memory>
-#include <mutex>
 
 namespace micm
 {
@@ -71,49 +65,38 @@ namespace micm
       if (auto search = cublas_handles_map.find(device_id); search == cublas_handles_map.end())
       {
         cublas_handles_map[device_id] = std::move(CreateCublasHandle());
-        cublasSetStream(*cublas_handles_map[device_id], micm::cuda::GetCudaStream(0));
+        cublasSetStream(*cublas_handles_map[device_id], cudastreams.GetCudaStream(0));
       }
       return *cublas_handles_map[device_id];
     }
 
     /*
-        The following functions are used to create and manage cuda streams
+        Define the following functions used in the CudaStreamSingleton class
     */
-
-    // Define a functor for the cudaStream unique pointer deleter
-    struct CudaStreamDeleter
-    {
-      void operator()(cudaStream_t* cuda_stream) const
-      {
-        if (cuda_stream != nullptr)
-        {
-          cudaStreamSynchronize(*cuda_stream);
-          CHECK_CUDA_ERROR(cudaStreamDestroy(*cuda_stream), "CUDA stream finalization failed");
-          delete cuda_stream;
-        }
-      }
-    };
-
-    // Define the smart pointer type using the functor for the custom deleter
-    using CudaStreamPtr = std::unique_ptr<cudaStream_t, CudaStreamDeleter>;
-
     // Create a CUDA stream and return a unique pointer to it
-    CudaStreamPtr CreateCudaStream()
+    CudaStreamPtr CudaStreamSingleton::CreateCudaStream()
     {
       cudaStream_t* cuda_stream = new cudaStream_t;
       CHECK_CUDA_ERROR(cudaStreamCreate(cuda_stream), "CUDA stream initialization failed...");
       return CudaStreamPtr(cuda_stream, CudaStreamDeleter());
-    }
+    }   
 
     // Get the CUDA stream given a stream ID
-    cudaStream_t& GetCudaStream(std::size_t stream_id)
+    cudaStream_t& CudaStreamSingleton::GetCudaStream(std::size_t stream_id)
     {
-      static std::map<int, CudaStreamPtr> cuda_streams_map;
-      if (auto search = cuda_streams_map.find(stream_id); search == cuda_streams_map.end())
+      std::lock_guard<std::mutex> lock(mutex_);     
+      if (auto search = cuda_streams_map_.find(stream_id); search == cuda_streams_map_.end())
       {
-        cuda_streams_map[stream_id] = std::move(CreateCudaStream());
+        cuda_streams_map_[stream_id] = std::move(CreateCudaStream());
       }
-      return *cuda_streams_map[stream_id];
-    } 
+      return *cuda_streams_map_[stream_id];
+    }      
+
+    // Empty the map variable to clean up all CUDA streams
+    void CudaStreamSingleton::CleanUp()
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      cuda_streams_map_.clear();
+    }
   }  // namespace cuda
 }  // namespace micm

--- a/src/util/cuda_util.cu
+++ b/src/util/cuda_util.cu
@@ -39,6 +39,7 @@ namespace micm
         {
           CHECK_CUBLAS_ERROR(cublasDestroy(*handle), "CUBLAS finalization failed");
           delete handle;
+          handle = nullptr;
         }
       }
     };
@@ -65,7 +66,7 @@ namespace micm
       if (auto search = cublas_handles_map.find(device_id); search == cublas_handles_map.end())
       {
         cublas_handles_map[device_id] = std::move(CreateCublasHandle());
-        cublasSetStream(*cublas_handles_map[device_id], cudastreams.GetCudaStream(0));
+        cublasSetStream(*cublas_handles_map[device_id], micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0));
       }
       return *cublas_handles_map[device_id];
     }
@@ -73,6 +74,13 @@ namespace micm
     /*
         Define the following functions used in the CudaStreamSingleton class
     */
+
+    CudaStreamSingleton& CudaStreamSingleton::GetInstance()
+    {
+        static CudaStreamSingleton instance;
+        return instance;
+    }
+
     // Create a CUDA stream and return a unique pointer to it
     CudaStreamPtr CudaStreamSingleton::CreateCudaStream()
     {

--- a/test/integration/cuda/CMakeLists.txt
+++ b/test/integration/cuda/CMakeLists.txt
@@ -6,4 +6,4 @@ include(test_util)
 ################################################################################
 # Tests
 
-create_standard_test(NAME cuda_analytical_rosenbrock_integration SOURCES test_cuda_analytical_rosenbrock.cpp LIBRARIES musica::micm_cuda)
+create_standard_test(NAME cuda_analytical_rosenbrock_integration SOURCES test_cuda_analytical_rosenbrock.cpp LIBRARIES musica::micm_cuda IS_CUDA_TEST)

--- a/test/unit/cuda/util/CMakeLists.txt
+++ b/test/unit/cuda/util/CMakeLists.txt
@@ -11,5 +11,9 @@ target_link_libraries(micm_cuda_test_utils PUBLIC cudart micm)
 target_sources(micm_cuda_test_utils PRIVATE cuda_matrix_utils.cu)
 set_target_properties(micm_cuda_test_utils PROPERTIES LINKER_LANGUAGE CXX)
 
+# add a library to use customized GTest main function for CUDA tests
+add_library(cuda_gtest_main STATIC cuda_gtest_main.cpp)
+target_link_libraries(cuda_gtest_main PUBLIC gtest micm)
+
 create_standard_test(NAME cuda_dense_matrix SOURCES test_cuda_dense_matrix.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils IS_CUDA_TEST)
 create_standard_test(NAME cuda_sparse_matrix SOURCES test_cuda_sparse_matrix.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils IS_CUDA_TEST)

--- a/test/unit/cuda/util/cuda_gtest_main.cpp
+++ b/test/unit/cuda/util/cuda_gtest_main.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+#include <micm/cuda/util/cuda_util.cuh>
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    micm::cuda::CudaStreamSingleton::GetInstance().CleanUp(); // Ensure cleanup
+    return result;
+}

--- a/test/unit/cuda/util/test_cuda_dense_matrix.cpp
+++ b/test/unit/cuda/util/test_cuda_dense_matrix.cpp
@@ -28,7 +28,8 @@ TEST(CudaDenseMatrix, DeviceMemCopy)
   micm::cuda::CopyToDevice<double>(param, h_vector);
   micm::cuda::SquareDriver(param);
   micm::cuda::CopyToHost<double>(param, h_vector);
-
+  micm::cuda::FreeVector(param);
+  
   EXPECT_EQ(h_vector[0], 1 * 1);
   EXPECT_EQ(h_vector[1], 2 * 2);
   EXPECT_EQ(h_vector[2], 3 * 3);


### PR DESCRIPTION
This PR:
- adds a singleton class to generate the CUDA streams
- makes all the CUDA kernel launches asynchronously
- modifies the default `main()` function for GTest to clean up the CUDA streams before the program exits

All the unit tests passed on Derecho's A100 GPU with `nvhpc/24.7`.