### PR TITLE
662 more strict tolerance for unitintegration tests

### DIFF
--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -1395,11 +1395,11 @@ void test_analytical_robertson(
   double time_step = 1.0;
   std::vector<double> times;
   times.push_back(0);
+  solver.CalculateRateConstants(state);
   for (size_t i_time = 0; i_time < N; ++i_time)
   {
     double solve_time = time_step + i_time * time_step;
     times.push_back(solve_time);
-    solver.CalculateRateConstants(state);
     prepare_for_solve(state);
     // Model results
     double actual_solve = 0;

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -1305,7 +1305,7 @@ void test_analytical_stiff_branched(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_robertson(
     BuilderPolicy builder,
-    double tolerance = 1e-8,
+    double relative_tolerance = 1e-8,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -1429,19 +1429,19 @@ void test_analytical_robertson(
   {
     double rel_error = relative_error(model_concentrations[i][_a], analytical_concentrations[i][0]);
     double abs_error = std::abs(model_concentrations[i][_a] - analytical_concentrations[i][0]);
-    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < tolerance)
+    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < relative_tolerance)
         << "Arrays differ at index (" << i << ", " << 0 << ") with relative error " << rel_error << " and absolute error "
         << abs_error;
 
     rel_error = relative_error(model_concentrations[i][_b], analytical_concentrations[i][1]);
     abs_error = std::abs(model_concentrations[i][_b] - analytical_concentrations[i][1]);
-    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < tolerance)
+    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < relative_tolerance)
         << "Arrays differ at index (" << i << ", " << 1 << ") with relative error " << rel_error << " and absolute error "
         << abs_error;
 
     rel_error = relative_error(model_concentrations[i][_c], analytical_concentrations[i][2]);
     abs_error = std::abs(model_concentrations[i][_c] - analytical_concentrations[i][2]);
-    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < tolerance)
+    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < relative_tolerance)
         << "Arrays differ at index (" << i << ", " << 2 << ") with relative error " << rel_error << " and absolute error "
         << abs_error;
   }
@@ -1450,7 +1450,7 @@ void test_analytical_robertson(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_oregonator(
     BuilderPolicy builder,
-    double tolerance = 1e-8,
+    double absolute_tolerance = 1e-8,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -1458,6 +1458,8 @@ void test_analytical_oregonator(
    * This problem is described in
    * Hairer, E., Wanner, G., 1996. Solving Ordinary Differential Equations II: Stiff and Differential-Algebraic Problems, 2nd
    * edition. ed. Springer, Berlin ; New York. Page 144. It actually comes from Field and Noyes (1974)
+   * A driver for a version of this is from here, but this needs a custom forcing and jacobian and so we tried to translate it
+   * https://www.unige.ch/~hairer/testset/testset.html
    *
    * Field, R.J., Noyes, R.M., 1974. Oscillations in chemical systems. IV. Limit cycle behavior in a model of a real chemical
    * reaction. The Journal of Chemical Physics 60, 1877–1884. https://doi.org/10.1063/1.1681288
@@ -1610,9 +1612,9 @@ void test_analytical_oregonator(
 
   for (size_t i = 0; i < model_concentrations.size(); ++i)
   {
-    EXPECT_NEAR(model_concentrations[i][_x], analytical_concentrations[i][0], tolerance);
-    EXPECT_NEAR(model_concentrations[i][_y], analytical_concentrations[i][1], tolerance);
-    EXPECT_NEAR(model_concentrations[i][_z], analytical_concentrations[i][2], tolerance);
+    EXPECT_NEAR(model_concentrations[i][_x], analytical_concentrations[i][0], absolute_tolerance);
+    EXPECT_NEAR(model_concentrations[i][_y], analytical_concentrations[i][1], absolute_tolerance);
+    EXPECT_NEAR(model_concentrations[i][_z], analytical_concentrations[i][2], absolute_tolerance);
   }
 }
 
@@ -1813,7 +1815,7 @@ void test_analytical_hires(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_e5(
     BuilderPolicy builder,
-    double tolerance = 1e-8,
+    double relative_tolerance = 1e-8,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -1936,28 +1938,28 @@ void test_analytical_e5(
     double absolute_tolerance = 1e-6;
     double rel_error = relative_error(model_concentrations[i][0], analytical_concentrations[i][0]);
     double abs_error = std::abs(model_concentrations[i][0] - analytical_concentrations[i][0]);
-    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < tolerance)
+    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < relative_tolerance)
         << "Arrays differ at index (" << i << ", " << 0 << ") with relative error " << rel_error << " and absolute error "
         << abs_error;
 
     absolute_tolerance = 1e-13;
     rel_error = relative_error(model_concentrations[i][1], analytical_concentrations[i][1]);
     abs_error = std::abs(model_concentrations[i][1] - analytical_concentrations[i][1]);
-    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < tolerance)
+    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < relative_tolerance)
         << "Arrays differ at index (" << i << ", " << 1 << ") with relative error " << rel_error << " and absolute error "
         << abs_error;
 
     absolute_tolerance = 1e-13;
     rel_error = relative_error(model_concentrations[i][2], analytical_concentrations[i][2]);
     abs_error = std::abs(model_concentrations[i][2] - analytical_concentrations[i][2]);
-    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < tolerance)
+    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < relative_tolerance)
         << "Arrays differ at index (" << i << ", " << 2 << ") with relative error " << rel_error << " and absolute error "
         << abs_error;
 
     absolute_tolerance = 1e-13;
     rel_error = relative_error(model_concentrations[i][3], analytical_concentrations[i][3]);
     abs_error = std::abs(model_concentrations[i][3] - analytical_concentrations[i][3]);
-    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < tolerance)
+    EXPECT_TRUE(abs_error < absolute_tolerance || rel_error < relative_tolerance)
         << "Arrays differ at index (" << i << ", " << 3 << ") with relative error " << rel_error << " and absolute error "
         << abs_error;
   }

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -30,7 +30,7 @@ constexpr size_t NUM_CELLS = 3;
 
 double relative_error(double a, double b)
 {
-  return abs(a - b) / abs(a);
+  return abs(a - b) / abs(b);
 }
 
 double relative_difference(double a, double b)
