### PR TITLE
Allow creation of State with specified number of grid cells

### DIFF
--- a/include/micm/cuda/solver/cuda_state.hpp
+++ b/include/micm/cuda/solver/cuda_state.hpp
@@ -26,8 +26,9 @@ namespace micm
 
     /// @brief Constructor which takes the state dimension information as input
     /// @param parameters State dimension information
-    CudaState(const StateParameters& parameters)
-        : State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy>(parameters)
+    /// @param number_of_grid_cells Number of grid cells
+    CudaState(const StateParameters& parameters, const std::size_t number_of_grid_cells)
+        : State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy>(parameters, number_of_grid_cells)
     {
       auto& atol = this->absolute_tolerance_;
 

--- a/include/micm/jit/solver/jit_linear_solver.inl
+++ b/include/micm/jit/solver/jit_linear_solver.inl
@@ -34,15 +34,6 @@ namespace micm
             [&](const SparseMatrixPolicy &m) -> LuDecompositionPolicy { return LuDecompositionPolicy(m); })
   {
     solve_function_ = NULL;
-    if (matrix.NumberOfBlocks() != L || matrix.GroupVectorSize() != L)
-    {
-      std::string msg = "JIT functions require the number of grid cells solved together (" +
-                        std::to_string(matrix.NumberOfBlocks()) +
-                        ") to match the vector dimension template parameter, "
-                        "currently: " +
-                        std::to_string(L);
-      throw std::system_error(make_error_code(MicmJitErrc::InvalidMatrix), msg);
-    }
     GenerateSolveFunction();
   }
 
@@ -72,6 +63,24 @@ namespace micm
       SparseMatrixPolicy &lower_matrix,
       SparseMatrixPolicy &upper_matrix) const
   {
+    if (lower_matrix.NumberOfBlocks() != L || lower_matrix.GroupVectorSize() != L)
+    {
+      std::string msg = "JIT functions require the number of grid cells solved together (" +
+                        std::to_string(lower_matrix.NumberOfBlocks()) +
+                        ") of the lower matrix to match the vector dimension template parameter, "
+                        "currently: " +
+                        std::to_string(L);
+      throw std::system_error(make_error_code(MicmJitErrc::InvalidMatrix), msg);
+    }
+    if (upper_matrix.NumberOfBlocks() != L || upper_matrix.GroupVectorSize() != L)
+    {
+      std::string msg = "JIT functions require the number of grid cells solved together (" +
+                        std::to_string(upper_matrix.NumberOfBlocks()) +
+                        ") of the upper matrix to match the vector dimension template parameter, "
+                        "currently: " +
+                        std::to_string(L);
+      throw std::system_error(make_error_code(MicmJitErrc::InvalidMatrix), msg);
+    }
     solve_function_(x.AsVector().data(), lower_matrix.AsVector().data(), upper_matrix.AsVector().data());
   }
 

--- a/include/micm/solver/backward_euler_temporary_variables.hpp
+++ b/include/micm/solver/backward_euler_temporary_variables.hpp
@@ -21,9 +21,9 @@ namespace micm
     BackwardEulerTemporaryVariables& operator=(BackwardEulerTemporaryVariables&& other) = default;
     ~BackwardEulerTemporaryVariables() = default;
 
-    BackwardEulerTemporaryVariables(const auto& state_parameters)
-        : Yn_(state_parameters.number_of_grid_cells_, state_parameters.number_of_species_),
-          forcing_(state_parameters.number_of_grid_cells_, state_parameters.number_of_species_)
+    BackwardEulerTemporaryVariables(const auto& state_parameters, const std::size_t number_of_grid_cells)
+        : Yn_(number_of_grid_cells, state_parameters.number_of_species_),
+          forcing_(number_of_grid_cells, state_parameters.number_of_species_)
     {
     }
   };

--- a/include/micm/solver/rosenbrock_temporary_variables.hpp
+++ b/include/micm/solver/rosenbrock_temporary_variables.hpp
@@ -25,14 +25,14 @@ namespace micm
     RosenbrockTemporaryVariables& operator=(RosenbrockTemporaryVariables&& other) = default;
     ~RosenbrockTemporaryVariables() = default;
 
-    RosenbrockTemporaryVariables(const auto& state_parameters, const auto& solver_parameters)
-        : Ynew_(state_parameters.number_of_grid_cells_, state_parameters.number_of_species_),
-          initial_forcing_(state_parameters.number_of_grid_cells_, state_parameters.number_of_species_),
-          Yerror_(state_parameters.number_of_grid_cells_, state_parameters.number_of_species_)
+    RosenbrockTemporaryVariables(const auto& state_parameters, const auto& solver_parameters, const std::size_t number_of_grid_cells)
+        : Ynew_(number_of_grid_cells, state_parameters.number_of_species_),
+          initial_forcing_(number_of_grid_cells, state_parameters.number_of_species_),
+          Yerror_(number_of_grid_cells, state_parameters.number_of_species_)
     {
       K_.reserve(solver_parameters.stages_);
       for (std::size_t i = 0; i < solver_parameters.stages_; ++i)
-        K_.emplace_back(state_parameters.number_of_grid_cells_, state_parameters.number_of_species_);
+        K_.emplace_back(number_of_grid_cells, state_parameters.number_of_species_);
     }
   };
 }  // namespace micm

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -80,13 +80,6 @@ namespace micm
       return solver_.Solve(time_step, state, params);
     }
 
-    /// @brief Returns the number of grid cells
-    /// @return
-    std::size_t GetNumberOfGridCells() const
-    {
-      return state_parameters_.number_of_grid_cells_;
-    }
-
     /// @brief Returns the number of species
     /// @return
     std::size_t GetNumberOfSpecies() const
@@ -99,17 +92,17 @@ namespace micm
       return state_parameters_.number_of_rate_constants_;
     }
 
