### PR TITLE
Add restrict keyword for local raw pointers in ProcessSet

### DIFF
--- a/include/micm/cuda/solver/cuda_rosenbrock.hpp
+++ b/include/micm/cuda/solver/cuda_rosenbrock.hpp
@@ -46,8 +46,7 @@ namespace micm
       RosenbrockSolver<RatesPolicy, LinearSolverPolicy>::operator=(std::move(other));
       devstruct_ = std::move(other.devstruct_);
       other.devstruct_.errors_input_ = nullptr;
-      other.devstruct_.errors_output_ = nullptr;
-      other.devstruct_.absolute_tolerance_ = nullptr;
+      other.devstruct_.errors_output_ = nullptr; 
       other.devstruct_.jacobian_diagonal_elements_ = nullptr;
       return *this;
     };

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -19,17 +19,17 @@ namespace micm
 
       // Local device variables
       size_t react_id_offset, prod_id_offset, yield_offset;
-      const size_t* const d_number_of_reactants = devstruct.number_of_reactants_;
-      const size_t* const d_reactant_ids = devstruct.reactant_ids_;
-      const size_t* const d_number_of_products = devstruct.number_of_products_;
-      const size_t* const d_product_ids = devstruct.product_ids_;
-      const double* const d_yields = devstruct.yields_;
+      const size_t* const __restrict__ d_number_of_reactants = devstruct.number_of_reactants_;
+      const size_t* const __restrict__ d_reactant_ids = devstruct.reactant_ids_;
+      const size_t* const __restrict__ d_number_of_products = devstruct.number_of_products_;
+      const size_t* const __restrict__ d_product_ids = devstruct.product_ids_;
+      const double* const __restrict__ d_yields = devstruct.yields_;
       const size_t number_of_grid_cells = rate_constants_param.number_of_grid_cells_;
       const size_t number_of_reactions =
           rate_constants_param.number_of_elements_ / rate_constants_param.number_of_grid_cells_;
-      const double* const d_rate_constants = rate_constants_param.d_data_;
-      const double* const d_state_variables = state_variables_param.d_data_;
-      double* const d_forcing = forcing_param.d_data_;
+      const double* const __restrict__ d_rate_constants = rate_constants_param.d_data_;
+      const double* const __restrict__ d_state_variables = state_variables_param.d_data_;
+      double* const __restrict__ d_forcing = forcing_param.d_data_;
 
       if (tid < number_of_grid_cells)
       {
@@ -73,15 +73,15 @@ namespace micm
       size_t react_ids_offset = 0;
       size_t yields_offset = 0;
       size_t flat_id_offset = 0;
-      const ProcessInfoParam* const d_jacobian_process_info = devstruct.jacobian_process_info_;
-      const size_t* const d_reactant_ids = devstruct.jacobian_reactant_ids_;
-      const double* const d_yields = devstruct.jacobian_yields_;
-      const size_t* const d_jacobian_flat_ids = devstruct.jacobian_flat_ids_;
+      const ProcessInfoParam* const __restrict__ d_jacobian_process_info = devstruct.jacobian_process_info_;
+      const size_t* const __restrict__ d_reactant_ids = devstruct.jacobian_reactant_ids_;
+      const double* const __restrict__ d_yields = devstruct.jacobian_yields_;
+      const size_t* const __restrict__ d_jacobian_flat_ids = devstruct.jacobian_flat_ids_;
       const size_t number_of_grid_cells = rate_constants_param.number_of_grid_cells_;
       const size_t number_of_process_infos = devstruct.jacobian_process_info_size_;
-      const double* const d_rate_constants = rate_constants_param.d_data_;
-      const double* const d_state_variables = state_variables_param.d_data_;
-      double* const d_jacobian = jacobian_param.d_data_;
+      const double* const __restrict__ d_rate_constants = rate_constants_param.d_data_;
+      const double* const __restrict__ d_state_variables = state_variables_param.d_data_;
+      double* const __restrict__ d_jacobian = jacobian_param.d_data_;
 
       if (tid < number_of_grid_cells)
       {


### PR DESCRIPTION
It seems that Matt has already made the optimization changes for the CUDA version of Jacobian matrix in his previous PR (#707). Thus here I just add the `__restrict__` keywords to the local raw pointers in the ProcessSet class.

All the CUDA tests pass on Derecho's A100 GPU using the `gcc/12.4.0` compiler.

fix #742 