### PR TITLE
Add in-place LU decomposition option for linear solve

### DIFF
--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -7,12 +7,30 @@
 #include <micm/solver/linear_solver_in_place.hpp>
 #include <micm/util/matrix.hpp>
 #include <micm/util/sparse_matrix.hpp>
+#include <micm/util/sparse_matrix_vector_ordering.hpp>
 
 #include <cmath>
 #include <functional>
 
 namespace micm
 {
+
+  /// @brief Concept for in-place linear solver algorithms
+  template<class T, class DenseMatrixPolicy, class SparseMatrixPolicy>
+  concept LinearSolverInPlaceConcept = requires(T t)
+  {
+    { t.Factor(std::declval<SparseMatrixPolicy&>()) };
+    { t.Solve(std::declval<DenseMatrixPolicy&>(), SparseMatrixPolicy{}) };
+  };
+  static_assert(LinearSolverInPlaceConcept<LinearSolverInPlace<StandardSparseMatrix>, StandardDenseMatrix, StandardSparseMatrix>, "LinearSolverInPlace does not meet the LinearSolverInPlaceConcept requirements");
+  static_assert(LinearSolverInPlaceConcept<
+                  LinearSolverInPlace<
+                    SparseMatrix<double, SparseMatrixVectorOrderingCompressedSparseRow<1>>,
+                    LuDecompositionMozartInPlace
+                  >,
+                  VectorMatrix<double, 1>,
+                  SparseMatrix<double, SparseMatrixVectorOrderingCompressedSparseRow<1>>
+                >, "LinearSolverInPlace for vector matrices does not meet the LinearSolverInPlaceConcept requirements");
 
   /// @brief Reorders a set of state variables using Diagonal Markowitz algorithm
   /// @param matrix Original matrix non-zero elements

--- a/include/micm/solver/linear_solver_in_place.hpp
+++ b/include/micm/solver/linear_solver_in_place.hpp
@@ -4,7 +4,6 @@
 
 #include <micm/profiler/instrumentation.hpp>
 #include <micm/solver/lu_decomposition.hpp>
-#include <micm/solver/linear_solver_in_place.hpp>
 #include <micm/util/matrix.hpp>
 #include <micm/util/sparse_matrix.hpp>
 
@@ -14,17 +13,12 @@
 namespace micm
 {
 
-  /// @brief Reorders a set of state variables using Diagonal Markowitz algorithm
-  /// @param matrix Original matrix non-zero elements
-  /// @result Reordered mapping vector (reordered[i] = original[map[i]])
-  template<template<class> class MatrixPolicy>
-  std::vector<std::size_t> DiagonalMarkowitzReorder(const MatrixPolicy<int>& matrix);
-
   /// @brief A general-use block-diagonal sparse-matrix linear solver
   ///
   /// The sparsity pattern of each block in the block diagonal matrix is the same.
-  template<class SparseMatrixPolicy, class LuDecompositionPolicy = LuDecomposition, class LMatrixPolicy = SparseMatrixPolicy, class UMatrixPolicy = SparseMatrixPolicy>
-  class LinearSolver
+  /// The L and U matrices are decomposed in-place over the original A matrix.
+  template<class SparseMatrixPolicy, class LuDecompositionPolicy = LuDecompositionInPlace>
+  class LinearSolverInPlace
   {
    protected:
     // Parameters needed to calculate L (U x) = b
@@ -39,9 +33,8 @@ namespace micm
     // x_N = y_N / U_NN
     // x_i = 1 / U_ii * [ y_i - sum( j = i+1...N ){ U_ij * x_j } ] i = N-1...1
 
-    // Number of non-zero elements (excluding the diagonal) and the index of the diagonal
-    // element for each row in L
-    std::vector<std::pair<std::size_t, std::size_t>> nLij_Lii_;
+    // Number of non-zero elements (excluding the diagonal) for each row in L
+    std::vector<std::size_t> nLij_;
     // Indices of non-zero combinations of L_ij and y_j
     std::vector<std::pair<std::size_t, std::size_t>> Lij_yj_;
     // Number of non-zero elements (exluding the diagonal) and the index of the diagonal
@@ -54,46 +47,46 @@ namespace micm
 
    public:
     /// @brief default constructor
-    LinearSolver(){};
+    LinearSolverInPlace(){};
 
-    LinearSolver(const LinearSolver&) = delete;
-    LinearSolver& operator=(const LinearSolver&) = delete;
-    LinearSolver(LinearSolver&&) = default;
-    LinearSolver& operator=(LinearSolver&&) = default;
+    LinearSolverInPlace(const LinearSolverInPlace&) = delete;
+    LinearSolverInPlace& operator=(const LinearSolverInPlace&) = delete;
+    LinearSolverInPlace(LinearSolverInPlace&&) = default;
+    LinearSolverInPlace& operator=(LinearSolverInPlace&&) = default;
 
     /// @brief Constructs a linear solver for the sparsity structure of the given matrix
     /// @param matrix Sparse matrix
     /// @param initial_value Initial value for matrix elements
-    LinearSolver(const SparseMatrixPolicy& matrix, typename SparseMatrixPolicy::value_type initial_value);
+    LinearSolverInPlace(const SparseMatrixPolicy& matrix, typename SparseMatrixPolicy::value_type initial_value);
 
     /// @brief Constructs a linear solver for the sparsity structure of the given matrix
     /// @param matrix Sparse matrix
     /// @param initial_value Initial value for matrix elements
     /// @param create_lu_decomp Function to create an LU Decomposition object that adheres to LuDecompositionPolicy
-    LinearSolver(
+    LinearSolverInPlace(
         const SparseMatrixPolicy& matrix,
         typename SparseMatrixPolicy::value_type initial_value,
         const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)> create_lu_decomp);
 
-    virtual ~LinearSolver() = default;
+    virtual ~LinearSolverInPlace() = default;
 
-    /// @brief Decompose the matrix into upper and lower triangular matrices
-    /// @param matrix Matrix to decompose into lower and upper triangular matrices
-    void Factor(const SparseMatrixPolicy& matrix, LMatrixPolicy& lower_matrix, UMatrixPolicy& upper_matrix) const;
+    /// @brief Decompose the matrix into upper and lower triangular matrices (matrix will be overwritten)
+    /// @param matrix Matrix to decompose in-place into lower and upper triangular matrices
+    void Factor(SparseMatrixPolicy& matrix) const;
 
     /// @brief Solve for x in Ax = b. x should be a copy of b and after Solve finishes x will contain the result
+    /// @param x The solution vector
+    /// @param LU The LU decomposition of the matrix as a square sparse matrix
     template<class MatrixPolicy>
     requires(!VectorizableDense<MatrixPolicy> || !VectorizableSparse<SparseMatrixPolicy>) void Solve(
         MatrixPolicy& x,
-        const LMatrixPolicy& lower_matrix,
-        const UMatrixPolicy& upper_matrix) const;
+        const SparseMatrixPolicy& lu_matrix) const;
     template<class MatrixPolicy>
     requires(VectorizableDense<MatrixPolicy>&& VectorizableSparse<SparseMatrixPolicy>) void Solve(
         MatrixPolicy& x,
-        const LMatrixPolicy& lower_matrix,
-        const UMatrixPolicy& upper_matrix) const;
+        const SparseMatrixPolicy& lu_matrix) const;
   };
 
 }  // namespace micm
 
-#include "linear_solver.inl"
+#include "linear_solver_in_place.inl"