-    StatePolicy GetState() const
+    StatePolicy GetState(const std::size_t number_of_grid_cells = 1) const
     {
-      auto state = std::move(StatePolicy(state_parameters_));
+      auto state = std::move(StatePolicy(state_parameters_, number_of_grid_cells));
       if constexpr (std::is_convertible_v<typename SolverPolicy::ParametersType, RosenbrockSolverParameters>)
       {
         state.temporary_variables_ =
-            std::make_unique<RosenbrockTemporaryVariables<DenseMatrixType>>(state_parameters_, solver_parameters_);
+            std::make_unique<RosenbrockTemporaryVariables<DenseMatrixType>>(state_parameters_, solver_parameters_, number_of_grid_cells);
       }
       else if constexpr (std::is_same_v<typename SolverPolicy::ParametersType, BackwardEulerSolverParameters>)
       {
-        state.temporary_variables_ = std::make_unique<BackwardEulerTemporaryVariables<DenseMatrixType>>(state_parameters_);
+        state.temporary_variables_ = std::make_unique<BackwardEulerTemporaryVariables<DenseMatrixType>>(state_parameters_, number_of_grid_cells);
       }
       else
       {

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -48,7 +48,6 @@ namespace micm
    protected:
     SolverParametersPolicy options_;
     System system_;
-    std::size_t number_of_grid_cells_ = 1;
     std::vector<Process> reactions_;
     bool ignore_unused_species_ = true;
     bool reorder_state_ = true;
@@ -74,11 +73,6 @@ namespace micm
     /// @param reactions The reactions
     /// @return Updated SolverBuilder
     SolverBuilder& SetReactions(const std::vector<Process>& reactions);
-
-    /// @brief Set the number of grid cells
-    /// @param number_of_grid_cells The number of grid cells
-    /// @return Updated SolverBuilder
-    SolverBuilder& SetNumberOfGridCells(int number_of_grid_cells);
 
     /// @brief Set whether to ignore unused species
     /// @param ignore_unused_species True if unused species should be ignored

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -140,35 +140,6 @@ namespace micm
       RatesPolicy,
       LuDecompositionPolicy,
       LinearSolverPolicy,
-      StatePolicy>::SetNumberOfGridCells(int number_of_grid_cells)
-  {
-    number_of_grid_cells_ = number_of_grid_cells;
-    return *this;
-  }
-
-  template<
-      class SolverParametersPolicy,
-      class DenseMatrixPolicy,
-      class SparseMatrixPolicy,
-      class RatesPolicy,
-      class LuDecompositionPolicy,
-      class LinearSolverPolicy,
-      class StatePolicy>
-  inline SolverBuilder<
-      SolverParametersPolicy,
-      DenseMatrixPolicy,
-      SparseMatrixPolicy,
-      RatesPolicy,
-      LuDecompositionPolicy,
-      LinearSolverPolicy,
-      StatePolicy>&
-  SolverBuilder<
-      SolverParametersPolicy,
-      DenseMatrixPolicy,
-      SparseMatrixPolicy,
-      RatesPolicy,
-      LuDecompositionPolicy,
-      LinearSolverPolicy,
       StatePolicy>::SetIgnoreUnusedSpecies(bool ignore_unused_species)
   {
     ignore_unused_species_ = ignore_unused_species;
@@ -398,7 +369,8 @@ namespace micm
 
     RatesPolicy rates(this->reactions_, species_map);
     auto nonzero_elements = rates.NonZeroJacobianElements();
-    auto jacobian = BuildJacobian<SparseMatrixPolicy>(nonzero_elements, this->number_of_grid_cells_, number_of_species);
+    // The actual number of grid cells is not needed to construct the various solver objects
+    auto jacobian = BuildJacobian<SparseMatrixPolicy>(nonzero_elements, 1, number_of_species);
 
     LinearSolverPolicy linear_solver(jacobian, 0);
     if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
@@ -412,8 +384,7 @@ namespace micm
     for (auto& species_pair : species_map)
       variable_names[species_pair.second] = species_pair.first;
 
-    StateParameters state_parameters = { .number_of_grid_cells_ = this->number_of_grid_cells_,
-                                         .number_of_species_ = number_of_species,
+    StateParameters state_parameters = { .number_of_species_ = number_of_species,
                                          .number_of_rate_constants_ = this->reactions_.size(),
                                          .variable_names_ = variable_names,
                                          .custom_rate_parameter_labels_ = labels,

--- a/include/micm/solver/state.hpp
+++ b/include/micm/solver/state.hpp
@@ -25,7 +25,6 @@ namespace micm
   /// @brief Invariants that can be used to construct a state
   struct StateParameters
   {
-    std::size_t number_of_grid_cells_{ 1 };
     std::size_t number_of_species_{ 0 };
     std::size_t number_of_rate_constants_{ 0 };
     std::vector<std::string> variable_names_{};
@@ -48,6 +47,8 @@ namespace micm
     using SparseMatrixPolicyType = SparseMatrixPolicy;
     using LuDecompositionPolicyType = LuDecompositionPolicy;
 
+    /// @brief The number of grid cells stored in the state
+    std::size_t number_of_grid_cells_{ 1 };
     /// @brief The concentration of chemicals, varies through time
     DenseMatrixPolicy variables_;
     /// @brief Rate paramters particular to user-defined rate constants, may vary in time
@@ -66,7 +67,6 @@ namespace micm
     LMatrixPolicy lower_matrix_;
     UMatrixPolicy upper_matrix_;
     std::size_t state_size_;
-    std::size_t number_of_grid_cells_;
     std::unique_ptr<TemporaryVariables> temporary_variables_;
     double relative_tolerance_;
     std::vector<double> absolute_tolerance_;
@@ -78,7 +78,7 @@ namespace micm
 
     /// @brief Constructor with parameters
     /// @param parameters State dimension information
-    State(const StateParameters& parameters);
+    State(const StateParameters& parameters, const std::size_t number_of_grid_cells);
 
     /// @brief Copy constructor
     /// @param other The state object to be copied
@@ -182,6 +182,13 @@ namespace micm
     }
 
     virtual ~State() = default;
+
+    /// @brief Get the number of grid cells
+    /// @return The number of grid cells
+    std::size_t NumberOfGridCells() const
+    {
+      return number_of_grid_cells_;
+    }
 
     /// @brief Set species' concentrations
     /// @param species_to_concentration

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -90,11 +90,11 @@ namespace micm
       class LMatrixPolicy,
       class UMatrixPolicy>
   inline State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::State(
-      const StateParameters& parameters)
-      : conditions_(parameters.number_of_grid_cells_),
-        variables_(parameters.number_of_grid_cells_, parameters.variable_names_.size(), 0.0),
-        custom_rate_parameters_(parameters.number_of_grid_cells_, parameters.custom_rate_parameter_labels_.size(), 0.0),
-        rate_constants_(parameters.number_of_grid_cells_, parameters.number_of_rate_constants_, 0.0),
+      const StateParameters& parameters, const std::size_t number_of_grid_cells)
+      : conditions_(number_of_grid_cells),
+        variables_(number_of_grid_cells, parameters.variable_names_.size(), 0.0),
+        custom_rate_parameters_(number_of_grid_cells, parameters.custom_rate_parameter_labels_.size(), 0.0),
+        rate_constants_(number_of_grid_cells, parameters.number_of_rate_constants_, 0.0),
         variable_map_(),
         custom_rate_parameter_map_(),
         variable_names_(parameters.variable_names_),
@@ -103,7 +103,7 @@ namespace micm
         lower_matrix_(),
         upper_matrix_(),
         state_size_(parameters.variable_names_.size()),
-        number_of_grid_cells_(parameters.number_of_grid_cells_),
+        number_of_grid_cells_(number_of_grid_cells),
         relative_tolerance_(parameters.relative_tolerance_),
         absolute_tolerance_(parameters.absolute_tolerance_)
   {
@@ -115,7 +115,7 @@ namespace micm
       custom_rate_parameter_map_[label] = index++;
 
     jacobian_ = BuildJacobian<SparseMatrixPolicy>(
-        parameters.nonzero_jacobian_elements_, parameters.number_of_grid_cells_, state_size_);
+        parameters.nonzero_jacobian_elements_, number_of_grid_cells, state_size_);
 
     if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
     {

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -139,7 +139,7 @@ void test_simple_system(
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve,
     std::unordered_map<std::string, std::vector<double>> custom_parameters = {})
 {
-  auto solver = builder.SetNumberOfGridCells(NUM_CELLS).Build();
+  auto solver = builder.Build();
 
   std::vector<double> temperatures = { 272.5, 254.7, 312.6 };
   std::vector<double> pressures = { 101253.3, 100672.5, 101319.8 };
@@ -156,7 +156,7 @@ void test_simple_system(
   }
 
   double time_step = 1.0;
-  auto state = solver.GetState();
+  auto state = solver.GetState(NUM_CELLS);
   auto map = state.variable_map_;
 
   state.SetCustomRateParameters(custom_parameters);
@@ -255,7 +255,7 @@ void test_simple_stiff_system(
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve,
     std::unordered_map<std::string, std::vector<double>> custom_parameters = {})
 {
-  auto solver = builder.SetNumberOfGridCells(NUM_CELLS).Build();
+  auto solver = builder.Build();
 
   std::vector<double> temperatures = { 272.5, 254.7, 312.6 };
   std::vector<double> pressures = { 101253.3, 100672.5, 101319.8 };
@@ -272,7 +272,7 @@ void test_simple_stiff_system(
   }
 
   double time_step = 1.0;
-  auto state = solver.GetState();
+  auto state = solver.GetState(NUM_CELLS);
   auto map = state.variable_map_;
 
   state.SetCustomRateParameters(custom_parameters);
@@ -1344,7 +1344,7 @@ void test_analytical_robertson(
   double pressure = 101253.3;
   double air_density = 1e6;
 
-  auto state = solver.GetState();
+  auto state = solver.GetState(1);
   state.SetRelativeTolerance(1e-10);
   state.SetAbsoluteTolerances(std::vector<double>(3, state.relative_tolerance_ * 1e-2));
 
@@ -1561,7 +1561,7 @@ void test_analytical_oregonator(
     row[2] *= rho_const;
   }
 
-  auto state = solver.GetState();
+  auto state = solver.GetState(1);
 
   state.SetRelativeTolerance(1e-6);
   state.SetAbsoluteTolerances(std::vector<double>(5, state.relative_tolerance_ * 1e-6));
@@ -1742,7 +1742,7 @@ void test_analytical_hires(
       0.004685507242281520 },
   };
 
-  auto state = solver.GetState();
+  auto state = solver.GetState(1);
   state.SetRelativeTolerance(1e-6);
   state.SetAbsoluteTolerances(std::vector<double>(8, state.relative_tolerance_ * 1e-2));
 
@@ -1903,7 +1903,7 @@ void test_analytical_e5(
     { 0.0000000000000000000e-000, 8.8612334976263783420e-023, 8.8612334976263783421e-023, 0.0000000000000000000e-000, 0, 0 }
   };
 
-  auto state = solver.GetState();
+  auto state = solver.GetState(1);
 
   state.SetRelativeTolerance(1e-13);
   state.SetAbsoluteTolerances(std::vector<double>(6, 1e-17));

--- a/test/integration/terminator.hpp
+++ b/test/integration/terminator.hpp
@@ -39,9 +39,8 @@ void TestTerminator(BuilderPolicy& builder, std::size_t number_of_grid_cells)
 
   auto solver = builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
                     .SetReactions(std::vector<micm::Process>{ toy_r1, toy_r2 })
-                    .SetNumberOfGridCells(number_of_grid_cells)
                     .Build();
-  auto state = solver.GetState();
+  auto state = solver.GetState(number_of_grid_cells);
   state.SetRelativeTolerance(1.0e-8);
 
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());

--- a/test/integration/test_integrated_reaction_rates.cpp
+++ b/test/integration/test_integrated_reaction_rates.cpp
@@ -37,10 +37,9 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
                     .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
                     .SetReactions({ r1, r2 })
-                    .SetNumberOfGridCells(1)
                     .Build();
 
-  auto state = solver.GetState();
+  auto state = solver.GetState(1);
 
   state.SetCustomRateParameter("r2", 1.0);
 

--- a/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
+++ b/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
@@ -46,8 +46,6 @@ namespace micm
 
     double absolute_tolerance_{ 1e-3 };
     double relative_tolerance_{ 1e-4 };
-
-    size_t number_of_grid_cells_{ 1 };  // Number of grid cells to solve simultaneously
   };
 
   /// @brief An implementation of the Chapman mechnanism solver
@@ -103,9 +101,10 @@ namespace micm
     /// @brief Sets parameters for the solver
     void three_stage_rosenbrock();
 
-    /// Returns a state variable for the Chapman system
+    /// @brief Returns a state variable for the Chapman system
+    /// @param number_of_grid_cells The number of grid cells to solve for
     /// @return State variable for Chapman
-    State<> GetState() const;
+    State<> GetState(const std::size_t number_of_grid_cells) const;
 
     /// @brief A virtual function to be defined by any solver baseclass
     /// @param time_start Time step to start at
@@ -296,16 +295,15 @@ namespace micm
     parameters_.gamma_[2] = 0.21851380027664058511513169485832e+01;
   }
 
-  inline State<> ChapmanODESolver::GetState() const
+  inline State<> ChapmanODESolver::GetState(const std::size_t number_of_grid_cells = 1) const
   {
     auto state_parameters = micm::StateParameters{
-      .number_of_grid_cells_ = 1,
       .number_of_rate_constants_ = 7,
       .variable_names_ = species_names(),
       .custom_rate_parameter_labels_ = photolysis_names(),
     };
 
-    return micm::State{ state_parameters };
+    return micm::State{ state_parameters, number_of_grid_cells };
   }
 
   inline ChapmanODESolver::SolverResult ChapmanODESolver::Solve(double time_start, double time_end, State<>& state) noexcept

--- a/test/regression/RosenbrockChapman/jit_util.hpp
+++ b/test/regression/RosenbrockChapman/jit_util.hpp
@@ -9,7 +9,7 @@ template<std::size_t L>
 using JitBuilder = micm::JitSolverBuilder<micm::JitRosenbrockSolverParameters, L>;
 
 template<std::size_t L>
-auto getTwoStageMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
+auto getTwoStageMultiCellJitChapmanSolver()
 {
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
@@ -17,13 +17,12 @@ auto getTwoStageMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
   return JitBuilder<L>(micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters())
       .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
       .SetReactions(std::move(processes))
-      .SetNumberOfGridCells(number_of_grid_cells)
       .SetIgnoreUnusedSpecies(true)
       .Build();
 }
 
 template<std::size_t L>
-auto getThreeStageMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
+auto getThreeStageMultiCellJitChapmanSolver()
 {
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
@@ -31,13 +30,12 @@ auto getThreeStageMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
   return JitBuilder<L>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
       .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
       .SetReactions(std::move(processes))
-      .SetNumberOfGridCells(number_of_grid_cells)
       .SetIgnoreUnusedSpecies(true)
       .Build();
 }
 
 template<std::size_t L>
-auto getFourStageMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
+auto getFourStageMultiCellJitChapmanSolver()
 {
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
@@ -45,13 +43,12 @@ auto getFourStageMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
   return JitBuilder<L>(micm::RosenbrockSolverParameters::FourStageRosenbrockParameters())
       .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
       .SetReactions(std::move(processes))
-      .SetNumberOfGridCells(number_of_grid_cells)
       .SetIgnoreUnusedSpecies(true)
       .Build();
 }
 
 template<std::size_t L>
-auto getFourStageDAMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
+auto getFourStageDAMultiCellJitChapmanSolver()
 {
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
@@ -59,13 +56,12 @@ auto getFourStageDAMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
   return JitBuilder<L>(micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
       .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
       .SetReactions(std::move(processes))
-      .SetNumberOfGridCells(number_of_grid_cells)
       .SetIgnoreUnusedSpecies(true)
       .Build();
 }
 
 template<std::size_t L>
-auto getSixStageDAMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
+auto getSixStageDAMultiCellJitChapmanSolver()
 {
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
@@ -73,7 +69,6 @@ auto getSixStageDAMultiCellJitChapmanSolver(const size_t number_of_grid_cells)
   return JitBuilder<L>(micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters())
       .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
       .SetReactions(std::move(processes))
-      .SetNumberOfGridCells(number_of_grid_cells)
       .SetIgnoreUnusedSpecies(true)
       .Build();
 }

--- a/test/regression/RosenbrockChapman/regression_test_dforce_dy.cpp
+++ b/test/regression/RosenbrockChapman/regression_test_dforce_dy.cpp
@@ -14,7 +14,7 @@ TEST(RegressionRosenbrock, Jacobian)
 {
   auto builder = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
       micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  auto solver = getChapmanSolver(builder, 3);
+  auto solver = getChapmanSolver(builder);
   testJacobian(solver);
 }
 
@@ -22,22 +22,22 @@ TEST(RegressionRosenbrock, VectorJacobian)
 {
   {
     auto builder = VectorBuilder<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testJacobian(solver);
   }
   {
     auto builder = VectorBuilder<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testJacobian(solver);
   }
   {
     auto builder = VectorBuilder<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testJacobian(solver);
   }
   {
     auto builder = VectorBuilder<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testJacobian(solver);
   }
 }

--- a/test/regression/RosenbrockChapman/regression_test_dforce_dy_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_dforce_dy_policy.hpp
@@ -14,7 +14,7 @@ void testJacobian(SolverPolicy& solver)
 
   micm::ChapmanODESolver fixed_solver{};
 
-  auto state = solver.GetState();
+  auto state = solver.GetState(3);
 
   auto& state_vec = state.variables_.AsVector();
   std::generate(state_vec.begin(), state_vec.end(), [&]() { return dist(engine); });

--- a/test/regression/RosenbrockChapman/regression_test_jit_dforce_dy.cpp
+++ b/test/regression/RosenbrockChapman/regression_test_jit_dforce_dy.cpp
@@ -8,6 +8,6 @@
 
 TEST(RegressionJitRosenbrock, VectorJacobian)
 {
-  auto solver = getThreeStageMultiCellJitChapmanSolver<3>(3);
+  auto solver = getThreeStageMultiCellJitChapmanSolver<3>();
   testJacobian<>(solver);
 }

--- a/test/regression/RosenbrockChapman/regression_test_jit_p_force.cpp
+++ b/test/regression/RosenbrockChapman/regression_test_jit_p_force.cpp
@@ -9,12 +9,12 @@
 
 TEST(RegressionJitRosenbrock, VectorRateConstants)
 {
-  auto solver = getThreeStageMultiCellJitChapmanSolver<3>(3);
+  auto solver = getThreeStageMultiCellJitChapmanSolver<3>();
   testRateConstants<>(solver);
 }
 
 TEST(RegressionJitRosenbrock, VectorForcing)
 {
-  auto solver = getThreeStageMultiCellJitChapmanSolver<3>(3);
+  auto solver = getThreeStageMultiCellJitChapmanSolver<3>();
   testForcing<micm::VectorMatrix<double, 3>>(solver);
 }

--- a/test/regression/RosenbrockChapman/regression_test_jit_solve.cpp
+++ b/test/regression/RosenbrockChapman/regression_test_jit_solve.cpp
@@ -8,30 +8,30 @@
 
 TEST(RegressionJitRosenbrock, TwoStageSolve)
 {
-  auto solver = getTwoStageMultiCellJitChapmanSolver<3>(3);
+  auto solver = getTwoStageMultiCellJitChapmanSolver<3>();
   testSolve<>(solver, 1.0e-2);
 }
 
 TEST(RegressionJitRosenbrock, ThreeStageSolve)
 {
-  auto solver = getThreeStageMultiCellJitChapmanSolver<3>(3);
+  auto solver = getThreeStageMultiCellJitChapmanSolver<3>();
   testSolve<>(solver, 1.0e-2);
 }
 
 TEST(RegressionJitRosenbrock, FourStageSolve)
 {
-  auto solver = getFourStageMultiCellJitChapmanSolver<3>(3);
+  auto solver = getFourStageMultiCellJitChapmanSolver<3>();
   testSolve<>(solver, 1.0e-2);
 }
 
 TEST(RegressionJitRosenbrock, FourStageDASolve)
 {
-  auto solver = getFourStageDAMultiCellJitChapmanSolver<3>(3);
+  auto solver = getFourStageDAMultiCellJitChapmanSolver<3>();
   testSolve<>(solver, 1.0e-2);
 }
 
 TEST(RegressionJitRosenbrock, SixStageDASolve)
 {
-  auto solver = getSixStageDAMultiCellJitChapmanSolver<3>(3);
+  auto solver = getSixStageDAMultiCellJitChapmanSolver<3>();
   testSolve<>(solver, 1.0e-2);
 }

--- a/test/regression/RosenbrockChapman/regression_test_p_force.cpp
+++ b/test/regression/RosenbrockChapman/regression_test_p_force.cpp
@@ -12,7 +12,7 @@ TEST(RegressionRosenbrock, RateConstants)
 {
   auto builder = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
       micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  auto solver = getChapmanSolver(builder, 3);
+  auto solver = getChapmanSolver(builder);
   testRateConstants(solver);
 }
 
@@ -20,22 +20,22 @@ TEST(RegressionRosenbrock, VectorRateConstants)
 {
   {
     auto builder = VectorBuilder<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testRateConstants(solver);
   }
   {
     auto builder = VectorBuilder<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testRateConstants(solver);
   }
   {
     auto builder = VectorBuilder<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testRateConstants(solver);
   }
   {
     auto builder = VectorBuilder<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testRateConstants(solver);
   }
 }
@@ -44,7 +44,7 @@ TEST(RegressionRosenbrock, Forcing)
 {
   auto builder = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
       micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  auto solver = getChapmanSolver(builder, 3);
+  auto solver = getChapmanSolver(builder);
   testForcing<micm::Matrix<double>>(solver);
 }
 
@@ -52,22 +52,22 @@ TEST(RegressionRosenbrock, VectorForcing)
 {
   {
     auto builder = VectorBuilder<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testForcing<micm::VectorMatrix<double, 1>>(solver);
   }
   {
     auto builder = VectorBuilder<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testForcing<micm::VectorMatrix<double, 2>>(solver);
   }
   {
     auto builder = VectorBuilder<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testForcing<micm::VectorMatrix<double, 3>>(solver);
   }
   {
     auto builder = VectorBuilder<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testForcing<micm::VectorMatrix<double, 4>>(solver);
   }
 }

--- a/test/regression/RosenbrockChapman/regression_test_p_force_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_p_force_policy.hpp
@@ -10,7 +10,7 @@ void testRateConstants(SolverPolicy& solver)
 {
   micm::ChapmanODESolver fixed_solver{};
 
-  auto state = solver.GetState();
+  auto state = solver.GetState(3);
   auto fixed_state = fixed_solver.GetState();
   const std::vector<std::vector<double>> photo_rates{ { 1.0e-4, 1.0e-5, 1.0e-6 },
                                                       { 3.2e-4, 7.3e-5, 3.2e-6 },
@@ -49,7 +49,7 @@ void testForcing(SolverPolicy& solver)
 
   micm::ChapmanODESolver fixed_solver{};
 
-  auto state = solver.GetState();
+  auto state = solver.GetState(3);
 
   auto& state_vec = state.variables_.AsVector();
   std::generate(begin(state_vec), end(state_vec), [&]() { return dist(engine); });

--- a/test/regression/RosenbrockChapman/regression_test_solve.cpp
+++ b/test/regression/RosenbrockChapman/regression_test_solve.cpp
@@ -11,7 +11,7 @@ TEST(RegressionRosenbrock, TwoStageSolve)
 {
   auto builder = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
       micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
-  auto solver = getChapmanSolver(builder, 3);
+  auto solver = getChapmanSolver(builder);
   testSolve(solver, 1.0e-2);
 }
 
@@ -19,7 +19,7 @@ TEST(RegressionRosenbrock, ThreeStageSolve)
 {
   auto builder = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
       micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-  auto solver = getChapmanSolver(builder, 3);
+  auto solver = getChapmanSolver(builder);
   testSolve(solver);
 }
 
@@ -27,7 +27,7 @@ TEST(RegressionRosenbrock, FourStageSolve)
 {
   auto builder = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
       micm::RosenbrockSolverParameters::FourStageRosenbrockParameters());
-  auto solver = getChapmanSolver(builder, 3);
+  auto solver = getChapmanSolver(builder);
   testSolve(solver, 1.0e-4);
 }
 
@@ -35,7 +35,7 @@ TEST(RegressionRosenbrock, FourStageDASolve)
 {
   auto builder = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
       micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters());
-  auto solver = getChapmanSolver(builder, 3);
+  auto solver = getChapmanSolver(builder);
   testSolve(solver, 1.0e-4);
 }
 
@@ -43,7 +43,7 @@ TEST(RegressionRosenbrock, SixStageDASolve)
 {
   auto builder = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
       micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters());
-  auto solver = getChapmanSolver(builder, 3);
+  auto solver = getChapmanSolver(builder);
   testSolve(solver, 1.0e-4);
 }
 
@@ -51,22 +51,22 @@ TEST(RegressionRosenbrock, VectorSolve)
 {
   {
     auto builder = VectorBuilder<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testSolve(solver);
   }
   {
     auto builder = VectorBuilder<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testSolve(solver);
   }
   {
     auto builder = VectorBuilder<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testSolve(solver);
   }
   {
     auto builder = VectorBuilder<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
-    auto solver = getChapmanSolver(builder, 3);
+    auto solver = getChapmanSolver(builder);
     testSolve(solver);
   }
 }

--- a/test/regression/RosenbrockChapman/regression_test_solve_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_solve_policy.hpp
@@ -9,8 +9,8 @@ void testSolve(SolverPolicy& solver, double relative_tolerance = 1.0e-8)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
   micm::ChapmanODESolver fixed_solver{};
 
-  auto state = solver.GetState();
-  auto fixed_state = fixed_solver.GetState();
+  auto state = solver.GetState(3);
+  auto fixed_state = fixed_solver.GetState(3);
 
   // set conditions
   const std::vector<std::vector<double>> photo_rates{ { 1.0e-4, 1.0e-5, 1.0e-6 },

--- a/test/regression/RosenbrockChapman/util.hpp
+++ b/test/regression/RosenbrockChapman/util.hpp
@@ -76,13 +76,12 @@ std::vector<micm::Process> createProcesses(const micm::Phase& gas_phase)
 }
 
 template<class SolverBuilderPolicy>
-auto getChapmanSolver(SolverBuilderPolicy& builder, const size_t number_of_grid_cells)
+auto getChapmanSolver(SolverBuilderPolicy& builder)
 {
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
 
   return builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
       .SetReactions(std::move(processes))
-      .SetNumberOfGridCells(number_of_grid_cells)
       .Build();
 }

--- a/test/tutorial/test_jit_tutorial.cpp
+++ b/test/tutorial/test_jit_tutorial.cpp
@@ -12,10 +12,10 @@ template<class T>
 using GroupVectorMatrix = micm::VectorMatrix<T, n_grid_cells>;
 using GroupSparseVectorMatrix = micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<n_grid_cells>>;
 
-auto run_solver(auto& solver)
+auto run_solver(auto& solver, const size_t n_grid_cells = 1)
 {
   SolverStats total_stats;
-  State state = solver.GetState();
+  State state = solver.GetState(n_grid_cells);
 
   state.variables_ = 1;
 
@@ -90,14 +90,12 @@ int main(const int argc, const char* argv[])
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(solver_parameters)
                     .SetSystem(chemical_system)
                     .SetReactions(reactions)
-                    .SetNumberOfGridCells(n_grid_cells)
                     .Build();
   
   auto start = std::chrono::high_resolution_clock::now();
   auto jit_solver = micm::JitSolverBuilder<micm::JitRosenbrockSolverParameters, n_grid_cells>(solver_parameters)
                         .SetSystem(chemical_system)
                         .SetReactions(reactions)
-                        .SetNumberOfGridCells(n_grid_cells)
                         .Build();
   auto end = std::chrono::high_resolution_clock::now();
   auto jit_compile_time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);

--- a/test/tutorial/test_multiple_grid_cells.cpp
+++ b/test/tutorial/test_multiple_grid_cells.cpp
@@ -37,10 +37,9 @@ int main()
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                     .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
                     .SetReactions({ r1, r2, r3 })
-                    .SetNumberOfGridCells(number_of_grid_cells)
                     .Build();
 
-  auto state = solver.GetState();
+  auto state = solver.GetState(number_of_grid_cells);
 
   // mol m-3
   state.SetConcentration(a, std::vector<double>{ 1, 2, 0.5 });

--- a/test/tutorial/test_solver_results.cpp
+++ b/test/tutorial/test_solver_results.cpp
@@ -38,10 +38,9 @@ int main()
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                     .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
                     .SetReactions({ r1, r2, r3 })
-                    .SetNumberOfGridCells(number_of_grid_cells)
                     .Build();
 
-  auto state = solver.GetState();
+  auto state = solver.GetState(number_of_grid_cells);
 
   // mol m-3
   state.SetConcentration(a, std::vector<double>{ 1, 2, 0.5 });

--- a/test/tutorial/test_vectorized_matrix_solver.cpp
+++ b/test/tutorial/test_vectorized_matrix_solver.cpp
@@ -81,10 +81,9 @@ int main()
   auto solver = CpuSolverBuilder<micm::RosenbrockSolverParameters>(params)
       .SetSystem(system)
       .SetReactions(reactions)
-      .SetNumberOfGridCells(number_of_grid_cells)
       .Build();
 
-  auto state = solver.GetState();
+  auto state = solver.GetState(number_of_grid_cells);
 
   state.SetConcentration(a, { 1.1, 2.1, 3.1 });
   state.SetConcentration(b, { 1.2, 2.2, 3.2 });
@@ -102,10 +101,9 @@ int main()
                                             SparseMatrix<double, SparseMatrixVectorOrdering<3>>>(params)
                                .SetSystem(system)
                                .SetReactions(reactions)
-                               .SetNumberOfGridCells(number_of_grid_cells)
                                .Build();
 
-  auto vectorized_state = vectorized_solver.GetState();
+  auto vectorized_state = vectorized_solver.GetState(number_of_grid_cells);
 
   vectorized_state.SetConcentration(a, { 1.1, 2.1, 3.1 });
   vectorized_state.SetConcentration(b, { 1.2, 2.2, 3.2 });

--- a/test/unit/cuda/process/test_cuda_process_set.cpp
+++ b/test/unit/cuda/process/test_cuda_process_set.cpp
@@ -42,17 +42,15 @@ void testRandomSystemAddForcingTerms(std::size_t n_cells, std::size_t n_reaction
   }
   micm::Phase gas_phase{ species };
   micm::State<CPUMatrixPolicy> cpu_state{ micm::StateParameters{
-      .number_of_grid_cells_ = n_cells,
       .number_of_rate_constants_ = n_reactions,
       .variable_names_{ species_names },
       .custom_rate_parameter_labels_{},
-  } };
+  }, n_cells };
   micm::State<GPUMatrixPolicy> gpu_state{ micm::StateParameters{
-      .number_of_grid_cells_ = n_cells,
       .number_of_rate_constants_ = n_reactions,
       .variable_names_{ species_names },
       .custom_rate_parameter_labels_{},
-  } };
+  }, n_cells };
 
   std::vector<micm::Process> processes{};
   for (std::size_t i = 0; i < n_reactions; ++i)
