### PR TITLE
Misc updates

### DIFF
--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -7,7 +7,7 @@
 
 // To make the NormalizedError function works properly on GPU,
 // make sure to choose the BLOCK_SIZE from [32, 64, 128, 256, 512, 1024]
-const std::size_t BLOCK_SIZE = 32;
+const std::size_t BLOCK_SIZE = 512;
 
 /// This struct holds the (1) pointer to, and (2) size of
 ///   each constatnt data member from the class "ProcessSet";

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -77,6 +77,11 @@ namespace micm
       return state_parameters_.number_of_species_;
     }
 
+    std::size_t GetNumberOfReactions() const
+    {
+      return state_parameters_.number_of_rate_constants_;
+    }
+
     StatePolicy GetState() const
     {
       auto state = std::move(StatePolicy(state_parameters_));


### PR DESCRIPTION
This PR:
- changes `BLOCK_SIZE` to 512 based on my profiling results.
- adds back the `GetNumberOfReactions` function, which is needed for the performance repo.

fix #632 