--- a/include/micm/solver/linear_solver_in_place.hpp
+++ b/include/micm/solver/linear_solver_in_place.hpp
@@ -12,7 +12,6 @@
 
 namespace micm
 {
-
   /// @brief A general-use block-diagonal sparse-matrix linear solver
   ///
   /// The sparsity pattern of each block in the block diagonal matrix is the same.

--- a/include/micm/solver/linear_solver_in_place.inl
+++ b/include/micm/solver/linear_solver_in_place.inl
@@ -1,0 +1,179 @@
+// Copyright (C) 2023-2024 National Center for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+namespace micm
+{
+  template<class SparseMatrixPolicy, class LuDecompositionPolicy>
+  inline LinearSolverInPlace<SparseMatrixPolicy, LuDecompositionPolicy>::LinearSolverInPlace(
+      const SparseMatrixPolicy& matrix,
+      typename SparseMatrixPolicy::value_type initial_value)
+      : LinearSolverInPlace<SparseMatrixPolicy, LuDecompositionPolicy>(
+            matrix,
+            initial_value,
+            [](const SparseMatrixPolicy& m) -> LuDecompositionPolicy
+            { return LuDecompositionPolicy::template Create<SparseMatrixPolicy>(m); })
+  {
+  }
+
+  template<class SparseMatrixPolicy, class LuDecompositionPolicy>
+  inline LinearSolverInPlace<SparseMatrixPolicy, LuDecompositionPolicy>::LinearSolverInPlace(
+      const SparseMatrixPolicy& matrix,
+      typename SparseMatrixPolicy::value_type initial_value,
+      const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)> create_lu_decomp)
+      : nLij_(),
+        Lij_yj_(),
+        nUij_Uii_(),
+        Uij_xj_(),
+        lu_decomp_(create_lu_decomp(matrix))
+  {
+    MICM_PROFILE_FUNCTION();
+
+    auto lu = lu_decomp_.template GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value);
+    for (std::size_t i = 0; i < lu.NumRows(); ++i)
+    {
+      std::size_t nLij = 0;
+      for (std::size_t j = 0; j < i; ++j)
+      {
+        if (lu.IsZero(i, j))
+          continue;
+        Lij_yj_.push_back(std::make_pair(lu.VectorIndex(0, i, j), j));
+        ++nLij;
+      }
+      nLij_.push_back(nLij);
+    }
+    for (std::size_t i = lu.NumRows() - 1; i != static_cast<std::size_t>(-1); --i)
+    {
+      std::size_t nUij = 0;
+      for (std::size_t j = i + 1; j < lu.NumColumns(); ++j)
+      {
+        if (lu.IsZero(i, j))
+          continue;
+        Uij_xj_.push_back(std::make_pair(lu.VectorIndex(0, i, j), j));
+        ++nUij;
+      }
+      // There must always be a non-zero element on the diagonal
+      nUij_Uii_.push_back(std::make_pair(nUij, lu.VectorIndex(0, i, i)));
+    }
+  };
+
+  template<class SparseMatrixPolicy, class LuDecompositionPolicy>
+  inline void LinearSolverInPlace<SparseMatrixPolicy, LuDecompositionPolicy>::Factor(
+      SparseMatrixPolicy& matrix) const
+  {
+    MICM_PROFILE_FUNCTION();
+
+    lu_decomp_.template Decompose<SparseMatrixPolicy>(matrix);
+  }
+
+  template<class SparseMatrixPolicy, class LuDecompositionPolicy>
+  template<class MatrixPolicy>
+  requires(
+      !VectorizableDense<MatrixPolicy> ||
+      !VectorizableSparse<SparseMatrixPolicy>) inline void LinearSolverInPlace<SparseMatrixPolicy, LuDecompositionPolicy>::
+      Solve(MatrixPolicy& x, const SparseMatrixPolicy& lu_matrix) const
+  {
+    MICM_PROFILE_FUNCTION();
+
+    for (std::size_t i_cell = 0; i_cell < x.NumRows(); ++i_cell)
+    {
+      auto x_cell = x[i_cell];
+      const std::size_t grid_offset = i_cell * lu_matrix.FlatBlockSize();
+      auto& y_cell = x_cell;  // Alias x for consistency with equations, but to reuse memory
+
+      // Forward Substitution
+      {
+        auto y_elem = y_cell.begin();
+        auto Lij_yj = Lij_yj_.begin();
+        for (auto& nLij : nLij_)
+        {
+          for (std::size_t i = 0; i < nLij; ++i)
+          {
+            *y_elem -= lu_matrix.AsVector()[grid_offset + (*Lij_yj).first] * y_cell[(*Lij_yj).second];
+            ++Lij_yj;
+          }
+          ++y_elem;
+        }
+      }
+
+      // Backward Substitution
+      {
+        auto x_elem = std::next(x_cell.end(), -1);
+        auto Uij_xj = Uij_xj_.begin();
+        for (auto& nUij_Uii : nUij_Uii_)
+        {
+          // x_elem starts out as y_elem from the previous loop
+          for (std::size_t i = 0; i < nUij_Uii.first; ++i)
+          {
+            *x_elem -= lu_matrix.AsVector()[grid_offset + (*Uij_xj).first] * x_cell[(*Uij_xj).second];
+            ++Uij_xj;
+          }
+
+          *(x_elem) /= lu_matrix.AsVector()[grid_offset + nUij_Uii.second];
+          // don't iterate before the beginning of the vector
+          if (x_elem != x_cell.begin())
+          {
+            --x_elem;
+          }
+        }
+      }
+    }
+  }
+
+  template<class SparseMatrixPolicy, class LuDecompositionPolicy>
+  template<class MatrixPolicy>
+  requires(VectorizableDense<MatrixPolicy>&&
+               VectorizableSparse<SparseMatrixPolicy>) inline void LinearSolverInPlace<SparseMatrixPolicy, LuDecompositionPolicy>::
+      Solve(MatrixPolicy& x, const SparseMatrixPolicy& lu_matrix) const
+  {
+    MICM_PROFILE_FUNCTION();
+    constexpr std::size_t n_cells = MatrixPolicy::GroupVectorSize();
+    // Loop over groups of blocks
+    for (std::size_t i_group = 0; i_group < x.NumberOfGroups(); ++i_group)
+    {
+      auto x_group = std::next(x.AsVector().begin(), i_group * x.GroupSize());
+      auto LU_group =
+          std::next(lu_matrix.AsVector().begin(), i_group * lu_matrix.GroupSize());
+      // Forward Substitution
+      {
+        auto y_elem = x_group;
+        auto Lij_yj = Lij_yj_.begin();
+        for (auto& nLij : nLij_)
+        {
+          for (std::size_t i = 0; i < nLij; ++i)
+          {
+            const std::size_t Lij_yj_first = (*Lij_yj).first;
+            const std::size_t Lij_yj_second_times_n_cells = (*Lij_yj).second * n_cells;
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+              y_elem[i_cell] -= LU_group[Lij_yj_first + i_cell] * x_group[Lij_yj_second_times_n_cells + i_cell];
+            ++Lij_yj;
+          }
+          y_elem += n_cells;
+        }
+      }
+
+      // Backward Substitution
+      {
+        auto x_elem = std::next(x_group, x.GroupSize() - n_cells);
+        auto Uij_xj = Uij_xj_.begin();
+        for (auto& nUij_Uii : nUij_Uii_)
+        {
+          // x_elem starts out as y_elem from the previous loop
+          for (std::size_t i = 0; i < nUij_Uii.first; ++i)
+          {
+            const std::size_t Uij_xj_first = (*Uij_xj).first;
+            const std::size_t Uij_xj_second_times_n_cells = (*Uij_xj).second * n_cells;
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+              x_elem[i_cell] -= LU_group[Uij_xj_first + i_cell] * x_group[Uij_xj_second_times_n_cells + i_cell];
+            ++Uij_xj;
+          }
+          const std::size_t nUij_Uii_second = nUij_Uii.second;
+          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            x_elem[i_cell] /= LU_group[nUij_Uii_second + i_cell];
+
+          // don't iterate before the beginning of the vector
+          const std::size_t x_elem_distance = std::distance(x.AsVector().begin(), x_elem);
+          x_elem -= std::min(n_cells, x_elem_distance);
+        }
+      }
+    }
+  }
+}  // namespace micm

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -5,9 +5,22 @@
 #include "lu_decomposition_doolittle.hpp"
 #include "lu_decomposition_mozart.hpp"
 #include "lu_decomposition_mozart_in_place.hpp"