@@ -212,8 +212,8 @@ void test_simple_system(
     EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     for (std::size_t i = 0; i < NUM_CELLS; ++i)
     {
-      EXPECT_NEAR(combined_error(k1[i], state.rate_constants_[i][0], 1e-15), 0, relative_tolerance);
-      EXPECT_NEAR(combined_error(k2[i], state.rate_constants_[i][1], 1e-15), 0, relative_tolerance);
+      EXPECT_NEAR(k1[i], state.rate_constants_[i][0], relative_tolerance);
+      EXPECT_NEAR(k2[i], state.rate_constants_[i][1], relative_tolerance);
       model_concentrations[i_time][i][idx_A] = state.variables_[i][_a];
       model_concentrations[i_time][i][idx_B] = state.variables_[i][_b];
       model_concentrations[i_time][i][idx_C] = state.variables_[i][_c];
@@ -244,27 +244,18 @@ void test_simple_system(
     for (std::size_t i_cell = 0; i_cell < model_concentrations[i_time].size(); ++i_cell)
     {
       EXPECT_NEAR(
-          combined_error(
-              model_concentrations[i_time][i_cell][idx_A],
-              analytical_concentrations[i_time][i_cell][idx_A],
-              absolute_tolerances[0]),
-          0,
+          model_concentrations[i_time][i_cell][idx_A],
+          analytical_concentrations[i_time][i_cell][idx_A],
           relative_tolerance)
           << "Arrays differ at index (" << i_time << ", " << i_cell << ", " << 0 << ") for " << test_label;
       EXPECT_NEAR(
-          combined_error(
-              model_concentrations[i_time][i_cell][idx_B],
-              analytical_concentrations[i_time][i_cell][idx_B],
-              absolute_tolerances[1]),
-          0,
+          model_concentrations[i_time][i_cell][idx_B],
+          analytical_concentrations[i_time][i_cell][idx_B],
           relative_tolerance)
           << "Arrays differ at index (" << i_time << ", " << i_cell << ", " << 1 << ") for " << test_label;
       EXPECT_NEAR(
-          combined_error(
-              model_concentrations[i_time][i_cell][idx_C],
-              analytical_concentrations[i_time][i_cell][idx_C],
-              absolute_tolerances[2]),
-          0,
+          model_concentrations[i_time][i_cell][idx_C],
+          analytical_concentrations[i_time][i_cell][idx_C],
           relative_tolerance)
           << "Arrays differ at index (" << i_time << ", " << i_cell << ", " << 2 << ") for " << test_label;
     }
@@ -375,27 +366,18 @@ void test_simple_stiff_system(
     for (std::size_t i_cell = 0; i_cell < model_concentrations[i_time].size(); ++i_cell)
     {
       EXPECT_NEAR(
-          combined_error(
-              model_concentrations[i_time][i_cell][idx_A],
-              analytical_concentrations[i_time][i_cell][idx_A],
-              absolute_tolerances[0]),
-          0,
+          model_concentrations[i_time][i_cell][idx_A],
+          analytical_concentrations[i_time][i_cell][idx_A],
           relative_tolerance)
           << "Arrays differ at index (" << i_time << ", " << i_cell << ", " << 0 << ") for " << test_label;
       EXPECT_NEAR(
-          combined_error(
-              model_concentrations[i_time][i_cell][idx_B],
-              analytical_concentrations[i_time][i_cell][idx_B],
-              absolute_tolerances[1]),
-          0,
+          model_concentrations[i_time][i_cell][idx_B],
+          analytical_concentrations[i_time][i_cell][idx_B],
           relative_tolerance)
           << "Arrays differ at index (" << i_time << ", " << i_cell << ", " << 1 << ") for " << test_label;
       EXPECT_NEAR(
-          combined_error(
-              model_concentrations[i_time][i_cell][idx_C],
-              analytical_concentrations[i_time][i_cell][idx_C],
-              absolute_tolerances[2]),
-          0,
+          model_concentrations[i_time][i_cell][idx_C],
+          analytical_concentrations[i_time][i_cell][idx_C],
           relative_tolerance)
           << "Arrays differ at index (" << i_time << ", " << i_cell << ", " << 2 << ") for " << test_label;
     }
@@ -409,7 +391,7 @@ void test_simple_stiff_system(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_troe(
     BuilderPolicy builder,
-    double tolerance = 1e-6,
+    double tolerance = 1e-10,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -564,7 +546,7 @@ void test_analytical_stiff_troe(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_photolysis(
     BuilderPolicy builder,
-    double tolerance = 1e-6,
+    double tolerance = 2e-6,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -623,7 +605,7 @@ void test_analytical_photolysis(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_stiff_photolysis(
     BuilderPolicy builder,
-    double tolerance = 1e-6,
+    double tolerance = 2e-5,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -705,7 +687,7 @@ void test_analytical_stiff_photolysis(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_ternary_chemical_activation(
     BuilderPolicy builder,
-    double tolerance = 1e-6,
+    double tolerance = 1e-08,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -861,7 +843,7 @@ void test_analytical_stiff_ternary_chemical_activation(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_tunneling(
     BuilderPolicy builder,
-    double tolerance = 1e-6,
+    double tolerance = 1e-8,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -995,7 +977,7 @@ void test_analytical_stiff_tunneling(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_arrhenius(
     BuilderPolicy builder,
-    double tolerance = 1e-6,
+    double tolerance = 1e-9,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -1129,7 +1111,7 @@ void test_analytical_stiff_arrhenius(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_branched(
     BuilderPolicy builder,
-    double tolerance = 1e-6,
+    double tolerance = 1e-13,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -1478,6 +1478,9 @@ void test_analytical_oregonator(
    *
    * solutions are provided here
    * https://www.unige.ch/~hairer/testset/testset.html
+   * 
+   * I don't understand the transfomrations. Multiplying the timestep by tau, and the concnetrations by the constants
+   * in the paper give very similar values.
    */
 
   auto X = micm::Species("X");
@@ -1524,7 +1527,8 @@ void test_analytical_oregonator(
                     .SetReactions(processes)
                     .Build();
 
-  double time_step = 30;
+  double tau = 0.1610;
+  double time_step = 30 * tau;
   size_t N = 12;
 
   std::vector<std::vector<double>> model_concentrations(N + 1, std::vector<double>(5));

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -144,8 +144,7 @@ template<class BuilderPolicy, class StateType>
 void test_simple_system(
     const std::string& test_label,
     BuilderPolicy builder,
-    double relative_tolerance,
-    std::vector<double> absolute_tolerances,
+    double absolute_tolerances,
     std::function<double(double temperature, double pressure, double air_density)> calculate_k1,
     std::function<double(double temperature, double pressure, double air_density)> calculate_k2,
     std::function<void(StateType&)> prepare_for_solve,
@@ -212,8 +211,8 @@ void test_simple_system(
     EXPECT_EQ(result.state_, (micm::SolverState::Converged));
     for (std::size_t i = 0; i < NUM_CELLS; ++i)
     {
-      EXPECT_NEAR(k1[i], state.rate_constants_[i][0], relative_tolerance);
-      EXPECT_NEAR(k2[i], state.rate_constants_[i][1], relative_tolerance);
+      EXPECT_NEAR(k1[i], state.rate_constants_[i][0], absolute_tolerances);
+      EXPECT_NEAR(k2[i], state.rate_constants_[i][1], absolute_tolerances);
       model_concentrations[i_time][i][idx_A] = state.variables_[i][_a];
       model_concentrations[i_time][i][idx_B] = state.variables_[i][_b];
       model_concentrations[i_time][i][idx_C] = state.variables_[i][_c];
@@ -246,17 +245,17 @@ void test_simple_system(
       EXPECT_NEAR(
           model_concentrations[i_time][i_cell][idx_A],
           analytical_concentrations[i_time][i_cell][idx_A],
-          relative_tolerance)
+          absolute_tolerances)
           << "Arrays differ at index (" << i_time << ", " << i_cell << ", " << 0 << ") for " << test_label;
       EXPECT_NEAR(
           model_concentrations[i_time][i_cell][idx_B],
           analytical_concentrations[i_time][i_cell][idx_B],
-          relative_tolerance)
+          absolute_tolerances)
           << "Arrays differ at index (" << i_time << ", " << i_cell << ", " << 1 << ") for " << test_label;
       EXPECT_NEAR(
           model_concentrations[i_time][i_cell][idx_C],
           analytical_concentrations[i_time][i_cell][idx_C],
-          relative_tolerance)
+          absolute_tolerances)
           << "Arrays differ at index (" << i_time << ", " << i_cell << ", " << 2 << ") for " << test_label;
     }
   }
@@ -267,8 +266,7 @@ template<class BuilderPolicy, class StateType>
 void test_simple_stiff_system(
     const std::string& test_label,
     BuilderPolicy builder,
-    double relative_tolerance,
-    std::vector<double> absolute_tolerances,
+    double absolute_tolerances,
     std::function<double(double temperature, double pressure, double air_density)> calculate_k1,
     std::function<double(double temperature, double pressure, double air_density)> calculate_k2,
     std::function<void(StateType&)> prepare_for_solve,
@@ -368,17 +366,17 @@ void test_simple_stiff_system(
       EXPECT_NEAR(
           model_concentrations[i_time][i_cell][idx_A],
           analytical_concentrations[i_time][i_cell][idx_A],
-          relative_tolerance)
+          absolute_tolerances)
           << "Arrays differ at index (" << i_time << ", " << i_cell << ", " << 0 << ") for " << test_label;
       EXPECT_NEAR(
           model_concentrations[i_time][i_cell][idx_B],
           analytical_concentrations[i_time][i_cell][idx_B],
-          relative_tolerance)
+          absolute_tolerances)
           << "Arrays differ at index (" << i_time << ", " << i_cell << ", " << 1 << ") for " << test_label;
       EXPECT_NEAR(
           model_concentrations[i_time][i_cell][idx_C],
           analytical_concentrations[i_time][i_cell][idx_C],
-          relative_tolerance)
+          absolute_tolerances)
           << "Arrays differ at index (" << i_time << ", " << i_cell << ", " << 2 << ") for " << test_label;
     }
   }
@@ -391,7 +389,7 @@ void test_simple_stiff_system(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_troe(
     BuilderPolicy builder,
-    double tolerance = 1e-10,
+    double absolute_tolerances = 1e-10,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -433,8 +431,7 @@ void test_analytical_troe(
   test_simple_system<BuilderPolicy, StateType>(
       "troe",
       builder,
-      tolerance,
-      { 1e-7, 1e-7, 1e-7 },
+      absolute_tolerances,
       [](double temperature, double pressure, double air_density)
       {
         // A->B reaction rate
@@ -458,7 +455,7 @@ void test_analytical_troe(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_stiff_troe(
     BuilderPolicy builder,
-    double tolerance = 1e-5,
+    double absolute_tolerances = 1e-5,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -521,8 +518,7 @@ void test_analytical_stiff_troe(
   test_simple_stiff_system<BuilderPolicy, StateType>(
       "troe",
       builder,
-      tolerance,
-      { 1e-7, 1e-7, 1e-7 },
+      absolute_tolerances,
       [](double temperature, double pressure, double air_density)
       {
         // A->B reaction rate
@@ -546,7 +542,7 @@ void test_analytical_stiff_troe(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_photolysis(
     BuilderPolicy builder,
-    double tolerance = 2e-6,
+    double absolute_tolerances = 2e-6,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -585,8 +581,7 @@ void test_analytical_photolysis(
   test_simple_system<BuilderPolicy, StateType>(
       "photolysis",
       builder,
-      tolerance,
-      { 1e-7, 1e-7, 1e-7 },
+      absolute_tolerances,
       [](double temperature, double pressure, double air_density)
       {
         // A->B reaction rate
@@ -605,7 +600,7 @@ void test_analytical_photolysis(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_stiff_photolysis(
     BuilderPolicy builder,
-    double tolerance = 2e-5,
+    double absolute_tolerances = 2e-5,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -667,8 +662,7 @@ void test_analytical_stiff_photolysis(
   test_simple_stiff_system<BuilderPolicy, StateType>(
       "photolysis",
       builder,
-      tolerance,
-      { 1e-7, 1e-7, 1e-7 },
+      absolute_tolerances,
       [](double temperature, double pressure, double air_density)
       {
         // A->B reaction rate
@@ -687,7 +681,7 @@ void test_analytical_stiff_photolysis(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_ternary_chemical_activation(
     BuilderPolicy builder,
-    double tolerance = 1e-08,
+    double absolute_tolerances = 1e-08,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -730,8 +724,7 @@ void test_analytical_ternary_chemical_activation(
   test_simple_system<BuilderPolicy, StateType>(
       "ternary_chemical_activation",
       builder,
-      tolerance,
-      { 1e-7, 1e-7, 1e-7 },
+      absolute_tolerances,
       [](double temperature, double pressure, double air_density)
       {
         // A->B reaction rate
@@ -755,7 +748,7 @@ void test_analytical_ternary_chemical_activation(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_stiff_ternary_chemical_activation(
     BuilderPolicy builder,
-    double tolerance = 1e-6,
+    double absolute_tolerances = 1e-6,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -818,8 +811,7 @@ void test_analytical_stiff_ternary_chemical_activation(
   test_simple_stiff_system<BuilderPolicy, StateType>(
       "ternary_chemical_activation",
       builder,
-      tolerance,
-      { 1e-7, 1e-7, 1e-7 },
+      absolute_tolerances,
       [](double temperature, double pressure, double air_density)
       {
         // A->B reaction rate
@@ -843,7 +835,7 @@ void test_analytical_stiff_ternary_chemical_activation(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_tunneling(
     BuilderPolicy builder,
-    double tolerance = 1e-8,
+    double absolute_tolerances = 1e-8,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -879,8 +871,7 @@ void test_analytical_tunneling(
   test_simple_system<BuilderPolicy, StateType>(
       "tunneling",
       builder,
-      tolerance,
-      { 1e-7, 1e-7, 1e-7 },
+      absolute_tolerances,
       [](double temperature, double pressure, double air_density)
       {
         // A->B reaction rate
@@ -900,7 +891,7 @@ void test_analytical_tunneling(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_stiff_tunneling(
     BuilderPolicy builder,
-    double tolerance = 1e-6,
+    double absolute_tolerances = 1e-6,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -956,8 +947,7 @@ void test_analytical_stiff_tunneling(
   test_simple_stiff_system<BuilderPolicy, StateType>(
       "tunneling",
       builder,
-      tolerance,
-      { 1e-7, 1e-7, 1e-7 },
+      absolute_tolerances,
       [](double temperature, double pressure, double air_density)
       {
         // A->B reaction rate
@@ -977,7 +967,7 @@ void test_analytical_stiff_tunneling(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_arrhenius(
     BuilderPolicy builder,
-    double tolerance = 1e-9,
+    double absolute_tolerances = 1e-9,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -1012,8 +1002,7 @@ void test_analytical_arrhenius(
   test_simple_system<BuilderPolicy, StateType>(
       "arrhenius",
       builder,
-      tolerance,
-      { 1e-7, 1e-7, 1e-7 },
+      absolute_tolerances,
       [](double temperature, double pressure, double air_density)
       {
         // A->B reaction rate
@@ -1033,7 +1022,7 @@ void test_analytical_arrhenius(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_stiff_arrhenius(
     BuilderPolicy builder,
-    double tolerance = 1e-6,
+    double absolute_tolerances = 1e-6,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -1090,8 +1079,7 @@ void test_analytical_stiff_arrhenius(
   test_simple_stiff_system<BuilderPolicy, StateType>(
       "arrhenius",
       builder,
-      tolerance,
-      { 1e-7, 1e-7, 1e-7 },
+      absolute_tolerances,
       [](double temperature, double pressure, double air_density)
       {
         // A->B reaction rate
@@ -1111,7 +1099,7 @@ void test_analytical_stiff_arrhenius(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_branched(
     BuilderPolicy builder,
-    double tolerance = 1e-13,
+    double absolute_tolerances = 1e-13,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -1156,8 +1144,7 @@ void test_analytical_branched(
   test_simple_system<BuilderPolicy, StateType>(
       "branched",
       builder,
-      tolerance,
-      { 1e-7, 1e-7, 1e-7 },
+      absolute_tolerances,
       [](double temperature, double pressure, double air_density)
       {
         // A->B reaction rate
@@ -1195,7 +1182,7 @@ void test_analytical_branched(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_stiff_branched(
     BuilderPolicy builder,
-    double tolerance = 1e-6,
+    double absolute_tolerances = 1e-6,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -1266,8 +1253,7 @@ void test_analytical_stiff_branched(
   test_simple_stiff_system<BuilderPolicy, StateType>(
       "branched",
       builder,
-      tolerance,
-      { 1e-7, 1e-7, 1e-7 },
+      absolute_tolerances,
       [](double temperature, double pressure, double air_density)
       {
         // A->B reaction rate
@@ -1625,7 +1611,7 @@ void test_analytical_oregonator(
 template<class BuilderPolicy, class StateType = micm::State<>>
 void test_analytical_hires(
     BuilderPolicy builder,
-    double tolerance = 1e-8,
+    double absolute_tolerance = 1e-8,
     std::function<void(StateType&)> prepare_for_solve = [](StateType& state) {},
     std::function<void(StateType&)> postpare_for_solve = [](StateType& state) {})
 {
@@ -1797,21 +1783,21 @@ void test_analytical_hires(
 
   for (size_t i = 1; i < model_concentrations.size(); ++i)
   {
-    EXPECT_NEAR(model_concentrations[i][_y0], analytical_concentrations[i][0], tolerance)
+    EXPECT_NEAR(model_concentrations[i][_y0], analytical_concentrations[i][0], absolute_tolerance)
         << "Arrays differ at index (" << i << ", " << 0 << ")";
-    EXPECT_NEAR(model_concentrations[i][_y1], analytical_concentrations[i][1], tolerance)
+    EXPECT_NEAR(model_concentrations[i][_y1], analytical_concentrations[i][1], absolute_tolerance)
         << "Arrays differ at index (" << i << ", " << 1 << ")";
-    EXPECT_NEAR(model_concentrations[i][_y2], analytical_concentrations[i][2], tolerance)
+    EXPECT_NEAR(model_concentrations[i][_y2], analytical_concentrations[i][2], absolute_tolerance)
         << "Arrays differ at index (" << i << ", " << 2 << ")";
-    EXPECT_NEAR(model_concentrations[i][_y3], analytical_concentrations[i][3], tolerance)
+    EXPECT_NEAR(model_concentrations[i][_y3], analytical_concentrations[i][3], absolute_tolerance)
         << "Arrays differ at index (" << i << ", " << 3 << ")";
-    EXPECT_NEAR(model_concentrations[i][_y4], analytical_concentrations[i][4], tolerance)
+    EXPECT_NEAR(model_concentrations[i][_y4], analytical_concentrations[i][4], absolute_tolerance)
         << "Arrays differ at index (" << i << ", " << 4 << ")";
-    EXPECT_NEAR(model_concentrations[i][_y5], analytical_concentrations[i][5], tolerance)
+    EXPECT_NEAR(model_concentrations[i][_y5], analytical_concentrations[i][5], absolute_tolerance)
         << "Arrays differ at index (" << i << ", " << 5 << ")";
-    EXPECT_NEAR(model_concentrations[i][_y6], analytical_concentrations[i][6], tolerance)
+    EXPECT_NEAR(model_concentrations[i][_y6], analytical_concentrations[i][6], absolute_tolerance)
         << "Arrays differ at index (" << i << ", " << 6 << ")";
-    EXPECT_NEAR(model_concentrations[i][_y7], analytical_concentrations[i][7], tolerance)
+    EXPECT_NEAR(model_concentrations[i][_y7], analytical_concentrations[i][7], absolute_tolerance)
         << "Arrays differ at index (" << i << ", " << 7 << ")";
   }
 }

--- a/test/integration/analytical_surface_rxn_policy.hpp
+++ b/test/integration/analytical_surface_rxn_policy.hpp
@@ -90,9 +90,9 @@ void test_analytical_surface_rxn(
 
   size_t idx_foo = 0, idx_bar = 1, idx_baz = 2;
 
-  std::cout << std::setw(3) << "i" << std::setw(7) << "time" << std::setw(11) << "true foo" << std::setw(11) << "model foo"
-            << std::setw(11) << "true bar" << std::setw(11) << "model bar" << std::setw(11) << "true baz" << std::setw(11)
-            << "model baz" << std::endl;
+  // std::cout << std::setw(3) << "i" << std::setw(7) << "time" << std::setw(11) << "true foo" << std::setw(11) << "model foo"
+  //           << std::setw(11) << "true bar" << std::setw(11) << "model bar" << std::setw(11) << "true baz" << std::setw(11)
+  //           << "model baz" << std::endl;
 
   for (int i = 1; i <= nstep; ++i)
   {
@@ -122,9 +122,9 @@ void test_analytical_surface_rxn(
     EXPECT_NEAR(0, relative_error(analytic_conc[i][idx_bar], model_conc[i][idx_bar]), tolerance);
     EXPECT_NEAR(0, relative_error(analytic_conc[i][idx_baz], model_conc[i][idx_baz]), tolerance);
 
-    std::cout << std::setw(3) << i << "  " << std::fixed << std::setprecision(2) << std::setw(5) << time << "  "
-              << std::fixed << std::setprecision(7) << analytic_conc[i][idx_foo] << "  " << model_conc[i][idx_foo] << "  "
-              << analytic_conc[i][idx_bar] << "  " << model_conc[i][idx_bar] << "  " << analytic_conc[i][idx_baz] << "  "
-              << model_conc[i][idx_baz] << "  " << std::endl;
+    // std::cout << std::setw(3) << i << "  " << std::fixed << std::setprecision(2) << std::setw(5) << time << "  "
+    //           << std::fixed << std::setprecision(7) << analytic_conc[i][idx_foo] << "  " << model_conc[i][idx_foo] << "  "
+    //           << analytic_conc[i][idx_bar] << "  " << model_conc[i][idx_bar] << "  " << analytic_conc[i][idx_baz] << "  "
+    //           << model_conc[i][idx_baz] << "  " << std::endl;
   }
 }

--- a/test/integration/analytical_surface_rxn_policy.hpp
+++ b/test/integration/analytical_surface_rxn_policy.hpp
@@ -90,10 +90,6 @@ void test_analytical_surface_rxn(
 
   size_t idx_foo = 0, idx_bar = 1, idx_baz = 2;
 
-  // std::cout << std::setw(3) << "i" << std::setw(7) << "time" << std::setw(11) << "true foo" << std::setw(11) << "model foo"
-  //           << std::setw(11) << "true bar" << std::setw(11) << "model bar" << std::setw(11) << "true baz" << std::setw(11)
-  //           << "model baz" << std::endl;
-
   for (int i = 1; i <= nstep; ++i)
   {
     double elapsed_solve_time = 0;
@@ -121,10 +117,5 @@ void test_analytical_surface_rxn(
     EXPECT_NEAR(0, relative_error(analytic_conc[i][idx_foo], model_conc[i][idx_foo]), tolerance);
     EXPECT_NEAR(0, relative_error(analytic_conc[i][idx_bar], model_conc[i][idx_bar]), tolerance);
     EXPECT_NEAR(0, relative_error(analytic_conc[i][idx_baz], model_conc[i][idx_baz]), tolerance);
-
-    // std::cout << std::setw(3) << i << "  " << std::fixed << std::setprecision(2) << std::setw(5) << time << "  "
-    //           << std::fixed << std::setprecision(7) << analytic_conc[i][idx_foo] << "  " << model_conc[i][idx_foo] << "  "
-    //           << analytic_conc[i][idx_bar] << "  " << model_conc[i][idx_bar] << "  " << analytic_conc[i][idx_baz] << "  "
-    //           << model_conc[i][idx_baz] << "  " << std::endl;
   }
 }

--- a/test/integration/cuda/test_cuda_analytical_rosenbrock.cpp
+++ b/test/integration/cuda/test_cuda_analytical_rosenbrock.cpp
@@ -36,47 +36,47 @@ auto copy_to_host = [](auto& state) -> void { state.SyncOutputsToHost(); };
 
 TEST(AnalyticalExamplesCudaRosenbrock, Troe)
 {
-  test_analytical_troe<builderType, stateType>(two, 2e-3, copy_to_device, copy_to_host);
-  test_analytical_troe<builderType, stateType>(three, 2e-7, copy_to_device, copy_to_host);
-  test_analytical_troe<builderType, stateType>(four, 2e-7, copy_to_device, copy_to_host);
-  test_analytical_troe<builderType, stateType>(four_da, 2e-7, copy_to_device, copy_to_host);
-  test_analytical_troe<builderType, stateType>(six_da, 2e-7, copy_to_device, copy_to_host);
+  test_analytical_troe<builderType, stateType>(two, 1e-10, copy_to_device, copy_to_host);
+  test_analytical_troe<builderType, stateType>(three, 1e-10, copy_to_device, copy_to_host);
+  test_analytical_troe<builderType, stateType>(four, 1e-10, copy_to_device, copy_to_host);
+  test_analytical_troe<builderType, stateType>(four_da, 1e-10, copy_to_device, copy_to_host);
+  test_analytical_troe<builderType, stateType>(six_da, 1e-10, copy_to_device, copy_to_host);
 }
 
 TEST(AnalyticalExamplesCudaRosenbrock, TroeSuperStiffButAnalytical)
 {
-  test_analytical_stiff_troe<builderType, stateType>(two, 1e-3, copy_to_device, copy_to_host);
-  test_analytical_stiff_troe<builderType, stateType>(three, 1e-3, copy_to_device, copy_to_host);
-  test_analytical_stiff_troe<builderType, stateType>(four, 1e-3, copy_to_device, copy_to_host);
-  test_analytical_stiff_troe<builderType, stateType>(four_da, 1e-3, copy_to_device, copy_to_host);
-  test_analytical_stiff_troe<builderType, stateType>(six_da, 1e-3, copy_to_device, copy_to_host);
+  test_analytical_stiff_troe<builderType, stateType>(two, 1e-5, copy_to_device, copy_to_host);
+  test_analytical_stiff_troe<builderType, stateType>(three, 1e-5, copy_to_device, copy_to_host);
+  test_analytical_stiff_troe<builderType, stateType>(four, 1e-5, copy_to_device, copy_to_host);
+  test_analytical_stiff_troe<builderType, stateType>(four_da, 1e-5, copy_to_device, copy_to_host);
+  test_analytical_stiff_troe<builderType, stateType>(six_da, 1e-5, copy_to_device, copy_to_host);
 }
 
 TEST(AnalyticalExamplesCudaRosenbrock, Photolysis)
 {
-  test_analytical_photolysis<builderType, stateType>(two, 1e-2, copy_to_device, copy_to_host);
-  test_analytical_photolysis<builderType, stateType>(three, 1e-6, copy_to_device, copy_to_host);
-  test_analytical_photolysis<builderType, stateType>(four, 1e-8, copy_to_device, copy_to_host);
-  test_analytical_photolysis<builderType, stateType>(four_da, 1e-6, copy_to_device, copy_to_host);
-  test_analytical_photolysis<builderType, stateType>(six_da, 1e-8, copy_to_device, copy_to_host);
+  test_analytical_photolysis<builderType, stateType>(two, 2e-6, copy_to_device, copy_to_host);
+  test_analytical_photolysis<builderType, stateType>(three, 2e-6, copy_to_device, copy_to_host);
+  test_analytical_photolysis<builderType, stateType>(four, 2e-8, copy_to_device, copy_to_host);
+  test_analytical_photolysis<builderType, stateType>(four_da, 2e-6, copy_to_device, copy_to_host);
+  test_analytical_photolysis<builderType, stateType>(six_da, 2e-6, copy_to_device, copy_to_host);
 }
 
 TEST(AnalyticalExamplesCudaRosenbrock, PhotolysisSuperStiffButAnalytical)
 {
-  test_analytical_stiff_photolysis<builderType, stateType>(two, 2e-2, copy_to_device, copy_to_host);
-  test_analytical_stiff_photolysis<builderType, stateType>(three, 2e-4, copy_to_device, copy_to_host);
-  test_analytical_stiff_photolysis<builderType, stateType>(four, 2e-4, copy_to_device, copy_to_host);
-  test_analytical_stiff_photolysis<builderType, stateType>(four_da, 2e-4, copy_to_device, copy_to_host);
-  test_analytical_stiff_photolysis<builderType, stateType>(six_da, 2e-4, copy_to_device, copy_to_host);
+  test_analytical_stiff_photolysis<builderType, stateType>(two, 2e-5, copy_to_device, copy_to_host);
+  test_analytical_stiff_photolysis<builderType, stateType>(three, 2e-5, copy_to_device, copy_to_host);
+  test_analytical_stiff_photolysis<builderType, stateType>(four, 2e-5, copy_to_device, copy_to_host);
+  test_analytical_stiff_photolysis<builderType, stateType>(four_da, 2e-5, copy_to_device, copy_to_host);
+  test_analytical_stiff_photolysis<builderType, stateType>(six_da, 2e-5, copy_to_device, copy_to_host);
 }
 
 TEST(AnalyticalExamplesCudaRosenbrock, TernaryChemicalActivation)
 {
-  test_analytical_ternary_chemical_activation<builderType, stateType>(two, 1e-3, copy_to_device, copy_to_host);
-  test_analytical_ternary_chemical_activation<builderType, stateType>(three, 2e-4, copy_to_device, copy_to_host);
-  test_analytical_ternary_chemical_activation<builderType, stateType>(four, 1e-4, copy_to_device, copy_to_host);
-  test_analytical_ternary_chemical_activation<builderType, stateType>(four_da, 1e-4, copy_to_device, copy_to_host);
-  test_analytical_ternary_chemical_activation<builderType, stateType>(six_da, 1e-4, copy_to_device, copy_to_host);
+  test_analytical_ternary_chemical_activation<builderType, stateType>(two, 1e-8, copy_to_device, copy_to_host);
+  test_analytical_ternary_chemical_activation<builderType, stateType>(three, 1e-8, copy_to_device, copy_to_host);
+  test_analytical_ternary_chemical_activation<builderType, stateType>(four, 1e-8, copy_to_device, copy_to_host);
+  test_analytical_ternary_chemical_activation<builderType, stateType>(four_da, 1e-8, copy_to_device, copy_to_host);
+  test_analytical_ternary_chemical_activation<builderType, stateType>(six_da, 1e-8, copy_to_device, copy_to_host);
 }
 
 TEST(AnalyticalExamplesCudaRosenbrock, TernaryChemicalActivationSuperStiffButAnalytical)
@@ -90,47 +90,47 @@ TEST(AnalyticalExamplesCudaRosenbrock, TernaryChemicalActivationSuperStiffButAna
 
 TEST(AnalyticalExamplesCudaRosenbrock, Tunneling)
 {
-  test_analytical_tunneling<builderType, stateType>(two, 1e-1, copy_to_device, copy_to_host);
-  test_analytical_tunneling<builderType, stateType>(three, 1e-5, copy_to_device, copy_to_host);
+  test_analytical_tunneling<builderType, stateType>(two, 2e-5, copy_to_device, copy_to_host);
+  test_analytical_tunneling<builderType, stateType>(three, 1e-6, copy_to_device, copy_to_host);
   test_analytical_tunneling<builderType, stateType>(four, 1e-6, copy_to_device, copy_to_host);
-  test_analytical_tunneling<builderType, stateType>(four_da, 1e-5, copy_to_device, copy_to_host);
+  test_analytical_tunneling<builderType, stateType>(four_da, 1e-6, copy_to_device, copy_to_host);
   test_analytical_tunneling<builderType, stateType>(six_da, 1e-6, copy_to_device, copy_to_host);
 }
 
 TEST(AnalyticalExamplesCudaRosenbrock, TunnelingSuperStiffButAnalytical)
 {
-  test_analytical_stiff_tunneling<builderType, stateType>(two, 1e-1, copy_to_device, copy_to_host);
-  test_analytical_stiff_tunneling<builderType, stateType>(three, 2e-4, copy_to_device, copy_to_host);
-  test_analytical_stiff_tunneling<builderType, stateType>(four, 2e-4, copy_to_device, copy_to_host);
-  test_analytical_stiff_tunneling<builderType, stateType>(four_da, 2e-4, copy_to_device, copy_to_host);
-  test_analytical_stiff_tunneling<builderType, stateType>(six_da, 2e-4, copy_to_device, copy_to_host);
+  test_analytical_stiff_tunneling<builderType, stateType>(two, 1e-4, copy_to_device, copy_to_host);
+  test_analytical_stiff_tunneling<builderType, stateType>(three, 1e-4, copy_to_device, copy_to_host);
+  test_analytical_stiff_tunneling<builderType, stateType>(four, 1e-4, copy_to_device, copy_to_host);
+  test_analytical_stiff_tunneling<builderType, stateType>(four_da, 1e-4, copy_to_device, copy_to_host);
+  test_analytical_stiff_tunneling<builderType, stateType>(six_da, 1e-4, copy_to_device, copy_to_host);
 }
 
 TEST(AnalyticalExamplesCudaRosenbrock, Arrhenius)
 {
-  test_analytical_arrhenius<builderType, stateType>(two, 1e-4, copy_to_device, copy_to_host);
-  test_analytical_arrhenius<builderType, stateType>(three, 1e-8, copy_to_device, copy_to_host);
-  test_analytical_arrhenius<builderType, stateType>(four, 1e-8, copy_to_device, copy_to_host);
-  test_analytical_arrhenius<builderType, stateType>(four_da, 1e-8, copy_to_device, copy_to_host);
-  test_analytical_arrhenius<builderType, stateType>(six_da, 1e-8, copy_to_device, copy_to_host);
+  test_analytical_arrhenius<builderType, stateType>(two, 4e-6, copy_to_device, copy_to_host);
+  test_analytical_arrhenius<builderType, stateType>(three, 1e-9, copy_to_device, copy_to_host);
+  test_analytical_arrhenius<builderType, stateType>(four, 1e-9, copy_to_device, copy_to_host);
+  test_analytical_arrhenius<builderType, stateType>(four_da, 1e-9, copy_to_device, copy_to_host);
+  test_analytical_arrhenius<builderType, stateType>(six_da, 1e-9, copy_to_device, copy_to_host);
 }
 
 TEST(AnalyticalExamplesCudaRosenbrock, ArrheniusSuperStiffButAnalytical)
 {
-  test_analytical_stiff_arrhenius<builderType, stateType>(two, 1e-3, copy_to_device, copy_to_host);
-  test_analytical_stiff_arrhenius<builderType, stateType>(three, 1e-3, copy_to_device, copy_to_host);
-  test_analytical_stiff_arrhenius<builderType, stateType>(four, 1e-3, copy_to_device, copy_to_host);
-  test_analytical_stiff_arrhenius<builderType, stateType>(four_da, 1e-3, copy_to_device, copy_to_host);
-  test_analytical_stiff_arrhenius<builderType, stateType>(six_da, 1e-3, copy_to_device, copy_to_host);
+  test_analytical_stiff_arrhenius<builderType, stateType>(two, 1e-4, copy_to_device, copy_to_host);
+  test_analytical_stiff_arrhenius<builderType, stateType>(three, 2e-5, copy_to_device, copy_to_host);
+  test_analytical_stiff_arrhenius<builderType, stateType>(four, 2e-5, copy_to_device, copy_to_host);
+  test_analytical_stiff_arrhenius<builderType, stateType>(four_da, 2e-5, copy_to_device, copy_to_host);
+  test_analytical_stiff_arrhenius<builderType, stateType>(six_da, 1e-5, copy_to_device, copy_to_host);
 }
 
 TEST(AnalyticalExamplesCudaRosenbrock, Branched)
 {
-  test_analytical_branched<builderType, stateType>(two, 1e-4, copy_to_device, copy_to_host);
-  test_analytical_branched<builderType, stateType>(three, 1e-5, copy_to_device, copy_to_host);
-  test_analytical_branched<builderType, stateType>(four, 1e-5, copy_to_device, copy_to_host);
-  test_analytical_branched<builderType, stateType>(four_da, 1e-5, copy_to_device, copy_to_host);
-  test_analytical_branched<builderType, stateType>(six_da, 1e-5, copy_to_device, copy_to_host);
+  test_analytical_branched<builderType, stateType>(two, 1e-10, copy_to_device, copy_to_host);
+  test_analytical_branched<builderType, stateType>(three, 1e-13, copy_to_device, copy_to_host);
+  test_analytical_branched<builderType, stateType>(four, 1e-13, copy_to_device, copy_to_host);
+  test_analytical_branched<builderType, stateType>(four_da, 1e-13, copy_to_device, copy_to_host);
+  test_analytical_branched<builderType, stateType>(six_da, 1e-13, copy_to_device, copy_to_host);
 }
 
 TEST(AnalyticalExamplesCudaRosenbrock, BranchedSuperStiffButAnalytical)
@@ -218,19 +218,19 @@ TEST(AnalyticalExamplesCudaRosenbrock, Oregonator)
   };
 
   auto solver = rosenbrock_solver(micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
-  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 1e-3, copy_to_device, copy_to_host);
+  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 4e-6, copy_to_device, copy_to_host);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 1e-3, copy_to_device, copy_to_host);
+  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 4e-6, copy_to_device, copy_to_host);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageRosenbrockParameters());
-  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 1e-3, copy_to_device, copy_to_host);
+  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 4e-6, copy_to_device, copy_to_host);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 1e-3, copy_to_device, copy_to_host);
+  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 4e-6, copy_to_device, copy_to_host);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 1e-3, copy_to_device, copy_to_host);
+  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 4e-6, copy_to_device, copy_to_host);
 }
 
 TEST(AnalyticalExamplesCudaRosenbrock, HIRES)
@@ -243,17 +243,17 @@ TEST(AnalyticalExamplesCudaRosenbrock, HIRES)
   };
 
   auto solver = rosenbrock_solver(micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
-  test_analytical_hires<builderType1Cell, stateType1Cell>(solver, 1e-4, copy_to_device, copy_to_host);
+  test_analytical_hires<builderType1Cell, stateType1Cell>(solver, 1e-6, copy_to_device, copy_to_host);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  test_analytical_hires<builderType1Cell, stateType1Cell>(solver, 1e-3, copy_to_device, copy_to_host);
+  test_analytical_hires<builderType1Cell, stateType1Cell>(solver, 1e-7, copy_to_device, copy_to_host);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageRosenbrockParameters());
-  test_analytical_hires<builderType1Cell, stateType1Cell>(solver, 1e-3, copy_to_device, copy_to_host);
+  test_analytical_hires<builderType1Cell, stateType1Cell>(solver, 1e-7, copy_to_device, copy_to_host);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_hires<builderType1Cell, stateType1Cell>(solver, 1e-3, copy_to_device, copy_to_host);
+  test_analytical_hires<builderType1Cell, stateType1Cell>(solver, 1e-6, copy_to_device, copy_to_host);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_hires<builderType1Cell, stateType1Cell>(solver, 1e-3, copy_to_device, copy_to_host);
+  test_analytical_hires<builderType1Cell, stateType1Cell>(solver, 1e-6, copy_to_device, copy_to_host);
 }

--- a/test/integration/cuda/test_cuda_analytical_rosenbrock.cpp
+++ b/test/integration/cuda/test_cuda_analytical_rosenbrock.cpp
@@ -218,19 +218,19 @@ TEST(AnalyticalExamplesCudaRosenbrock, Oregonator)
   };
 
   auto solver = rosenbrock_solver(micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
-  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 4e-6, copy_to_device, copy_to_host);
+  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 2e-3, copy_to_device, copy_to_host);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 4e-6, copy_to_device, copy_to_host);
+  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 2e-3, copy_to_device, copy_to_host);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageRosenbrockParameters());
-  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 4e-6, copy_to_device, copy_to_host);
+  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 2e-3, copy_to_device, copy_to_host);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 4e-6, copy_to_device, copy_to_host);
+  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 2e-3, copy_to_device, copy_to_host);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 4e-6, copy_to_device, copy_to_host);
+  test_analytical_oregonator<builderType1Cell, stateType1Cell>(solver, 2e-3, copy_to_device, copy_to_host);
 }
 
 TEST(AnalyticalExamplesCudaRosenbrock, HIRES)

--- a/test/integration/jit/test_jit_analytical_rosenbrock.cpp
+++ b/test/integration/jit/test_jit_analytical_rosenbrock.cpp
@@ -28,7 +28,7 @@ auto param_six_da = micm::RosenbrockSolverParameters::SixStageDifferentialAlgebr
 
 TEST(AnalyticalExamplesJitRosenbrock, Troe)
 {
-  test_analytical_troe<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 1e-3);
+  test_analytical_troe<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two));
   test_analytical_troe<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three));
   test_analytical_troe<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four));
   test_analytical_troe<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four_da));
@@ -37,7 +37,7 @@ TEST(AnalyticalExamplesJitRosenbrock, Troe)
 
 TEST(AnalyticalExamplesJitRosenbrock, TroeSuperStiffButAnalytical)
 {
-  test_analytical_stiff_troe<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 1e-3);
+  test_analytical_stiff_troe<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two));
   test_analytical_stiff_troe<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three));
   test_analytical_stiff_troe<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four));
   test_analytical_stiff_troe<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four_da));
@@ -46,27 +46,26 @@ TEST(AnalyticalExamplesJitRosenbrock, TroeSuperStiffButAnalytical)
 
 TEST(AnalyticalExamplesJitRosenbrock, Photolysis)
 {
-  test_analytical_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 1e-2);
-  test_analytical_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three), 1e-4);
-  test_analytical_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four), 1e-5);
-  test_analytical_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four_da), 1e-5);
-  test_analytical_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_six_da), 1e-5);
+  test_analytical_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two));
+  test_analytical_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three));
+  test_analytical_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four));
+  test_analytical_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four_da));
+  test_analytical_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_six_da));
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, PhotolysisSuperStiffButAnalytical)
 {
-  test_analytical_stiff_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 1e-2);
-  test_analytical_stiff_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three), 1e-3);
-  test_analytical_stiff_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four), 1e-3);
-  test_analytical_stiff_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(
-      BuilderType<NUM_CELLS>(param_four_da), 1e-3);
-  test_analytical_stiff_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_six_da), 1e-3);
+  test_analytical_stiff_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two));
+  test_analytical_stiff_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three));
+  test_analytical_stiff_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four));
+  test_analytical_stiff_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four_da));
+  test_analytical_stiff_photolysis<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_six_da));
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, TernaryChemicalActivation)
 {
   test_analytical_ternary_chemical_activation<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(
-      BuilderType<NUM_CELLS>(param_two), 1e-3);
+      BuilderType<NUM_CELLS>(param_two));
   test_analytical_ternary_chemical_activation<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(
       BuilderType<NUM_CELLS>(param_three));
   test_analytical_ternary_chemical_activation<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(
@@ -93,16 +92,16 @@ TEST(AnalyticalExamplesJitRosenbrock, TernaryChemicalActivationSuperStiffButAnal
 
 TEST(AnalyticalExamplesJitRosenbrock, Tunneling)
 {
-  test_analytical_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 1e-1);
-  test_analytical_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three), 1e-5);
+  test_analytical_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 2e-5);
+  test_analytical_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three));
   test_analytical_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four));
