### PR TITLE
Fix substepping issue for Rosenbrock solver with inline LU decomposition

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run CMake
-        run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -T ClangCL
+        run: cmake -S . -B build -D CMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -T ClangCL
       - name: Build
         run: cmake --build build --config Debug --parallel 10
       - name: Test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,12 +77,12 @@ jobs:
     continue-on-error: true 
     strategy:
       matrix:
-        architecture: [Win32, x64]
+        architecture: [x64]
 
     steps:
       - uses: actions/checkout@v4
       - name: Run CMake
-        run: cmake -S . -B build -D CMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -T ClangCL
+        run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -T ClangCL
       - name: Build
         run: cmake --build build --config Debug --parallel 10
       - name: Test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,6 +84,6 @@ jobs:
       - name: Run CMake
         run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -T ClangCL
       - name: Build
-        run: cmake --build build --config Debug --parallel 5
+        run: cmake --build build --config Debug --parallel 10
       - name: Test
         run: cd build ; ctest -j 10 -C Debug --exclude-regex "test-unicode" --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,6 +84,6 @@ jobs:
       - name: Run CMake
         run: cmake -S . -B build -G "Visual Studio 16 2019" -A ${{ matrix.architecture }} -T ClangCL
       - name: Build
-        run: cmake --build build --config Debug --parallel 10
+        run: cmake --build build --config Debug --parallel 5
       - name: Test
         run: cd build ; ctest -j 10 -C Debug --exclude-regex "test-unicode" --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,9 @@ if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux" AND "${CMAKE_CXX_COMPILER_ID}" STR
 endif()
 
 # on Windows with MSVC, add the /bigobj flag to allow for large object files
-if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows" AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_CXX_COMPILER}" STREQUAL "clang-cl"))
+if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows" AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # If the compiler is MSVC or Clang on Windows, use /bigobj
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-  message(STATUS "Added /bigobj flag to CMAKE_CXX_FLAGS")
 endif()
 
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,12 @@ if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux" AND "${CMAKE_CXX_COMPILER_ID}" STR
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 
+# on Windows with MSVC, add the /bigobj flag to allow for large object files
+if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows" AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  # If the compiler is MSVC, use /bigobj
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+endif()
+
 ################################################################################
 # Command-line driver examples / Command-line profiler
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows" AND "${CMAKE_CXX_COMPILER_ID}" S
   # If the compiler is MSVC, use /bigobj
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
   message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+  add_compile_options(/bigobj)
 endif()
 
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,13 @@ if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux" AND "${CMAKE_CXX_COMPILER_ID}" STR
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 
+# on Windows with MSVC, add the /bigobj flag to allow for large object files
+if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows" AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  # If the compiler is MSVC, use /bigobj
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+  message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+endif()
+
 ################################################################################
 # Dependencies
 
@@ -94,14 +101,6 @@ endif()
 if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux" AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # If the compiler is Clang, use libc++
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-endif()
-
-# on Windows with MSVC, add the /bigobj flag to allow for large object files
-if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows" AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  # If the compiler is MSVC, use /bigobj
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-  message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
-  add_compile_options(/bigobj)
 endif()
 
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,9 @@ if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux" AND "${CMAKE_CXX_COMPILER_ID}" STR
 endif()
 
 # on Windows with MSVC, add the /bigobj flag to allow for large object files
-if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows" AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  # If the compiler is MSVC, use /bigobj
+if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows" AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
+  # If the compiler is MSVC or Clang on Windows, use /bigobj
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-  message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 endif()
 
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ endif()
 if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows" AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # If the compiler is MSVC, use /bigobj
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+  message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 endif()
 
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,10 @@ if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux" AND "${CMAKE_CXX_COMPILER_ID}" STR
 endif()
 
 # on Windows with MSVC, add the /bigobj flag to allow for large object files
-if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows" AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
+if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows" AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_CXX_COMPILER}" STREQUAL "clang-cl"))
   # If the compiler is MSVC or Clang on Windows, use /bigobj
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+  message(STATUS "Added /bigobj flag to CMAKE_CXX_FLAGS")
 endif()
 
 ################################################################################

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -104,7 +104,7 @@ namespace micm
     /// @param number_densities The number densities
     /// @param stats The solver stats
     /// @param state The state
