### PR TITLE
Improve the CPU performance by increasing the iterator directly

### DIFF
--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -306,7 +306,7 @@ namespace micm
           if (i < number_of_products_[i_rxn])
           {
             idx_prod_forcing = offset_forcing + prod_id[i] * L;
-          {
+          } 
           for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
           {
             if (idx_state_variables != -999) rate[i_cell] *= v_state_variables[idx_state_variables + i_cell];

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -412,26 +412,21 @@ namespace micm
               continue;
             }
             const std::size_t idx_state_variables = offset_state + (react_id[i_react] * L);
-            auto v_state_variables_it = v_state_variables.begin() + idx_state_variables;
-            auto d_rate_d_ind_it = d_rate_d_ind.begin();
             for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
-              *(d_rate_d_ind_it++) *= *(v_state_variables_it++);
+              d_rate_d_ind[i_cell] *= v_state_variables[idx_state_variables + i_cell];
           }
           for (std::size_t i_dep = 0; i_dep < number_of_reactants_[i_rxn]; ++i_dep)
           {
             auto v_jacobian_it = v_jacobian.begin() + offset_jacobian + *flat_id;
-            auto d_rate_d_ind_it = d_rate_d_ind.begin();
             for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
-              *(v_jacobian_it++) += *(d_rate_d_ind_it++);
+              v_jacobian_it[i_cell] += d_rate_d_ind[i_cell];
             ++flat_id;
           }
           for (std::size_t i_dep = 0; i_dep < number_of_products_[i_rxn]; ++i_dep)
           {
             auto v_jacobian_it = v_jacobian.begin() + offset_jacobian + *flat_id;
-            auto d_rate_d_ind_it = d_rate_d_ind.begin();
-            auto yield_value = yield[i_dep];
             for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
-              *(v_jacobian_it++) -= yield_value * *(d_rate_d_ind_it++);
+              v_jacobian_it[i_cell] -= yield[i_dep] * d_rate_d_ind[i_cell];
             ++flat_id;
           }
         }

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -422,26 +422,23 @@ namespace micm
             for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
               *(d_rate_d_ind_it++) *= *(v_state_variables_it++);
           }
-          std::size_t max_number_of_products_reactants = std::max(number_of_reactants_[i_rxn], number_of_products_[i_rxn]);
-          for (std::size_t i_dep = 0; i_dep < max_number_of_products_reactants; ++i_dep)
+          for (std::size_t i_dep = 0; i_dep < number_of_reactants_[i_rxn]; ++i_dep)
           {
-            std::size_t react_idx_jacobian = offset_jacobian + *flat_id;
-            auto v_jacobian_react_it = v_jacobian.begin() + react_idx_jacobian;
-            std::size_t prod_idx_jacobian = offset_jacobian + *(flat_id + number_of_reactants_[i_rxn]);
-            auto v_jacobian_prod_it = v_jacobian.begin() + prod_idx_jacobian;
-            bool is_react_jacobian = (i_dep < number_of_reactants_[i_rxn]); 
-            bool is_prod_jacobian = (i_dep < number_of_products_[i_rxn]);
-            auto yield_value = yield[i_dep];
+            auto v_jacobian_it = v_jacobian.begin() + offset_jacobian + *flat_id;
             auto d_rate_d_ind_it = d_rate_d_ind.begin();
             for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
-            {
-              if (is_react_jacobian) *(v_jacobian_react_it++) += *d_rate_d_ind_it;
-              if (is_prod_jacobian) *(v_jacobian_prod_it++) -= yield_value * *d_rate_d_ind_it;
-              ++d_rate_d_ind_it;
-            }
+              *(v_jacobian_it++) += *(d_rate_d_ind_it++);
             ++flat_id;
           }