-  test_analytical_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four_da), 1e-5);
+  test_analytical_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four_da));
   test_analytical_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_six_da));
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, TunnelingSuperStiffButAnalytical)
 {
-  test_analytical_stiff_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 1e-1);
+  test_analytical_stiff_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 1e-4);
   test_analytical_stiff_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three), 1e-4);
   test_analytical_stiff_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four), 1e-4);
   test_analytical_stiff_tunneling<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four_da), 1e-4);
@@ -111,7 +110,7 @@ TEST(AnalyticalExamplesJitRosenbrock, TunnelingSuperStiffButAnalytical)
 
 TEST(AnalyticalExamplesJitRosenbrock, Arrhenius)
 {
-  test_analytical_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 1e-3);
+  test_analytical_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 4e-6);
   test_analytical_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three));
   test_analytical_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four));
   test_analytical_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four_da));
@@ -120,16 +119,16 @@ TEST(AnalyticalExamplesJitRosenbrock, Arrhenius)
 
 TEST(AnalyticalExamplesJitRosenbrock, ArrheniusSuperStiffButAnalytical)
 {
-  test_analytical_stiff_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 1e-1);
-  test_analytical_stiff_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three), 1e-3);
-  test_analytical_stiff_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four), 1e-4);
-  test_analytical_stiff_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four_da), 1e-4);
-  test_analytical_stiff_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_six_da), 1e-3);
+  test_analytical_stiff_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 1e-4);
+  test_analytical_stiff_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three), 2e-5);
+  test_analytical_stiff_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four), 2e-5);
+  test_analytical_stiff_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four_da), 2e-5);
+  test_analytical_stiff_arrhenius<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_six_da), 1e-5);
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, Branched)
 {
-  test_analytical_branched<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 1e-3);
+  test_analytical_branched<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_two), 1e-10);
   test_analytical_branched<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_three));
   test_analytical_branched<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four));
   test_analytical_branched<BuilderType<NUM_CELLS>, StateType<NUM_CELLS>>(BuilderType<NUM_CELLS>(param_four_da));
