### PR TITLE
adding a swap method to save on memory copies

### DIFF
--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -218,6 +218,9 @@ namespace micm
       {
         throw std::runtime_error("Both CUDA dense matrices must have the same size.");
       }
+      // We don't swap the memory allocated on the host, we just swap the
+      // device pointers. This is because the device memory will be overwrite
+      // the host memory when the device data is copied to the host.
       std::swap(this->param_.d_data_, other.param_.d_data_);
     }
 

--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -211,6 +211,16 @@ namespace micm
       CHECK_CUDA_ERROR(micm::cuda::CopyToDeviceFromDevice<T>(this->param_, other.param_), "cudaMemcpyDeviceToDevice");
     }
 
+    // Swap the device data from the other Cuda dense matrix into this one
+    void Swap(const CudaDenseMatrix& other)
+    {
+      if (other.param_.number_of_elements_ != this->param_.number_of_elements_)
+      {
+        throw std::runtime_error("Both CUDA dense matrices must have the same size.");
+      }
+      std::swap(this->param_.d_data_, other.param_.d_data_);
+    }
+
     /// @brief Set every matrix element to a given value on the GPU
     /// @param val Value to set each element to
     void Fill(T val)

--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -212,7 +212,7 @@ namespace micm
     }
 
     // Swap the device data from the other Cuda dense matrix into this one
-    void Swap(const CudaDenseMatrix& other)
+    void Swap(CudaDenseMatrix& other)
     {
       if (other.param_.number_of_elements_ != this->param_.number_of_elements_)
       {

--- a/include/micm/solver/backward_euler.inl
+++ b/include/micm/solver/backward_euler.inl
@@ -76,20 +76,14 @@ namespace micm
     auto& Yn1 = state.variables_;  // Yn1 will hold the new solution at the end of the solve
     auto& forcing = derived_class_temporary_variables->forcing_;
 
+    // Ensure Yn starts with the same values as the state variables
+    Yn.Copy(Yn1);
+
     while (t < time_step)
     {
       result.state_ = SolverState::Running;
       bool converged = false;
       std::size_t iterations = 0;
-
-      if (result.stats_.number_of_steps_ == 0)
-      {
-        Yn.Copy(Yn1);
-      }
-      else
-      {
-        Yn1.Copy(Yn);
-      }
 
       do
       {
@@ -167,6 +161,8 @@ namespace micm
         }
         else
         {
+          // if we fail, we need to reset the solution to the last known good solution
+          Yn1.Copy(Yn);
           H *= time_step_reductions[n_convergence_failures++];
         }
       }
@@ -175,7 +171,7 @@ namespace micm
         result.stats_.accepted_++;
         result.state_ = SolverState::Converged;
         t += H;
-        Yn = Yn1;
+        Yn.Copy(Yn1);
 
         // when we accept two solutions in a row, we can increase the time step
         n_successful_integrations++;

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -62,12 +62,6 @@ namespace micm
       rates_.AddForcingTerms(state.rate_constants_, Y, initial_forcing);
       stats.function_calls_ += 1;
 
-      // For memory optimization, the initial forcing can be reused for the first stage.
-      // However, we must always copy the initial forcing to the first stage because K[0] 
-      // and the initial forcing are frequently swapped. This ensures the initial forcing 
-      // remains available for reuse.
-      K[0].Copy(initial_forcing);
-
       // compute the negative jacobian at the beginning of the current time
       state.jacobian_.Fill(0);
       rates_.SubtractJacobianTerms(state.rate_constants_, Y, state.jacobian_);
@@ -97,7 +91,7 @@ namespace micm
           double stage_combinations = ((stage + 1) - 1) * ((stage + 1) - 2) / 2;
           if (stage == 0)
           {
-            K[stage].Swap(initial_forcing);
+            K[stage].Copy(initial_forcing);
           }
           else
           {

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -265,8 +265,15 @@ namespace micm
     void Copy(const Matrix &other)
     {
       if (other.AsVector().size() != this->data_.size())
-        throw std::runtime_error("Both vector matrices must have the same size.");
+        throw std::runtime_error("Both matrices must have the same size.");
       this->data_.assign(other.AsVector().begin(), other.AsVector().end());
+    }
+
+    void Swap(Matrix &other)
+    {
+      if (other.AsVector().size() != this->data_.size())
+        throw std::runtime_error("Both matrices must have the same size.");
+      data_.swap(other.AsVector());
     }
 
     // Print the matrix to the output stream

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -360,6 +360,13 @@ namespace micm
       this->data_.assign(other.AsVector().begin(), other.AsVector().end());
     }
 
+    void Swap(VectorMatrix &other)
+    {
+      if (other.AsVector().size() != this->data_.size())
+        throw std::runtime_error("Both vector matrices must have the same size.");
+      data_.swap(other.AsVector());
+    }
+
     // Print the VectorMatrix to the output stream
     friend std::ostream &operator<<(std::ostream &os, const VectorMatrix &matrix)
     {


### PR DESCRIPTION
Just a small idea I had. Rosenbrock can elide some memory copies if we just swap the pointers of the vector data when we need to copy some memory. Feel free to reject this if we don't think it's useful