-    void LinearFactor(const double alpha, const auto& number_densities, SolverStats& stats, auto& state) const;
+    void LinearFactor(const double alpha, SolverStats& stats, auto& state) const;
 
     /// @brief Computes the scaled norm of the vector errors
     /// @param y the original vector

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -69,10 +69,10 @@ namespace micm
 
       bool accepted = false;
       double last_alpha = 0.0;
-      double alpha = 0.0;
       //  Repeat step calculation until current step accepted
       while (!accepted)
       {
+        double alpha = 0.0;
         if constexpr (LinearSolverInPlaceConcept<LinearSolverPolicy, DenseMatrixPolicy, SparseMatrixPolicy>)
         {
           // Compute alpha for AlphaMinusJacobian function 

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -68,10 +68,7 @@ namespace micm
       stats.jacobian_updates_ += 1;
 
       bool accepted = false;
-      if constexpr (!LinearSolverInPlaceConcept<LinearSolverPolicy, DenseMatrixPolicy, SparseMatrixPolicy>)
-      {
-        double last_alpha = 0.0;
-      }
+      double last_alpha = 0.0;
       double alpha = 0.0;
       //  Repeat step calculation until current step accepted
       while (!accepted)

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -72,17 +72,13 @@ namespace micm
       //  Repeat step calculation until current step accepted
       while (!accepted)
       {
-        double alpha = 0.0;
-        if constexpr (LinearSolverInPlaceConcept<LinearSolverPolicy, DenseMatrixPolicy, SparseMatrixPolicy>)
-        {
-          // Compute alpha for AlphaMinusJacobian function 
-          alpha = 1.0 / (H * parameters.gamma_[0]);
-        }
-        else
+        // Compute alpha for AlphaMinusJacobian function 
+        double alpha = 1.0 / (H * parameters.gamma_[0]);
+        if constexpr (!LinearSolverInPlaceConcept<LinearSolverPolicy, DenseMatrixPolicy, SparseMatrixPolicy>)
         { 
           // Compute alpha accounting for the last alpha value
           // This is necessary to avoid the need to re-factor the jacobian for non-inline LU algorithms
-          alpha = 1.0 / (H * parameters.gamma_[0]) - last_alpha;
+          alpha -= last_alpha;
           last_alpha = alpha;
         }
 

--- a/test/integration/test_analytical_rosenbrock.cpp
+++ b/test/integration/test_analytical_rosenbrock.cpp
@@ -68,6 +68,46 @@ template<std::size_t L>
 using VectorStateType =
     micm::State<micm::VectorMatrix<double, L>, micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<L>>>;
 
+template<std::size_t L>
+using VectorRosenbrockDolittleCSC = micm::CpuSolverBuilder<
+    micm::RosenbrockSolverParameters,
+    micm::VectorMatrix<double, L>,
+    micm::SparseMatrix<double, micm::SparseMatrixVectorOrderingCompressedSparseColumn<L>>,
+    micm::LuDecompositionDoolittle>;
+
+template<std::size_t L>
+using VectorStateTypeDoolittleCSC = typename VectorRosenbrockDolittleCSC<L>::StatePolicyType;
+
+template<std::size_t L>
+using VectorRosenbrockMozartCSC = micm::CpuSolverBuilder<
+    micm::RosenbrockSolverParameters,
+    micm::VectorMatrix<double, L>,
+    micm::SparseMatrix<double, micm::SparseMatrixVectorOrderingCompressedSparseColumn<L>>,
+    micm::LuDecompositionMozart>;
+
+template<std::size_t L>
+using VectorStateTypeMozartCSC = typename VectorRosenbrockMozartCSC<L>::StatePolicyType;
+
+template<std::size_t L>
+using VectorRosenbrockDoolittleInPlace = micm::CpuSolverBuilderInPlace<
+    micm::RosenbrockSolverParameters,
+    micm::VectorMatrix<double, L>,
+    micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<L>>,
+    micm::LuDecompositionDoolittleInPlace>;
+
+template<std::size_t L>
+using VectorStateTypeDoolittleInPlace = typename VectorRosenbrockDoolittleInPlace<L>::StatePolicyType;
+
+template<std::size_t L>
+using VectorRosenbrockMozartInPlace = micm::CpuSolverBuilderInPlace<
+    micm::RosenbrockSolverParameters,
+    micm::VectorMatrix<double, L>,
+    micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<L>>,
+    micm::LuDecompositionMozartInPlace>;
+
+template<std::size_t L>
+using VectorStateTypeMozartInPlace = typename VectorRosenbrockMozartInPlace<L>::StatePolicyType;
+
 auto rosenbrock_2stage = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
     micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
 auto rosenbrock_3stage = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
@@ -105,6 +145,42 @@ auto rosenbrock_vector_mozart_3 =
 auto rosenbrock_vector_mozart_4 =
     VectorRosenbrockMozart<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
 
+auto rosenbrock_vector_doolittle_csc_1 =
+    VectorRosenbrockDolittleCSC<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_doolittle_csc_2 =
+    VectorRosenbrockDolittleCSC<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_doolittle_csc_3 =
+    VectorRosenbrockDolittleCSC<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_doolittle_csc_4 =
+    VectorRosenbrockDolittleCSC<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+
+auto rosenbrock_vector_mozart_csc_1 =
+    VectorRosenbrockMozartCSC<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_mozart_csc_2 =
+    VectorRosenbrockMozartCSC<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_mozart_csc_3 =
+    VectorRosenbrockMozartCSC<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_mozart_csc_4 =
+    VectorRosenbrockMozartCSC<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+
+auto rosenbrock_vector_doolittle_in_place_1 =
+    VectorRosenbrockDoolittleInPlace<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_doolittle_in_place_2 =
+    VectorRosenbrockDoolittleInPlace<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_doolittle_in_place_3 =
+    VectorRosenbrockDoolittleInPlace<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_doolittle_in_place_4 =
+    VectorRosenbrockDoolittleInPlace<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+
+auto rosenbrock_vector_mozart_in_place_1 =
+    VectorRosenbrockMozartInPlace<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_mozart_in_place_2 =
+    VectorRosenbrockMozartInPlace<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_mozart_in_place_3 =
+    VectorRosenbrockMozartInPlace<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_mozart_in_place_4 =
+    VectorRosenbrockMozartInPlace<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+
 TEST(AnalyticalExamples, Troe)
 {
   test_analytical_troe(rosenbrock_2stage);
@@ -126,6 +202,22 @@ TEST(AnalyticalExamples, Troe)
   test_analytical_troe(rosenbrock_vector_mozart_2);
   test_analytical_troe(rosenbrock_vector_mozart_3);
   test_analytical_troe(rosenbrock_vector_mozart_4);
+  test_analytical_troe(rosenbrock_vector_doolittle_csc_1);
+  test_analytical_troe(rosenbrock_vector_doolittle_csc_2);
+  test_analytical_troe(rosenbrock_vector_doolittle_csc_3);
+  test_analytical_troe(rosenbrock_vector_doolittle_csc_4);
+  test_analytical_troe(rosenbrock_vector_mozart_csc_1);
+  test_analytical_troe(rosenbrock_vector_mozart_csc_2);
+  test_analytical_troe(rosenbrock_vector_mozart_csc_3);
+  test_analytical_troe(rosenbrock_vector_mozart_csc_4);
+  test_analytical_troe(rosenbrock_vector_doolittle_in_place_1);
+  test_analytical_troe(rosenbrock_vector_doolittle_in_place_2);
+  test_analytical_troe(rosenbrock_vector_doolittle_in_place_3);
+  test_analytical_troe(rosenbrock_vector_doolittle_in_place_4);
+  test_analytical_troe(rosenbrock_vector_mozart_in_place_1);
+  test_analytical_troe(rosenbrock_vector_mozart_in_place_2);
+  test_analytical_troe(rosenbrock_vector_mozart_in_place_3);
+  test_analytical_troe(rosenbrock_vector_mozart_in_place_4);
 }
 
 TEST(AnalyticalExamples, TroeSuperStiffButAnalytical)
@@ -139,6 +231,22 @@ TEST(AnalyticalExamples, TroeSuperStiffButAnalytical)
   test_analytical_stiff_troe(rosenbrock_vector_2);
   test_analytical_stiff_troe(rosenbrock_vector_3);
   test_analytical_stiff_troe(rosenbrock_vector_4);
+  test_analytical_stiff_troe(rosenbrock_vector_doolittle_csc_1);
+  test_analytical_stiff_troe(rosenbrock_vector_doolittle_csc_2);
+  test_analytical_stiff_troe(rosenbrock_vector_doolittle_csc_3);
+  test_analytical_stiff_troe(rosenbrock_vector_doolittle_csc_4);
+  test_analytical_stiff_troe(rosenbrock_vector_mozart_csc_1);
+  test_analytical_stiff_troe(rosenbrock_vector_mozart_csc_2);
+  test_analytical_stiff_troe(rosenbrock_vector_mozart_csc_3);
+  test_analytical_stiff_troe(rosenbrock_vector_mozart_csc_4);
+  test_analytical_stiff_troe(rosenbrock_vector_doolittle_in_place_1);
+  test_analytical_stiff_troe(rosenbrock_vector_doolittle_in_place_2);
+  test_analytical_stiff_troe(rosenbrock_vector_doolittle_in_place_3);
+  test_analytical_stiff_troe(rosenbrock_vector_doolittle_in_place_4);
+  test_analytical_stiff_troe(rosenbrock_vector_mozart_in_place_1);
+  test_analytical_stiff_troe(rosenbrock_vector_mozart_in_place_2);
+  test_analytical_stiff_troe(rosenbrock_vector_mozart_in_place_3);
+  test_analytical_stiff_troe(rosenbrock_vector_mozart_in_place_4);
 }
 
 TEST(AnalyticalExamples, Photolysis)
@@ -152,6 +260,22 @@ TEST(AnalyticalExamples, Photolysis)
   test_analytical_photolysis(rosenbrock_vector_2);
   test_analytical_photolysis(rosenbrock_vector_3);
   test_analytical_photolysis(rosenbrock_vector_4);
+  test_analytical_photolysis(rosenbrock_vector_doolittle_csc_1);
+  test_analytical_photolysis(rosenbrock_vector_doolittle_csc_2);
+  test_analytical_photolysis(rosenbrock_vector_doolittle_csc_3);
+  test_analytical_photolysis(rosenbrock_vector_doolittle_csc_4);
+  test_analytical_photolysis(rosenbrock_vector_mozart_csc_1);
+  test_analytical_photolysis(rosenbrock_vector_mozart_csc_2);
+  test_analytical_photolysis(rosenbrock_vector_mozart_csc_3);
+  test_analytical_photolysis(rosenbrock_vector_mozart_csc_4);
+  test_analytical_photolysis(rosenbrock_vector_doolittle_in_place_1);
+  test_analytical_photolysis(rosenbrock_vector_doolittle_in_place_2);
+  test_analytical_photolysis(rosenbrock_vector_doolittle_in_place_3);
+  test_analytical_photolysis(rosenbrock_vector_doolittle_in_place_4);
+  test_analytical_photolysis(rosenbrock_vector_mozart_in_place_1);
+  test_analytical_photolysis(rosenbrock_vector_mozart_in_place_2);
+  test_analytical_photolysis(rosenbrock_vector_mozart_in_place_3);
+  test_analytical_photolysis(rosenbrock_vector_mozart_in_place_4);
 }
 
 TEST(AnalyticalExamples, PhotolysisSuperStiffButAnalytical)
@@ -165,6 +289,22 @@ TEST(AnalyticalExamples, PhotolysisSuperStiffButAnalytical)
   test_analytical_stiff_photolysis(rosenbrock_vector_2);
   test_analytical_stiff_photolysis(rosenbrock_vector_3);
   test_analytical_stiff_photolysis(rosenbrock_vector_4);
+  test_analytical_stiff_photolysis(rosenbrock_vector_doolittle_csc_1);
+  test_analytical_stiff_photolysis(rosenbrock_vector_doolittle_csc_2);
+  test_analytical_stiff_photolysis(rosenbrock_vector_doolittle_csc_3);
+  test_analytical_stiff_photolysis(rosenbrock_vector_doolittle_csc_4);
+  test_analytical_stiff_photolysis(rosenbrock_vector_mozart_csc_1);
+  test_analytical_stiff_photolysis(rosenbrock_vector_mozart_csc_2);
+  test_analytical_stiff_photolysis(rosenbrock_vector_mozart_csc_3);
+  test_analytical_stiff_photolysis(rosenbrock_vector_mozart_csc_4);
+  test_analytical_stiff_photolysis(rosenbrock_vector_doolittle_in_place_1);
+  test_analytical_stiff_photolysis(rosenbrock_vector_doolittle_in_place_2);
+  test_analytical_stiff_photolysis(rosenbrock_vector_doolittle_in_place_3);
+  test_analytical_stiff_photolysis(rosenbrock_vector_doolittle_in_place_4);
+  test_analytical_stiff_photolysis(rosenbrock_vector_mozart_in_place_1);
+  test_analytical_stiff_photolysis(rosenbrock_vector_mozart_in_place_2);
+  test_analytical_stiff_photolysis(rosenbrock_vector_mozart_in_place_3);
+  test_analytical_stiff_photolysis(rosenbrock_vector_mozart_in_place_4);
 }
 
 TEST(AnalyticalExamples, TernaryChemicalActivation)