@@ -155,28 +154,28 @@ TEST(AnalyticalExamplesJitRosenbrock, Robertson)
   };
 
   auto solver = rosenbrock_solver(micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
-  test_analytical_robertson<BuilderType<1>, StateType<1>>(solver, 2e-1);
+  test_analytical_robertson<BuilderType<1>, StateType<1>>(solver, 1e-1);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  test_analytical_robertson<BuilderType<1>, StateType<1>>(solver, 2e-1);
+  test_analytical_robertson<BuilderType<1>, StateType<1>>(solver, 1e-1);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageRosenbrockParameters());
-  test_analytical_robertson<BuilderType<1>, StateType<1>>(solver, 2e-1);
+  test_analytical_robertson<BuilderType<1>, StateType<1>>(solver, 1e-1);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_robertson<BuilderType<1>, StateType<1>>(solver, 2e-1);
+  test_analytical_robertson<BuilderType<1>, StateType<1>>(solver, 1e-1);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_robertson<BuilderType<1>, StateType<1>>(solver, 2e-1);
+  test_analytical_robertson<BuilderType<1>, StateType<1>>(solver, 1e-1);
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, SurfaceRxn)
 {
   test_analytical_surface_rxn<BuilderType<1>, StateType<1>>(two, 1e-4);
-  test_analytical_surface_rxn<BuilderType<1>, StateType<1>>(three, 1e-4);
-  test_analytical_surface_rxn<BuilderType<1>, StateType<1>>(four, 1e-4);
-  test_analytical_surface_rxn<BuilderType<1>, StateType<1>>(four_da, 1e-4);
-  test_analytical_surface_rxn<BuilderType<1>, StateType<1>>(six_da, 1e-4);
+  test_analytical_surface_rxn<BuilderType<1>, StateType<1>>(three, 1e-5);
+  test_analytical_surface_rxn<BuilderType<1>, StateType<1>>(four, 1e-5);
+  test_analytical_surface_rxn<BuilderType<1>, StateType<1>>(four_da, 1e-5);
+  test_analytical_surface_rxn<BuilderType<1>, StateType<1>>(six_da, 1e-5);
 }
 
 TEST(AnalyticalExamplesJitRosenbrock, E5)
