### PR TITLE
Add maximum grid cells function

### DIFF
--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -83,7 +83,7 @@ namespace micm
 
     /// @brief Returns the maximum number of grid cells per state
     /// @return Number of grid cells
-    /// @details This is the maximum number of grid cells that can that fit
+    /// @details This is the maximum number of grid cells that can fit
     ///          within one group for vectorized solvers. For non-vectorized solvers,
     ///          there is no limit other than the maximum size of a std::size_t.
     std::size_t MaximumNumberOfGridCells() const

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -8,6 +8,7 @@
 #include <micm/solver/rosenbrock.hpp>
 #include <micm/solver/rosenbrock_temporary_variables.hpp>
 #include <micm/solver/solver_result.hpp>
+#include <micm/util/matrix.hpp>
 
 #include <type_traits>
 
@@ -78,6 +79,23 @@ namespace micm
     {
       solver_parameters_ = params;
       return solver_.Solve(time_step, state, params);
+    }
+
+    /// @brief Returns the maximum number of grid cells per state
+    /// @return Number of grid cells
+    /// @details This is the maximum number of grid cells that can that fit
+    ///          within one group for vectorized solvers. For non-vectorized solvers,
+    ///          there is no limit other than the maximum size of a std::size_t.
+    std::size_t MaximumNumberOfGridCells() const
+    {
+      if constexpr (VectorizableDense<DenseMatrixType>)
+      {
+        return DenseMatrixType::GroupVectorSize();
+      }
+      else
+      {
+        return std::numeric_limits<std::size_t>::max();
+      }
     }
 
     /// @brief Returns the number of species

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -81,6 +81,8 @@ TEST(SolverBuilder, CanBuildBackwardEuler)
   EXPECT_EQ(backward_euler_vector.GetSystem().gas_phase_.name_, the_system.gas_phase_.name_);
   EXPECT_EQ(backward_euler_vector.GetSystem().gas_phase_.species_.size(), the_system.gas_phase_.species_.size());
   EXPECT_EQ(backward_euler_vector.GetSystem().phases_.size(), the_system.phases_.size());
+  EXPECT_GT(backward_euler.MaximumNumberOfGridCells(), 1e10);
+  EXPECT_EQ(backward_euler_vector.MaximumNumberOfGridCells(), 4);
 }
 
 TEST(SolverBuilder, CanBuildRosenbrock)
@@ -104,6 +106,8 @@ TEST(SolverBuilder, CanBuildRosenbrock)
   EXPECT_EQ(rosenbrock_vector.GetSystem().gas_phase_.name_, the_system.gas_phase_.name_);
   EXPECT_EQ(rosenbrock_vector.GetSystem().gas_phase_.species_.size(), the_system.gas_phase_.species_.size());
   EXPECT_EQ(rosenbrock_vector.GetSystem().phases_.size(), the_system.phases_.size());
+  EXPECT_GT(rosenbrock.MaximumNumberOfGridCells(), 1e10);
+  EXPECT_EQ(rosenbrock_vector.MaximumNumberOfGridCells(), 4);
 }
 
 TEST(SolverBuilder, CanBuildBackwardEulerOverloadedSolverMethod)

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -81,7 +81,7 @@ TEST(SolverBuilder, CanBuildBackwardEuler)
   EXPECT_EQ(backward_euler_vector.GetSystem().gas_phase_.name_, the_system.gas_phase_.name_);
   EXPECT_EQ(backward_euler_vector.GetSystem().gas_phase_.species_.size(), the_system.gas_phase_.species_.size());
   EXPECT_EQ(backward_euler_vector.GetSystem().phases_.size(), the_system.phases_.size());
-  EXPECT_GT(backward_euler.MaximumNumberOfGridCells(), 1e10);
+  EXPECT_GT(backward_euler.MaximumNumberOfGridCells(), 1e8);
   EXPECT_EQ(backward_euler_vector.MaximumNumberOfGridCells(), 4);
 }
 
@@ -106,7 +106,7 @@ TEST(SolverBuilder, CanBuildRosenbrock)
   EXPECT_EQ(rosenbrock_vector.GetSystem().gas_phase_.name_, the_system.gas_phase_.name_);
   EXPECT_EQ(rosenbrock_vector.GetSystem().gas_phase_.species_.size(), the_system.gas_phase_.species_.size());
   EXPECT_EQ(rosenbrock_vector.GetSystem().phases_.size(), the_system.phases_.size());
-  EXPECT_GT(rosenbrock.MaximumNumberOfGridCells(), 1e10);
+  EXPECT_GT(rosenbrock.MaximumNumberOfGridCells(), 1e8);
   EXPECT_EQ(rosenbrock_vector.MaximumNumberOfGridCells(), 4);
 }
 


### PR DESCRIPTION
Adds a function to the Solver class that can be used to get the maximum number of grid cells that can fit in one group of vectorized State matrices.