@@ -178,6 +318,22 @@ TEST(AnalyticalExamples, TernaryChemicalActivation)
   test_analytical_ternary_chemical_activation(rosenbrock_vector_2);
   test_analytical_ternary_chemical_activation(rosenbrock_vector_3);
   test_analytical_ternary_chemical_activation(rosenbrock_vector_4);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_doolittle_csc_1);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_doolittle_csc_2);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_doolittle_csc_3);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_doolittle_csc_4);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_mozart_csc_1);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_mozart_csc_2);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_mozart_csc_3);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_mozart_csc_4);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_doolittle_in_place_1);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_doolittle_in_place_2);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_doolittle_in_place_3);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_doolittle_in_place_4);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_mozart_in_place_1);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_mozart_in_place_2);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_mozart_in_place_3);
+  test_analytical_ternary_chemical_activation(rosenbrock_vector_mozart_in_place_4);
 }
 
 TEST(AnalyticalExamples, TernaryChemicalActivationSuperStiffButAnalytical)
@@ -191,6 +347,22 @@ TEST(AnalyticalExamples, TernaryChemicalActivationSuperStiffButAnalytical)
   test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_2, 2e-3);
   test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_3, 2e-3);
   test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_4, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_doolittle_csc_1, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_doolittle_csc_2, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_doolittle_csc_3, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_doolittle_csc_4, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_mozart_csc_1, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_mozart_csc_2, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_mozart_csc_3, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_mozart_csc_4, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_doolittle_in_place_1, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_doolittle_in_place_2, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_doolittle_in_place_3, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_doolittle_in_place_4, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_mozart_in_place_1, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_mozart_in_place_2, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_mozart_in_place_3, 2e-3);