@@ -129,17 +127,15 @@ void testRandomSystemSubtractJacobianTerms(std::size_t n_cells, std::size_t n_re
   micm::Phase gas_phase{ species };
 
   micm::State<CPUMatrixPolicy> cpu_state{ micm::StateParameters{
-      .number_of_grid_cells_ = n_cells,
       .number_of_rate_constants_ = n_reactions,
       .variable_names_{ species_names },
       .custom_rate_parameter_labels_{},
-  } };
+  }, n_cells };
   micm::State<GPUDenseMatrixPolicy> gpu_state{ micm::StateParameters{
-      .number_of_grid_cells_ = n_cells,
       .number_of_rate_constants_ = n_reactions,
       .variable_names_{ species_names },
       .custom_rate_parameter_labels_{},
-  } };
+  }, n_cells };
 
   std::vector<micm::Process> processes{};
   for (std::size_t i = 0; i < n_reactions; ++i)

--- a/test/unit/cuda/solver/test_cuda_rosenbrock.cpp
+++ b/test/unit/cuda/solver/test_cuda_rosenbrock.cpp
@@ -21,13 +21,13 @@ void testAlphaMinusJacobian()
   std::size_t number_of_grid_cells = L;
   auto gpu_builder = GpuBuilder<L>(micm::CudaRosenbrockSolverParameters::ThreeStageRosenbrockParameters());
   gpu_builder = getSolver(gpu_builder);
