### PR TITLE
correcting indexing for LU decomposition

### DIFF
--- a/docker/Dockerfile.llvm
+++ b/docker/Dockerfile.llvm
@@ -1,4 +1,5 @@
 FROM fedora:37
+# We need llvm version 15.0.7
 
 RUN dnf -y update \
     && dnf -y install \
@@ -9,7 +10,7 @@ RUN dnf -y update \
         git \
         make \
         zlib-devel \
-        llvm-devel \
+        llvm-devel \ 
         openmpi-devel \
         valgrind \
     && dnf clean all

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -91,7 +91,7 @@ namespace micm
       // There must always be a non-zero element on the diagonal
       nLij_Lii_.push_back(std::make_pair(nLij, lower_matrix.VectorIndex(0, i, i)));
     }
-    for (std::size_t i = upper_matrix.NumRows() - 1; i != static_cast<std::size_t>(-1); --i)
+    for (std::size_t i = upper_matrix.NumRows(); i--;)
     {
       std::size_t nUij = 0;
       for (std::size_t j_id = upper_matrix.RowStartVector()[i]; j_id < upper_matrix.RowStartVector()[i + 1]; ++j_id)
@@ -128,6 +128,9 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
+    auto& lower_matrix_vector = lower_matrix.AsVector();
+    auto& upper_matrix_vector = upper_matrix.AsVector();
+
     for (std::size_t i_cell = 0; i_cell < x.NumRows(); ++i_cell)
     {
       auto x_cell = x[i_cell];
@@ -143,10 +146,10 @@ namespace micm
         {
           for (std::size_t i = 0; i < nLij_Lii.first; ++i)
           {
-            *y_elem -= lower_matrix.AsVector()[lower_grid_offset + (*Lij_yj).first] * y_cell[(*Lij_yj).second];
+            *y_elem -= lower_matrix_vector[lower_grid_offset + (*Lij_yj).first] * y_cell[(*Lij_yj).second];
             ++Lij_yj;
           }
-          *(y_elem++) /= lower_matrix.AsVector()[lower_grid_offset + nLij_Lii.second];
+          *(y_elem++) /= lower_matrix_vector[lower_grid_offset + nLij_Lii.second];
         }
       }
 
@@ -159,11 +162,11 @@ namespace micm
           // x_elem starts out as y_elem from the previous loop
           for (std::size_t i = 0; i < nUij_Uii.first; ++i)
           {
-            *x_elem -= upper_matrix.AsVector()[upper_grid_offset + (*Uij_xj).first] * x_cell[(*Uij_xj).second];
+            *x_elem -= upper_matrix_vector[upper_grid_offset + (*Uij_xj).first] * x_cell[(*Uij_xj).second];
             ++Uij_xj;
           }
 
-          *(x_elem) /= upper_matrix.AsVector()[upper_grid_offset + nUij_Uii.second];
+          *(x_elem) /= upper_matrix_vector[upper_grid_offset + nUij_Uii.second];
           // don't iterate before the beginning of the vector
           if (x_elem != x_cell.begin())
           {

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -24,7 +24,7 @@ namespace micm
   /// The LU decomposition uses the Doolittle algorithm following the
   /// naming used here: https://www.geeksforgeeks.org/doolittle-algorithm-lu-decomposition/
   ///
-  /// The sudo-code for the corresponding dense matrix algorithm for matrix A
+  /// The psuedo-code for the corresponding dense matrix algorithm for matrix A
   /// and lower (upper) triangular matrix L(U) would be:
   ///
   /// for i = 0...n-1                 // Outer loop over rows (columns) for upper (lower) triangular matrix

--- a/include/micm/solver/lu_decomposition.inl
+++ b/include/micm/solver/lu_decomposition.inl
@@ -301,15 +301,12 @@ namespace micm
           if (*(do_aik++))
           {
             auto elem = *(aik++);
-            
-                  
-                  if (elem == std::numeric_limits<std::size_t>::max()) {
-                      U_vector[uik_nkj->first] = 0;
-                      std::fill(U_vector + uik_nkj_first, U_vector + uik_nkj_first + n_cells, 0);
-                  }
-                  else {
-                      std::copy(A_vector + *aik, A_vector + *aik + n_cells, U_vector + uik_nkj_first);
-                  }
+              if (elem == std::numeric_limits<std::size_t>::max()) {
+                  std::fill(U_vector + uik_nkj_first, U_vector + uik_nkj_first + n_cells, 0);
+              }
+              else {
+                  std::copy(A_vector + elem, A_vector + elem + n_cells, U_vector + uik_nkj_first);
+              }
           }
           for (std::size_t ikj = 0; ikj < uik_nkj->second; ++ikj)
           {
@@ -329,11 +326,16 @@ namespace micm
         for (std::size_t iL = 0; iL < inLU.first; ++iL)
         {
           lki_nkj_first = lki_nkj->first;
-          if (*(do_aki++))
-          {
-            std::copy(A_vector + *aki, A_vector + *aki + n_cells, L_vector + lki_nkj_first);
-            ++aki;
-          }
+            if (*(do_aki++))
+            {
+              auto elem = *(aki++);
+                if (elem == std::numeric_limits<std::size_t>::max()) {
+                    std::fill(L_vector + lki_nkj_first, L_vector + lki_nkj_first + n_cells, 0);
+                }
+                else {
+                    std::copy(A_vector + elem, A_vector + elem + n_cells, L_vector + lki_nkj_first);
+                }
+            }
           for (std::size_t ikj = 0; ikj < lki_nkj->second; ++ikj)
           {
             std::size_t lkj_uji_first = lkj_uji->first;

--- a/include/micm/solver/lu_decomposition.inl
+++ b/include/micm/solver/lu_decomposition.inl
@@ -9,14 +9,15 @@ namespace micm
   }
 
   template<class SparseMatrixPolicy>
-  requires(SparseMatrixConcept<SparseMatrixPolicy>) inline LuDecomposition::LuDecomposition(const SparseMatrixPolicy& matrix)
+    requires(SparseMatrixConcept<SparseMatrixPolicy>)
+  inline LuDecomposition::LuDecomposition(const SparseMatrixPolicy& matrix)
   {
     Initialize<SparseMatrixPolicy>(matrix, typename SparseMatrixPolicy::value_type());
   }
 
   template<class SparseMatrixPolicy>
-  requires(SparseMatrixConcept<SparseMatrixPolicy>) inline LuDecomposition LuDecomposition::Create(
-      const SparseMatrixPolicy& matrix)
+    requires(SparseMatrixConcept<SparseMatrixPolicy>)
+  inline LuDecomposition LuDecomposition::Create(const SparseMatrixPolicy& matrix)
   {
     LuDecomposition lu_decomp{};
     lu_decomp.Initialize<SparseMatrixPolicy>(matrix, typename SparseMatrixPolicy::value_type());
@@ -24,9 +25,8 @@ namespace micm
   }
 
   template<class SparseMatrixPolicy>
-  requires(SparseMatrixConcept<SparseMatrixPolicy>) inline void LuDecomposition::Initialize(
-      const SparseMatrixPolicy& matrix,
-      auto initial_value)
+    requires(SparseMatrixConcept<SparseMatrixPolicy>)
+  inline void LuDecomposition::Initialize(const SparseMatrixPolicy& matrix, auto initial_value)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -64,13 +64,14 @@ namespace micm
         else
         {
           do_aik_.push_back(true);
-            if (matrix.IsZero(i, k)) {
-                aik_.push_back(std::numeric_limits<std::size_t>::max());
-            }
-            else {
-                aik_.push_back(matrix.VectorIndex(0, i, k));
-            }
-          
+          if (matrix.IsZero(i, k))
+          {
+            aik_.push_back(std::numeric_limits<std::size_t>::max());
+          }
+          else
+          {
+            aik_.push_back(matrix.VectorIndex(0, i, k));
+          }
         }
         uik_nkj_.push_back(std::make_pair(upper_matrix.VectorIndex(0, i, k), nkj));
         ++(iLU.second);
@@ -99,12 +100,14 @@ namespace micm
         else
         {
           do_aki_.push_back(true);
-            if (matrix.IsZero(k, i)) {
-                aki_.push_back(std::numeric_limits<std::size_t>::max());
-            }
-            else {
-                aki_.push_back(matrix.VectorIndex(0, k, i));
-            }
+          if (matrix.IsZero(k, i))
+          {
+            aki_.push_back(std::numeric_limits<std::size_t>::max());
+          }
+          else
+          {
+            aki_.push_back(matrix.VectorIndex(0, k, i));
+          }
         }
         uii_.push_back(upper_matrix.VectorIndex(0, i, i));
         lki_nkj_.push_back(std::make_pair(lower_matrix.VectorIndex(0, k, i), nkj));
@@ -116,9 +119,10 @@ namespace micm
   }
 
   template<class SparseMatrixPolicy>
-  requires(
-      SparseMatrixConcept<SparseMatrixPolicy>) inline std::pair<SparseMatrixPolicy, SparseMatrixPolicy> LuDecomposition::
-      GetLUMatrices(const SparseMatrixPolicy& A, typename SparseMatrixPolicy::value_type initial_value)
+    requires(SparseMatrixConcept<SparseMatrixPolicy>)
+  inline std::pair<SparseMatrixPolicy, SparseMatrixPolicy> LuDecomposition::GetLUMatrices(
+      const SparseMatrixPolicy& A,
+      typename SparseMatrixPolicy::value_type initial_value)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -178,7 +182,8 @@ namespace micm
   }
 
   template<class SparseMatrixPolicy>
-  requires(!VectorizableSparse<SparseMatrixPolicy>) inline void LuDecomposition::Decompose(
+    requires(!VectorizableSparse<SparseMatrixPolicy>)
+  inline void LuDecomposition::Decompose(
       const SparseMatrixPolicy& A,
       SparseMatrixPolicy& L,
       SparseMatrixPolicy& U,
@@ -207,16 +212,19 @@ namespace micm
         // Upper trianglur matrix
         for (std::size_t iU = 0; iU < inLU.second; ++iU)
         {
-            if (*(do_aik++)) {
-                auto elem = *(aik++);
-                if (elem == std::numeric_limits<std::size_t>::max()) {
-                    U_vector[uik_nkj->first] = 0;
-                }
-                else {
-                    U_vector[uik_nkj->first] = A_vector[elem];
-                }
+          if (*(do_aik++))
+          {
+            auto elem = *(aik++);
+            if (elem == std::numeric_limits<std::size_t>::max())
+            {
+              U_vector[uik_nkj->first] = 0;
             }
-            
+            else
+            {
+              U_vector[uik_nkj->first] = A_vector[elem];
+            }
+          }
+
           for (std::size_t ikj = 0; ikj < uik_nkj->second; ++ikj)
           {
             U_vector[uik_nkj->first] -= L_vector[lij_ujk->first] * U_vector[lij_ujk->second];
@@ -228,15 +236,18 @@ namespace micm
         L_vector[(lki_nkj++)->first] = 1.0;
         for (std::size_t iL = 0; iL < inLU.first; ++iL)
         {
-            if (*(do_aki++)){
-                auto elem = *(aki++);
-                if (elem == std::numeric_limits<std::size_t>::max()) {
-                    L_vector[lki_nkj->first] = 0;
-                }
-                else {
-                    L_vector[lki_nkj->first] = A_vector[elem];
-                }
+          if (*(do_aki++))
+          {
+            auto elem = *(aki++);
+            if (elem == std::numeric_limits<std::size_t>::max())
+            {
+              L_vector[lki_nkj->first] = 0;
             }
+            else
+            {
+              L_vector[lki_nkj->first] = A_vector[elem];
+            }
+          }
           for (std::size_t ikj = 0; ikj < lki_nkj->second; ++ikj)
           {
             L_vector[lki_nkj->first] -= L_vector[lkj_uji->first] * U_vector[lkj_uji->second];
@@ -261,7 +272,8 @@ namespace micm
   }
 
   template<class SparseMatrixPolicy>
-  requires(VectorizableSparse<SparseMatrixPolicy>) inline void LuDecomposition::Decompose(
+    requires(VectorizableSparse<SparseMatrixPolicy>)
+  inline void LuDecomposition::Decompose(
       const SparseMatrixPolicy& A,
       SparseMatrixPolicy& L,
       SparseMatrixPolicy& U,
@@ -301,12 +313,14 @@ namespace micm
           if (*(do_aik++))
           {
             auto elem = *(aik++);
-              if (elem == std::numeric_limits<std::size_t>::max()) {
-                  std::fill(U_vector + uik_nkj_first, U_vector + uik_nkj_first + n_cells, 0);
-              }
-              else {
-                  std::copy(A_vector + elem, A_vector + elem + n_cells, U_vector + uik_nkj_first);
-              }
+            if (elem == std::numeric_limits<std::size_t>::max())
+            {
+              std::fill(U_vector + uik_nkj_first, U_vector + uik_nkj_first + n_cells, 0);
+            }
+            else
+            {
+              std::copy(A_vector + elem, A_vector + elem + n_cells, U_vector + uik_nkj_first);
+            }
           }
           for (std::size_t ikj = 0; ikj < uik_nkj->second; ++ikj)
           {
@@ -326,16 +340,18 @@ namespace micm
         for (std::size_t iL = 0; iL < inLU.first; ++iL)
         {
           lki_nkj_first = lki_nkj->first;
-            if (*(do_aki++))
+          if (*(do_aki++))
+          {
+            auto elem = *(aki++);
+            if (elem == std::numeric_limits<std::size_t>::max())
             {
-              auto elem = *(aki++);
-                if (elem == std::numeric_limits<std::size_t>::max()) {
-                    std::fill(L_vector + lki_nkj_first, L_vector + lki_nkj_first + n_cells, 0);
-                }
-                else {
-                    std::copy(A_vector + elem, A_vector + elem + n_cells, L_vector + lki_nkj_first);
-                }
+              std::fill(L_vector + lki_nkj_first, L_vector + lki_nkj_first + n_cells, 0);
             }
+            else
+            {
+              std::copy(A_vector + elem, A_vector + elem + n_cells, L_vector + lki_nkj_first);
+            }
+          }
           for (std::size_t ikj = 0; ikj < lki_nkj->second; ++ikj)
           {
             std::size_t lkj_uji_first = lkj_uji->first;

--- a/include/micm/solver/lu_decomposition.inl
+++ b/include/micm/solver/lu_decomposition.inl
@@ -19,7 +19,7 @@ namespace micm
       const SparseMatrixPolicy& matrix)
   {
     LuDecomposition lu_decomp{};
-    lu_decomp.Initialize<SparseMatrixPolicy>(matrix, INFINITY);
+    lu_decomp.Initialize<SparseMatrixPolicy>(matrix, typename SparseMatrixPolicy::value_type());
     return lu_decomp;
   }
 
@@ -304,10 +304,11 @@ namespace micm
             
                   
                   if (elem == std::numeric_limits<std::size_t>::max()) {
+                      U_vector[uik_nkj->first] = 0;
                       std::fill(U_vector + uik_nkj_first, U_vector + uik_nkj_first + n_cells, 0);
                   }
                   else {
-                      std::copy(A_vector + elem, A_vector + elem + n_cells, U_vector + uik_nkj_first);
+                      std::copy(A_vector + *aik, A_vector + *aik + n_cells, U_vector + uik_nkj_first);
                   }
           }
           for (std::size_t ikj = 0; ikj < uik_nkj->second; ++ikj)
@@ -330,14 +331,8 @@ namespace micm
           lki_nkj_first = lki_nkj->first;
           if (*(do_aki++))
           {
-              auto elem = *(aki++);
-              
-              if (elem == std::numeric_limits<std::size_t>::max()) {
-                  std::fill(L_vector + lki_nkj_first, L_vector + lki_nkj_first + n_cells, 0);
-              }
-              else {
-                  std::copy(A_vector + elem, A_vector + elem + n_cells, L_vector + lki_nkj_first);
-              }
+            std::copy(A_vector + *aki, A_vector + *aki + n_cells, L_vector + lki_nkj_first);
+            ++aki;
           }
           for (std::size_t ikj = 0; ikj < lki_nkj->second; ++ikj)
           {

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -197,6 +197,17 @@ namespace micm
       return y_dim_;
     }
 
+    void print() {
+      for (std::size_t i = 0; i < x_dim_; ++i)
+      {
+        for (std::size_t j = 0; j < y_dim_; ++j)
+        {
+          std::cout << data_[i * y_dim_ + j] << " ";
+        }
+        std::cout << std::endl;
+      }
+    }
+
     /// @brief Set every matrix element to a given value
     /// @param val Value to set each element to
     void Fill(T val)

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -197,7 +197,7 @@ namespace micm
       return y_dim_;
     }
 
-    void print() {
+    void print() const {
       for (std::size_t i = 0; i < x_dim_; ++i)
       {
         for (std::size_t j = 0; j < y_dim_; ++j)

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -12,6 +12,7 @@
 #include <stdexcept>
 #include <utility>
 #include <vector>
+#include <iostream>
 
 namespace micm
 {

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -17,8 +17,7 @@ namespace micm
 {
   /// Concept for vectorizable matrices
   template<typename T>
-  concept VectorizableSparse = requires(T t)
-  {
+  concept VectorizableSparse = requires(T t) {
     t.GroupSize(0);
     t.GroupVectorSize();
     t.NumberOfGroups(0);
@@ -184,6 +183,28 @@ namespace micm
       data_ = std::vector<T>(OrderingPolicy::VectorSize(number_of_blocks_, row_ids_, row_start_), builder.initial_value_);
 
       return *this;
+    }
+
+    void print() const
+    {
+      for (std::size_t block = 0; block < number_of_blocks_; ++block)
+      {
+        for (std::size_t i = 0; i < row_start_.size() - 1; ++i)
+        {
+          for (std::size_t j = 0; j < row_start_.size() - 1; ++j)
+          {
+            if (IsZero(i, j))
+            {
+              std::cout << "0 ";
+            }
+            else
+            {
+              std::cout << data_[VectorIndex(block, i, j)] << " ";
+            }
+          }
+          std::cout << std::endl;
+        }
+      }
     }
 
     void AddToDiagonal(T value)

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -223,6 +223,17 @@ namespace micm
       return L * y_dim_;
     }
 
+    void print() const {
+      for (std::size_t i = 0; i < x_dim_; ++i)
+      {
+        for (std::size_t j = 0; j < y_dim_; ++j)
+        {
+          std::cout << (*this)[i][j] << " ";
+        }
+        std::cout << std::endl;
+      }
+    }
+
     constexpr std::size_t GroupVectorSize() const
     {
       return L;

--- a/src/solver/lu_decomposition.cu
+++ b/src/solver/lu_decomposition.cu
@@ -49,6 +49,7 @@ namespace micm
       *d_is_singular = false;
 
       size_t sentinel = ::cuda::std::numeric_limits<size_t>::max();
+      std::cout << "sentinel: " << sentinel << std::endl;
 
       if (tid < number_of_grid_cells)
       {

--- a/src/solver/lu_decomposition.cu
+++ b/src/solver/lu_decomposition.cu
@@ -62,12 +62,12 @@ namespace micm
             if (d_do_aik[do_aik_offset++])
             {
               size_t U_idx = d_uik_nkj[uik_nkj_offset].first + tid;
-              size_t A_idx = d_aik[aik_offset++];
+              size_t A_idx = d_aik[aik_offset++] + tid;
               if (A_idx == sentinel) {
                 d_U[U_idx] = 0;
               }
               else {
-                d_U[U_idx] = d_A[A_idx + tid];
+                d_U[U_idx] = d_A[A_idx];
               }
             }
 
@@ -90,12 +90,12 @@ namespace micm
             if (d_do_aki[do_aki_offset++])
             {
               size_t L_idx = d_lki_nkj[lki_nkj_offset].first + tid;
-              size_t A_idx = d_aki[aki_offset++];
+              size_t A_idx = d_aki[aki_offset++] + tid;
               if (A_idx == sentinel) {
                 d_L[L_idx] = 0;
               }
               else {
-                d_L[L_idx] = d_A[A_idx + tid];
+                d_L[L_idx] = d_A[A_idx];
               }
             }
             for (size_t ikj = 0; ikj < d_lki_nkj[lki_nkj_offset].second; ++ikj)

--- a/src/solver/lu_decomposition.cu
+++ b/src/solver/lu_decomposition.cu
@@ -3,6 +3,7 @@
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>
 #include <cuda/std/limits>
+#include <iostream>
 
 namespace micm
 {

--- a/src/solver/lu_decomposition.cu
+++ b/src/solver/lu_decomposition.cu
@@ -3,7 +3,7 @@
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>
 #include <cuda/std/limits>
-#include <iostream>
+#include <stdio.h>
 
 namespace micm
 {
@@ -50,7 +50,7 @@ namespace micm
       *d_is_singular = false;
 
       size_t sentinel = ::cuda::std::numeric_limits<size_t>::max();
-      std::cout << "sentinel: " << sentinel << std::endl;
+      printf("sentinel: %zu\n", sentinel);
 
       if (tid < number_of_grid_cells)
       {

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(MICM_ENABLE_JSON)
+if(MICM_ENABLE_CONFIG_READER)
   add_subdirectory(configure)
 endif()
 if(MICM_ENABLE_CUDA)

--- a/test/unit/configure/process/test_user_defined_config.cpp
+++ b/test/unit/configure/process/test_user_defined_config.cpp
@@ -46,9 +46,9 @@ TEST(UserDefinedConfig, ParseConfig)
   // first reaction
   {
     EXPECT_EQ(process_vector[0].reactants_.size(), 3);
-    EXPECT_EQ(process_vector[0].reactants_[0].name_, "bar");
+    EXPECT_EQ(process_vector[0].reactants_[0].name_, "foo");
     EXPECT_EQ(process_vector[0].reactants_[1].name_, "bar");
-    EXPECT_EQ(process_vector[0].reactants_[2].name_, "foo");
+    EXPECT_EQ(process_vector[0].reactants_[2].name_, "bar");
     EXPECT_EQ(process_vector[0].products_.size(), 2);
     EXPECT_EQ(process_vector[0].products_[0].first.name_, "baz");
     EXPECT_EQ(process_vector[0].products_[0].second, 1.4);

--- a/test/unit/cuda/solver/test_cuda_lu_decomposition.cpp
+++ b/test/unit/cuda/solver/test_cuda_lu_decomposition.cpp
@@ -52,6 +52,7 @@ void testCudaRandomMatrix(size_t n_grids)
   micm::LuDecomposition cpu_lud = micm::LuDecomposition::Create<CPUSparseMatrixPolicy>(cpu_A);
   auto cpu_LU = micm::LuDecomposition::GetLUMatrices<CPUSparseMatrixPolicy>(cpu_A, 1.0e-30);
   bool singular{ false };
+  std::cout << "CPU sentinel: " << std::numeric_limits<std::size_t>::max() << std::endl;
   cpu_lud.Decompose<CPUSparseMatrixPolicy>(cpu_A, cpu_LU.first, cpu_LU.second, singular);
 
   // checking GPU result again CPU

--- a/test/unit/solver/test_linear_solver.cpp
+++ b/test/unit/solver/test_linear_solver.cpp
@@ -25,6 +25,13 @@ TEST(LinearSolver, RandomMatrixStandardOrdering)
   testRandomMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<SparseMatrixTest>>(5);
 }
 
+TEST(LinearSolver, StandardOrderingAgnosticToInitialValue)
+{
+  double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
+  for(auto initial_value : initial_values)
+    testLargeMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<SparseMatrixTest>>(5, initial_value);
+}
+
 TEST(LinearSolver, DiagonalMatrixStandardOrdering)
 {
   testDiagonalMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<SparseMatrixTest>>(5);
@@ -59,6 +66,17 @@ TEST(LinearSolver, RandomMatrixVectorOrdering)
   testRandomMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<Group2SparseVectorMatrix>>(5);
   testRandomMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<Group3SparseVectorMatrix>>(5);
   testRandomMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<Group4SparseVectorMatrix>>(5);
+}
+
+TEST(LinearSolver, VectorOrderingAgnosticToInitialValue)
+{
+  double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
+  for(auto initial_value : initial_values) {
+    testLargeMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolver<Group1SparseVectorMatrix>>(5, initial_value);
+    testLargeMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolver<Group2SparseVectorMatrix>>(5, initial_value);
+    testLargeMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolver<Group3SparseVectorMatrix>>(5, initial_value);
+    testLargeMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolver<Group4SparseVectorMatrix>>(5, initial_value);
+  }
 }
 
 TEST(LinearSolver, DiagonalMatrixVectorOrdering)

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -308,7 +308,7 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-13); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy>

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -214,7 +214,7 @@ void testLargeMatrix(std::size_t number_of_blocks, double initial_value)
 
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), generator);
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), generator);
-  const size_t size = 4;
+  const size_t size = 20;
 
   auto builder = SparseMatrixPolicy::Create(size).SetNumberOfBlocks(number_of_blocks).InitialValue(1e-30);
   for (std::size_t i = 0; i < size; ++i)
@@ -259,7 +259,7 @@ void testLargeMatrix(std::size_t number_of_blocks, double initial_value)
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-13); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-11); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -201,7 +201,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-11); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -308,7 +308,7 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-8); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy>

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -201,7 +201,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-09); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-07); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -201,7 +201,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-07); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-06); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -201,7 +201,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-09); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -201,7 +201,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-06); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-09); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
@@ -308,7 +308,7 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-8); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-13); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy>

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -147,7 +147,7 @@ void testDenseMatrix()
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-13); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
@@ -201,7 +201,65 @@ void testRandomMatrix(std::size_t number_of_blocks)
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-11); });
+}
+
+template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
+void testLargeMatrix(std::size_t number_of_blocks, double initial_value)
+{
+  using FloatingPointType = typename MatrixPolicy::value_type;
+
+  const unsigned int seed = 12345;
+  std::default_random_engine generator(seed);
+
+  auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), generator);
+  auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), generator);
+  const size_t size = 4;
+
+  auto builder = SparseMatrixPolicy::Create(size).SetNumberOfBlocks(number_of_blocks).InitialValue(1e-30);
+  for (std::size_t i = 0; i < size; ++i)
+    for (std::size_t j = 0; j < size; ++j)
+      if (i == j || gen_bool())
+        builder = builder.WithElement(i, j);
+
+  SparseMatrixPolicy A(builder);
+  MatrixPolicy b(number_of_blocks, size, 0.0);
+  MatrixPolicy x(number_of_blocks, size, 0.0);
+
+  for (std::size_t i = 0; i < size; ++i)
+    for (std::size_t j = 0; j < size; ++j)
+      if (!A.IsZero(i, j))
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+          A[i_block][i][j] = get_double();
+
+  for (std::size_t i = 0; i < size; ++i)
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+      b[i_block][i] = get_double();
+
+  x = b;
+
+  // Only copy the data to the device when it is a CudaMatrix
+  CopyToDeviceSparse<SparseMatrixPolicy>(A);
+  CopyToDeviceDense<MatrixPolicy>(x);
+
+  LinearSolverPolicy solver = LinearSolverPolicy(A, initial_value);
+  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy>(A, initial_value);
+  auto lower_matrix = std::move(lu.first);
+  auto upper_matrix = std::move(lu.second);
+  bool is_singular = false;
+
+  // Only copy the data to the device when it is a CudaMatrix
+  CopyToDeviceSparse<SparseMatrixPolicy>(lower_matrix);
+  CopyToDeviceSparse<SparseMatrixPolicy>(upper_matrix);
+
+  solver.Factor(A, lower_matrix, upper_matrix, is_singular);
+  solver.template Solve<MatrixPolicy>(x, lower_matrix, upper_matrix);
+
+  // Only copy the data to the host when it is a CudaMatrix
+  CopyToHostDense<MatrixPolicy>(x);
+
+  check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-13); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
@@ -250,7 +308,7 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-13); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy>

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -259,7 +259,7 @@ void testLargeMatrix(std::size_t number_of_blocks, double initial_value)
   CopyToHostDense<MatrixPolicy>(x);
 
   check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
-      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-11); });
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });
 }
 
 template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>


### PR DESCRIPTION
Closes #625 

See the issue for more detail, but this fixes a bug where the L or U matrix would sometimes not be set to the value in the jacobian matrix, leading to a drifting value of the LU matrices. This would lead to incorrect results and eventually the solver would stop converging. We noticed this in the performance repository and learned that we couldn't reuse the state matrix.

We started setting the LU matrices to zero back in #410, but later removed in #594 when we thought it was just an issue around a vectorized normalized error function. It wasn't.