+  test_analytical_stiff_ternary_chemical_activation(rosenbrock_vector_mozart_in_place_4, 2e-3);
 }
 
 TEST(AnalyticalExamples, Tunneling)
@@ -204,6 +376,22 @@ TEST(AnalyticalExamples, Tunneling)
   test_analytical_tunneling(rosenbrock_vector_2);
   test_analytical_tunneling(rosenbrock_vector_3);
   test_analytical_tunneling(rosenbrock_vector_4);
+  test_analytical_tunneling(rosenbrock_vector_doolittle_csc_1);
+  test_analytical_tunneling(rosenbrock_vector_doolittle_csc_2);
+  test_analytical_tunneling(rosenbrock_vector_doolittle_csc_3);
+  test_analytical_tunneling(rosenbrock_vector_doolittle_csc_4);
+  test_analytical_tunneling(rosenbrock_vector_mozart_csc_1);
+  test_analytical_tunneling(rosenbrock_vector_mozart_csc_2);
+  test_analytical_tunneling(rosenbrock_vector_mozart_csc_3);
+  test_analytical_tunneling(rosenbrock_vector_mozart_csc_4);
+  test_analytical_tunneling(rosenbrock_vector_doolittle_in_place_1);
+  test_analytical_tunneling(rosenbrock_vector_doolittle_in_place_2);
+  test_analytical_tunneling(rosenbrock_vector_doolittle_in_place_3);
+  test_analytical_tunneling(rosenbrock_vector_doolittle_in_place_4);
+  test_analytical_tunneling(rosenbrock_vector_mozart_in_place_1);
+  test_analytical_tunneling(rosenbrock_vector_mozart_in_place_2);
+  test_analytical_tunneling(rosenbrock_vector_mozart_in_place_3);
+  test_analytical_tunneling(rosenbrock_vector_mozart_in_place_4);
 }
 
 TEST(AnalyticalExamples, TunnelingSuperStiffButAnalytical)