@@ -210,7 +209,7 @@ TEST(AnalyticalExamplesJitRosenbrock, E5)
   test_analytical_e5<BuilderType<1>, StateType<1>>(solver, 1e-3);
 }
 
-TEST(AnalyticalExamples, Oregonator)
+TEST(AnalyticalExamplesJitRosenbrock, Oregonator)
 {
   auto rosenbrock_solver = [](auto params)
   {
@@ -221,22 +220,22 @@ TEST(AnalyticalExamples, Oregonator)
   };
 
   auto solver = rosenbrock_solver(micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
-  test_analytical_oregonator<BuilderType<1>, StateType<1>>(solver, 1e-3);
+  test_analytical_oregonator<BuilderType<1>, StateType<1>>(solver, 4e-4);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  test_analytical_oregonator<BuilderType<1>, StateType<1>>(solver, 1e-3);
+  test_analytical_oregonator<BuilderType<1>, StateType<1>>(solver, 4e-4);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageRosenbrockParameters());
-  test_analytical_oregonator<BuilderType<1>, StateType<1>>(solver, 1e-3);
+  test_analytical_oregonator<BuilderType<1>, StateType<1>>(solver, 4e-4);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_oregonator<BuilderType<1>, StateType<1>>(solver, 1e-3);
+  test_analytical_oregonator<BuilderType<1>, StateType<1>>(solver, 4e-4);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_oregonator<BuilderType<1>, StateType<1>>(solver, 1e-3);
+  test_analytical_oregonator<BuilderType<1>, StateType<1>>(solver, 4e-4);
 }
 