+#include <micm/util/sparse_matrix.hpp>
+#include <micm/util/sparse_matrix_vector_ordering.hpp>
 
 namespace micm
 {
+
+  /// @brief Concept for in-place LU decomposition algorithms
+  template<class T, class SparseMatrixPolicy>
+  concept LuDecompositionInPlaceConcept = requires(T t)
+  {
+    { t.GetLUMatrix(SparseMatrixPolicy{}, 0.0) };
+    { t.Decompose(std::declval<SparseMatrixPolicy&>()) };
+  };
+  static_assert(LuDecompositionInPlaceConcept<LuDecompositionMozartInPlace, StandardSparseMatrix>, "LuDecompositionMozartInPlace does not meet the LuDecompositionInPlaceConcept requirements");
+  static_assert(LuDecompositionInPlaceConcept<LuDecompositionMozartInPlace, SparseMatrix<double, SparseMatrixVectorOrderingCompressedSparseRow<1>>>, "LuDecompositionMozartInPlace for vector matrices does not meet the LuDecompositionInPlaceConcept requirements");
+
   /// @brief Alias for the default LU decomposition algorithm
   using LuDecomposition = LuDecompositionDoolittle;
 

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -4,6 +4,7 @@
 
 #include "lu_decomposition_doolittle.hpp"
 #include "lu_decomposition_mozart.hpp"
+#include "lu_decomposition_mozart_in_place.hpp"
 
 namespace micm
 {

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -10,4 +10,7 @@ namespace micm
 {
   /// @brief Alias for the default LU decomposition algorithm
   using LuDecomposition = LuDecompositionDoolittle;
+
+  /// @brief Alias for the default in-place LU decomposition algorithm
+  using LuDecompositionInPlace = LuDecompositionMozartInPlace;
 }  // namespace micm

--- a/include/micm/solver/lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.hpp
@@ -1,0 +1,99 @@
+// Copyright (C) 2023-2024 National Center for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <micm/profiler/instrumentation.hpp>
+#include <micm/util/sparse_matrix.hpp>
+
+namespace micm
+{
+
+  /// @brief LU decomposer for SparseMatrix following the algorithm from the MOZART model
+  ///
+  /// This LU decomposition uses the algorithm from the MOZART chemistry preprocessor at:
+  /// https://github.com/ESCOMP/CHEM_PREPROCESSOR/blob/f923081508f4264e61fcef2753a9898e55d1598e/src/cam_chempp/make_lu_fac.f#L127-L214
+  ///
+  /// The MOZART function overwrote the A matrix with the L and U matrices. The pseudo-code
+  /// in C++ for the corresponding dense matrix algorithm for matrix A (inline change) would be:
+  ///
+  /// for i = 0...n-1                     // Outer loop over columns of the sparse matrix A
+  ///   for j = i+1...n-1                 // Multiply column below diagonal
+  ///     A[j][i] = A[j][i] / A[i][i]
+  ///   for k = i+1...n-1                 // Modify sub-matrix
+  ///     for j = i+1...n-1
+  ///       A[j][k] = A[j][k] – A[j][i] * A[i][k]
+  ///
+  /// For the sparse matrix algorithm, the indices of non-zero terms are stored in
+  /// several arrays during construction. These arrays are iterated through during
+  /// calls to Decompose to do the actual decomposition.
+  ///
+  /// The GetLUMatrices function creates a new sparse matrix that includes the superset
+  /// of the non-zero elements in the L and U matrices. It is expected that the elements
+  /// of the L and U matrices that are zero in the A matrix will be set to zero before the
+  /// combined matrix is passed to the decomposition function.
+  class LuDecompositionMozartInPlace
+  {
+   protected:
+    /// Index in A.data_ for all diagonal elements, the number of iterations of the inner (j) loop
+    /// for each (i) used to set A[j][i], and the number of iterations of the middle (k) loop for
+    /// each (i) used to set A[j][k]
+    std::vector<std::tuple<std::size_t, std::size_t, std::size_t>> aii_nji_nki_;
+    /// Index in A.data_ for A[j][i] for each iteration of the inner (j) loop
+    /// used to set the value of A[j][i]
+    std::vector<std::size_t> aji_;
+    /// Index in A.data_ for A[i][k] for each iteration of the middle (k) loop,
+    /// and the number of iterations of the inner (j) loop for each (k) used to set A[j][k]
+    std::vector<std::pair<std::size_t, std::size_t>> aik_njk_;
+    /// Index in A.data_ for A[j][k] and A[j][i] for each iteration of the inner (j) loop
+    std::vector<std::pair<std::size_t, std::size_t>> ajk_aji_;
+
+   public:
+    /// @brief default constructor
+    LuDecompositionMozartInPlace();
+
+    LuDecompositionMozartInPlace(const LuDecompositionMozartInPlace&) = delete;
+    LuDecompositionMozartInPlace& operator=(const LuDecompositionMozartInPlace&) = delete;
+
+    LuDecompositionMozartInPlace(LuDecompositionMozartInPlace&& other) = default;
+    LuDecompositionMozartInPlace& operator=(LuDecompositionMozartInPlace&&) = default;
+
+    /// @brief Construct an LU decomposition algorithm for a given sparse matrix
+    /// @param matrix Sparse matrix
+    template<class SparseMatrixPolicy>
+    requires(SparseMatrixConcept<SparseMatrixPolicy>) LuDecompositionMozartInPlace(const SparseMatrixPolicy& matrix);
+
+    ~LuDecompositionMozartInPlace() = default;
+
+    /// @brief Create an LU decomposition algorithm for a given sparse matrix policy
+    /// @param matrix Sparse matrix
+    template<class SparseMatrixPolicy>
+    requires(SparseMatrixConcept<SparseMatrixPolicy>) static LuDecompositionMozartInPlace Create(const SparseMatrixPolicy& matrix);
+
+    /// @brief Create a combined sparse L and U matrix for a given A matrix
+    /// @param A Sparse matrix that will be decomposed
+    /// @return combined L and U Sparse matrices
+    template<class SparseMatrixPolicy>
+    requires(SparseMatrixConcept<SparseMatrixPolicy>) static SparseMatrixPolicy GetLUMatrix(
+        const SparseMatrixPolicy& A,
+        typename SparseMatrixPolicy::value_type initial_value);
+
+    /// @brief Perform an LU decomposition on a given A matrix.
+    ///        All elements of L and U that are zero in A should be set to zero before calling this function.
+    /// @param ALU Sparse matrix to decompose (will be overwritten with L and U matrices)
+    template<class SparseMatrixPolicy>
+    requires(!VectorizableSparse<SparseMatrixPolicy>) void Decompose(
+        SparseMatrixPolicy& ALU) const;
+    template<class SparseMatrixPolicy>
+    requires(VectorizableSparse<SparseMatrixPolicy>) void Decompose(
+        SparseMatrixPolicy& ALU) const;
+
+   private:
+    /// @brief Initialize arrays for the LU decomposition
+    /// @param A Sparse matrix to decompose
+    template<class SparseMatrixPolicy>
+    requires(SparseMatrixConcept<SparseMatrixPolicy>) void Initialize(const SparseMatrixPolicy& matrix, auto initial_value);
+  };
+
+}  // namespace micm
+
+#include "lu_decomposition_mozart_in_place.inl"

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -1,0 +1,183 @@
+// Copyright (C) 2023-2024 National Center for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+
+namespace micm
+{
+
+  inline LuDecompositionMozartInPlace::LuDecompositionMozartInPlace()
+  {
+  }
+
+  template<class SparseMatrixPolicy>
+  requires(SparseMatrixConcept<SparseMatrixPolicy>) inline LuDecompositionMozartInPlace::LuDecompositionMozartInPlace(const SparseMatrixPolicy& matrix)
+  {
+    Initialize<SparseMatrixPolicy>(matrix, typename SparseMatrixPolicy::value_type());
+  }
+
+  template<class SparseMatrixPolicy>
+  requires(SparseMatrixConcept<SparseMatrixPolicy>) inline LuDecompositionMozartInPlace LuDecompositionMozartInPlace::Create(
+      const SparseMatrixPolicy& matrix)
+  {
+    LuDecompositionMozartInPlace lu_decomp{};
+    lu_decomp.Initialize<SparseMatrixPolicy>(matrix, typename SparseMatrixPolicy::value_type());
+    return lu_decomp;
+  }
+
+  template<class SparseMatrixPolicy>
+  requires(SparseMatrixConcept<SparseMatrixPolicy>) inline void LuDecompositionMozartInPlace::Initialize(
+      const SparseMatrixPolicy& matrix,
+      auto initial_value)
+  {
+    MICM_PROFILE_FUNCTION();
+
+    std::size_t n = matrix.NumRows();
+    auto ALU = GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value);
+    for (std::size_t i = 0; i < n; ++i)
+    {
+      if (ALU.IsZero(i, i)) {
+        throw std::runtime_error("Diagonal element is zero in LU decomposition");
+      }
+      std::tuple<std::size_t, std::size_t, std::size_t> aii_nji_nki(ALU.VectorIndex(0, i, i), 0, 0);
+      for (std::size_t j = i + 1; j < n; ++j)
+      {
+        if (ALU.IsZero(j, i))
+          continue;
+        aji_.push_back(ALU.VectorIndex(0, j, i));
+        ++(std::get<1>(aii_nji_nki));
+      }
+      for (std::size_t k = i + 1; k < n; ++k)
+      {
+        if (ALU.IsZero(i, k))
+          continue;
+        std::pair<std::size_t, std::size_t> aik_njk(ALU.VectorIndex(0, i, k), 0);
+        for (std::size_t j = i + 1; j < n; ++j)
+        {
+          if (ALU.IsZero(j, i))
+            continue;
+          std::pair<std::size_t, std::size_t> ajk_aji(ALU.VectorIndex(0, j, k), ALU.VectorIndex(0, j, i));
+          ajk_aji_.push_back(ajk_aji);
+          ++(std::get<1>(aik_njk));
+        }
+        aik_njk_.push_back(aik_njk);
+        ++(std::get<2>(aii_nji_nki));
+      }
+      aii_nji_nki_.push_back(aii_nji_nki);
+    }
+  }
+
+  template<class SparseMatrixPolicy>
+  requires(
+      SparseMatrixConcept<SparseMatrixPolicy>) inline SparseMatrixPolicy LuDecompositionMozartInPlace::
+      GetLUMatrix(const SparseMatrixPolicy& A, typename SparseMatrixPolicy::value_type initial_value)
+  {
+    MICM_PROFILE_FUNCTION();
+
+    std::size_t n = A.NumRows();
+    std::set<std::pair<std::size_t, std::size_t>> ALU_ids;
+    for (std::size_t i = 0; i < n; ++i)
+    {
+      for (std::size_t j = 0; j < n; ++j)
+        if (!A.IsZero(i, j))
+          ALU_ids.insert(std::make_pair(i, j));
+    }
+    for (std::size_t i = 0; i < n; ++i)
+    {
+      for (std::size_t j = i + 1; j < n; ++j)
+        if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(j, i)) != ALU_ids.end())
+          ALU_ids.insert(std::make_pair(j, i));
+      for (std::size_t k = i + 1; k < n; ++k)
+        if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(i, k)) != ALU_ids.end())
+          for (std::size_t j = i + 1; j < n; ++j)
+            if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(j, i)) != ALU_ids.end())
+              ALU_ids.insert(std::make_pair(j, k));
+    }
+    auto ALU_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
+    for (auto& pair : ALU_ids)
+    {
+      ALU_builder = ALU_builder.WithElement(pair.first, pair.second);
+    }
+    return SparseMatrixPolicy(ALU_builder);
+  }
+
+  template<class SparseMatrixPolicy>
+  requires(!VectorizableSparse<SparseMatrixPolicy>) inline void LuDecompositionMozartInPlace::Decompose(
+      SparseMatrixPolicy& ALU) const
+  {
+    MICM_PROFILE_FUNCTION();
+    const std::size_t n = ALU.NumRows();
+
+    // Loop over blocks
+    for (std::size_t i_block = 0; i_block < ALU.NumberOfBlocks(); ++i_block)
+    {
+      auto ALU_vector = std::next(ALU.AsVector().begin(), i_block * ALU.FlatBlockSize());
+      auto aji = aji_.begin();
+      auto aik_njk = aik_njk_.begin();
+      auto ajk_aji = ajk_aji_.begin();
+      
+      for (const auto& aii_nji_nki : aii_nji_nki_)
+      {
+        const typename SparseMatrixPolicy::value_type Aii_inverse = 1.0 / ALU_vector[std::get<0>(aii_nji_nki)];
+        for (std::size_t ij = 0; ij < std::get<1>(aii_nji_nki); ++ij)
+        {
+          ALU_vector[*aji] *= Aii_inverse;
+          ++aji;
+        }
+        for (std::size_t ik = 0; ik < std::get<2>(aii_nji_nki); ++ik)
+        {
+          const typename SparseMatrixPolicy::value_type Aik = ALU_vector[std::get<0>(*aik_njk)];
+          for (std::size_t ijk = 0; ijk < std::get<1>(*aik_njk); ++ijk)
+          {
+            ALU_vector[ajk_aji->first] -= ALU_vector[ajk_aji->second] * Aik;
+            ++ajk_aji;
+          }
+          ++aik_njk;
+        }
+      }
+    }
+  }
+
+  template<class SparseMatrixPolicy>
+  requires(VectorizableSparse<SparseMatrixPolicy>) inline void LuDecompositionMozartInPlace::Decompose(
+      SparseMatrixPolicy& ALU) const
+  {
+    MICM_PROFILE_FUNCTION();
+
+    const std::size_t n = ALU.NumRows();
+    const std::size_t ALU_BlockSize = ALU.NumberOfBlocks();
+    constexpr std::size_t ALU_GroupVectorSize = SparseMatrixPolicy::GroupVectorSize();
+    const std::size_t ALU_GroupSizeOfFlatBlockSize = ALU.GroupSize();
+    double Aii_inverse[ALU_GroupVectorSize];
+
+    // Loop over groups of blocks
+    for (std::size_t i_group = 0; i_group < ALU.NumberOfGroups(ALU_BlockSize); ++i_group)
+    {
+      auto ALU_vector = std::next(ALU.AsVector().begin(), i_group * ALU_GroupSizeOfFlatBlockSize);
+      const std::size_t n_cells = std::min(ALU_GroupVectorSize, ALU_BlockSize - i_group * ALU_GroupVectorSize);
+      auto aji = aji_.begin();
+      auto aik_njk = aik_njk_.begin();
+      auto ajk_aji = ajk_aji_.begin();
+      for (const auto& aii_nji_nki : aii_nji_nki_)
+      {
+        for (std::size_t i = 0; i < n_cells; ++i)
+          Aii_inverse[i] = 1.0 / ALU_vector[std::get<0>(aii_nji_nki) + i];
+        for (std::size_t ij = 0; ij < std::get<1>(aii_nji_nki); ++ij)
+        {
+          for (std::size_t i = 0; i < n_cells; ++i)
+            ALU_vector[*aji + i] *= Aii_inverse[i];
+          ++aji;
+        }
+        for (std::size_t ik = 0; ik < std::get<2>(aii_nji_nki); ++ik)
+        {
+          const std::size_t aik = std::get<0>(*aik_njk);
+          for (std::size_t ijk = 0; ijk < std::get<1>(*aik_njk); ++ijk)
+          {
+            for (std::size_t i = 0; i < n_cells; ++i)
+              ALU_vector[ajk_aji->first + i] -= ALU_vector[ajk_aji->second + i] * ALU_vector[aik + i];
+            ++ajk_aji;
+          }
+          ++aik_njk;
+        }
+      }
+    }
+  }
+}  // namespace micm

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -91,12 +91,20 @@ namespace micm
 
     jacobian_ = BuildJacobian<SparseMatrixPolicy>(
         parameters.nonzero_jacobian_elements_, parameters.number_of_grid_cells_, state_size_);
