### PR TITLE
dealing with static initializaiton issue

### DIFF
--- a/include/micm/util/property_keys.hpp
+++ b/include/micm/util/property_keys.hpp
@@ -8,7 +8,7 @@ namespace micm
 {
   namespace property_keys
   {
-    static const std::string GAS_DIFFUSION_COEFFICIENT = "diffusion coefficient [m2 s-1]";
-    static const std::string MOLECULAR_WEIGHT = "molecular weight [kg mol-1]";
+    static constexpr const char* GAS_DIFFUSION_COEFFICIENT = "diffusion coefficient [m2 s-1]";
+    static constexpr const char*  MOLECULAR_WEIGHT = "molecular weight [kg mol-1]";
   }  // namespace property_keys
 }  // namespace micm


### PR DESCRIPTION
When using std::string, we were running into a [static initialization problem](https://stackoverflow.com/a/1005709/5217293) (also see the [linked article](https://isocpp.org/wiki/faq/ctors#static-init-order) in the answer for more detail). This apparently isn't a problem within the library, but attempting to use those values in the musica performance repo caused this issue to pop up here and in [mechanism configuration](https://github.com/NCAR/MechanismConfiguration/pull/85).