-TEST(AnalyticalExamples, HIRES)
+TEST(AnalyticalExamplesJitRosenbrock, HIRES)
 {
   auto rosenbrock_solver = [](auto params)
   {
@@ -246,17 +245,17 @@ TEST(AnalyticalExamples, HIRES)
   };
 
   auto solver = rosenbrock_solver(micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
-  test_analytical_hires<BuilderType<1>, StateType<1>>(solver, 5e-2);
+  test_analytical_hires<BuilderType<1>, StateType<1>>(solver, 1e-6);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  test_analytical_hires<BuilderType<1>, StateType<1>>(solver, 1e-3);
+  test_analytical_hires<BuilderType<1>, StateType<1>>(solver, 1e-7);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageRosenbrockParameters());
-  test_analytical_hires<BuilderType<1>, StateType<1>>(solver, 1e-3);
+  test_analytical_hires<BuilderType<1>, StateType<1>>(solver, 1e-7);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_hires<BuilderType<1>, StateType<1>>(solver, 1e-3);
+  test_analytical_hires<BuilderType<1>, StateType<1>>(solver, 1e-6);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_hires<BuilderType<1>, StateType<1>>(solver, 1e-3);
+  test_analytical_hires<BuilderType<1>, StateType<1>>(solver, 1e-6);
 }

--- a/test/integration/test_analytical_backward_euler.cpp
+++ b/test/integration/test_analytical_backward_euler.cpp
@@ -26,119 +26,114 @@ auto backard_euler_vector_4 = VectorBackwardEuler<4>(micm::BackwardEulerSolverPa
 
 TEST(AnalyticalExamples, Troe)
 {
-  test_analytical_troe(backward_euler, 5e-1);
-  test_analytical_troe<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 5e-1);
-  test_analytical_troe<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 5e-1);
-  test_analytical_troe<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 5e-1);
-  test_analytical_troe<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 5e-1);
+  test_analytical_troe(backward_euler, 1e-6);
+  test_analytical_troe<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 1e-6);
+  test_analytical_troe<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 1e-6);
+  test_analytical_troe<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 1e-6);
+  test_analytical_troe<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 1e-6);
 }
 
 TEST(AnalyticalExamples, TroeSuperStiffButAnalytical)
 {
-  test_analytical_stiff_troe(backward_euler, 5e-1);
-  test_analytical_stiff_troe<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 5e-1);
-  test_analytical_stiff_troe<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 5e-1);
-  test_analytical_stiff_troe<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 5e-1);
-  test_analytical_stiff_troe<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 5e-1);
+  test_analytical_stiff_troe(backward_euler);
+  test_analytical_stiff_troe<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1);
+  test_analytical_stiff_troe<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2);
+  test_analytical_stiff_troe<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3);
+  test_analytical_stiff_troe<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4);
 }
 
 TEST(AnalyticalExamples, Photolysis)
 {
-  test_analytical_photolysis(backward_euler, 7e-1);
-  test_analytical_photolysis<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 7e-1);
-  test_analytical_photolysis<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 7e-1);
-  test_analytical_photolysis<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 7e-1);
-  test_analytical_photolysis<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 7e-1);
+  test_analytical_photolysis(backward_euler, 1e-3);
+  test_analytical_photolysis<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 1e-3);
+  test_analytical_photolysis<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 1e-3);
+  test_analytical_photolysis<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 1e-3);
+  test_analytical_photolysis<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 1e-3);
 }
 
 TEST(AnalyticalExamples, PhotolysisSuperStiffButAnalytical)
 {
-  test_analytical_stiff_photolysis(backward_euler, 7e-1);
-  test_analytical_stiff_photolysis<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 7e-1);
-  test_analytical_stiff_photolysis<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 7e-1);
-  test_analytical_stiff_photolysis<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 7e-1);
-  test_analytical_stiff_photolysis<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 7e-1);
+  test_analytical_stiff_photolysis(backward_euler, 1e-3);
+  test_analytical_stiff_photolysis<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 1e-3);
+  test_analytical_stiff_photolysis<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 1e-3);
+  test_analytical_stiff_photolysis<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 1e-3);
+  test_analytical_stiff_photolysis<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 1e-3);
 }
 
 TEST(AnalyticalExamples, TernaryChemicalActivation)
 {
-  test_analytical_ternary_chemical_activation(backward_euler, 5e-1);
-  test_analytical_ternary_chemical_activation<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 5e-1);
-  test_analytical_ternary_chemical_activation<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 5e-1);
-  test_analytical_ternary_chemical_activation<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 5e-1);
-  test_analytical_ternary_chemical_activation<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 5e-1);
+  test_analytical_ternary_chemical_activation(backward_euler, 1e-5);
+  test_analytical_ternary_chemical_activation<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 1e-5);
+  test_analytical_ternary_chemical_activation<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 1e-5);
+  test_analytical_ternary_chemical_activation<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 1e-5);
+  test_analytical_ternary_chemical_activation<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 1e-5);
 }
 
 TEST(AnalyticalExamples, TernaryChemicalActivationSuperStiffButAnalytical)
 {
-  test_analytical_stiff_ternary_chemical_activation(backward_euler, 5e-1);
+  test_analytical_stiff_ternary_chemical_activation(backward_euler, 1e-2);
   test_analytical_stiff_ternary_chemical_activation<VectorBackwardEuler<1>, VectorStateType<1>>(
-      backard_euler_vector_1, 5e-1);
+      backard_euler_vector_1, 1e-2);
   test_analytical_stiff_ternary_chemical_activation<VectorBackwardEuler<2>, VectorStateType<2>>(
-      backard_euler_vector_2, 5e-1);
+      backard_euler_vector_2, 1e-2);
   test_analytical_stiff_ternary_chemical_activation<VectorBackwardEuler<3>, VectorStateType<3>>(
-      backard_euler_vector_3, 5e-1);
+      backard_euler_vector_3, 1e-2);
   test_analytical_stiff_ternary_chemical_activation<VectorBackwardEuler<4>, VectorStateType<4>>(
-      backard_euler_vector_4, 5e-1);
+      backard_euler_vector_4, 1e-2);
 }
 
 TEST(AnalyticalExamples, Tunneling)
 {
-  test_analytical_tunneling(backward_euler, 7e-1);
-  test_analytical_tunneling<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 7e-1);
-  test_analytical_tunneling<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 7e-1);
-  test_analytical_tunneling<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 7e-1);
-  test_analytical_tunneling<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 7e-1);
+  test_analytical_tunneling(backward_euler, 1e-3);
+  test_analytical_tunneling<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 1e-3);
+  test_analytical_tunneling<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 1e-3);
+  test_analytical_tunneling<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 1e-3);
+  test_analytical_tunneling<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 1e-3);
 }
 
 TEST(AnalyticalExamples, TunnelingSuperStiffButAnalytical)
 {
-  test_analytical_stiff_tunneling(backward_euler, 7e-1);
-  test_analytical_stiff_tunneling<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 7e-1);
-  test_analytical_stiff_tunneling<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 7e-1);
-  test_analytical_stiff_tunneling<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 7e-1);
-  test_analytical_stiff_tunneling<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 7e-1);
+  test_analytical_stiff_tunneling(backward_euler, 1e-3);
+  test_analytical_stiff_tunneling<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 1e-3);
+  test_analytical_stiff_tunneling<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 1e-3);
+  test_analytical_stiff_tunneling<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 1e-3);
+  test_analytical_stiff_tunneling<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 1e-3);
 }
 
 TEST(AnalyticalExamples, Arrhenius)
 {
-  test_analytical_arrhenius(backward_euler, 5e-1);
-  test_analytical_arrhenius<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 5e-1);
-  test_analytical_arrhenius<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 5e-1);
-  test_analytical_arrhenius<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 5e-1);
-  test_analytical_arrhenius<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 5e-1);
+  test_analytical_arrhenius(backward_euler, 1e-3);
+  test_analytical_arrhenius<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 1e-3);
+  test_analytical_arrhenius<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 1e-3);
+  test_analytical_arrhenius<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 1e-3);
+  test_analytical_arrhenius<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 1e-3);
 }
 
 TEST(AnalyticalExamples, ArrheniusSuperStiffButAnalytical)
 {
-  test_analytical_stiff_arrhenius(backward_euler, 5e-1);
-  test_analytical_stiff_arrhenius<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 5e-1);
-  test_analytical_stiff_arrhenius<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 5e-1);
-  test_analytical_stiff_arrhenius<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 5e-1);
-  test_analytical_stiff_arrhenius<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 5e-1);
+  test_analytical_stiff_arrhenius(backward_euler, 1e-3);
+  test_analytical_stiff_arrhenius<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 1e-3);
+  test_analytical_stiff_arrhenius<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 1e-3);
+  test_analytical_stiff_arrhenius<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 1e-3);
+  test_analytical_stiff_arrhenius<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 1e-3);
 }
 
 TEST(AnalyticalExamples, Branched)
 {
-  test_analytical_branched(backward_euler, 5e-1);
-  test_analytical_branched<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 5e-1);
-  test_analytical_branched<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 5e-1);
-  test_analytical_branched<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 5e-1);
-  test_analytical_branched<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 5e-1);
+  test_analytical_branched(backward_euler, 1e-5);
+  test_analytical_branched<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 1e-5);
+  test_analytical_branched<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 1e-5);
+  test_analytical_branched<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 1e-5);
+  test_analytical_branched<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 1e-5);
 }
 
 TEST(AnalyticalExamples, BranchedSuperStiffButAnalytical)
 {
-  test_analytical_stiff_branched(backward_euler, 5e-1);
-  test_analytical_stiff_branched<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 5e-1);
-  test_analytical_stiff_branched<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 5e-1);
-  test_analytical_stiff_branched<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 5e-1);
-  test_analytical_stiff_branched<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 5e-1);
-}
-
-TEST(AnalyticalExamples, Robertson)
-{
-  test_analytical_robertson(backward_euler, 1);
+  test_analytical_stiff_branched(backward_euler, 1e-2);
+  test_analytical_stiff_branched<VectorBackwardEuler<1>, VectorStateType<1>>(backard_euler_vector_1, 1e-2);
+  test_analytical_stiff_branched<VectorBackwardEuler<2>, VectorStateType<2>>(backard_euler_vector_2, 1e-2);
+  test_analytical_stiff_branched<VectorBackwardEuler<3>, VectorStateType<3>>(backard_euler_vector_3, 1e-2);
+  test_analytical_stiff_branched<VectorBackwardEuler<4>, VectorStateType<4>>(backard_euler_vector_4, 1e-2);
 }
 
 TEST(AnalyticalExamples, SurfaceRxn)