@@ -217,6 +405,22 @@ TEST(AnalyticalExamples, TunnelingSuperStiffButAnalytical)
   test_analytical_stiff_tunneling(rosenbrock_vector_2, 1e-4);
   test_analytical_stiff_tunneling(rosenbrock_vector_3, 1e-4);
   test_analytical_stiff_tunneling(rosenbrock_vector_4, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_doolittle_csc_1, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_doolittle_csc_2, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_doolittle_csc_3, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_doolittle_csc_4, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_mozart_csc_1, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_mozart_csc_2, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_mozart_csc_3, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_mozart_csc_4, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_doolittle_in_place_1, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_doolittle_in_place_2, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_doolittle_in_place_3, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_doolittle_in_place_4, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_mozart_in_place_1, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_mozart_in_place_2, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_mozart_in_place_3, 1e-4);
+  test_analytical_stiff_tunneling(rosenbrock_vector_mozart_in_place_4, 1e-4);
 }
 
 TEST(AnalyticalExamples, Arrhenius)
@@ -230,6 +434,22 @@ TEST(AnalyticalExamples, Arrhenius)
   test_analytical_arrhenius(rosenbrock_vector_2);
   test_analytical_arrhenius(rosenbrock_vector_3);
   test_analytical_arrhenius(rosenbrock_vector_4);
