### PR TITLE
Fixes a bug in the logic used to calculate alpha - jacobian

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -12,30 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  xcode_macos_12:
-    runs-on: macos-12
-    strategy:
-      matrix:
-        # all available versions of xcode: https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
-        xcode: ['14.1']
-        build_type: [Release]
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run Cmake 
-        run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
-
-      - name: Build
-        run: cmake --build build --parallel 10
-
-      - name: Run tests
-        run: |
-          cd build
-          ctest -C ${{ matrix.build_type }} --rerun-failed --output-on-failure . --verbose -j 10
-
   xcode_macos_13:
     runs-on: macos-13
     continue-on-error: true 

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -103,12 +103,11 @@ namespace micm
         requires(VectorizableSparse<SparseMatrixPolicy>);
 
     /// @brief Perform the LU decomposition of the matrix
-    /// @param H The time step
-    /// @param gamma The gamma value
+    /// @param alpha The alpha value
     /// @param number_densities The number densities
     /// @param stats The solver stats
     /// @param state The state
-    void LinearFactor(double& H, const double gamma, const auto& number_densities, SolverStats& stats, auto& state) const;
+    void LinearFactor(const double alpha, const auto& number_densities, SolverStats& stats, auto& state) const;
 
     /// @brief Computes the scaled norm of the vector errors
     /// @param y the original vector


### PR DESCRIPTION
Inside the convergence loop of the Rosenbrock solver there may be repeated calls to `AbstractRosenbrockSolver::LinearFactor()`. Because this function overwrites the negative jacobian stored in `state.jacobian_`, the alpha values from successive calls accumulate along the diagonal.

This apparently didn't have enough of an impact to affect the results of the analytical tests, but should be corrected.

I wasn't sure of the best way to test this fix, because the impact was small and we don't currently have unit tests for the `AbstractRosenbrockSolver::Solve()` function because exact outputs are difficult to calculate. If anyone has suggestions for tests, I can add them.