-  auto gpu_solver = gpu_builder.SetNumberOfGridCells(number_of_grid_cells).Build();
+  auto gpu_solver = gpu_builder.Build();
   auto cpu_builder = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
       micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
   cpu_builder = getSolver(cpu_builder);
-  auto cpu_solver = cpu_builder.SetNumberOfGridCells(number_of_grid_cells).Build();
+  auto cpu_solver = cpu_builder.Build();
 
-  auto gpu_state = gpu_solver.GetState();
+  auto gpu_state = gpu_solver.GetState(number_of_grid_cells);
   auto gpu_jacobian = gpu_state.jacobian_;
   auto gpu_diagonal_elements = gpu_state.jacobian_diagonal_elements_;
   EXPECT_EQ(gpu_jacobian.NumberOfBlocks(), number_of_grid_cells);
@@ -59,7 +59,7 @@ void testAlphaMinusJacobian()
   // Negate the Jacobian matrix (-J) here
   std::transform(gpu_jacobian_vec.cbegin(), gpu_jacobian_vec.cend(), gpu_jacobian_vec.begin(), std::negate<>{});
 
-  auto cpu_state = cpu_solver.GetState();
+  auto cpu_state = cpu_solver.GetState(number_of_grid_cells);
   auto cpu_jacobian = cpu_state.jacobian_;
   auto cpu_diagonal_elements = cpu_state.jacobian_diagonal_elements_;
   for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