-
-    auto lu = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(jacobian_, 0);
-    auto lower_matrix = std::move(lu.first);
-    auto upper_matrix = std::move(lu.second);
-    lower_matrix_ = lower_matrix;
-    upper_matrix_ = upper_matrix;
+    
+    if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
+    {
+      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian_, 0);
+      jacobian_ = std::move(lu);
+    }
+    else
+    {
+      auto lu = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(jacobian_, 0);
+      auto lower_matrix = std::move(lu.first);
+      auto upper_matrix = std::move(lu.second);
+      lower_matrix_ = lower_matrix;
+      upper_matrix_ = upper_matrix;
+    }
   }
 
   template<class DenseMatrixPolicy, class SparseMatrixPolicy, class LuDecompositionPolicy, class LMatrixPolicy, class UMatrixPolicy>

--- a/test/integration/test_analytical_backward_euler.cpp
+++ b/test/integration/test_analytical_backward_euler.cpp
@@ -65,6 +65,25 @@ template<std::size_t L>
 using VectorStateTypeMozartCSC =
     micm::State<micm::VectorMatrix<double, L>, micm::SparseMatrix<double, micm::SparseMatrixVectorOrderingCompressedSparseColumn<L>>, micm::LuDecompositionMozart>;
 
+template<std::size_t L>
+using VectorBackwardEulerMozartInPlace = micm::SolverBuilder<
+    micm::BackwardEulerSolverParameters,
+    micm::VectorMatrix<double, L>,
+    micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<L>>,
+    micm::ProcessSet,
+    micm::LuDecompositionMozartInPlace,
+    micm::LinearSolverInPlace<micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<L>>, micm::LuDecompositionMozartInPlace>,
+    micm::State<
+    micm::VectorMatrix<double, L>,
+    micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<L>>,
+    micm::LuDecompositionMozartInPlace>>;
+
+template<std::size_t L>
+using VectorStateTypeMozartInPlace = micm::State<
+    micm::VectorMatrix<double, L>,
+    micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<L>>,
+    micm::LuDecompositionMozartInPlace>;
+
 auto backward_euler = micm::CpuSolverBuilder<micm::BackwardEulerSolverParameters>(micm::BackwardEulerSolverParameters());
 auto backard_euler_vector_1 = VectorBackwardEuler<1>(micm::BackwardEulerSolverParameters());
 auto backard_euler_vector_2 = VectorBackwardEuler<2>(micm::BackwardEulerSolverParameters());