@@ -151,7 +146,7 @@ TEST(AnalyticalExamples, HIRES)
   test_analytical_hires(backward_euler, 1e-1);
 }
 
-TEST(AnalyticalExamples, E5)
+TEST(AnalyticalExamples, Oregonator)
 {
-  test_analytical_e5(backward_euler, 1);
+  test_analytical_oregonator(backward_euler, 1e-3);
 }

--- a/test/integration/test_analytical_rosenbrock.cpp
+++ b/test/integration/test_analytical_rosenbrock.cpp
@@ -261,7 +261,7 @@ TEST(AnalyticalExamples, Oregonator)
   };
 
   auto solver = rosenbrock_solver(micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
-  test_analytical_oregonator(solver, 1e-3);
+  test_analytical_oregonator(solver, 1e-4);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
   test_analytical_oregonator(solver, 1e-3);

--- a/test/integration/test_analytical_rosenbrock.cpp
+++ b/test/integration/test_analytical_rosenbrock.cpp
@@ -40,7 +40,7 @@ auto rosenbrock_vector_4 = VectorRosenbrock<4>(micm::RosenbrockSolverParameters:
 
 TEST(AnalyticalExamples, Troe)
 {
-  test_analytical_troe(rosenbrock_2stage, 1e-3);
+  test_analytical_troe(rosenbrock_2stage);
   test_analytical_troe(rosenbrock_3stage);
   test_analytical_troe(rosenbrock_4stage);
   test_analytical_troe(rosenbrock_4stage_da);
@@ -53,7 +53,7 @@ TEST(AnalyticalExamples, Troe)
 
 TEST(AnalyticalExamples, TroeSuperStiffButAnalytical)
 {
-  test_analytical_stiff_troe(rosenbrock_2stage, 1e-3);
+  test_analytical_stiff_troe(rosenbrock_2stage);
   test_analytical_stiff_troe(rosenbrock_3stage);
   test_analytical_stiff_troe(rosenbrock_4stage);
   test_analytical_stiff_troe(rosenbrock_4stage_da);
@@ -66,41 +66,41 @@ TEST(AnalyticalExamples, TroeSuperStiffButAnalytical)
 
 TEST(AnalyticalExamples, Photolysis)
 {
-  test_analytical_photolysis(rosenbrock_2stage, 1e-2);
-  test_analytical_photolysis(rosenbrock_3stage, 1e-4);
-  test_analytical_photolysis(rosenbrock_4stage, 1e-5);
-  test_analytical_photolysis(rosenbrock_4stage_da, 1e-5);
-  test_analytical_photolysis(rosenbrock_6stage_da, 1e-5);
-  test_analytical_photolysis<VectorRosenbrock<1>, VectorStateType<1>>(rosenbrock_vector_1, 1e-4);
-  test_analytical_photolysis<VectorRosenbrock<2>, VectorStateType<2>>(rosenbrock_vector_2, 1e-4);
-  test_analytical_photolysis<VectorRosenbrock<3>, VectorStateType<3>>(rosenbrock_vector_3, 1e-4);
-  test_analytical_photolysis<VectorRosenbrock<4>, VectorStateType<4>>(rosenbrock_vector_4, 1e-4);
+  test_analytical_photolysis(rosenbrock_2stage);
+  test_analytical_photolysis(rosenbrock_3stage);
+  test_analytical_photolysis(rosenbrock_4stage);
+  test_analytical_photolysis(rosenbrock_4stage_da);
+  test_analytical_photolysis(rosenbrock_6stage_da);
+  test_analytical_photolysis<VectorRosenbrock<1>, VectorStateType<1>>(rosenbrock_vector_1);
+  test_analytical_photolysis<VectorRosenbrock<2>, VectorStateType<2>>(rosenbrock_vector_2);
+  test_analytical_photolysis<VectorRosenbrock<3>, VectorStateType<3>>(rosenbrock_vector_3);
+  test_analytical_photolysis<VectorRosenbrock<4>, VectorStateType<4>>(rosenbrock_vector_4);
 }
 
 TEST(AnalyticalExamples, PhotolysisSuperStiffButAnalytical)
 {
-  test_analytical_stiff_photolysis(rosenbrock_2stage, 1e-2);
-  test_analytical_stiff_photolysis(rosenbrock_3stage, 1e-3);
-  test_analytical_stiff_photolysis(rosenbrock_4stage, 1e-3);
-  test_analytical_stiff_photolysis(rosenbrock_4stage_da, 1e-3);
-  test_analytical_stiff_photolysis(rosenbrock_6stage_da, 1e-3);
-  test_analytical_stiff_photolysis<VectorRosenbrock<1>, VectorStateType<1>>(rosenbrock_vector_1, 1e-3);
-  test_analytical_stiff_photolysis<VectorRosenbrock<2>, VectorStateType<2>>(rosenbrock_vector_2, 1e-3);
-  test_analytical_stiff_photolysis<VectorRosenbrock<3>, VectorStateType<3>>(rosenbrock_vector_3, 1e-3);
-  test_analytical_stiff_photolysis<VectorRosenbrock<4>, VectorStateType<4>>(rosenbrock_vector_4, 1e-3);
+  test_analytical_stiff_photolysis(rosenbrock_2stage);
+  test_analytical_stiff_photolysis(rosenbrock_3stage);
+  test_analytical_stiff_photolysis(rosenbrock_4stage);
+  test_analytical_stiff_photolysis(rosenbrock_4stage_da);
+  test_analytical_stiff_photolysis(rosenbrock_6stage_da);
+  test_analytical_stiff_photolysis<VectorRosenbrock<1>, VectorStateType<1>>(rosenbrock_vector_1);
+  test_analytical_stiff_photolysis<VectorRosenbrock<2>, VectorStateType<2>>(rosenbrock_vector_2);
+  test_analytical_stiff_photolysis<VectorRosenbrock<3>, VectorStateType<3>>(rosenbrock_vector_3);
+  test_analytical_stiff_photolysis<VectorRosenbrock<4>, VectorStateType<4>>(rosenbrock_vector_4);
 }
 
 TEST(AnalyticalExamples, TernaryChemicalActivation)
 {
-  test_analytical_ternary_chemical_activation(rosenbrock_2stage, 1e-3);
-  test_analytical_ternary_chemical_activation(rosenbrock_3stage, 1e-5);
-  test_analytical_ternary_chemical_activation(rosenbrock_4stage, 1e-5);
-  test_analytical_ternary_chemical_activation(rosenbrock_4stage_da, 1e-5);
-  test_analytical_ternary_chemical_activation(rosenbrock_6stage_da, 1e-5);
-  test_analytical_ternary_chemical_activation<VectorRosenbrock<1>, VectorStateType<1>>(rosenbrock_vector_1, 1e-5);
-  test_analytical_ternary_chemical_activation<VectorRosenbrock<2>, VectorStateType<2>>(rosenbrock_vector_2, 1e-5);
-  test_analytical_ternary_chemical_activation<VectorRosenbrock<3>, VectorStateType<3>>(rosenbrock_vector_3, 1e-5);
-  test_analytical_ternary_chemical_activation<VectorRosenbrock<4>, VectorStateType<4>>(rosenbrock_vector_4, 1e-5);
+  test_analytical_ternary_chemical_activation(rosenbrock_2stage);
+  test_analytical_ternary_chemical_activation(rosenbrock_3stage);
+  test_analytical_ternary_chemical_activation(rosenbrock_4stage);
+  test_analytical_ternary_chemical_activation(rosenbrock_4stage_da);
+  test_analytical_ternary_chemical_activation(rosenbrock_6stage_da);
+  test_analytical_ternary_chemical_activation<VectorRosenbrock<1>, VectorStateType<1>>(rosenbrock_vector_1);
+  test_analytical_ternary_chemical_activation<VectorRosenbrock<2>, VectorStateType<2>>(rosenbrock_vector_2);
+  test_analytical_ternary_chemical_activation<VectorRosenbrock<3>, VectorStateType<3>>(rosenbrock_vector_3);
+  test_analytical_ternary_chemical_activation<VectorRosenbrock<4>, VectorStateType<4>>(rosenbrock_vector_4);
 }
 
 TEST(AnalyticalExamples, TernaryChemicalActivationSuperStiffButAnalytical)
@@ -118,20 +118,20 @@ TEST(AnalyticalExamples, TernaryChemicalActivationSuperStiffButAnalytical)
 
 TEST(AnalyticalExamples, Tunneling)
 {
-  test_analytical_tunneling(rosenbrock_2stage, 1e-1);
-  test_analytical_tunneling(rosenbrock_3stage, 1e-5);
+  test_analytical_tunneling(rosenbrock_2stage, 2e-5);
+  test_analytical_tunneling(rosenbrock_3stage);
   test_analytical_tunneling(rosenbrock_4stage);
-  test_analytical_tunneling(rosenbrock_4stage_da, 1e-5);
+  test_analytical_tunneling(rosenbrock_4stage_da);
   test_analytical_tunneling(rosenbrock_6stage_da);
-  test_analytical_tunneling<VectorRosenbrock<1>, VectorStateType<1>>(rosenbrock_vector_1, 1e-5);
-  test_analytical_tunneling<VectorRosenbrock<2>, VectorStateType<2>>(rosenbrock_vector_2, 1e-5);
-  test_analytical_tunneling<VectorRosenbrock<3>, VectorStateType<3>>(rosenbrock_vector_3, 1e-5);
-  test_analytical_tunneling<VectorRosenbrock<4>, VectorStateType<4>>(rosenbrock_vector_4, 1e-5);
+  test_analytical_tunneling<VectorRosenbrock<1>, VectorStateType<1>>(rosenbrock_vector_1);
+  test_analytical_tunneling<VectorRosenbrock<2>, VectorStateType<2>>(rosenbrock_vector_2);
+  test_analytical_tunneling<VectorRosenbrock<3>, VectorStateType<3>>(rosenbrock_vector_3);
+  test_analytical_tunneling<VectorRosenbrock<4>, VectorStateType<4>>(rosenbrock_vector_4);
 }
 
 TEST(AnalyticalExamples, TunnelingSuperStiffButAnalytical)
 {
-  test_analytical_stiff_tunneling(rosenbrock_2stage, 1e-1);
+  test_analytical_stiff_tunneling(rosenbrock_2stage, 1e-4);
   test_analytical_stiff_tunneling(rosenbrock_3stage, 1e-4);
   test_analytical_stiff_tunneling(rosenbrock_4stage, 1e-4);
   test_analytical_stiff_tunneling(rosenbrock_4stage_da, 1e-4);
@@ -144,7 +144,7 @@ TEST(AnalyticalExamples, TunnelingSuperStiffButAnalytical)
 
 TEST(AnalyticalExamples, Arrhenius)
 {
-  test_analytical_arrhenius(rosenbrock_2stage, 1e-3);
+  test_analytical_arrhenius(rosenbrock_2stage, 4e-6);
   test_analytical_arrhenius(rosenbrock_3stage);
   test_analytical_arrhenius(rosenbrock_4stage);
   test_analytical_arrhenius(rosenbrock_4stage_da);
@@ -157,20 +157,20 @@ TEST(AnalyticalExamples, Arrhenius)
 
 TEST(AnalyticalExamples, ArrheniusSuperStiffButAnalytical)
 {
-  test_analytical_stiff_arrhenius(rosenbrock_2stage, 1e-1);
-  test_analytical_stiff_arrhenius(rosenbrock_3stage, 1e-3);
-  test_analytical_stiff_arrhenius(rosenbrock_4stage, 1e-4);
-  test_analytical_stiff_arrhenius(rosenbrock_4stage_da, 1e-4);
-  test_analytical_stiff_arrhenius(rosenbrock_6stage_da, 1e-3);
-  test_analytical_stiff_arrhenius<VectorRosenbrock<1>, VectorStateType<1>>(rosenbrock_vector_1, 1e-3);
-  test_analytical_stiff_arrhenius<VectorRosenbrock<2>, VectorStateType<2>>(rosenbrock_vector_2, 1e-3);
-  test_analytical_stiff_arrhenius<VectorRosenbrock<3>, VectorStateType<3>>(rosenbrock_vector_3, 1e-3);
-  test_analytical_stiff_arrhenius<VectorRosenbrock<4>, VectorStateType<4>>(rosenbrock_vector_4, 1e-3);
+  test_analytical_stiff_arrhenius(rosenbrock_2stage, 1e-4);
+  test_analytical_stiff_arrhenius(rosenbrock_3stage, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_4stage, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_4stage_da, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_6stage_da, 1e-5);
+  test_analytical_stiff_arrhenius<VectorRosenbrock<1>, VectorStateType<1>>(rosenbrock_vector_1, 2e-5);
+  test_analytical_stiff_arrhenius<VectorRosenbrock<2>, VectorStateType<2>>(rosenbrock_vector_2, 2e-5);
+  test_analytical_stiff_arrhenius<VectorRosenbrock<3>, VectorStateType<3>>(rosenbrock_vector_3, 2e-5);
+  test_analytical_stiff_arrhenius<VectorRosenbrock<4>, VectorStateType<4>>(rosenbrock_vector_4, 2e-5);
 }
 
 TEST(AnalyticalExamples, Branched)
 {
-  test_analytical_branched(rosenbrock_2stage, 1e-3);
+  test_analytical_branched(rosenbrock_2stage, 1e-10);
   test_analytical_branched(rosenbrock_3stage);
   test_analytical_branched(rosenbrock_4stage);
   test_analytical_branched(rosenbrock_4stage_da);
@@ -204,19 +204,19 @@ TEST(AnalyticalExamples, Robertson)
   };
 
   auto solver = rosenbrock_solver(micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
-  test_analytical_robertson<BuilderType, StateType>(solver, 2e-1);
+  test_analytical_robertson<BuilderType, StateType>(solver, 1e-1);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  test_analytical_robertson<BuilderType, StateType>(solver, 2e-1);
+  test_analytical_robertson<BuilderType, StateType>(solver, 1e-1);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageRosenbrockParameters());
-  test_analytical_robertson<BuilderType, StateType>(solver, 2e-1);
+  test_analytical_robertson<BuilderType, StateType>(solver, 1e-1);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_robertson<BuilderType, StateType>(solver, 2e-1);
+  test_analytical_robertson<BuilderType, StateType>(solver, 1e-1);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_robertson<BuilderType, StateType>(solver, 2e-1);
+  test_analytical_robertson<BuilderType, StateType>(solver, 1e-1);
 }
 
 TEST(AnalyticalExamples, E5)

--- a/test/integration/test_analytical_rosenbrock.cpp
+++ b/test/integration/test_analytical_rosenbrock.cpp
@@ -255,25 +255,25 @@ TEST(AnalyticalExamples, Oregonator)
   auto rosenbrock_solver = [](auto params)
   {
     // anything below 1e-6 is too strict for the Oregonator
-    params.relative_tolerance_ = 1e-6;
-    params.absolute_tolerance_ = std::vector<double>(5, params.relative_tolerance_ * 1e-2);
+    params.relative_tolerance_ = 1e-8;
+    params.absolute_tolerance_ = std::vector<double>(5, params.relative_tolerance_ * 1e-6);
     return micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(params);
   };
 
   auto solver = rosenbrock_solver(micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
-  test_analytical_oregonator(solver, 1e-4);
+  test_analytical_oregonator(solver, 4e-6);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  test_analytical_oregonator(solver, 1e-3);
+  test_analytical_oregonator(solver, 4e-6);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageRosenbrockParameters());
-  test_analytical_oregonator(solver, 1e-3);
+  test_analytical_oregonator(solver, 4e-6);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_oregonator(solver, 1e-3);
+  test_analytical_oregonator(solver, 4e-6);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_oregonator(solver, 1e-3);
+  test_analytical_oregonator(solver, 4e-6);
 }
 
 TEST(AnalyticalExamples, SurfaceRxn)
@@ -295,17 +295,17 @@ TEST(AnalyticalExamples, HIRES)
   };
 
   auto solver = rosenbrock_solver(micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
-  test_analytical_hires(solver, 5e-2);
+  test_analytical_hires(solver, 1e-6);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  test_analytical_hires(solver, 1e-3);
+  test_analytical_hires(solver, 1e-7);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageRosenbrockParameters());
-  test_analytical_hires(solver, 1e-3);
+  test_analytical_hires(solver, 1e-7);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_hires(solver, 1e-3);
+  test_analytical_hires(solver, 1e-6);
 
   solver = rosenbrock_solver(micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters());
-  test_analytical_hires(solver, 1e-3);
+  test_analytical_hires(solver, 1e-6);
 }


### PR DESCRIPTION
Closes #662

This also corrects the oregonator test translation which happened in #593 (originally introduced in #222). We weren't actually testing anything useful. However, now we have the same shape and order of magnitude. I don't understand why I had to do the transformations on the true values. I do get why I needed to multiple time by the tau transformation value, but not anything else about it