@@ -119,8 +119,8 @@ void testNormalizedErrorConst()
   std::size_t number_of_grid_cells = L;
   auto gpu_builder = GpuBuilder<L>(micm::CudaRosenbrockSolverParameters::ThreeStageRosenbrockParameters());
   gpu_builder = getSolver(gpu_builder);
-  auto gpu_solver = gpu_builder.SetNumberOfGridCells(number_of_grid_cells).Build();
-  auto state = gpu_solver.GetState();
+  auto gpu_solver = gpu_builder.Build();
+  auto state = gpu_solver.GetState(number_of_grid_cells);
   auto& atol = state.absolute_tolerance_;
   double rtol = state.relative_tolerance_;
 
@@ -165,8 +165,8 @@ void testNormalizedErrorDiff()
   std::size_t number_of_grid_cells = L;
   auto gpu_builder = GpuBuilder<L>(micm::CudaRosenbrockSolverParameters::ThreeStageRosenbrockParameters());
   gpu_builder = getSolver(gpu_builder);
-  auto gpu_solver = gpu_builder.SetNumberOfGridCells(number_of_grid_cells).Build();
-  auto state = gpu_solver.GetState();
+  auto gpu_solver = gpu_builder.Build();
+  auto state = gpu_solver.GetState(number_of_grid_cells);
   auto& atol = state.absolute_tolerance_;
   double rtol = state.relative_tolerance_;
   auto y_old = micm::CudaDenseMatrix<double, L>(number_of_grid_cells, state.state_size_, 7.7);

--- a/test/unit/cuda/solver/test_cuda_solver_builder.cpp
+++ b/test/unit/cuda/solver/test_cuda_solver_builder.cpp
@@ -40,6 +40,6 @@ TEST(SolverBuilder, CanBuildCudaSolvers)
   auto cuda_rosenbrock = GpuBuilder<L>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                              .SetSystem(the_system)
                              .SetReactions(reactions)
-                             .SetNumberOfGridCells(L)
                              .Build();
+  auto state = cuda_rosenbrock.GetState(L);
 }

--- a/test/unit/jit/process/test_jit_forcing_calculation.cpp
+++ b/test/unit/jit/process/test_jit_forcing_calculation.cpp
@@ -32,9 +32,9 @@ TEST(JitProcessSet, ForcingFunction)
   micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c, d, e, f } };
 
   micm::State<ForcingTestVectorMatrix, ForcingTestSparseVectorMatrix> state(
-      micm::StateParameters{ .number_of_grid_cells_ = NUM_GRID_CELLS,
-                             .number_of_rate_constants_ = 3,
-                             .variable_names_{ "A", "B", "C", "D", "E", "F" } });
+      micm::StateParameters{ .number_of_rate_constants_ = 3,
+                             .variable_names_{ "A", "B", "C", "D", "E", "F" } },
+      NUM_GRID_CELLS);
 
   micm::Process r1 =
       micm::Process::Create().SetReactants({ a, b }).SetProducts({ micm::Yield{ d, 3.2 } }).SetPhase(gas_phase);