@@ -87,7 +106,10 @@ auto backward_euler_vector_mozart_csc_1 = VectorBackwardEulerMozartCSC<1>(micm::
 auto backward_euler_vector_mozart_csc_2 = VectorBackwardEulerMozartCSC<2>(micm::BackwardEulerSolverParameters());
 auto backward_euler_vector_mozart_csc_3 = VectorBackwardEulerMozartCSC<3>(micm::BackwardEulerSolverParameters());
 auto backward_euler_vector_mozart_csc_4 = VectorBackwardEulerMozartCSC<4>(micm::BackwardEulerSolverParameters());
-
+auto backward_euler_vector_mozart_in_place_1 = VectorBackwardEulerMozartInPlace<1>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_mozart_in_place_2 = VectorBackwardEulerMozartInPlace<2>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_mozart_in_place_3 = VectorBackwardEulerMozartInPlace<3>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_mozart_in_place_4 = VectorBackwardEulerMozartInPlace<4>(micm::BackwardEulerSolverParameters());
 
 TEST(AnalyticalExamples, Troe)
 {
@@ -116,6 +138,14 @@ TEST(AnalyticalExamples, Troe)
   test_analytical_troe<VectorBackwardEulerMozartCSC<2>, VectorStateTypeMozartCSC<2>>(backward_euler_vector_mozart_csc_2, 1e-6);
   test_analytical_troe<VectorBackwardEulerMozartCSC<3>, VectorStateTypeMozartCSC<3>>(backward_euler_vector_mozart_csc_3, 1e-6);
   test_analytical_troe<VectorBackwardEulerMozartCSC<4>, VectorStateTypeMozartCSC<4>>(backward_euler_vector_mozart_csc_4, 1e-6);
+  test_analytical_troe<VectorBackwardEulerMozartInPlace<1>, VectorStateTypeMozartInPlace<1>>(
+      backward_euler_vector_mozart_in_place_1, 1e-6);
+  test_analytical_troe<VectorBackwardEulerMozartInPlace<2>, VectorStateTypeMozartInPlace<2>>(
+      backward_euler_vector_mozart_in_place_2, 1e-6);
+  test_analytical_troe<VectorBackwardEulerMozartInPlace<3>, VectorStateTypeMozartInPlace<3>>(
+      backward_euler_vector_mozart_in_place_3, 1e-6);
+  test_analytical_troe<VectorBackwardEulerMozartInPlace<4>, VectorStateTypeMozartInPlace<4>>(
+      backward_euler_vector_mozart_in_place_4, 1e-6);
 }
 
 TEST(AnalyticalExamples, TroeSuperStiffButAnalytical)

--- a/test/unit/solver/CMakeLists.txt
+++ b/test/unit/solver/CMakeLists.txt
@@ -10,6 +10,7 @@ create_standard_test(NAME chapman_ode_solver SOURCES test_chapman_ode_solver.cpp
 create_standard_test(NAME linear_solver SOURCES test_linear_solver.cpp)
 create_standard_test(NAME lu_decomposition_doolittle SOURCES test_lu_decomposition_doolittle.cpp)
 create_standard_test(NAME lu_decomposition_mozart SOURCES test_lu_decomposition_mozart.cpp)
+create_standard_test(NAME lu_decomposition_mozart_in_place SOURCES test_lu_decomposition_mozart_in_place.cpp)
 create_standard_test(NAME rosenbrock SOURCES test_rosenbrock.cpp)
 create_standard_test(NAME state SOURCES test_state.cpp)
 create_standard_test(NAME backward_euler SOURCES test_backward_euler.cpp)

--- a/test/unit/solver/CMakeLists.txt
+++ b/test/unit/solver/CMakeLists.txt
@@ -8,6 +8,7 @@ include(test_util)
 
 create_standard_test(NAME chapman_ode_solver SOURCES test_chapman_ode_solver.cpp)
 create_standard_test(NAME linear_solver SOURCES test_linear_solver.cpp)
+create_standard_test(NAME linear_solver_in_place SOURCES test_linear_solver_in_place.cpp)
 create_standard_test(NAME lu_decomposition_doolittle SOURCES test_lu_decomposition_doolittle.cpp)
 create_standard_test(NAME lu_decomposition_mozart SOURCES test_lu_decomposition_mozart.cpp)
 create_standard_test(NAME lu_decomposition_mozart_in_place SOURCES test_lu_decomposition_mozart_in_place.cpp)

--- a/test/unit/solver/test_linear_solver_in_place.cpp
+++ b/test/unit/solver/test_linear_solver_in_place.cpp
@@ -1,0 +1,101 @@
+#include "test_linear_solver_in_place_policy.hpp"
+
+#include <micm/solver/linear_solver.hpp>
+#include <micm/util/matrix.hpp>
+#include <micm/util/sparse_matrix.hpp>
+#include <micm/util/sparse_matrix_vector_ordering.hpp>
+#include <micm/util/vector_matrix.hpp>
+
+#include <gtest/gtest.h>
+
+#include <functional>
+
+using FloatingPointType = double;
+
+using DenseMatrixTest = micm::Matrix<FloatingPointType>;
+using SparseMatrixTest = micm::SparseMatrix<FloatingPointType>;
+
+TEST(LinearSolverInPlace, DenseMatrixStandardOrdering)
+{
+  testDenseMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolverInPlace<SparseMatrixTest>>();
+}
+
+TEST(LinearSolverInPlace, RandomMatrixStandardOrdering)
+{
+  testRandomMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolverInPlace<SparseMatrixTest>>(5);
+}
+
+TEST(LinearSolverInPlace, DiagonalMatrixStandardOrdering)
+{
+  testDiagonalMatrix<DenseMatrixTest, SparseMatrixTest, micm::LinearSolverInPlace<SparseMatrixTest>>(5);
+}
+
+TEST(LinearSolverInPlace, DiagonalMarkowitzReorder)
+{
+  testMarkowitzReordering<micm::Matrix<int>, SparseMatrixTest>();
+}
+
+TEST(LinearSolverInPlace, StandardOrderingAgnosticToInitialValue)
+{
+  double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
+  for (auto initial_value : initial_values)
+    testExtremeInitialValue<DenseMatrixTest, SparseMatrixTest, micm::LinearSolverInPlace<SparseMatrixTest>>(5, initial_value);
+}
+
+using Group1VectorMatrix = micm::VectorMatrix<FloatingPointType, 1>;
+using Group2VectorMatrix = micm::VectorMatrix<FloatingPointType, 2>;
+using Group3VectorMatrix = micm::VectorMatrix<FloatingPointType, 3>;
+using Group4VectorMatrix = micm::VectorMatrix<FloatingPointType, 4>;
+
+using Group1SparseVectorMatrix = micm::SparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<1>>;
+using Group2SparseVectorMatrix = micm::SparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<2>>;
+using Group3SparseVectorMatrix = micm::SparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<3>>;
+using Group4SparseVectorMatrix = micm::SparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<4>>;
+
+TEST(LinearSolverInPlace, DenseMatrixVectorOrdering)
+{
+  testDenseMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolverInPlace<Group1SparseVectorMatrix>>();
+  testDenseMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolverInPlace<Group2SparseVectorMatrix>>();
+  testDenseMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolverInPlace<Group3SparseVectorMatrix>>();
+  testDenseMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolverInPlace<Group4SparseVectorMatrix>>();
+}
+
+TEST(LinearSolverInPlace, RandomMatrixVectorOrdering)
+{
+  testRandomMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolverInPlace<Group1SparseVectorMatrix>>(5);
+  testRandomMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolverInPlace<Group2SparseVectorMatrix>>(5);
+  testRandomMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolverInPlace<Group3SparseVectorMatrix>>(5);
+  testRandomMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolverInPlace<Group4SparseVectorMatrix>>(5);
+}
+
+TEST(LinearSolverInPlace, VectorOrderingAgnosticToInitialValue)
+{
+  double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
+  for (auto initial_value : initial_values)
+  {
+    testExtremeInitialValue<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolverInPlace<Group1SparseVectorMatrix>>(
+        1, initial_value);
+    testExtremeInitialValue<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolverInPlace<Group2SparseVectorMatrix>>(
+        2, initial_value);
+    testExtremeInitialValue<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolverInPlace<Group3SparseVectorMatrix>>(
+        5, initial_value);
+    testExtremeInitialValue<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolverInPlace<Group4SparseVectorMatrix>>(
+        5, initial_value);
+  }
+}
+
+TEST(LinearSolverInPlace, DiagonalMatrixVectorOrdering)
+{
+  testDiagonalMatrix<Group1VectorMatrix, Group1SparseVectorMatrix, micm::LinearSolverInPlace<Group1SparseVectorMatrix>>(5);
+  testDiagonalMatrix<Group2VectorMatrix, Group2SparseVectorMatrix, micm::LinearSolverInPlace<Group2SparseVectorMatrix>>(5);
+  testDiagonalMatrix<Group3VectorMatrix, Group3SparseVectorMatrix, micm::LinearSolverInPlace<Group3SparseVectorMatrix>>(5);
+  testDiagonalMatrix<Group4VectorMatrix, Group4SparseVectorMatrix, micm::LinearSolverInPlace<Group4SparseVectorMatrix>>(5);
+}
+
+TEST(LinearSolverInPlace, VectorDiagonalMarkowitzReordering)
+{
+  testMarkowitzReordering<Group1VectorMatrix, Group1SparseVectorMatrix>();
+  testMarkowitzReordering<Group2VectorMatrix, Group2SparseVectorMatrix>();
+  testMarkowitzReordering<Group3VectorMatrix, Group3SparseVectorMatrix>();
+  testMarkowitzReordering<Group4VectorMatrix, Group4SparseVectorMatrix>();
+}

--- a/test/unit/solver/test_linear_solver_in_place_policy.hpp
+++ b/test/unit/solver/test_linear_solver_in_place_policy.hpp
@@ -1,0 +1,373 @@
+#include <micm/solver/linear_solver.hpp>
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <random>
+
+// Define the following three functions that only work for the CudaMatrix; the if constexpr statement is evalauted at
+// compile-time Reference: https://www.modernescpp.com/index.php/using-requires-expression-in-c-20-as-a-standalone-feature/
+template<class MatrixPolicy>
+void CopyToDeviceDense(MatrixPolicy& matrix)
+{
+  if constexpr (requires {
+                  {
+                    matrix.CopyToDevice()
+                    } -> std::same_as<void>;
+                })
+    matrix.CopyToDevice();
+}
+
+template<class SparseMatrixPolicy>
+void CopyToDeviceSparse(SparseMatrixPolicy& matrix)
+{
+  if constexpr (requires {
+                  {
+                    matrix.CopyToDevice()
+                    } -> std::same_as<void>;
+                })
+    matrix.CopyToDevice();
+}
+
+template<class MatrixPolicy>
+void CopyToHostDense(MatrixPolicy& matrix)
+{
+  if constexpr (requires {
+                  {
+                    matrix.CopyToHost()
+                    } -> std::same_as<void>;
+                })
+    matrix.CopyToHost();
+}
+
+template<typename T, class MatrixPolicy, class SparseMatrixPolicy>
+void check_results(
+    const SparseMatrixPolicy A,
+    const MatrixPolicy b,
+    const MatrixPolicy x,
+    const std::function<void(const T, const T)> f)
+{
+  T result;
+  EXPECT_EQ(A.NumberOfBlocks(), b.NumRows());
+  EXPECT_EQ(A.NumberOfBlocks(), x.NumRows());
+  for (std::size_t i_block = 0; i_block < A.NumberOfBlocks(); ++i_block)
+  {
+    for (std::size_t i = 0; i < A.NumRows(); ++i)
+    {
+      result = 0.0;
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
+        if (!A.IsZero(i, j))
+          result += A[i_block][i][j] * x[i_block][j];
+      f(b[i_block][i], result);
+    }
+  }
+}
+
+template<class SparseMatrixPolicy>
+void print_matrix(const SparseMatrixPolicy& matrix, std::size_t width)
+{
+  for (std::size_t i_block = 0; i_block < matrix.NumberOfBlocks(); ++i_block)
+  {
+    std::cout << "block: " << i_block << std::endl;
+    for (std::size_t i = 0; i < matrix.NumRows(); ++i)
+    {
+      for (std::size_t j = 0; j < matrix.NumColumns(); ++j)
+      {
+        if (matrix.IsZero(i, j))
+        {
+          std::cout << " " << std::setfill('-') << std::setw(width) << "-"
+                    << " ";
+        }
+        else
+        {
+          std::cout << " " << std::setfill(' ') << std::setw(width) << matrix[i_block][i][j] << " ";
+        }
+      }
+      std::cout << std::endl;
+    }
+    std::cout << std::endl;
+  }
+}
+
+template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
+void testDenseMatrix()
+{
+  using FloatingPointType = typename MatrixPolicy::value_type;
+
+  SparseMatrixPolicy A = SparseMatrixPolicy(SparseMatrixPolicy::Create(3)
+                                                .InitialValue(0)
+                                                .WithElement(0, 0)
+                                                .WithElement(0, 1)
+                                                .WithElement(0, 2)
+                                                .WithElement(1, 0)
+                                                .WithElement(1, 1)
+                                                .WithElement(1, 2)
+                                                .WithElement(2, 0)
+                                                .WithElement(2, 1)
+                                                .WithElement(2, 2));
+  MatrixPolicy b(1, 3, 0.0);
+  MatrixPolicy x(1, 3, 0.0);
+
+  A[0][0][0] = 2;
+  A[0][0][1] = -1;
+  A[0][0][2] = -2;
+  A[0][1][0] = -4;
+  A[0][1][1] = 6;
+  A[0][1][2] = 3;
+  A[0][2][0] = -4;
+  A[0][2][1] = -2;
+  A[0][2][2] = 8;
+
+  b[0][0] = 23;
+  b[0][1] = 42;
+  b[0][2] = 9;
+
+  x = b;
+
+  // Only copy the data to the device when it is a CudaMatrix
+  CopyToDeviceDense<MatrixPolicy>(b);
+  CopyToDeviceDense<MatrixPolicy>(x);
+
+  LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0);
+  alu.Fill(0);
+  for (std::size_t i = 0; i < A.NumRows(); ++i)
+    for (std::size_t j = 0; j < A.NumColumns(); ++j)
+      if (!A.IsZero(i, j))
+        alu[0][i][j] = A[0][i][j];
+
+  // Only copy the data to the device when it is a CudaMatrix
+  CopyToDeviceSparse<SparseMatrixPolicy>(alu);
+  
+  solver.Factor(alu);
+  solver.template Solve<MatrixPolicy>(x, alu);
+
+  // Only copy the data to the host when it is a CudaMatrix
+  CopyToHostDense<MatrixPolicy>(x);
+
+  check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
+}
+
+template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
+void testRandomMatrix(std::size_t number_of_blocks)
+{
+  using FloatingPointType = typename MatrixPolicy::value_type;
+
+  auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
+  auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
+
+  auto builder = SparseMatrixPolicy::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
+  for (std::size_t i = 0; i < 10; ++i)
+    for (std::size_t j = 0; j < 10; ++j)
+      if (i == j || gen_bool())
+        builder = builder.WithElement(i, j);
+
+  SparseMatrixPolicy A(builder);
+  MatrixPolicy b(number_of_blocks, 10, 0.0);
+  MatrixPolicy x(number_of_blocks, 10, 0.0);
+
+  for (std::size_t i = 0; i < 10; ++i)
+    for (std::size_t j = 0; j < 10; ++j)
+      if (!A.IsZero(i, j))
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+          A[i_block][i][j] = get_double();
+
+  for (std::size_t i = 0; i < 10; ++i)
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+      b[i_block][i] = get_double();
+
+  x = b;
+
+  // Only copy the data to the device when it is a CudaMatrix
+  CopyToDeviceDense<MatrixPolicy>(x);
+
+  LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0);
+  alu.Fill(0);
+  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    for (std::size_t i = 0; i < A.NumRows(); ++i)
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
+        if (!A.IsZero(i, j))
+          alu[i_block][i][j] = A[i_block][i][j];
+
+  // Only copy the data to the device when it is a CudaMatrix
+  CopyToDeviceSparse<SparseMatrixPolicy>(alu);
+
+  solver.Factor(alu);
+  solver.template Solve<MatrixPolicy>(x, alu);
+
+  // Only copy the data to the host when it is a CudaMatrix
+  CopyToHostDense<MatrixPolicy>(x);
+
+  check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-6); });
+}
+
+template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
+void testExtremeInitialValue(std::size_t number_of_blocks, double initial_value)
+{
+  using FloatingPointType = typename MatrixPolicy::value_type;
+
+  const unsigned int seed = 12345;
+  std::mt19937 generator(seed);
+  const double point_five = 0.5;
+  const double two = 2.0;
+
+  auto gen_bool = std::bind(std::bernoulli_distribution(point_five), generator);
+  auto get_double = std::bind(std::lognormal_distribution<double>(-two, two), generator);
+  const size_t size = 30;
+
+  auto builder = SparseMatrixPolicy::Create(size).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t j = 0; j < size; ++j)
+    {
+      if (i == j || gen_bool())
+      {
+        builder = builder.WithElement(i, j);
+      }
+    }
+  }
+
+  SparseMatrixPolicy A(builder);
+  MatrixPolicy b(number_of_blocks, size, 0.0);
+  MatrixPolicy x(number_of_blocks, size, 0.0);
+
+  for (std::size_t i = 0; i < size; ++i)
+    for (std::size_t j = 0; j < size; ++j)
+      if (!A.IsZero(i, j))
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+          A[i_block][i][j] = get_double();
+
+  for (std::size_t i = 0; i < size; ++i)
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+      b[i_block][i] = get_double();
+
+  x = b;
+
+  // Only copy the data to the device when it is a CudaMatrix
+  CopyToDeviceDense<MatrixPolicy>(x);
+
+  LinearSolverPolicy solver = LinearSolverPolicy(A, initial_value);
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, initial_value);
+  alu.Fill(0);
+  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    for (std::size_t i = 0; i < A.NumRows(); ++i)
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
+        if (!A.IsZero(i, j))
+          alu[i_block][i][j] = A[i_block][i][j];
+
+  // Only copy the data to the device when it is a CudaMatrix
+  CopyToDeviceSparse<SparseMatrixPolicy>(alu);
+
+  solver.Factor(alu);
+
+  // Only copy the data to the host when it is a CudaMatrix
+  CopyToHostDense<SparseMatrixPolicy>(alu);
+
+  solver.template Solve<MatrixPolicy>(x, alu);
+
+  // Only copy the data to the host when it is a CudaMatrix
+  CopyToHostDense<MatrixPolicy>(x);
+
+  check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 2.0e-06); });
+}
+
+template<class MatrixPolicy, class SparseMatrixPolicy, class LinearSolverPolicy>
+void testDiagonalMatrix(std::size_t number_of_blocks)
+{
+  using FloatingPointType = typename MatrixPolicy::value_type;
+
+  auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
+
+  auto builder = SparseMatrixPolicy::Create(6).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
+  for (std::size_t i = 0; i < 6; ++i)
+    builder = builder.WithElement(i, i);
+
+  SparseMatrixPolicy A(builder);
+  MatrixPolicy b(number_of_blocks, 6, 0.0);
+  MatrixPolicy x(number_of_blocks, 6, 0.0);
+
+  for (std::size_t i = 0; i < 6; ++i)
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+      A[i_block][i][i] = get_double();
+
+  for (std::size_t i = 0; i < 6; ++i)
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+      b[i_block][i] = get_double();
+
+  x = b;
+
+  // Only copy the data to the device when it is a CudaMatrix
+  CopyToDeviceDense<MatrixPolicy>(x);
+
+  LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0);
+  alu.Fill(0);
+  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    for (std::size_t i = 0; i < A.NumRows(); ++i)
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
+        if (!A.IsZero(i, j))
+          alu[i_block][i][j] = A[i_block][i][j];
+
+  // Only copy the data to the device when it is a CudaMatrix
+  CopyToDeviceSparse<SparseMatrixPolicy>(alu);
+
+  solver.Factor(alu);
+  solver.template Solve<MatrixPolicy>(x, alu);
+
+  // Only copy the data to the host when it is a CudaMatrix
+  CopyToHostDense<MatrixPolicy>(x);
+
+  check_results<FloatingPointType, MatrixPolicy, SparseMatrixPolicy>(
+      A, b, x, [&](const FloatingPointType a, const FloatingPointType b) -> void { EXPECT_NEAR(a, b, 1.0e-5); });
+}
+
+template<class MatrixPolicy, class SparseMatrixPolicy>
+void testMarkowitzReordering()
+{
+  const std::size_t order = 50;
+  auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
+  MatrixPolicy orig(order, order, 0);
+
+  for (std::size_t i = 0; i < order; ++i)
+    for (std::size_t j = 0; j < order; ++j)
+      orig[i][j] = (i == j || gen_bool()) ? 1 : 0;
+
+  auto reorder_map = micm::DiagonalMarkowitzReorder<MatrixPolicy>(orig);
+
+  auto builder = SparseMatrixPolicy::Create(50);
+  for (std::size_t i = 0; i < order; ++i)
+    for (std::size_t j = 0; j < order; ++j)
+      if (orig[i][j] != 0)
+        builder = builder.WithElement(i, j);
+  SparseMatrixPolicy orig_jac{ builder };
+
+  builder = SparseMatrixPolicy::Create(50);
+  for (std::size_t i = 0; i < order; ++i)
+    for (std::size_t j = 0; j < order; ++j)
+      if (orig[reorder_map[i]][reorder_map[j]] != 0)
+        builder = builder.WithElement(i, j);
+  SparseMatrixPolicy reordered_jac{ builder };
+
+  auto orig_LU_calc = micm::LuDecompositionInPlace::Create<SparseMatrixPolicy>(orig_jac);
+  auto reordered_LU_calc = micm::LuDecompositionInPlace::Create<SparseMatrixPolicy>(reordered_jac);
+
+  auto orig_LU = orig_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(orig_jac, 0.0);
+  auto reordered_LU = reordered_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(reordered_jac, 0.0);
+
+  std::size_t sum_orig = 0;
+  std::size_t sum_reordered = 0;
+  for (std::size_t i = 0; i < reorder_map.size(); ++i)
+  {
+    sum_orig += i;
+    sum_reordered += reorder_map[i];
+  }
+
+  EXPECT_EQ(sum_orig, sum_reordered);
+  EXPECT_GT(
+      orig_LU.FlatBlockSize(),
+      reordered_LU.FlatBlockSize());
+}

