### PR TITLE
Set hstart to timestep

### DIFF
--- a/include/micm/solver/backward_euler.inl
+++ b/include/micm/solver/backward_euler.inl
@@ -61,7 +61,7 @@ namespace micm
     std::size_t max_iter = parameters_.max_number_of_steps_;
     const auto time_step_reductions = parameters_.time_step_reductions_;
 
-    double H = time_step;
+    double H = parameters_.h_start_ == 0.0 ? time_step : parameters_.h_start_;
     double t = 0.0;
     std::size_t n_successful_integrations = 0;
     std::size_t n_convergence_failures = 0;

--- a/include/micm/solver/backward_euler_solver_parameters.hpp
+++ b/include/micm/solver/backward_euler_solver_parameters.hpp
@@ -22,6 +22,7 @@ namespace micm
     std::vector<double> absolute_tolerance_;
     double relative_tolerance_{ 1.0e-8 };
     double small_{ 1.0e-40 };
+    double h_start_{ 0.0 };
     size_t max_number_of_steps_{ 11 };
     // The time step reductions are used to determine the time step after a failed solve
     // This default set of time step reductions is used by CAM-Chem

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -21,8 +21,8 @@ namespace micm
     auto& K = derived_class_temporary_variables->K_;
     auto& Yerror = derived_class_temporary_variables->Yerror_;
     const double h_max = parameters_.h_max_ == 0.0 ? time_step : std::min(time_step, parameters_.h_max_);
-    const double h_start =
-        parameters_.h_start_ == 0.0 ? std::max(parameters_.h_min_, DELTA_MIN) : std::min(h_max, parameters_.h_start_);
+    const double h_start = time_step;
+        // parameters_.h_start_ == 0.0 ? std::max(parameters_.h_min_, DELTA_MIN) : std::min(h_max, parameters_.h_start_);
 
     SolverStats stats;
 

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -21,8 +21,8 @@ namespace micm
     auto& K = derived_class_temporary_variables->K_;
     auto& Yerror = derived_class_temporary_variables->Yerror_;
     const double h_max = parameters_.h_max_ == 0.0 ? time_step : std::min(time_step, parameters_.h_max_);
-    const double h_start = time_step;
-        // parameters_.h_start_ == 0.0 ? std::max(parameters_.h_min_, DELTA_MIN) : std::min(h_max, parameters_.h_start_);
+    const double h_start = 
+        parameters_.h_start_ == 0.0 ? std::max(parameters_.h_min_, DELTA_MIN) : std::min(h_max, parameters_.h_start_);
 
     SolverStats stats;
 


### PR DESCRIPTION
To make it easy to test backward euler in the performance repository, I've added `h_start` to the backward euler parameters. This means we can use the same testing code for rosenbrock or backward euler