--- a/test/unit/jit/solver/test_jit_solver_builder.cpp
+++ b/test/unit/jit/solver/test_jit_solver_builder.cpp
@@ -45,6 +45,6 @@ TEST(SolverBuilder, CanBuildJitRosenbrock)
                             micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                             .SetSystem(the_system)
                             .SetReactions(reactions)
-                            .SetNumberOfGridCells(L)
                             .Build();
+  auto state = jit_rosenbrock.GetState(L);
 }

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -30,11 +30,10 @@ void testProcessUpdateState(const std::size_t number_of_grid_cells)
     for (auto& label : process.rate_constant_->CustomParameters())
       param_labels.push_back(label);
   micm::State<DenseMatrixPolicy> state{ micm::StateParameters{
-      .number_of_grid_cells_ = number_of_grid_cells,
       .number_of_rate_constants_ = processes.size(),
       .variable_names_ = { "foo", "bar'" },
       .custom_rate_parameter_labels_ = param_labels,
-  } };
+  }, number_of_grid_cells };
 
   DenseMatrixPolicy expected_rate_constants(number_of_grid_cells, 3, 0.0);
   std::vector<double> params = { 0.0, 0.0, 0.0 };

--- a/test/unit/process/test_process_set_policy.hpp
+++ b/test/unit/process/test_process_set_policy.hpp
@@ -28,9 +28,8 @@ void testProcessSet()
   micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar, qux, baz, quz, quuz, corge } };
 
   micm::State<DenseMatrixPolicy, SparseMatrixPolicy> state(
-      micm::StateParameters{ .number_of_grid_cells_ = 2,
-                             .number_of_rate_constants_ = 3,
-                             .variable_names_{ "foo", "bar", "baz", "quz", "quuz", "corge" } });
+      micm::StateParameters{ .number_of_rate_constants_ = 3,
+                             .variable_names_{ "foo", "bar", "baz", "quz", "quuz", "corge" } }, 2);
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ foo, baz })
@@ -163,10 +162,9 @@ void testRandomSystem(std::size_t n_cells, std::size_t n_reactions, std::size_t 
   }
   micm::Phase gas_phase{ species };
   micm::State<DenseMatrixPolicy, SparseMatrixPolicy> state{ micm::StateParameters{
-      .number_of_grid_cells_ = n_cells,
       .number_of_rate_constants_ = n_reactions,
       .variable_names_{ species_names },
-  } };
+  }, n_cells };
   std::vector<micm::Process> processes{};
   for (std::size_t i = 0; i < n_reactions; ++i)
   {

--- a/test/unit/process/test_surface_rate_constant.cpp
+++ b/test/unit/process/test_surface_rate_constant.cpp
@@ -9,13 +9,12 @@ TEST(SurfaceRateConstant, CalculateDefaultProbability)
   micm::Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }, { "diffusion coefficient [m2 s-1]", 2.3e2 } });
 
   auto state_parameters_ = micm::StateParameters{
-    .number_of_grid_cells_ = 1,
     .number_of_rate_constants_ = 1,
     .variable_names_ = { "surface" },
     .custom_rate_parameter_labels_ = { "effective radius [m]", "particle number concentration [# m-3]" },
   };
 
-  micm::State state{ state_parameters_ };
+  micm::State state{ state_parameters_, 1 };
   state.custom_rate_parameters_[0][0] = 1.0e-7;  // effective radius [m]
   state.custom_rate_parameters_[0][1] = 2.5e6;   // particle concentration [# m-3]
   state.conditions_[0].temperature_ = 273.65;    // K
@@ -34,13 +33,12 @@ TEST(SurfaceRateConstant, CalculateSpecifiedProbability)
 {
   micm::Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }, { "diffusion coefficient [m2 s-1]", 2.3e2 } });
   auto state_parameters_ = micm::StateParameters{
-    .number_of_grid_cells_ = 1,
     .number_of_rate_constants_ = 1,
     .variable_names_ = { "surface" },
     .custom_rate_parameter_labels_ = { "effective radius [m]", "particle number concentration [# m-3]" },
   };
 
-  micm::State state{ state_parameters_ };
+  micm::State state{ state_parameters_, 1 };
   state.custom_rate_parameters_[0][0] = 1.0e-7;  // effective radius [m]
   state.custom_rate_parameters_[0][1] = 2.5e6;   // particle concentration [# m-3]
   state.conditions_[0].temperature_ = 273.65;    // K