--- a/test/unit/solver/test_lu_decomposition_doolittle.cpp
+++ b/test/unit/solver/test_lu_decomposition_doolittle.cpp
@@ -29,7 +29,7 @@ TEST(LuDecompositionDoolittle, DiagonalMatrixStandardOrdering)
   testDiagonalMatrix<SparseMatrixTest, micm::LuDecompositionDoolittle>(5);
 }
 
-TEST(LuDecompositionDoolittle, AgnosticToInitialValue)
+TEST(LuDecompositionDoolittle, AgnosticToInitialValueStandardOrdering)
 {
   double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
   for (auto& value : initial_values)
@@ -62,7 +62,7 @@ TEST(LuDecompositionDoolittle, DiagonalMatrixVectorOrdering)
   testDiagonalMatrix<Group4SparseVectorMatrix, micm::LuDecompositionDoolittle>(5);
 }
 
-TEST(LuDecompositionDoolittle, VectorOrderingAgnosticToInitialValue)
+TEST(LuDecompositionDoolittle, AgnosticToInitialValueVectorOrdering)
 {
   double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
   for (auto& value : initial_values)

--- a/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
@@ -1,0 +1,237 @@
+#include <micm/util/sparse_matrix.hpp>
+#include <micm/util/sparse_matrix_vector_ordering.hpp>
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <random>
+
+template<class MatrixPolicy>
+void CopyToDevice(MatrixPolicy& matrix)
+{
+  if constexpr (requires {
+                  {
+                    matrix.CopyToDevice()
+                    } -> std::same_as<void>;
+                })
+    matrix.CopyToDevice();
+}
+
+template<class MatrixPolicy>
+void CopyToHost(MatrixPolicy& matrix)
+{
+  if constexpr (requires {
+                  {
+                    matrix.CopyToHost()
+                    } -> std::same_as<void>;
+                })
+    matrix.CopyToHost();
+}
+
+template<typename T, class SparseMatrixPolicy>
+void check_results(
+    const SparseMatrixPolicy& A,
+    const SparseMatrixPolicy& LU,
+    const std::function<void(const T, const T)> f)
+{
+  EXPECT_EQ(A.NumberOfBlocks(), LU.NumberOfBlocks());
+  for (std::size_t i_block = 0; i_block < A.NumberOfBlocks(); ++i_block)
+  {
+    for (std::size_t i = 0; i < A.NumRows(); ++i)
+    {
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
+      {
+        T result{};
+        for (std::size_t k = 0; k <= j; ++k)
+        {
+          if (i == k && !(LU.IsZero(k, j)))
+          {
+            result += LU[i_block][k][j];
+          }
+          else
+          if (k < i && !(LU.IsZero(i, k) || LU.IsZero(k, j)))
+          {
+            result += LU[i_block][i][k] * LU[i_block][k][j];
+          }
+        }
+        if (A.IsZero(i, j))
+        {
+          f(result, T{});
+        }
+        else
+        {
+          f(result, A[i_block][i][j]);
+        }
+      }
+    }
+  }
+}
+
+void print_matrix(const auto& matrix, std::size_t width)
+{
+  for (std::size_t i_block = 0; i_block < matrix.NumberOfBlocks(); ++i_block)
+  {
+    std::cout << "block: " << i_block << std::endl;
+    for (std::size_t i = 0; i < matrix.NumRows(); ++i)
+    {
+      for (std::size_t j = 0; j < matrix.NumColumns(); ++j)
+      {
+        if (matrix.IsZero(i, j))
+        {
+          std::cout << " " << std::setfill('-') << std::setw(width) << "-"
+                    << " ";
+        }
+        else
+        {
+          std::cout << " " << std::setfill(' ') << std::setw(width) << matrix[i_block][i][j] << " ";
+        }
+      }
+      std::cout << std::endl;
+    }
+    std::cout << std::endl;
+  }
+}
+
+// tests example from https://www.geeksforgeeks.org/doolittle-algorithm-lu-decomposition/
+template<class SparseMatrixPolicy, class LuDecompositionPolicy>
+void testDenseMatrix()
+{
+  SparseMatrixPolicy A = SparseMatrixPolicy(SparseMatrixPolicy::Create(3)
+                                                .InitialValue(0)
+                                                .WithElement(0, 0)
+                                                .WithElement(0, 1)
+                                                .WithElement(0, 2)
+                                                .WithElement(1, 0)
+                                                .WithElement(1, 1)
+                                                .WithElement(1, 2)
+                                                .WithElement(2, 0)
+                                                .WithElement(2, 1)
+                                                .WithElement(2, 2));
+
+  A[0][0][0] = 2;
+  A[0][0][1] = -1;
+  A[0][0][2] = -2;
+  A[0][1][0] = -4;
+  A[0][1][1] = 6;
+  A[0][1][2] = 3;
+  A[0][2][0] = -4;
+  A[0][2][1] = -2;
+  A[0][2][2] = 8;
+
+  LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0);
+  ALU.Fill(0);
+  for (std::size_t i = 0; i < 3; ++i)
+    for (std::size_t j = 0; j < 3; ++j)
+      if (!A.IsZero(i, j))
+        ALU[0][i][j] = A[0][i][j];
+  lud.template Decompose<SparseMatrixPolicy>(ALU);
+  check_results<double, SparseMatrixPolicy>(
+      A, ALU, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });
+}
+
+template<class SparseMatrixPolicy, class LuDecompositionPolicy>
+void testRandomMatrix(std::size_t number_of_blocks)
+{
+  auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
+  auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
+
+  auto builder = SparseMatrixPolicy::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
+  for (std::size_t i = 0; i < 10; ++i)
+    for (std::size_t j = 0; j < 10; ++j)
+      if (i == j || gen_bool())
+        builder = builder.WithElement(i, j);
+
+  SparseMatrixPolicy A(builder);
+
+  for (std::size_t i = 0; i < 10; ++i)
+    for (std::size_t j = 0; j < 10; ++j)
+      if (!A.IsZero(i, j))
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+          A[i_block][i][j] = get_double();
+
+  LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0);
+  ALU.Fill(0);
+  for (std::size_t i = 0; i < 10; ++i)
+    for (std::size_t j = 0; j < 10; ++j)
+      if (!A.IsZero(i, j))
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+          ALU[i_block][i][j] = A[i_block][i][j];
+  lud.template Decompose<SparseMatrixPolicy>(ALU);
+  check_results<double, SparseMatrixPolicy>(
+      A, ALU, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-9); });
+}
+
+template<class SparseMatrixPolicy, class LuDecompositionPolicy>
+void testExtremeValueInitialization(std::size_t number_of_blocks, double initial_value)
+{
+  auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
+  auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
+  auto size = 10;
+
+  auto builder = SparseMatrixPolicy::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(initial_value);
+  for (std::size_t i = 0; i < size; ++i)
+    for (std::size_t j = 0; j < size; ++j)
+      if (i == j || gen_bool())
+        builder = builder.WithElement(i, j);
+
+  SparseMatrixPolicy A(builder);
+
+  // for nvhpc, the lognormal distribution produces significantly different values
+  // for very large numbers of grid cells
+  // To keep the accuracy on the check results function small, we only generat 1 blocks worth of
+  // random values and then copy that into every other block
+  for (std::size_t i = 0; i < size; ++i)
+    for (std::size_t j = 0; j < size; ++j)
+      if (!A.IsZero(i, j))
+      {
+        A[0][i][j] = get_double();
+        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block)
+          A[i_block][i][j] = A[0][i][j];
+      }
+
+  LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, initial_value);
+  ALU.Fill(0);
+  for (std::size_t i = 0; i < size; ++i)
+    for (std::size_t j = 0; j < size; ++j)
+      if (!A.IsZero(i, j))
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+          ALU[i_block][i][j] = A[i_block][i][j];
+
+  CopyToDevice<SparseMatrixPolicy>(ALU);
+
+  lud.template Decompose<SparseMatrixPolicy>(ALU);
+
+  CopyToHost<SparseMatrixPolicy>(ALU);
+
+  check_results<double, SparseMatrixPolicy>(
+      A, ALU, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-09); });
+}
+
+template<class SparseMatrixPolicy, class LuDecompositionPolicy>
+void testDiagonalMatrix(std::size_t number_of_blocks)
+{
+  auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
+
+  auto builder = SparseMatrixPolicy::Create(6).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
+  for (std::size_t i = 0; i < 6; ++i)
+    builder = builder.WithElement(i, i);
+
+  SparseMatrixPolicy A(builder);
+
+  for (std::size_t i = 0; i < 6; ++i)
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+      A[i_block][i][i] = get_double();
+
+  LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0);
+  ALU.Fill(0);
+  for (std::size_t i = 0; i < 6; ++i)
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+      ALU[i_block][i][i] = A[i_block][i][i];
+  lud.template Decompose<SparseMatrixPolicy>(ALU);
+  check_results<double, SparseMatrixPolicy>(
+      A, ALU, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });
+}