+  test_analytical_arrhenius(rosenbrock_vector_doolittle_csc_1);
+  test_analytical_arrhenius(rosenbrock_vector_doolittle_csc_2);
+  test_analytical_arrhenius(rosenbrock_vector_doolittle_csc_3);
+  test_analytical_arrhenius(rosenbrock_vector_doolittle_csc_4);
+  test_analytical_arrhenius(rosenbrock_vector_mozart_csc_1);
+  test_analytical_arrhenius(rosenbrock_vector_mozart_csc_2);
+  test_analytical_arrhenius(rosenbrock_vector_mozart_csc_3);
+  test_analytical_arrhenius(rosenbrock_vector_mozart_csc_4);
+  test_analytical_arrhenius(rosenbrock_vector_doolittle_in_place_1);
+  test_analytical_arrhenius(rosenbrock_vector_doolittle_in_place_2);
+  test_analytical_arrhenius(rosenbrock_vector_doolittle_in_place_3);
+  test_analytical_arrhenius(rosenbrock_vector_doolittle_in_place_4);
+  test_analytical_arrhenius(rosenbrock_vector_mozart_in_place_1);
+  test_analytical_arrhenius(rosenbrock_vector_mozart_in_place_2);
+  test_analytical_arrhenius(rosenbrock_vector_mozart_in_place_3);
+  test_analytical_arrhenius(rosenbrock_vector_mozart_in_place_4);
 }
 
 TEST(AnalyticalExamples, ArrheniusSuperStiffButAnalytical)
@@ -243,6 +463,22 @@ TEST(AnalyticalExamples, ArrheniusSuperStiffButAnalytical)
   test_analytical_stiff_arrhenius(rosenbrock_vector_2, 2e-5);
   test_analytical_stiff_arrhenius(rosenbrock_vector_3, 2e-5);
   test_analytical_stiff_arrhenius(rosenbrock_vector_4, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_doolittle_csc_1, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_doolittle_csc_2, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_doolittle_csc_3, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_doolittle_csc_4, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_mozart_csc_1, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_mozart_csc_2, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_mozart_csc_3, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_mozart_csc_4, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_doolittle_in_place_1, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_doolittle_in_place_2, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_doolittle_in_place_3, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_doolittle_in_place_4, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_mozart_in_place_1, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_mozart_in_place_2, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_mozart_in_place_3, 2e-5);
+  test_analytical_stiff_arrhenius(rosenbrock_vector_mozart_in_place_4, 2e-5);
 }
 
 TEST(AnalyticalExamples, Branched)
@@ -256,6 +492,22 @@ TEST(AnalyticalExamples, Branched)
   test_analytical_branched(rosenbrock_vector_2);
   test_analytical_branched(rosenbrock_vector_3);
   test_analytical_branched(rosenbrock_vector_4);