--- a/test/unit/process/test_user_defined_rate_constant.cpp
+++ b/test/unit/process/test_user_defined_rate_constant.cpp
@@ -7,13 +7,12 @@
 TEST(UserDefinedRateConstant, CalculateWithSystem)
 {
   auto state_parameters_ = micm::StateParameters{
-    .number_of_grid_cells_ = 1,
     .number_of_rate_constants_ = 1,
     .variable_names_ = {"user"},
     .custom_rate_parameter_labels_ = { "my rate", },
   };
 
-  micm::State state{ state_parameters_ };
+  micm::State state{ state_parameters_, 1 };
   state.custom_rate_parameters_[0][0] = 0.5;
 
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
@@ -25,13 +24,12 @@ TEST(UserDefinedRateConstant, CalculateWithSystem)
 TEST(UserDefinedRateConstant, ConstructorWithRate)
 {
   auto state_parameters_ = micm::StateParameters{
-    .number_of_grid_cells_ = 1,
     .number_of_rate_constants_ = 1,
     .variable_names_ = {"user"},
     .custom_rate_parameter_labels_ = { "my rate", },
   };
 
-  micm::State state{ state_parameters_ };
+  micm::State state{ state_parameters_, 1 };
   state.custom_rate_parameters_[0][0] = 1.1;
 
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
@@ -43,13 +41,12 @@ TEST(UserDefinedRateConstant, ConstructorWithRate)
 TEST(UserDefinedRateConstant, ConstructorWithRateAndName)
 {
   auto state_parameters_ = micm::StateParameters{
-    .number_of_grid_cells_ = 1,
     .number_of_rate_constants_ = 1,
     .variable_names_ = {"user"},
     .custom_rate_parameter_labels_ = { "my rate", },
   };
 
-  micm::State state{ state_parameters_ };
+  micm::State state{ state_parameters_, 1 };
   state.custom_rate_parameters_[0][0] = 1.1;
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
   micm::UserDefinedRateConstant photo({ .label_ = "a name" });
@@ -61,13 +58,12 @@ TEST(UserDefinedRateConstant, ConstructorWithRateAndName)
 TEST(UserDefinedRateConstant, CustomScalingFactor)
 {
   auto state_parameters = micm::StateParameters{
-    .number_of_grid_cells_ = 1,
     .number_of_rate_constants_ = 1,
     .variable_names_ = {"user"},
     .custom_rate_parameter_labels_ = { "my rate", },
   };
 
-  micm::State state{ state_parameters };
+  micm::State state{ state_parameters, 1 };
   state.custom_rate_parameters_[0][0] = 1.2;
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
   micm::UserDefinedRateConstant photo({ .label_ = "a name", .scaling_factor_ = 2.0 });

--- a/test/unit/solver/test_backward_euler.cpp
+++ b/test/unit/solver/test_backward_euler.cpp
@@ -43,11 +43,10 @@ TEST(BackwardEuler, CanCallSolve)
   auto be = micm::CpuSolverBuilder<micm::BackwardEulerSolverParameters>(params)
                 .SetSystem(the_system)
                 .SetReactions(reactions)
-                .SetNumberOfGridCells(1)
                 .Build();
   double time_step = 1.0;
 
-  auto state = be.GetState();
+  auto state = be.GetState(1);
   state.SetAbsoluteTolerances({ 1e-6, 1e-6, 1e-6 });
 
   state.variables_[0] = { 1.0, 0.0, 0.0 };

--- a/test/unit/solver/test_rosenbrock.cpp
+++ b/test/unit/solver/test_rosenbrock.cpp
@@ -16,8 +16,8 @@ template<class SolverBuilderPolicy>
 void testNormalizedErrorDiff(SolverBuilderPolicy builder, std::size_t number_of_grid_cells)
 {
   builder = getSolver(builder);
-  auto solver = builder.SetNumberOfGridCells(number_of_grid_cells).Build();
-  auto state = solver.GetState();
+  auto solver = builder.Build();
+  auto state = solver.GetState(number_of_grid_cells);
   const std::vector<double>& atol = state.absolute_tolerance_;
   double rtol = state.relative_tolerance_;
 
@@ -104,9 +104,8 @@ TEST(RosenbrockSolver, CanSetTolerances)
                       micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                       .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
                       .SetReactions(std::vector<micm::Process>{ r1 })
-                      .SetNumberOfGridCells(number_of_grid_cells)
                       .Build();
-    auto state = solver.GetState();
+    auto state = solver.GetState(number_of_grid_cells);
     auto absolute_tolerances = state.absolute_tolerance_;
     EXPECT_EQ(absolute_tolerances.size(), 2);
     EXPECT_EQ(absolute_tolerances[0], 1.0e-07);

--- a/test/unit/solver/test_rosenbrock_solver_policy.hpp
+++ b/test/unit/solver/test_rosenbrock_solver_policy.hpp
@@ -52,8 +52,8 @@ template<class SolverBuilderPolicy>
 void testAlphaMinusJacobian(SolverBuilderPolicy builder, std::size_t number_of_grid_cells)
 {
   builder = getSolver(builder);
-  auto solver = builder.SetNumberOfGridCells(number_of_grid_cells).Build();
-  auto state = solver.GetState();
+  auto solver = builder.Build();
+  auto state = solver.GetState(number_of_grid_cells);
   auto jacobian = state.jacobian_;
   auto diagonal_elements = state.jacobian_diagonal_elements_;
 

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -44,7 +44,6 @@ TEST(SolverBuilder, ThrowsMissingSystem)
 {
   EXPECT_THROW(
       micm::CpuSolverBuilder<micm::BackwardEulerSolverParameters>(micm::BackwardEulerSolverParameters{})
-          .SetNumberOfGridCells(1)
           .Build(),
       std::system_error);
 }
@@ -54,7 +53,6 @@ TEST(SolverBuilder, ThrowsMissingReactions)
   EXPECT_THROW(
       micm::CpuSolverBuilder<micm::BackwardEulerSolverParameters>(micm::BackwardEulerSolverParameters{})
           .SetSystem(the_system)
-          .SetNumberOfGridCells(1)
           .Build(),
       std::system_error);
   EXPECT_THROW(
@@ -70,7 +68,6 @@ TEST(SolverBuilder, CanBuildBackwardEuler)
   auto backward_euler = micm::CpuSolverBuilder<micm::BackwardEulerSolverParameters>(micm::BackwardEulerSolverParameters{})
                             .SetSystem(the_system)
                             .SetReactions(reactions)
-                            .SetNumberOfGridCells(1)
                             .Build();
 
   constexpr std::size_t L = 4;
@@ -81,7 +78,6 @@ TEST(SolverBuilder, CanBuildBackwardEuler)
           micm::SparseMatrix<double, micm::SparseMatrixVectorOrdering<L>>>(micm::BackwardEulerSolverParameters{})
           .SetSystem(the_system)
           .SetReactions(reactions)
-          .SetNumberOfGridCells(1)
           .Build();
   EXPECT_EQ(backward_euler_vector.GetSystem().gas_phase_.name_, the_system.gas_phase_.name_);
   EXPECT_EQ(backward_euler_vector.GetSystem().gas_phase_.species_.size(), the_system.gas_phase_.species_.size());
@@ -94,7 +90,6 @@ TEST(SolverBuilder, CanBuildRosenbrock)
                         micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                         .SetSystem(the_system)
                         .SetReactions(reactions)
-                        .SetNumberOfGridCells(1)
                         .Build();
 
   constexpr std::size_t L = 4;
@@ -105,7 +100,6 @@ TEST(SolverBuilder, CanBuildRosenbrock)
                                micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                                .SetSystem(the_system)
                                .SetReactions(reactions)
-                               .SetNumberOfGridCells(1)
                                .Build();
 
   EXPECT_EQ(rosenbrock_vector.GetSystem().gas_phase_.name_, the_system.gas_phase_.name_);
@@ -118,9 +112,8 @@ TEST(SolverBuilder, CanBuildBackwardEulerOverloadedSolverMethod)
   auto solver = micm::CpuSolverBuilder<micm::BackwardEulerSolverParameters>(micm::BackwardEulerSolverParameters{})
                     .SetSystem(the_system)
                     .SetReactions(reactions)
-                    .SetNumberOfGridCells(1)
                     .Build();
-  auto state = solver.GetState();
+  auto state = solver.GetState(1);
   auto options = micm::BackwardEulerSolverParameters();
   auto solve = solver.Solve(5, state, options);
 
@@ -148,9 +141,8 @@ TEST(SolverBuilder, CanBuildRosenbrockOverloadedSolveMethod)
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
                     .SetSystem(the_system)
                     .SetReactions(reactions)
-                    .SetNumberOfGridCells(1)
                     .Build();
-  auto state = solver.GetState();
+  auto state = solver.GetState(1);
   state.variables_[0] = { 1.0, 0.0, 0.0 };
 
   auto solve = solver.Solve(5, state);

--- a/test/unit/solver/test_state.cpp
+++ b/test/unit/solver/test_state.cpp
@@ -11,11 +11,10 @@ TEST(State, DefaultConstructor)
 TEST(State, Constructor)
 {
   micm::State state{ micm::StateParameters{
-      .number_of_grid_cells_ = 3,
       .number_of_rate_constants_ = 10,
       .variable_names_{ "foo", "bar", "baz", "quz" },
       .custom_rate_parameter_labels_{ "quux", "corge" },
-  } };
+  }, 3 };
 
   EXPECT_EQ(state.conditions_.size(), 3);
   EXPECT_EQ(state.variable_map_["foo"], 0);
@@ -37,12 +36,11 @@ TEST(State, Constructor)
 
 TEST(State, CopyConstructor)
 {
-  micm::State original{ micm::StateParameters{ .number_of_grid_cells_ = 3,
-                                               .number_of_rate_constants_ = 10,
+  micm::State original{ micm::StateParameters{ .number_of_rate_constants_ = 10,
                                                .variable_names_{ "foo", "bar", "baz", "quz" },
                                                .custom_rate_parameter_labels_{ "quux", "corge" },
                                                .relative_tolerance_ = 1e-05,
-                                               .absolute_tolerance_ = { 1e-10, 1e-10, 1e-10, 1e-10 } } };
+                                               .absolute_tolerance_ = { 1e-10, 1e-10, 1e-10, 1e-10 } }, 3 };
 
   micm::State copy = original;
 
@@ -85,12 +83,11 @@ TEST(State, CopyConstructor)
 
 TEST(State, CopyAssignmentOperator)
 {
-  micm::State original{ micm::StateParameters{ .number_of_grid_cells_ = 3,
-                                               .number_of_rate_constants_ = 10,
+  micm::State original{ micm::StateParameters{ .number_of_rate_constants_ = 10,
                                                .variable_names_{ "foo", "bar", "baz", "quz" },
                                                .custom_rate_parameter_labels_{ "quux", "corge" },
                                                .relative_tolerance_ = 1e-05,
-                                               .absolute_tolerance_ = { 1e-10, 1e-10, 1e-10, 1e-10 } } };
+                                               .absolute_tolerance_ = { 1e-10, 1e-10, 1e-10, 1e-10 } }, 3 };
 
   micm::State copy;
   copy = original;
@@ -134,12 +131,11 @@ TEST(State, CopyAssignmentOperator)
 
 TEST(State, MoveConstructor)
 {
-  micm::State original{ micm::StateParameters{ .number_of_grid_cells_ = 3,
-                                               .number_of_rate_constants_ = 10,
+  micm::State original{ micm::StateParameters{ .number_of_rate_constants_ = 10,
                                                .variable_names_{ "foo", "bar", "baz", "quz" },
                                                .custom_rate_parameter_labels_{ "quux", "corge" },
                                                .relative_tolerance_ = 1e-05,
-                                               .absolute_tolerance_ = { 1e-10, 1e-10, 1e-10, 1e-10 } } };
+                                               .absolute_tolerance_ = { 1e-10, 1e-10, 1e-10, 1e-10 } }, 3 };
 
   auto expected_variable_names = original.variable_names_;
   auto expected_custom_rate_parameter_map = original.custom_rate_parameter_map_;
@@ -188,12 +184,11 @@ TEST(State, MoveConstructor)
 
 TEST(State, MoveAssignmentOperator)
 {
-  micm::State original{ micm::StateParameters{ .number_of_grid_cells_ = 3,
-                                               .number_of_rate_constants_ = 10,
+  micm::State original{ micm::StateParameters{ .number_of_rate_constants_ = 10,
                                                .variable_names_{ "foo", "bar", "baz", "quz" },
                                                .custom_rate_parameter_labels_{ "quux", "corge" },
                                                .relative_tolerance_ = 1e-05,
-                                               .absolute_tolerance_ = { 1e-10, 1e-10, 1e-10, 1e-10 } } };
+                                               .absolute_tolerance_ = { 1e-10, 1e-10, 1e-10, 1e-10 } }, 3 };
 
   auto expected_variable_names = original.variable_names_;
   auto expected_custom_rate_parameter_map = original.custom_rate_parameter_map_;
@@ -244,11 +239,10 @@ TEST(State, MoveAssignmentOperator)
 TEST(State, SettingSingleConcentrationWithInvalidArgumentsThowsException)
 {
   micm::State state{ micm::StateParameters{
-      .number_of_grid_cells_ = 3,
       .number_of_rate_constants_ = 10,
       .variable_names_{ "foo", "bar", "baz", "quz" },
       .custom_rate_parameter_labels_{ "quux", "corge" },
-  } };
+  }, 3 };
   EXPECT_ANY_THROW(state.SetConcentration(micm::Species{ "foo" }, 1.0));
   EXPECT_ANY_THROW(state.SetConcentration(micm::Species{ "foo" }, std::vector<double>{ 1.0, 2.0 }));
   EXPECT_ANY_THROW(state.SetConcentration(micm::Species{ "not foo" }, 1.0));
@@ -259,11 +253,10 @@ TEST(State, SetSingleConcentration)
 {
   {
     micm::State state{ micm::StateParameters{
-        .number_of_grid_cells_ = 3,
         .number_of_rate_constants_ = 10,
         .variable_names_{ "foo", "bar", "baz", "quz" },
         .custom_rate_parameter_labels_{ "quux", "corge" },
-    } };
+    }, 3 };
     std::vector<double> concentrations{ 12.0, 42.0, 35.2 };
     state.SetConcentration(micm::Species{ "bar" }, concentrations);
     for (std::size_t i = 0; i < concentrations.size(); ++i)
@@ -271,11 +264,10 @@ TEST(State, SetSingleConcentration)
   }
   {
     micm::State state{ micm::StateParameters{
-        .number_of_grid_cells_ = 1,
         .number_of_rate_constants_ = 10,
         .variable_names_{ "foo", "bar", "baz", "quz" },
         .custom_rate_parameter_labels_{ "quux", "corge" },
-    } };
+    }, 1 };
     state.SetConcentration(micm::Species{ "bar" }, 324.2);
     EXPECT_EQ(state.variables_[0][state.variable_map_["bar"]], 324.2);
   }
@@ -284,11 +276,10 @@ TEST(State, SetSingleConcentration)
 TEST(State, SettingConcentrationsWithInvalidArguementsThrowsException)
 {
   micm::State state{ micm::StateParameters{
-      .number_of_grid_cells_ = 3,
       .number_of_rate_constants_ = 10,
       .variable_names_{ "foo", "bar", "baz", "quz" },
       .custom_rate_parameter_labels_{ "quux", "corge" },
-  } };
+  }, 3 };
 
   std::unordered_map<std::string, std::vector<double>> concentrations = {
     { "FUU", { 0.1 } }, { "bar", { 0.2 } }, { "baz", { 0.3 } }, { "quz", { 0.4 } }
@@ -303,11 +294,10 @@ TEST(State, SetConcentrations)
   uint32_t num_species = 4;
 
   micm::State state{ micm::StateParameters{
-      .number_of_grid_cells_ = num_grid_cells,
       .number_of_rate_constants_ = 10,
       .variable_names_{ "foo", "bar", "baz", "quz" },
       .custom_rate_parameter_labels_{ "quux", "corge" },
-  } };
+  }, num_grid_cells };
 
   std::unordered_map<std::string, std::vector<double>> concentrations = { { "bar", { 0.2, 0.22, 0.222 } },
                                                                           { "baz", { 0.3, 0.33, 0.333 } },
@@ -334,11 +324,10 @@ TEST(State, SetConcentrations)
 TEST(State, SettingCustomRateParameterWithInvalidVectorSizeThrowsException)
 {
   micm::State state{ micm::StateParameters{
-      .number_of_grid_cells_ = 3,
       .number_of_rate_constants_ = 10,
       .variable_names_{ "foo", "bar", "baz", "quz" },
       .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
-  } };
+  }, 3 };
 
   // user input for custom rate parameters (unordered)
   std::unordered_map<std::string, std::vector<double>> custom_params = {
@@ -351,11 +340,10 @@ TEST(State, SettingCustomRateParameterWithInvalidVectorSizeThrowsException)
 TEST(State, SettingCustomRateParameterWithInvalidLabelThrowsException)
 {
   micm::State state{ micm::StateParameters{
-      .number_of_grid_cells_ = 1,
       .number_of_rate_constants_ = 10,
       .variable_names_{ "foo", "bar", "baz", "quz" },
       .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
-  } };
+  }, 1 };
 
   // user input for custom rate parameters (unordered)
   std::unordered_map<std::string, std::vector<double>> custom_params = {
@@ -368,11 +356,10 @@ TEST(State, SettingCustomRateParameterWithInvalidLabelThrowsException)
 TEST(State, SetCustomRateParameter)
 {
   micm::State state{ micm::StateParameters{
-      .number_of_grid_cells_ = 1,
       .number_of_rate_constants_ = 10,
       .variable_names_{ "foo", "bar", "baz", "quz" },
       .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
-  } };
+  }, 1 };
 
   state.SetCustomRateParameter("O2", 42.3);
   EXPECT_EQ(state.custom_rate_parameters_[0][1], 42.3);
@@ -383,11 +370,10 @@ TEST(State, SetCustomRateParameters)
   uint32_t num_grid_cells = 3;
 
   micm::State state{ micm::StateParameters{
-      .number_of_grid_cells_ = num_grid_cells,
       .number_of_rate_constants_ = 10,
       .variable_names_{ "foo", "bar", "baz", "quz" },
       .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
-  } };
+  }, num_grid_cells };
 
   // user input for custom rate parameters (unordered)
   std::unordered_map<std::string, std::vector<double>> custom_params = { { "O3", { 0.3, 0.33, 0.333 } },
@@ -414,11 +400,10 @@ TEST(State, SetCustomRateParameters)
 TEST(State, UnsafelySetCustomRateParameterOneCell)
 {
   micm::State state{ micm::StateParameters{
-      .number_of_grid_cells_ = 1,
       .number_of_rate_constants_ = 10,
       .variable_names_{ "foo", "bar", "baz", "quz" },
       .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
-  } };
+  }, 1 };
 
   std::vector<std::vector<double>> parameters = { { 0.1, 0.2, 0.3, 0.4, 0.5 } };
 
@@ -435,11 +420,10 @@ TEST(State, UnsafelySetCustomRateParameterMultiCell)
   uint32_t num_grid_cells = 3;
 
   micm::State state{ micm::StateParameters{
-      .number_of_grid_cells_ = num_grid_cells,
       .number_of_rate_constants_ = 10,
       .variable_names_{ "foo", "bar", "baz", "quz" },
       .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
-  } };
+  }, num_grid_cells };
 
   std::vector<std::vector<double>> parameters = { { 0.1, 0.2, 0.3, 0.4, 0.5 },
                                                   { 0.1, 0.2, 0.3, 0.4, 0.5 },
@@ -459,11 +443,10 @@ TEST(State, UnsafelySetCustomRateParameterMultiCell)
 TEST(State, UnsafelySetCustomRateParameterCatchesTooFewGridCells)
 {
   micm::State state{ micm::StateParameters{
-      .number_of_grid_cells_ = 2,
       .number_of_rate_constants_ = 10,
       .variable_names_{ "foo", "bar", "baz", "quz" },
       .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
-  } };
+  }, 2 };
 
   std::vector<std::vector<double>> parameters = { { 0.1, 0.2, 0.3, 0.4, 0.5 } };
 
@@ -473,11 +456,10 @@ TEST(State, UnsafelySetCustomRateParameterCatchesTooFewGridCells)
 TEST(State, UnsafelySetCustomRateParameterCatchesTooParameters)
 {
   micm::State state{ micm::StateParameters{
-      .number_of_grid_cells_ = 2,
       .number_of_rate_constants_ = 10,
       .variable_names_{ "foo", "bar", "baz", "quz" },
       .custom_rate_parameter_labels_{ "O1", "O2", "O3", "AAA", "BBB" },
-  } };
+  }, 2 };
 
   std::vector<std::vector<double>> parameters = { { 0.1, 0.2, 0.3 } };
 


### PR DESCRIPTION
Removes the requirement that the number of grid cells for one solver be fixed and known at construction. Instead, one solver can be used to create any number of State objects, each with their own specified number of grid cells

closes #686