--- a/test/unit/solver/test_lu_decomposition_mozart.cpp
+++ b/test/unit/solver/test_lu_decomposition_mozart.cpp
@@ -29,7 +29,7 @@ TEST(LuDecompositionMozart, DiagonalMatrixStandardOrdering)
   testDiagonalMatrix<SparseMatrixTest, micm::LuDecompositionMozart>(5);
 }
 
-TEST(LuDecompositionMozart, AgnosticToInitialValue)
+TEST(LuDecompositionMozart, AgnosticToInitialValueStandardOrdering)
 {
   double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
   for (auto& value : initial_values)
@@ -62,7 +62,7 @@ TEST(LuDecompositionMozart, DiagonalMatrixVectorOrdering)
   testDiagonalMatrix<Group4SparseVectorMatrix, micm::LuDecompositionMozart>(5);
 }
 
-TEST(LuDecompositionMozart, VectorOrderingAgnosticToInitialValue)
+TEST(LuDecompositionMozart, AgnosticToInitialValueVectorOrdering)
 {
   double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
   for (auto& value : initial_values)

--- a/test/unit/solver/test_lu_decomposition_mozart_in_place.cpp
+++ b/test/unit/solver/test_lu_decomposition_mozart_in_place.cpp
@@ -1,0 +1,75 @@
+#include "test_lu_decomposition_in_place_policy.hpp"
+
+#include <micm/solver/lu_decomposition.hpp>
+#include <micm/util/sparse_matrix.hpp>
+#include <micm/util/sparse_matrix_vector_ordering.hpp>
+
+#include <gtest/gtest.h>
+
+using SparseMatrixTest = micm::SparseMatrix<double>;
+
+using Group1SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>;
+using Group2SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<2>>;
+using Group3SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
+using Group4SparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<4>>;
+
+TEST(LuDecompositionMozartInPlace, DenseMatrixStandardOrdering)
+{
+  testDenseMatrix<SparseMatrixTest, micm::LuDecompositionMozartInPlace>();
+}
+
+TEST(LuDecompositionMozartInPlace, RandomMatrixStandardOrdering)
+{
+  testRandomMatrix<SparseMatrixTest, micm::LuDecompositionMozartInPlace>(1);
+  testRandomMatrix<SparseMatrixTest, micm::LuDecompositionMozartInPlace>(5);
+}
+
+TEST(LuDecompositionMozartInPlace, DiagonalMatrixStandardOrdering)
+{
+  testDiagonalMatrix<SparseMatrixTest, micm::LuDecompositionMozartInPlace>(5);
+}
+
+TEST(LuDecompositionMozartInPlace, AgnosticToInitialValueStandardOrdering)
+{
+  double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
+  for (auto& value : initial_values)
+  {
+    testExtremeValueInitialization<SparseMatrixTest, micm::LuDecompositionMozartInPlace>(5, value);
+  }
+}
+
+TEST(LuDecompositionMozartInPlace, DenseMatrixVectorOrdering)
+{
+  testDenseMatrix<Group1SparseVectorMatrix, micm::LuDecompositionMozartInPlace>();
+  testDenseMatrix<Group2SparseVectorMatrix, micm::LuDecompositionMozartInPlace>();
+  testDenseMatrix<Group3SparseVectorMatrix, micm::LuDecompositionMozartInPlace>();
+  testDenseMatrix<Group4SparseVectorMatrix, micm::LuDecompositionMozartInPlace>();
+}
+
+TEST(LuDecompositionMozartInPlace, RandomMatrixVectorOrdering)
+{
+  testRandomMatrix<Group1SparseVectorMatrix, micm::LuDecompositionMozartInPlace>(5);
+  testRandomMatrix<Group2SparseVectorMatrix, micm::LuDecompositionMozartInPlace>(5);
+  testRandomMatrix<Group3SparseVectorMatrix, micm::LuDecompositionMozartInPlace>(5);
+  testRandomMatrix<Group4SparseVectorMatrix, micm::LuDecompositionMozartInPlace>(5);
+}
+
+TEST(LuDecompositionMozartInPlace, DiagonalMatrixVectorOrdering)
+{
+  testDiagonalMatrix<Group1SparseVectorMatrix, micm::LuDecompositionMozartInPlace>(5);
+  testDiagonalMatrix<Group2SparseVectorMatrix, micm::LuDecompositionMozartInPlace>(5);
+  testDiagonalMatrix<Group3SparseVectorMatrix, micm::LuDecompositionMozartInPlace>(5);
+  testDiagonalMatrix<Group4SparseVectorMatrix, micm::LuDecompositionMozartInPlace>(5);
+}
+
+TEST(LuDecompositionMozartInPlace, AgnosticToInitialValueVectorOrdering)
+{
+  double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
+  for (auto& value : initial_values)
+  {
+    testExtremeValueInitialization<Group1SparseVectorMatrix, micm::LuDecompositionMozartInPlace>(5, value);
+    testExtremeValueInitialization<Group2SparseVectorMatrix, micm::LuDecompositionMozartInPlace>(5, value);
+    testExtremeValueInitialization<Group3SparseVectorMatrix, micm::LuDecompositionMozartInPlace>(5, value);
+    testExtremeValueInitialization<Group4SparseVectorMatrix, micm::LuDecompositionMozartInPlace>(5, value);
+  }
+}


### PR DESCRIPTION
Adds an option for doing in-place LU decomposition that overwrites the original A matrix with the combined L and U matrices. Adds a test using in-place LU decomposition with the Backward Euler solver.

closes #695 