### PR TITLE
Update references to NCAR to NSF NCAR

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 National Center for Atmospheric Research
+   Copyright 2019 National Science Foundation-National Center for Atmospheric Research
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+   Copyright 2019-2025 University Corporation for Atmospheric Research
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 National Science Foundation-National Center for Atmospheric Research
+   Copyright 2019-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Model Independent Chemical Module. MICM can be used to configure and solve atmos
 [![FAIR checklist badge](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=31&a=32113&i=22322&r=123)
 
 
-Copyright (C) 2018-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+Copyright (C) 2018-2025 University Corporation for Atmospheric Research
 
 
 <p align="center">
@@ -217,4 +217,4 @@ installation and usage instructions.
 
 - [Apache 2.0](/LICENSE)
 
-Copyright (C) 2018-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+Copyright (C) 2018-2025 University Corporation for Atmospheric Research

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Model Independent Chemical Module. MICM can be used to configure and solve atmos
 [![FAIR checklist badge](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=31&a=32113&i=22322&r=123)
 
 
-Copyright (C) 2018-2025 National Center for Atmospheric Research
+Copyright (C) 2018-2025 National Science Foundation-National Center for Atmospheric Research
 
 
 <p align="center">
@@ -217,4 +217,4 @@ installation and usage instructions.
 
 - [Apache 2.0](/LICENSE)
 
-Copyright (C) 2018-2025 National Center for Atmospheric Research
+Copyright (C) 2018-2025 National Science Foundation-National Center for Atmospheric Research

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Model Independent Chemical Module. MICM can be used to configure and solve atmos
 [![FAIR checklist badge](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=31&a=32113&i=22322&r=123)
 
 
-Copyright (C) 2018-2025 National Science Foundation-National Center for Atmospheric Research
+Copyright (C) 2018-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 
 
 <p align="center">
@@ -217,4 +217,4 @@ installation and usage instructions.
 
 - [Apache 2.0](/LICENSE)
 
-Copyright (C) 2018-2025 National Science Foundation-National Center for Atmospheric Research
+Copyright (C) 2018-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research

--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -6,7 +6,7 @@ Contributing
 For all proposed changes (bug fixes, new feature, documentation upates, etc.) please file
 an `issue <https://github.com/NCAR/micm/issues/new/choose>`_ detailing what your ask is or what you intend to do.
 
-The NCAR software developers will work with you on that issue to help recommend implementations, work through questions,
+The NSF NCAR software developers will work with you on that issue to help recommend implementations, work through questions,
 or provide other background knowledge.
 
 Testing

--- a/include/micm/CPU.hpp
+++ b/include/micm/CPU.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/CPU.hpp
+++ b/include/micm/CPU.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/GPU.hpp
+++ b/include/micm/GPU.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/GPU.hpp
+++ b/include/micm/GPU.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/JIT.hpp
+++ b/include/micm/JIT.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/JIT.hpp
+++ b/include/micm/JIT.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/Process.hpp
+++ b/include/micm/Process.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/Process.hpp
+++ b/include/micm/Process.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/Solver.hpp
+++ b/include/micm/Solver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/Solver.hpp
+++ b/include/micm/Solver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/System.hpp
+++ b/include/micm/System.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/System.hpp
+++ b/include/micm/System.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/Util.hpp
+++ b/include/micm/Util.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/Util.hpp
+++ b/include/micm/Util.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2024-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/cuda/process/cuda_process_set.cuh
+++ b/include/micm/cuda/process/cuda_process_set.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/process/cuda_process_set.cuh
+++ b/include/micm/cuda/process/cuda_process_set.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/process/cuda_process_set.cuh
+++ b/include/micm/cuda/process/cuda_process_set.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/process/cuda_process_set.hpp
+++ b/include/micm/cuda/process/cuda_process_set.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/process/cuda_process_set.hpp
+++ b/include/micm/cuda/process/cuda_process_set.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/process/cuda_process_set.hpp
+++ b/include/micm/cuda/process/cuda_process_set.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.cuh
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.cuh
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.cuh
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_lu_decomposition.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_lu_decomposition.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_lu_decomposition.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.cuh
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.cuh
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.cuh
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_rosenbrock.cuh
+++ b/include/micm/cuda/solver/cuda_rosenbrock.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_rosenbrock.cuh
+++ b/include/micm/cuda/solver/cuda_rosenbrock.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_rosenbrock.cuh
+++ b/include/micm/cuda/solver/cuda_rosenbrock.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_rosenbrock.hpp
+++ b/include/micm/cuda/solver/cuda_rosenbrock.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_rosenbrock.hpp
+++ b/include/micm/cuda/solver/cuda_rosenbrock.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_rosenbrock.hpp
+++ b/include/micm/cuda/solver/cuda_rosenbrock.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_solver_builder.hpp
+++ b/include/micm/cuda/solver/cuda_solver_builder.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/cuda/solver/cuda_solver_builder.hpp
+++ b/include/micm/cuda/solver/cuda_solver_builder.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/cuda/solver/cuda_solver_builder.hpp
+++ b/include/micm/cuda/solver/cuda_solver_builder.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/cuda/solver/cuda_solver_parameters.hpp
+++ b/include/micm/cuda/solver/cuda_solver_parameters.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/cuda/solver/cuda_solver_parameters.hpp
+++ b/include/micm/cuda/solver/cuda_solver_parameters.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/cuda/solver/cuda_solver_parameters.hpp
+++ b/include/micm/cuda/solver/cuda_solver_parameters.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/cuda/solver/cuda_state.hpp
+++ b/include/micm/cuda/solver/cuda_state.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_state.hpp
+++ b/include/micm/cuda/solver/cuda_state.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/solver/cuda_state.hpp
+++ b/include/micm/cuda/solver/cuda_state.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_matrix.cuh
+++ b/include/micm/cuda/util/cuda_matrix.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_matrix.cuh
+++ b/include/micm/cuda/util/cuda_matrix.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_matrix.cuh
+++ b/include/micm/cuda/util/cuda_matrix.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_sparse_matrix.hpp
+++ b/include/micm/cuda/util/cuda_sparse_matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_sparse_matrix.hpp
+++ b/include/micm/cuda/util/cuda_sparse_matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_sparse_matrix.hpp
+++ b/include/micm/cuda/util/cuda_sparse_matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_util.cuh
+++ b/include/micm/cuda/util/cuda_util.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_util.cuh
+++ b/include/micm/cuda/util/cuda_util.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/cuda/util/cuda_util.cuh
+++ b/include/micm/cuda/util/cuda_util.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/jit_compiler.hpp
+++ b/include/micm/jit/jit_compiler.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 //
 // Based on examples from the LLVM Project,

--- a/include/micm/jit/jit_compiler.hpp
+++ b/include/micm/jit/jit_compiler.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 //
 // Based on examples from the LLVM Project,

--- a/include/micm/jit/jit_compiler.hpp
+++ b/include/micm/jit/jit_compiler.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 //
 // Based on examples from the LLVM Project,

--- a/include/micm/jit/jit_function.hpp
+++ b/include/micm/jit/jit_function.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/jit_function.hpp
+++ b/include/micm/jit/jit_function.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/jit_function.hpp
+++ b/include/micm/jit/jit_function.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/process/jit_process_set.hpp
+++ b/include/micm/jit/process/jit_process_set.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/process/jit_process_set.hpp
+++ b/include/micm/jit/process/jit_process_set.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/process/jit_process_set.hpp
+++ b/include/micm/jit/process/jit_process_set.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/solver/jit_linear_solver.hpp
+++ b/include/micm/jit/solver/jit_linear_solver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/solver/jit_linear_solver.hpp
+++ b/include/micm/jit/solver/jit_linear_solver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/solver/jit_linear_solver.hpp
+++ b/include/micm/jit/solver/jit_linear_solver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/solver/jit_linear_solver.inl
+++ b/include/micm/jit/solver/jit_linear_solver.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/jit/solver/jit_linear_solver.inl
+++ b/include/micm/jit/solver/jit_linear_solver.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/jit/solver/jit_linear_solver.inl
+++ b/include/micm/jit/solver/jit_linear_solver.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/jit/solver/jit_lu_decomposition.hpp
+++ b/include/micm/jit/solver/jit_lu_decomposition.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/solver/jit_lu_decomposition.hpp
+++ b/include/micm/jit/solver/jit_lu_decomposition.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/solver/jit_lu_decomposition.hpp
+++ b/include/micm/jit/solver/jit_lu_decomposition.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/solver/jit_lu_decomposition_doolittle.hpp
+++ b/include/micm/jit/solver/jit_lu_decomposition_doolittle.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/solver/jit_lu_decomposition_doolittle.hpp
+++ b/include/micm/jit/solver/jit_lu_decomposition_doolittle.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/solver/jit_lu_decomposition_doolittle.hpp
+++ b/include/micm/jit/solver/jit_lu_decomposition_doolittle.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/jit/solver/jit_lu_decomposition_doolittle.inl
+++ b/include/micm/jit/solver/jit_lu_decomposition_doolittle.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/jit/solver/jit_lu_decomposition_doolittle.inl
+++ b/include/micm/jit/solver/jit_lu_decomposition_doolittle.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/jit/solver/jit_lu_decomposition_doolittle.inl
+++ b/include/micm/jit/solver/jit_lu_decomposition_doolittle.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/jit/solver/jit_rosenbrock.hpp
+++ b/include/micm/jit/solver/jit_rosenbrock.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 //
 // Much of this solver was formulated and implemented from this book:

--- a/include/micm/jit/solver/jit_rosenbrock.hpp
+++ b/include/micm/jit/solver/jit_rosenbrock.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 //
 // Much of this solver was formulated and implemented from this book:

--- a/include/micm/jit/solver/jit_rosenbrock.hpp
+++ b/include/micm/jit/solver/jit_rosenbrock.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 //
 // Much of this solver was formulated and implemented from this book:

--- a/include/micm/jit/solver/jit_solver_builder.hpp
+++ b/include/micm/jit/solver/jit_solver_builder.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/jit/solver/jit_solver_builder.hpp
+++ b/include/micm/jit/solver/jit_solver_builder.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/jit/solver/jit_solver_builder.hpp
+++ b/include/micm/jit/solver/jit_solver_builder.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/jit/solver/jit_solver_parameters.hpp
+++ b/include/micm/jit/solver/jit_solver_parameters.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/jit/solver/jit_solver_parameters.hpp
+++ b/include/micm/jit/solver/jit_solver_parameters.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/jit/solver/jit_solver_parameters.hpp
+++ b/include/micm/jit/solver/jit_solver_parameters.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/process/arrhenius_rate_constant.hpp
+++ b/include/micm/process/arrhenius_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/arrhenius_rate_constant.hpp
+++ b/include/micm/process/arrhenius_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/arrhenius_rate_constant.hpp
+++ b/include/micm/process/arrhenius_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/branched_rate_constant.hpp
+++ b/include/micm/process/branched_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/branched_rate_constant.hpp
+++ b/include/micm/process/branched_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/branched_rate_constant.hpp
+++ b/include/micm/process/branched_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/rate_constant.hpp
+++ b/include/micm/process/rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/rate_constant.hpp
+++ b/include/micm/process/rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/rate_constant.hpp
+++ b/include/micm/process/rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/surface_rate_constant.hpp
+++ b/include/micm/process/surface_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/surface_rate_constant.hpp
+++ b/include/micm/process/surface_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/surface_rate_constant.hpp
+++ b/include/micm/process/surface_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/ternary_chemical_activation_rate_constant.hpp
+++ b/include/micm/process/ternary_chemical_activation_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/ternary_chemical_activation_rate_constant.hpp
+++ b/include/micm/process/ternary_chemical_activation_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/ternary_chemical_activation_rate_constant.hpp
+++ b/include/micm/process/ternary_chemical_activation_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/troe_rate_constant.hpp
+++ b/include/micm/process/troe_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/troe_rate_constant.hpp
+++ b/include/micm/process/troe_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/troe_rate_constant.hpp
+++ b/include/micm/process/troe_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/tunneling_rate_constant.hpp
+++ b/include/micm/process/tunneling_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/tunneling_rate_constant.hpp
+++ b/include/micm/process/tunneling_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/tunneling_rate_constant.hpp
+++ b/include/micm/process/tunneling_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/user_defined_rate_constant.hpp
+++ b/include/micm/process/user_defined_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/user_defined_rate_constant.hpp
+++ b/include/micm/process/user_defined_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/process/user_defined_rate_constant.hpp
+++ b/include/micm/process/user_defined_rate_constant.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/profiler/instrumentation.hpp
+++ b/include/micm/profiler/instrumentation.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // Copyright (C) 2019-2022 Hazel Engine
 // SPDX-License-Identifier: Apache-2.0
 #pragma once

--- a/include/micm/profiler/instrumentation.hpp
+++ b/include/micm/profiler/instrumentation.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // Copyright (C) 2019-2022 Hazel Engine
 // SPDX-License-Identifier: Apache-2.0
 #pragma once

--- a/include/micm/profiler/instrumentation.hpp
+++ b/include/micm/profiler/instrumentation.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // Copyright (C) 2019-2022 Hazel Engine
 // SPDX-License-Identifier: Apache-2.0
 #pragma once

--- a/include/micm/solver/backward_euler.hpp
+++ b/include/micm/solver/backward_euler.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/backward_euler.hpp
+++ b/include/micm/solver/backward_euler.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/backward_euler.hpp
+++ b/include/micm/solver/backward_euler.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/backward_euler.inl
+++ b/include/micm/solver/backward_euler.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 enum class MicmBackwardEulerErrc
 {

--- a/include/micm/solver/backward_euler.inl
+++ b/include/micm/solver/backward_euler.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 enum class MicmBackwardEulerErrc
 {

--- a/include/micm/solver/backward_euler.inl
+++ b/include/micm/solver/backward_euler.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 enum class MicmBackwardEulerErrc
 {

--- a/include/micm/solver/backward_euler_solver_parameters.hpp
+++ b/include/micm/solver/backward_euler_solver_parameters.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/backward_euler_solver_parameters.hpp
+++ b/include/micm/solver/backward_euler_solver_parameters.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/backward_euler_solver_parameters.hpp
+++ b/include/micm/solver/backward_euler_solver_parameters.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/backward_euler_temporary_variables.hpp
+++ b/include/micm/solver/backward_euler_temporary_variables.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/solver/backward_euler_temporary_variables.hpp
+++ b/include/micm/solver/backward_euler_temporary_variables.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/solver/backward_euler_temporary_variables.hpp
+++ b/include/micm/solver/backward_euler_temporary_variables.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/linear_solver_in_place.hpp
+++ b/include/micm/solver/linear_solver_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/linear_solver_in_place.hpp
+++ b/include/micm/solver/linear_solver_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/linear_solver_in_place.hpp
+++ b/include/micm/solver/linear_solver_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/linear_solver_in_place.inl
+++ b/include/micm/solver/linear_solver_in_place.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 namespace micm
 {

--- a/include/micm/solver/linear_solver_in_place.inl
+++ b/include/micm/solver/linear_solver_in_place.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 namespace micm
 {

--- a/include/micm/solver/linear_solver_in_place.inl
+++ b/include/micm/solver/linear_solver_in_place.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 namespace micm
 {

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_doolittle.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_doolittle.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_doolittle.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/lu_decomposition_mozart.hpp
+++ b/include/micm/solver/lu_decomposition_mozart.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_mozart.hpp
+++ b/include/micm/solver/lu_decomposition_mozart.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_mozart.hpp
+++ b/include/micm/solver/lu_decomposition_mozart.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 namespace micm

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 //
 // Much of this solver was formulated and implemented from this book:

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 //
 // Much of this solver was formulated and implemented from this book:

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 //
 // Much of this solver was formulated and implemented from this book:

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 namespace micm
 {

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 namespace micm
 {

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 namespace micm
 {

--- a/include/micm/solver/rosenbrock_solver_parameters.hpp
+++ b/include/micm/solver/rosenbrock_solver_parameters.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/rosenbrock_solver_parameters.hpp
+++ b/include/micm/solver/rosenbrock_solver_parameters.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/rosenbrock_solver_parameters.hpp
+++ b/include/micm/solver/rosenbrock_solver_parameters.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/rosenbrock_temporary_variables.hpp
+++ b/include/micm/solver/rosenbrock_temporary_variables.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/solver/rosenbrock_temporary_variables.hpp
+++ b/include/micm/solver/rosenbrock_temporary_variables.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/solver/rosenbrock_temporary_variables.hpp
+++ b/include/micm/solver/rosenbrock_temporary_variables.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 enum class MicmSolverBuilderErrc

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 enum class MicmSolverBuilderErrc

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 enum class MicmSolverBuilderErrc

--- a/include/micm/solver/solver_result.hpp
+++ b/include/micm/solver/solver_result.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/solver/solver_result.hpp
+++ b/include/micm/solver/solver_result.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/solver/solver_result.hpp
+++ b/include/micm/solver/solver_result.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+/* Copyright (C) 2023-2025 University Corporation for Atmospheric Research
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/micm/solver/state.hpp
+++ b/include/micm/solver/state.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/state.hpp
+++ b/include/micm/solver/state.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/state.hpp
+++ b/include/micm/solver/state.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 enum class MicmStateErrc

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 enum class MicmStateErrc

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 enum class MicmStateErrc

--- a/include/micm/solver/temporary_variables.hpp
+++ b/include/micm/solver/temporary_variables.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/solver/temporary_variables.hpp
+++ b/include/micm/solver/temporary_variables.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/solver/temporary_variables.hpp
+++ b/include/micm/solver/temporary_variables.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/include/micm/system/conditions.hpp
+++ b/include/micm/system/conditions.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/system/conditions.hpp
+++ b/include/micm/system/conditions.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/system/conditions.hpp
+++ b/include/micm/system/conditions.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/system/phase.hpp
+++ b/include/micm/system/phase.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/system/phase.hpp
+++ b/include/micm/system/phase.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/system/phase.hpp
+++ b/include/micm/system/phase.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/system/system.hpp
+++ b/include/micm/system/system.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/system/system.hpp
+++ b/include/micm/system/system.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/system/system.hpp
+++ b/include/micm/system/system.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/constants.hpp
+++ b/include/micm/util/constants.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/constants.hpp
+++ b/include/micm/util/constants.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/constants.hpp
+++ b/include/micm/util/constants.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/error.hpp
+++ b/include/micm/util/error.hpp
@@ -1,5 +1,5 @@
 #if 0
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 // This file defines error categories and codes for MICM

--- a/include/micm/util/error.hpp
+++ b/include/micm/util/error.hpp
@@ -1,5 +1,5 @@
 #if 0
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 // This file defines error categories and codes for MICM

--- a/include/micm/util/error.hpp
+++ b/include/micm/util/error.hpp
@@ -1,5 +1,5 @@
 #if 0
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 // This file defines error categories and codes for MICM

--- a/include/micm/util/internal_error.hpp
+++ b/include/micm/util/internal_error.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/internal_error.hpp
+++ b/include/micm/util/internal_error.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/internal_error.hpp
+++ b/include/micm/util/internal_error.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/jacobian.hpp
+++ b/include/micm/util/jacobian.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/jacobian.hpp
+++ b/include/micm/util/jacobian.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/jacobian.hpp
+++ b/include/micm/util/jacobian.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/matrix_error.hpp
+++ b/include/micm/util/matrix_error.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/matrix_error.hpp
+++ b/include/micm/util/matrix_error.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/matrix_error.hpp
+++ b/include/micm/util/matrix_error.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/property_keys.hpp
+++ b/include/micm/util/property_keys.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/property_keys.hpp
+++ b/include/micm/util/property_keys.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/property_keys.hpp
+++ b/include/micm/util/property_keys.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/random_string.hpp
+++ b/include/micm/util/random_string.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/random_string.hpp
+++ b/include/micm/util/random_string.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/random_string.hpp
+++ b/include/micm/util/random_string.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_standard_ordering.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_standard_ordering.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_standard_ordering.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 National Center for Atmospheric Research
+// Copyright (C) 2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_vector_ordering.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_vector_ordering.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_vector_ordering.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2025 University Corporation for Atmospheric ResearchNational Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 National Center for Atmospheric Research
+// Copyright (C) 2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 University Corporation for Atmospheric ResearchNational Center for Atmospheric Research
+// Copyright (C) 2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/include/micm/version.hpp
+++ b/include/micm/version.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 // clang-format off
 #pragma once

--- a/include/micm/version.hpp
+++ b/include/micm/version.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 // clang-format off
 #pragma once

--- a/include/micm/version.hpp
+++ b/include/micm/version.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 // clang-format off
 #pragma once

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>

--- a/src/solver/linear_solver_in_place.cu
+++ b/src/solver/linear_solver_in_place.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>

--- a/src/solver/linear_solver_in_place.cu
+++ b/src/solver/linear_solver_in_place.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>

--- a/src/solver/linear_solver_in_place.cu
+++ b/src/solver/linear_solver_in_place.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>

--- a/src/solver/lu_decomposition_mozart_in_place.cu
+++ b/src/solver/lu_decomposition_mozart_in_place.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>

--- a/src/solver/lu_decomposition_mozart_in_place.cu
+++ b/src/solver/lu_decomposition_mozart_in_place.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>

--- a/src/solver/lu_decomposition_mozart_in_place.cu
+++ b/src/solver/lu_decomposition_mozart_in_place.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_matrix.cuh>
 #include <micm/cuda/util/cuda_param.hpp>

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_matrix.cuh>
 #include <micm/cuda/util/cuda_param.hpp>

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_matrix.cuh>
 #include <micm/cuda/util/cuda_param.hpp>

--- a/src/util/cuda_util.cu
+++ b/src/util/cuda_util.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_util.cuh>
 #include <micm/util/internal_error.hpp>

--- a/src/util/cuda_util.cu
+++ b/src/util/cuda_util.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_util.cuh>
 #include <micm/util/internal_error.hpp>

--- a/src/util/cuda_util.cu
+++ b/src/util/cuda_util.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 #include <micm/cuda/util/cuda_util.cuh>
 #include <micm/util/internal_error.hpp>

--- a/src/version.hpp.in
+++ b/src/version.hpp.in
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 // clang-format off
 #pragma once

--- a/src/version.hpp.in
+++ b/src/version.hpp.in
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 // clang-format off
 #pragma once

--- a/src/version.hpp.in
+++ b/src/version.hpp.in
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 // clang-format off
 #pragma once

--- a/test/integration/cuda/test_cuda_analytical_rosenbrock.cpp
+++ b/test/integration/cuda/test_cuda_analytical_rosenbrock.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Center for Atmospheric Research
+// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #include "../analytical_policy.hpp"

--- a/test/integration/cuda/test_cuda_analytical_rosenbrock.cpp
+++ b/test/integration/cuda/test_cuda_analytical_rosenbrock.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 National Science Foundation-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #include "../analytical_policy.hpp"

--- a/test/integration/cuda/test_cuda_analytical_rosenbrock.cpp
+++ b/test/integration/cuda/test_cuda_analytical_rosenbrock.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 University Corporation for Atmospheric Research-National Center for Atmospheric Research
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
 #include "../analytical_policy.hpp"


### PR DESCRIPTION
added National Center for Atmospheric Research- when we see "National Center for Atmospheric Research"
and NSF to NCAR

closes #688 