### PR TITLE
Fix bug in inline BE solver

### DIFF
--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -409,8 +409,13 @@ namespace micm
     auto nonzero_elements = rates.NonZeroJacobianElements();
     auto jacobian = BuildJacobian<SparseMatrixPolicy>(nonzero_elements, this->number_of_grid_cells_, number_of_species);
 
-    rates.SetJacobianFlatIds(jacobian);
     LinearSolverPolicy linear_solver(jacobian, 0);
+    if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
+    {
+      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian, 0);
+      jacobian = std::move(lu);
+    }
+    rates.SetJacobianFlatIds(jacobian);
 
     std::vector<std::string> variable_names{ number_of_species };
     for (auto& species_pair : species_map)

--- a/test/integration/test_analytical_backward_euler.cpp
+++ b/test/integration/test_analytical_backward_euler.cpp
@@ -260,6 +260,10 @@ TEST(AnalyticalExamples, HIRES)
   test_analytical_hires(backward_euler_vector_mozart_2, 1e-1);
   test_analytical_hires(backward_euler_vector_mozart_3, 1e-1);
   test_analytical_hires(backward_euler_vector_mozart_4, 1e-1);
+  test_analytical_hires(backward_euler_vector_mozart_in_place_1, 1e-1);
+  test_analytical_hires(backward_euler_vector_mozart_in_place_2, 1e-1);
+  test_analytical_hires(backward_euler_vector_mozart_in_place_3, 1e-1);
+  test_analytical_hires(backward_euler_vector_mozart_in_place_4, 1e-1);
 }
 
 TEST(AnalyticalExamples, Oregonator)
@@ -277,4 +281,8 @@ TEST(AnalyticalExamples, Oregonator)
   test_analytical_oregonator(backward_euler_vector_mozart_2, 1e-3);
   test_analytical_oregonator(backward_euler_vector_mozart_3, 1e-3);
   test_analytical_oregonator(backward_euler_vector_mozart_4, 1e-3);
+  test_analytical_oregonator(backward_euler_vector_mozart_in_place_1, 1e-3);
+  test_analytical_oregonator(backward_euler_vector_mozart_in_place_2, 1e-3);
+  test_analytical_oregonator(backward_euler_vector_mozart_in_place_3, 1e-3);
+  test_analytical_oregonator(backward_euler_vector_mozart_in_place_4, 1e-3);
 }


### PR DESCRIPTION
There was a bug in the creation of the linear solver when using in-line LU decomposition. This fixes it and adds a test of the in-line BE solver for the HIRES test, which was failing before the bug was fixed.