### PR TITLE
676 setup a run on the ncar cloud for gpu runs

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -14,5 +14,15 @@ jobs:
     name: job1
     runs-on: gha-runner-micm
     steps:
-      - name: test1
-        run: nvidia-smi
+      - uses: actions/checkout@v4
+
+      - name: Run Cmake 
+        run: cmake -S . -B build -DMICM_GPU_TYPE="a10"
+
+      - name: Build
+        run: cmake --build build --parallel 10
+
+      - name: Run tests
+        run: |
+          cd build
+          ctest --rerun-failed --output-on-failure . --verbose -j 10

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install cmake
+        run: |
+          apt update
+          apt install -y cmake
+
       - name: Run Cmake 
         run: cmake -S . -B build -DMICM_GPU_TYPE="a10"
 

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Install cmake
         run: |
-           sudo apt update
-           sudo apt install -y cmake g++
+           apt update
+           apt install -y cmake g++
 
       - name: Run Cmake 
         run: cmake -S . -B build -DMICM_GPU_TYPE="a10"

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -15,4 +15,4 @@ jobs:
     runs-on: gha-runner-micm
     steps:
       - name: test1
-        run: ls
+        run: nvidia-smi

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -2,6 +2,8 @@ name: Designated Runner
 
 on: 
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
   

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: gha-runner-micm
     steps:
       - name: Clone micm repository
-        run: git clone https://github.com/your-org/micm.git .
+        run: git clone https://github.com/NCAR/micm.git
 
       - name: Checkout current branch
         run: |

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,4 +1,4 @@
-name: Designated Runner
+name: Designated GPU Runner
 
 on: 
   push:

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -18,8 +18,8 @@ jobs:
 
       - name: Install cmake
         run: |
-          apt update
-          apt install -y cmake
+          sudo apt update
+          sudo apt install -y cmake
 
       - name: Run Cmake 
         run: cmake -S . -B build -DMICM_GPU_TYPE="a10"

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -18,8 +18,8 @@ jobs:
 
       - name: Install cmake
         run: |
-          sudo apt update
-          sudo apt install -y cmake
+           sudo apt update
+           sudo apt install -y cmake g++
 
       - name: Run Cmake 
         run: cmake -S . -B build -DMICM_GPU_TYPE="a10"

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install cmake
+      - name: Install dependencies
         run: |
            apt update
            apt install -y cmake g++

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -14,16 +14,10 @@ jobs:
     name: job1
     runs-on: gha-runner-micm
     steps:
-      - name: Clone micm repository
-        run: git clone https://github.com/NCAR/micm.git
-
-      - name: Checkout current branch
-        run: |
-          git fetch origin ${{ github.ref }}
-          git checkout ${{ github.ref_name }}
+      - uses: actions/checkout@v4
 
       - name: Run Cmake 
-        run: cmake -S micm -B build -DMICM_GPU_TYPE="a10"
+        run: cmake -S . -B build -DMICM_GPU_TYPE="a10"
 
       - name: Build
         run: cmake --build build --parallel 10

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -14,10 +14,16 @@ jobs:
     name: job1
     runs-on: gha-runner-micm
     steps:
-      - uses: actions/checkout@v4
+      - name: Clone micm repository
+        run: git clone https://github.com/your-org/micm.git .
+
+      - name: Checkout current branch
+        run: |
+          git fetch origin ${{ github.ref }}
+          git checkout ${{ github.ref_name }}
 
       - name: Run Cmake 
-        run: cmake -S . -B build -DMICM_GPU_TYPE="a10"
+        run: cmake -S micm -B build -DMICM_GPU_TYPE="a10"
 
       - name: Build
         run: cmake --build build --parallel 10

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -12,8 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  job1:
-    name: job1
+  cuda_tests:
     runs-on: gha-runner-micm
     container:
       image: nvcr.io/nvidia/nvhpc:23.7-devel-cuda12.2-ubuntu22.04

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -13,6 +13,9 @@ jobs:
   job1:
     name: job1
     runs-on: gha-runner-micm
+    container:
+      image: nvcr.io/nvidia/nvhpc:23.7-devel-cuda12.2-ubuntu22.04
+      options: --gpus all
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -26,6 +26,10 @@ jobs:
 
       - name: Run Cmake 
         run: cmake -S . -B build -DMICM_GPU_TYPE="a10"
+      
+      - name: Copy cublas headers
+        run: |
+          cp -r /opt/nvidia/hpc_sdk/*/23.7/cuda/include/* /usr/include/
 
       - name: Build
         run: cmake --build build --parallel 10

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,0 +1,18 @@
+name: Designated Runner
+
+on: 
+  push:
+  pull_request:
+  workflow_dispatch:
+  
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  job1:
+    name: job1
+    runs-on: gha-runner-micm
+    steps:
+      - name: test1
+        run: ls

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -106,6 +106,7 @@ if(NOT ${MICM_GPU_TYPE} STREQUAL "None")
   string(TOLOWER ${MICM_GPU_TYPE} MICM_GPU_TYPE_LOWER)
   # Data center GPUs
   set(cuda_arch_map_a100 80)
+  set(cuda_arch_map_a10 86)
   set(cuda_arch_map_v100 70)
   set(cuda_arch_map_h100 90a)
   set(cuda_arch_map_h200 90a)


### PR DESCRIPTION
Closes #676 

Thanks to NRIT, or someone within NCAR, we now have a dedicated runner that runs on a Kubernetes instance internal to NCAR running on NCAR hardware. This gives us access to an a10 GPU that will allow our tests to run our cuda code on PRs.