### PR TITLE
Add a workflow to close stale issue/PR

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -1,0 +1,24 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    # Run every day at 7PM UTC
+    - cron: '0 19 * * *'
+jobs:
+  close-stale:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          days-before-stale: 30 # Mark as stale after 30 days of inactivity
+          days-before-close: 5  # Close issue if no activity after 5 days of being stale
+          days-before-pr-close: -1
+          # Issues with this label are exempt from being checked if they are stale...
+          exempt-issue-labels: Low Priority
+          # Below are currently defaults, but given in case we decide to change
+          operations-per-run: 30           # This setting specifies the maximum number of operations (such as marking issues as stale or closing them) that the action will perform in a single run
+          stale-issue-label: Stale         # This setting defines the label that will be applied to issues that are considered stale
+          close-issue-reason: not_planned  # This setting specifies the reason that will be given when closing stale issues

--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -14,7 +14,7 @@ jobs:
           stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 14 days with no activity.'
           days-before-stale: 180 # Mark as stale after 180 days of inactivity
-          days-before-close: 14  # Close issue if no activity after 5 days of being stale
+          days-before-close: 14  # Close issue if no activity after 14 days of being stale
           days-before-pr-close: -1
           # Issues with this label are exempt from being checked if they are stale...
           exempt-issue-labels: Low Priority

--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -1,4 +1,4 @@
-name: 'Close stale issues and PRs'
+name: 'Close stale issues'
 on:
   schedule:
     # Run every day at 7PM UTC
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
-          days-before-stale: 30 # Mark as stale after 30 days of inactivity
-          days-before-close: 5  # Close issue if no activity after 5 days of being stale
+          stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 14 days with no activity.'
+          days-before-stale: 180 # Mark as stale after 180 days of inactivity
+          days-before-close: 14  # Close issue if no activity after 5 days of being stale
           days-before-pr-close: -1
           # Issues with this label are exempt from being checked if they are stale...
           exempt-issue-labels: Low Priority


### PR DESCRIPTION
This workflow is modified from the CIME repo workflow (https://github.com/ESMCI/cime/blob/master/.github/workflows/stale.yml) and is expected to close any issues or PRs that have no activity within the past 30 days.

I try to add comments for most settings and we can discuss what is the best value for the MICM repo.

fix #728 