+  test_analytical_branched(rosenbrock_vector_doolittle_csc_1);
+  test_analytical_branched(rosenbrock_vector_doolittle_csc_2);
+  test_analytical_branched(rosenbrock_vector_doolittle_csc_3);
+  test_analytical_branched(rosenbrock_vector_doolittle_csc_4);
+  test_analytical_branched(rosenbrock_vector_mozart_csc_1);
+  test_analytical_branched(rosenbrock_vector_mozart_csc_2);
+  test_analytical_branched(rosenbrock_vector_mozart_csc_3);
+  test_analytical_branched(rosenbrock_vector_mozart_csc_4);
+  test_analytical_branched(rosenbrock_vector_doolittle_in_place_1);
+  test_analytical_branched(rosenbrock_vector_doolittle_in_place_2);
+  test_analytical_branched(rosenbrock_vector_doolittle_in_place_3);
+  test_analytical_branched(rosenbrock_vector_doolittle_in_place_4);
+  test_analytical_branched(rosenbrock_vector_mozart_in_place_1);
+  test_analytical_branched(rosenbrock_vector_mozart_in_place_2);
+  test_analytical_branched(rosenbrock_vector_mozart_in_place_3);
+  test_analytical_branched(rosenbrock_vector_mozart_in_place_4);
 }
 
 TEST(AnalyticalExamples, BranchedSuperStiffButAnalytical)
@@ -269,6 +521,22 @@ TEST(AnalyticalExamples, BranchedSuperStiffButAnalytical)
   test_analytical_stiff_branched(rosenbrock_vector_2, 2e-3);
   test_analytical_stiff_branched(rosenbrock_vector_3, 2e-3);
   test_analytical_stiff_branched(rosenbrock_vector_4, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_doolittle_csc_1, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_doolittle_csc_2, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_doolittle_csc_3, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_doolittle_csc_4, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_mozart_csc_1, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_mozart_csc_2, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_mozart_csc_3, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_mozart_csc_4, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_doolittle_in_place_1, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_doolittle_in_place_2, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_doolittle_in_place_3, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_doolittle_in_place_4, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_mozart_in_place_1, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_mozart_in_place_2, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_mozart_in_place_3, 2e-3);
+  test_analytical_stiff_branched(rosenbrock_vector_mozart_in_place_4, 2e-3);
 }
 
 TEST(AnalyticalExamples, SurfaceRxn)
@@ -296,6 +564,22 @@ TEST(AnalyticalExamples, Robertson)
   test_analytical_robertson(rosenbrock_vector_mozart_2, 1e-1);
   test_analytical_robertson(rosenbrock_vector_mozart_3, 1e-1);
   test_analytical_robertson(rosenbrock_vector_mozart_4, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_doolittle_csc_1, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_doolittle_csc_2, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_doolittle_csc_3, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_doolittle_csc_4, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_mozart_csc_1, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_mozart_csc_2, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_mozart_csc_3, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_mozart_csc_4, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_doolittle_in_place_1, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_doolittle_in_place_2, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_doolittle_in_place_3, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_doolittle_in_place_4, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_mozart_in_place_1, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_mozart_in_place_2, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_mozart_in_place_3, 1e-1);
+  test_analytical_robertson(rosenbrock_vector_mozart_in_place_4, 1e-1);
 }
 
 TEST(AnalyticalExamples, E5)
@@ -314,6 +598,22 @@ TEST(AnalyticalExamples, E5)
   test_analytical_e5(rosenbrock_vector_mozart_2, 1e-3);
   test_analytical_e5(rosenbrock_vector_mozart_3, 1e-3);
   test_analytical_e5(rosenbrock_vector_mozart_4, 1e-3);
+  test_analytical_e5(rosenbrock_vector_doolittle_csc_1, 1e-3);
+  test_analytical_e5(rosenbrock_vector_doolittle_csc_2, 1e-3);
+  test_analytical_e5(rosenbrock_vector_doolittle_csc_3, 1e-3);
+  test_analytical_e5(rosenbrock_vector_doolittle_csc_4, 1e-3);
+  test_analytical_e5(rosenbrock_vector_mozart_csc_1, 1e-3);
+  test_analytical_e5(rosenbrock_vector_mozart_csc_2, 1e-3);
+  test_analytical_e5(rosenbrock_vector_mozart_csc_3, 1e-3);
+  test_analytical_e5(rosenbrock_vector_mozart_csc_4, 1e-3);
+  test_analytical_e5(rosenbrock_vector_doolittle_in_place_1, 1e-3);
+  test_analytical_e5(rosenbrock_vector_doolittle_in_place_2, 1e-3);
+  test_analytical_e5(rosenbrock_vector_doolittle_in_place_3, 1e-3);
+  test_analytical_e5(rosenbrock_vector_doolittle_in_place_4, 1e-3);
+  test_analytical_e5(rosenbrock_vector_mozart_in_place_1, 1e-3);
+  test_analytical_e5(rosenbrock_vector_mozart_in_place_2, 1e-3);
+  test_analytical_e5(rosenbrock_vector_mozart_in_place_3, 1e-3);
+  test_analytical_e5(rosenbrock_vector_mozart_in_place_4, 1e-3);
 }
 
 TEST(AnalyticalExamples, Oregonator)