-          flat_id = flat_id + number_of_reactants_[i_rxn] + number_of_products_[i_rxn] - max_number_of_products_reactants;
+          for (std::size_t i_dep = 0; i_dep < number_of_products_[i_rxn]; ++i_dep)
+          {
+            auto v_jacobian_it = v_jacobian.begin() + offset_jacobian + *flat_id;
+            auto d_rate_d_ind_it = d_rate_d_ind.begin();
+            auto yield_value = yield[i_dep];
+            for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+              *(v_jacobian_it++) -= yield_value * *(d_rate_d_ind_it++);
+            ++flat_id;
+          }
         }
         react_id += number_of_reactants_[i_rxn];
         yield += number_of_products_[i_rxn];

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -288,11 +288,13 @@ namespace micm
       const std::size_t offset_state = i_group * state_variables.GroupSize();
       const std::size_t offset_forcing = i_group * forcing.GroupSize();
       std::vector<double> rate(L, 0);
-      for (std::size_t i_rxn = 0; i_rxn < number_of_reactants_.size(); ++i_rxn)
+      const std::size_t number_of_reactions = number_of_reactants_.size();
+      for (std::size_t i_rxn = 0; i_rxn < number_of_reactions; ++i_rxn)
       {
         const auto v_rate_subrange_begin = v_rate_constants_begin + offset_rc + (i_rxn * L);
         rate.assign(v_rate_subrange_begin, v_rate_subrange_begin + L);
-        for (std::size_t i_react = 0; i_react < number_of_reactants_[i_rxn]; ++i_react)
+        const std::size_t number_of_reactants = number_of_reactants_[i_rxn];
+        for (std::size_t i_react = 0; i_react < number_of_reactants; ++i_react)
         {
           std::size_t idx_state_variables = offset_state + react_id[i_react] * L;
           auto rate_it = rate.begin();
@@ -300,14 +302,15 @@ namespace micm
           for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
             *(rate_it++) *= *(v_state_variables_it++);
         }
-        for (std::size_t i_react = 0; i_react < number_of_reactants_[i_rxn]; ++i_react)
+        for (std::size_t i_react = 0; i_react < number_of_reactants; ++i_react)
         {
           auto v_forcing_it = v_forcing.begin() + offset_forcing + react_id[i_react] * L;
           auto rate_it = rate.begin();
           for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
             *(v_forcing_it++) -= *(rate_it++);
         }
-        for (std::size_t i_prod = 0; i_prod < number_of_products_[i_rxn]; ++i_prod)
+        const std::size_t number_of_products = number_of_products_[i_rxn];
+        for (std::size_t i_prod = 0; i_prod < number_of_products; ++i_prod)
         {
           auto v_forcing_it = v_forcing.begin() + offset_forcing + prod_id[i_prod] * L;
           auto rate_it = rate.begin();
@@ -402,14 +405,16 @@ namespace micm
       const std::size_t offset_state = i_group * state_variables.GroupSize();
       const std::size_t offset_jacobian = i_group * jacobian.GroupSize();
       auto flat_id = jacobian_flat_ids_.begin();
-
-      for (std::size_t i_rxn = 0; i_rxn < number_of_reactants_.size(); ++i_rxn)
+      const std::size_t number_of_reactions = number_of_reactants_.size();
+      for (std::size_t i_rxn = 0; i_rxn < number_of_reactions; ++i_rxn)
       {
         auto v_rate_subrange_begin = v_rate_constants_begin + offset_rc + (i_rxn * L);
-        for (std::size_t i_ind = 0; i_ind < number_of_reactants_[i_rxn]; ++i_ind)
+        const std::size_t number_of_reactants = number_of_reactants_[i_rxn];
+        const std::size_t number_of_products = number_of_products_[i_rxn];
+        for (std::size_t i_ind = 0; i_ind < number_of_reactants; ++i_ind)
         { 
           d_rate_d_ind.assign(v_rate_subrange_begin, v_rate_subrange_begin + L);
-          for (std::size_t i_react = 0; i_react < number_of_reactants_[i_rxn]; ++i_react)
+          for (std::size_t i_react = 0; i_react < number_of_reactants; ++i_react)
           {
             if (i_react == i_ind)
             {
@@ -421,7 +426,7 @@ namespace micm
             for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
               *(d_rate_d_ind_it++) *= *(v_state_variables_it++);
           }
-          for (std::size_t i_dep = 0; i_dep < number_of_reactants_[i_rxn]; ++i_dep)
+          for (std::size_t i_dep = 0; i_dep < number_of_reactants; ++i_dep)
           {
             auto v_jacobian_it = v_jacobian.begin() + offset_jacobian + *flat_id;
             auto d_rate_d_ind_it = d_rate_d_ind.begin();
@@ -429,7 +434,7 @@ namespace micm
               *(v_jacobian_it++) += *(d_rate_d_ind_it++);
             ++flat_id;
           }
-          for (std::size_t i_dep = 0; i_dep < number_of_products_[i_rxn]; ++i_dep)
+          for (std::size_t i_dep = 0; i_dep < number_of_products; ++i_dep)
           {
             auto v_jacobian_it = v_jacobian.begin() + offset_jacobian + *flat_id;
             auto d_rate_d_ind_it = d_rate_d_ind.begin();

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -298,7 +298,7 @@ namespace micm
           auto rate_it = rate.begin();
           auto v_state_variables_it = v_state_variables.begin() + idx_state_variables;
           for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
-            *(rate++) *= *(v_state_variables_it++);
+            *(rate_it++) *= *(v_state_variables_it++);
         }
         std::size_t max_number_of_products_reactants = std::max(number_of_reactants_[i_rxn], number_of_products_[i_rxn]);
         for (std::size_t i = 0; i < max_number_of_products_reactants; ++i)

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -292,15 +292,28 @@ namespace micm
       {
         const auto v_rate_subrange_begin = v_rate_constants_begin + offset_rc + (i_rxn * L);
         rate.assign(v_rate_subrange_begin, v_rate_subrange_begin + L);
-        for (std::size_t i_react = 0; i_react < number_of_reactants_[i_rxn]; ++i_react)
+        std::size_t max_number_of_products_reactants = std::max(number_of_reactants_[i_rxn], number_of_products_[i_rxn]);
+        for (std::size_t i = 0; i < max_number_of_products_reactants; ++i)
+        {
+          std::size_t idx_state_variables = -999;
+          std::size_t idx_react_forcing = -999;
+          std::size_t idx_prod_forcing = -999;
+          if (i < number_of_reactants_[i_rxn]) 
+          {
+            idx_state_variables = offset_state + react_id[i] * L;
+            idx_react_forcing = offset_forcing + react_id[i] * L;
+          }
+          if (i < number_of_products_[i_rxn])
+          {
+            idx_prod_forcing = offset_forcing + prod_id[i] * L;
+          {
           for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
-            rate[i_cell] *= v_state_variables[offset_state + react_id[i_react] * L + i_cell];
-        for (std::size_t i_react = 0; i_react < number_of_reactants_[i_rxn]; ++i_react)
-          for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
-            v_forcing[offset_forcing + react_id[i_react] * L + i_cell] -= rate[i_cell];
-        for (std::size_t i_prod = 0; i_prod < number_of_products_[i_rxn]; ++i_prod)
-          for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
-            v_forcing[offset_forcing + prod_id[i_prod] * L + i_cell] += yield[i_prod] * rate[i_cell];
+          {
+            if (idx_state_variables != -999) rate[i_cell] *= v_state_variables[idx_state_variables + i_cell];
+            if (idx_react_forcing != -999) v_forcing[idx_react_forcing + i_cell] -= rate[i_cell];
+            if (idx_prod_forcing != -999) v_forcing[idx_prod_forcing + i_cell] += yield[i] * rate[i_cell];
+          }
+        }    
         react_id += number_of_reactants_[i_rxn];
         prod_id += number_of_products_[i_rxn];
         yield += number_of_products_[i_rxn];

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -311,8 +311,9 @@ namespace micm
           auto rate_it = rate.begin();
           for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
           {
-            if (idx_react_forcing != std::numeric_limits<std::size_t>::max()) *(v_forcing_react_it++) -= *(rate_it++);
-            if (idx_prod_forcing != std::numeric_limits<std::size_t>::max()) *(v_forcing_prod_it++) += yield_value * *(rate_it++);
+            if (idx_react_forcing != std::numeric_limits<std::size_t>::max()) *(v_forcing_react_it++) -= *rate_it;
+            if (idx_prod_forcing != std::numeric_limits<std::size_t>::max()) *(v_forcing_prod_it++) += yield_value * *rate_it;
+            ++rate_it;
           }
         }
         react_id += number_of_reactants_[i_rxn];
@@ -434,8 +435,9 @@ namespace micm
             auto d_rate_d_ind_it = d_rate_d_ind.begin();
             for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
             {
-              if (is_react_jacobian) *(v_jacobian_react_it++) += *(d_rate_d_ind_it++);
-              if (is_prod_jacobian) *(v_jacobian_prod_it++) -= yield_value * *(d_rate_d_ind_it++);
+              if (is_react_jacobian) *(v_jacobian_react_it++) += *d_rate_d_ind_it;
+              if (is_prod_jacobian) *(v_jacobian_prod_it++) -= yield_value * *d_rate_d_ind_it;
+              ++d_rate_d_ind_it;
             }
             ++flat_id;
           }

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -292,15 +292,19 @@ namespace micm
       {
         const auto v_rate_subrange_begin = v_rate_constants_begin + offset_rc + (i_rxn * L);
         rate.assign(v_rate_subrange_begin, v_rate_subrange_begin + L);
+        for (std::size_t i_react = 0; i_react < number_of_reactants_[i_rxn]; ++i_react)
+        {
+          std::size_t idx_state_variables = offset_state + react_id[i_react] * L; 
+          for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+            rate[i_cell] *= v_state_variables[idx_state_variables + i_cell];
+        }
         std::size_t max_number_of_products_reactants = std::max(number_of_reactants_[i_rxn], number_of_products_[i_rxn]);
         for (std::size_t i = 0; i < max_number_of_products_reactants; ++i)
         {
-          std::size_t idx_state_variables = -999;
           std::size_t idx_react_forcing = -999;
           std::size_t idx_prod_forcing = -999;
           if (i < number_of_reactants_[i_rxn]) 
           {
-            idx_state_variables = offset_state + react_id[i] * L;
             idx_react_forcing = offset_forcing + react_id[i] * L;
           }
           if (i < number_of_products_[i_rxn])
@@ -309,7 +313,6 @@ namespace micm
           } 
           for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
           {
-            if (idx_state_variables != -999) rate[i_cell] *= v_state_variables[idx_state_variables + i_cell];
             if (idx_react_forcing != -999) v_forcing[idx_react_forcing + i_cell] -= rate[i_cell];
             if (idx_prod_forcing != -999) v_forcing[idx_prod_forcing + i_cell] += yield[i] * rate[i_cell];
           }

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -301,16 +301,8 @@ namespace micm
         std::size_t max_number_of_products_reactants = std::max(number_of_reactants_[i_rxn], number_of_products_[i_rxn]);
         for (std::size_t i = 0; i < max_number_of_products_reactants; ++i)
         {
-          std::size_t idx_react_forcing = -999;
-          std::size_t idx_prod_forcing = -999;
-          if (i < number_of_reactants_[i_rxn]) 
-          {
-            idx_react_forcing = offset_forcing + react_id[i] * L;
-          }
-          if (i < number_of_products_[i_rxn])
-          {
-            idx_prod_forcing = offset_forcing + prod_id[i] * L;
-          } 
+          std::size_t idx_react_forcing = (i < number_of_reactants_[i_rxn]) ? offset_forcing + react_id[i] * L : -999;
+          std::size_t idx_prod_forcing = (i < number_of_products_[i_rxn]) ? offset_forcing + prod_id[i] * L : -999;
           for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
           {
             if (idx_react_forcing != -999) v_forcing[idx_react_forcing + i_cell] -= rate[i_cell];

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -300,21 +300,20 @@ namespace micm
           for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
             *(rate_it++) *= *(v_state_variables_it++);
         }
-        std::size_t max_number_of_products_reactants = std::max(number_of_reactants_[i_rxn], number_of_products_[i_rxn]);
-        for (std::size_t i = 0; i < max_number_of_products_reactants; ++i)
+        for (std::size_t i_react = 0; i_react < number_of_reactants_[i_rxn]; ++i_react)
         {
-          std::size_t idx_react_forcing = (i < number_of_reactants_[i_rxn]) ? offset_forcing + react_id[i] * L : std::numeric_limits<std::size_t>::max();
-          std::size_t idx_prod_forcing = (i < number_of_products_[i_rxn]) ? offset_forcing + prod_id[i] * L : std::numeric_limits<std::size_t>::max();
-          auto v_forcing_react_it = v_forcing.begin() + idx_react_forcing;
-          auto v_forcing_prod_it = v_forcing.begin() + idx_prod_forcing;
-          auto yield_value = (idx_prod_forcing != std::numeric_limits<std::size_t>::max()) ? yield[i] : 0;
+          auto v_forcing_it = v_forcing.begin() + offset_forcing + react_id[i_react] * L;
           auto rate_it = rate.begin();
           for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
-          {
-            if (idx_react_forcing != std::numeric_limits<std::size_t>::max()) *(v_forcing_react_it++) -= *rate_it;
-            if (idx_prod_forcing != std::numeric_limits<std::size_t>::max()) *(v_forcing_prod_it++) += yield_value * *rate_it;
-            ++rate_it;
-          }
+            *(v_forcing_it++) -= *(rate_it++);
+        }
+        for (std::size_t i_prod = 0; i_prod < number_of_products_[i_rxn]; ++i_prod)
+        {
+          auto v_forcing_it = v_forcing.begin() + offset_forcing + prod_id[i_prod] * L;
+          auto rate_it = rate.begin();
+          auto yield_value = yield[i_prod];
+          for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+            *(v_forcing_it++) += yield_value * *(rate_it++);
         }
         react_id += number_of_reactants_[i_rxn];
         prod_id += number_of_products_[i_rxn];

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -412,21 +412,26 @@ namespace micm
               continue;
             }
             const std::size_t idx_state_variables = offset_state + (react_id[i_react] * L);
+            auto v_state_variables_it = v_state_variables.begin() + idx_state_variables;
+            auto d_rate_d_ind_it = d_rate_d_ind.begin();
             for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
-              d_rate_d_ind[i_cell] *= v_state_variables[idx_state_variables + i_cell];
+              *(d_rate_d_ind_it++) *= *(v_state_variables_it++);
           }
           for (std::size_t i_dep = 0; i_dep < number_of_reactants_[i_rxn]; ++i_dep)
           {
             auto v_jacobian_it = v_jacobian.begin() + offset_jacobian + *flat_id;
+            auto d_rate_d_ind_it = d_rate_d_ind.begin();
             for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
-              v_jacobian_it[i_cell] += d_rate_d_ind[i_cell];
+              *(v_jacobian_it++) += *(d_rate_d_ind_it++);
             ++flat_id;
           }
           for (std::size_t i_dep = 0; i_dep < number_of_products_[i_rxn]; ++i_dep)
           {
             auto v_jacobian_it = v_jacobian.begin() + offset_jacobian + *flat_id;
+            auto d_rate_d_ind_it = d_rate_d_ind.begin();
+            auto yield_value = yield[i_dep];
             for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
-              v_jacobian_it[i_cell] -= yield[i_dep] * d_rate_d_ind[i_cell];
+              *(v_jacobian_it++) -= yield_value * *(d_rate_d_ind_it++);
             ++flat_id;
           }
         }

--- a/include/micm/solver/linear_solver_in_place.inl
+++ b/include/micm/solver/linear_solver_in_place.inl
@@ -141,8 +141,11 @@ namespace micm
           {
             const std::size_t Lij_yj_first = (*Lij_yj).first;
             const std::size_t Lij_yj_second_times_n_cells = (*Lij_yj).second * n_cells;
+            auto LU_group_it = LU_group + Lij_yj_first;
+            auto x_group_it = x_group + Lij_yj_second_times_n_cells;
+            auto y_elem_it = y_elem;
             for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
-              y_elem[i_cell] -= LU_group[Lij_yj_first + i_cell] * x_group[Lij_yj_second_times_n_cells + i_cell];
+              *(y_elem_it++) -= *(LU_group_it++) * *(x_group_it++);
             ++Lij_yj;
           }
           y_elem += n_cells;
@@ -160,13 +163,18 @@ namespace micm
           {
             const std::size_t Uij_xj_first = (*Uij_xj).first;
             const std::size_t Uij_xj_second_times_n_cells = (*Uij_xj).second * n_cells;
+            auto LU_group_it = LU_group + Uij_xj_first;
+            auto x_group_it = x_group + Uij_xj_second_times_n_cells;
+            auto x_elem_it = x_elem;
             for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
-              x_elem[i_cell] -= LU_group[Uij_xj_first + i_cell] * x_group[Uij_xj_second_times_n_cells + i_cell];
+              *(x_elem_it++) -= *(LU_group_it++) * *(x_group_it++);
             ++Uij_xj;
           }
           const std::size_t nUij_Uii_second = nUij_Uii.second;
+          auto LU_group_it = LU_group + nUij_Uii_second;
+          auto x_elem_it = x_elem;
           for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
-            x_elem[i_cell] /= LU_group[nUij_Uii_second + i_cell];
+            *(x_elem_it++) /= *(LU_group_it++);
 
           // don't iterate before the beginning of the vector
           const std::size_t x_elem_distance = std::distance(x.AsVector().begin(), x_elem);

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -191,26 +191,38 @@ namespace micm
       auto akj_aji = akj_aji_.begin();
       for (const auto& nik_nki_aii : nik_nki_aii_)
       {
-        for (std::size_t ik = 0; ik < std::get<0>(nik_nki_aii); ++ik)
+        const std::size_t ik_limit = std::get<0>(nik_nki_aii); 
+        for (std::size_t ik = 0; ik < ik_limit; ++ik)
         {
-          for (std::size_t jk = 0; jk < aik_njk->second; ++jk)
+          const std::size_t jk_limit = aik_njk->second; 
+          for (std::size_t jk = 0; jk < jk_limit; ++jk)
           {
+            auto ALU_vector_aik_njk_it = ALU_vector + aik_njk->first;
+            auto ALU_vector_aij_ajk_first_it = ALU_vector + aij_ajk->first;
+            auto ALU_vector_aij_ajk_second_it = ALU_vector + aij_ajk->second;
             for (std::size_t i = 0; i < n_cells; ++i)
-              ALU_vector[aik_njk->first + i] -= ALU_vector[aij_ajk->first + i] * ALU_vector[aij_ajk->second + i];
+              *(ALU_vector_aik_njk_it++) -= *(ALU_vector_aij_ajk_first_it++) * *(ALU_vector_aij_ajk_second_it++);
             ++aij_ajk;
           }
           ++aik_njk;
         }
-        for (std::size_t ki = 0; ki < std::get<1>(nik_nki_aii); ++ki)
+        const std::size_t ki_limit = std::get<1>(nik_nki_aii);
+        for (std::size_t ki = 0; ki < ki_limit; ++ki)
         {
-          for (std::size_t ji = 0; ji < aki_nji->second; ++ji)
+          const std::size_t ji_limit = aki_nji->second;
+          for (std::size_t ji = 0; ji < ji_limit; ++ji)
           {
+            auto ALU_vector_aki_nji_it = ALU_vector + aki_nji->first;
+            auto ALU_vector_akj_aji_first_it = ALU_vector + akj_aji->first;
+            auto ALU_vector_akj_aji_second_it = ALU_vector + akj_aji->second;
             for (std::size_t i = 0; i < n_cells; ++i)
-              ALU_vector[aki_nji->first + i] -= ALU_vector[akj_aji->first + i] * ALU_vector[akj_aji->second + i];
+              *(ALU_vector_aki_nji_it++) -= *(ALU_vector_akj_aji_first_it++) * *(ALU_vector_akj_aji_second_it++);
             ++akj_aji;
           }
+          auto ALU_vector_aki_nji_it = ALU_vector + aki_nji->first;
+          auto ALU_vector_nik_nki_aii_it = ALU_vector + std::get<2>(nik_nki_aii);
           for (std::size_t i = 0; i < n_cells; ++i)
-            ALU_vector[aki_nji->first + i] /= ALU_vector[std::get<2>(nik_nki_aii) + i];
+            *(ALU_vector_aki_nji_it++) /= *(ALU_vector_nik_nki_aii_it++);
           ++aki_nji;
         }
       }


### PR DESCRIPTION
As suggested by Matt, I revised the `i_cell` loop to increase the iterator explicitly rather than use the `[]` syntax.

This improves the CPU performance for gcc, intel and nvhpc compilers on Derecho.