@@ -332,6 +632,22 @@ TEST(AnalyticalExamples, Oregonator)
   test_analytical_oregonator(rosenbrock_vector_mozart_2, 4e-6);
   test_analytical_oregonator(rosenbrock_vector_mozart_3, 4e-6);
   test_analytical_oregonator(rosenbrock_vector_mozart_4, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_doolittle_csc_1, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_doolittle_csc_2, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_doolittle_csc_3, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_doolittle_csc_4, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_mozart_csc_1, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_mozart_csc_2, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_mozart_csc_3, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_mozart_csc_4, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_doolittle_in_place_1, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_doolittle_in_place_2, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_doolittle_in_place_3, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_doolittle_in_place_4, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_mozart_in_place_1, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_mozart_in_place_2, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_mozart_in_place_3, 4e-6);
+  test_analytical_oregonator(rosenbrock_vector_mozart_in_place_4, 4e-6);
 }
 
 TEST(AnalyticalExamples, HIRES)
@@ -350,4 +666,28 @@ TEST(AnalyticalExamples, HIRES)
   test_analytical_hires(rosenbrock_vector_mozart_2, 1e-7);
   test_analytical_hires(rosenbrock_vector_mozart_3, 1e-7);
   test_analytical_hires(rosenbrock_vector_mozart_4, 1e-7);
+  test_analytical_hires(rosenbrock_vector_doolittle_1, 1e-7);
+  test_analytical_hires(rosenbrock_vector_doolittle_2, 1e-7);
+  test_analytical_hires(rosenbrock_vector_doolittle_3, 1e-7);
+  test_analytical_hires(rosenbrock_vector_doolittle_4, 1e-7);
+  test_analytical_hires(rosenbrock_vector_mozart_1, 1e-7);
+  test_analytical_hires(rosenbrock_vector_mozart_2, 1e-7);
+  test_analytical_hires(rosenbrock_vector_mozart_3, 1e-7);
+  test_analytical_hires(rosenbrock_vector_mozart_4, 1e-7);
+  test_analytical_hires(rosenbrock_vector_doolittle_csc_1, 1e-7);
+  test_analytical_hires(rosenbrock_vector_doolittle_csc_2, 1e-7);
+  test_analytical_hires(rosenbrock_vector_doolittle_csc_3, 1e-7);
+  test_analytical_hires(rosenbrock_vector_doolittle_csc_4, 1e-7);
+  test_analytical_hires(rosenbrock_vector_mozart_csc_1, 1e-7);
+  test_analytical_hires(rosenbrock_vector_mozart_csc_2, 1e-7);
+  test_analytical_hires(rosenbrock_vector_mozart_csc_3, 1e-7);
+  test_analytical_hires(rosenbrock_vector_mozart_csc_4, 1e-7);
+  test_analytical_hires(rosenbrock_vector_doolittle_in_place_1, 1e-7);
+  test_analytical_hires(rosenbrock_vector_doolittle_in_place_2, 1e-7);
+  test_analytical_hires(rosenbrock_vector_doolittle_in_place_3, 1e-7);
+  test_analytical_hires(rosenbrock_vector_doolittle_in_place_4, 1e-7);
+  test_analytical_hires(rosenbrock_vector_mozart_in_place_1, 1e-7);
+  test_analytical_hires(rosenbrock_vector_mozart_in_place_2, 1e-7);
+  test_analytical_hires(rosenbrock_vector_mozart_in_place_3, 1e-7);
+  test_analytical_hires(rosenbrock_vector_mozart_in_place_4, 1e-7);
 }


### PR DESCRIPTION
This PR fixes a potential issue of using Rosenbrock solver with inline LU decomposition algorithm, when a substepping happens.

Basically we need to:
- re-compute the Jacobian matrix after each sub step because the Jacobian matrix is now modified by the LU decomposition algorithm in place
- only keep the `last_alpha` code for the non-inline LU decomposition algorithm.

fix #704 