### PR TITLE
Address out of memory error on GPU with large number of grid cells

### DIFF
--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -66,7 +66,7 @@ namespace micm
     {
       this->param_.number_of_grid_cells_ = 0;
       this->param_.number_of_elements_ = this->data_.size();
-      CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
+      if (this->param_.number_of_elements_ != 0) CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
     }
 
     CudaDenseMatrix(std::size_t x_dim, std::size_t y_dim)
@@ -74,7 +74,7 @@ namespace micm
     {
       this->param_.number_of_elements_ = this->data_.size();
       this->param_.number_of_grid_cells_ = x_dim;
-      CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
+      if (this->param_.number_of_elements_ != 0) CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
     }
 
     CudaDenseMatrix(std::size_t x_dim, std::size_t y_dim, T initial_value)
@@ -98,7 +98,7 @@ namespace micm
       {
         this->param_.number_of_elements_ += inner_vector.size();
       }
-      CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
+      if (this->param_.number_of_elements_ != 0) CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
     }
 
     CudaDenseMatrix(const CudaDenseMatrix& other)

--- a/include/micm/cuda/util/cuda_sparse_matrix.hpp
+++ b/include/micm/cuda/util/cuda_sparse_matrix.hpp
@@ -32,11 +32,11 @@ namespace micm
       this->param_.d_data_ = nullptr;
     }
 
-    CudaSparseMatrix(const SparseMatrixBuilder<T, OrderingPolicy>& builder, bool empty_matrix = false)
-        : SparseMatrix<T, OrderingPolicy>(builder, empty_matrix)
+    CudaSparseMatrix(const SparseMatrixBuilder<T, OrderingPolicy>& builder, bool indexing_only = false)
+        : SparseMatrix<T, OrderingPolicy>(builder, indexing_only)
     {
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
-      if (! empty_matrix) CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->data_.size()), "cudaMalloc");
+      if (! indexing_only) CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->data_.size()), "cudaMalloc");
     }
 
     CudaSparseMatrix<T, OrderingPolicy>& operator=(const SparseMatrixBuilder<T, OrderingPolicy>& builder)

--- a/include/micm/cuda/util/cuda_sparse_matrix.hpp
+++ b/include/micm/cuda/util/cuda_sparse_matrix.hpp
@@ -32,18 +32,18 @@ namespace micm
       this->param_.d_data_ = nullptr;
     }
 
-    CudaSparseMatrix(const SparseMatrixBuilder<T, OrderingPolicy>& builder)
-        : SparseMatrix<T, OrderingPolicy>(builder)
+    CudaSparseMatrix(const SparseMatrixBuilder<T, OrderingPolicy>& builder, bool empty_matrix = false)
+        : SparseMatrix<T, OrderingPolicy>(builder, empty_matrix)
     {
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
-      CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->data_.size()), "cudaMalloc");
+      if (! empty_matrix) CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->data_.size()), "cudaMalloc");
     }
 
     CudaSparseMatrix<T, OrderingPolicy>& operator=(const SparseMatrixBuilder<T, OrderingPolicy>& builder)
     {
       SparseMatrix<T, OrderingPolicy>::operator=(builder);
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
-      CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->data_.size()), "cudaMalloc");
+      if (this->data_.size() != 0) CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->data_.size()), "cudaMalloc");
       return *this;
     }
 

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -74,7 +74,7 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    auto lu = lu_decomp_.template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks());
+    auto lu = lu_decomp_.template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks(), true);
     auto lower_matrix = std::move(lu.first);
     auto upper_matrix = std::move(lu.second);
     for (std::size_t i = 0; i < lower_matrix.NumRows(); ++i)

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -74,7 +74,7 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    auto lu = lu_decomp_.template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks(), true);
+    auto lu = lu_decomp_.template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, true);
     auto lower_matrix = std::move(lu.first);
     auto upper_matrix = std::move(lu.second);
     for (std::size_t i = 0; i < lower_matrix.NumRows(); ++i)

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -74,7 +74,7 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    auto lu = lu_decomp_.template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value);
+    auto lu = lu_decomp_.template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks());
     auto lower_matrix = std::move(lu.first);
     auto upper_matrix = std::move(lu.second);
     for (std::size_t i = 0; i < lower_matrix.NumRows(); ++i)

--- a/include/micm/solver/linear_solver_in_place.inl
+++ b/include/micm/solver/linear_solver_in_place.inl
@@ -27,7 +27,7 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    auto lu = lu_decomp_.template GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value);
+    auto lu = lu_decomp_.template GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks());
     for (std::size_t i = 0; i < lu.NumRows(); ++i)
     {
       std::size_t nLij = 0;

--- a/include/micm/solver/linear_solver_in_place.inl
+++ b/include/micm/solver/linear_solver_in_place.inl
@@ -27,7 +27,7 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    auto lu = lu_decomp_.template GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks(), true);
+    auto lu = lu_decomp_.template GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, true);
     for (std::size_t i = 0; i < lu.NumRows(); ++i)
     {
       std::size_t nLij = 0;

--- a/include/micm/solver/linear_solver_in_place.inl
+++ b/include/micm/solver/linear_solver_in_place.inl
@@ -27,7 +27,7 @@ namespace micm
   {
     MICM_PROFILE_FUNCTION();
 
-    auto lu = lu_decomp_.template GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks());
+    auto lu = lu_decomp_.template GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks(), true);
     for (std::size_t i = 0; i < lu.NumRows(); ++i)
     {
       std::size_t nLij = 0;

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -16,7 +16,7 @@ namespace micm
   /// @brief Concept for in-place LU decomposition algorithms
   template<class T, class SparseMatrixPolicy>
   concept LuDecompositionInPlaceConcept = requires(T t) {
-    { t.GetLUMatrix(SparseMatrixPolicy{}, 0.0) };
+    { t.GetLUMatrix(SparseMatrixPolicy{}, 0.0, 1) };
     { t.Decompose(std::declval<SparseMatrixPolicy&>()) };
   };
   static_assert(

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -16,7 +16,7 @@ namespace micm
   /// @brief Concept for in-place LU decomposition algorithms
   template<class T, class SparseMatrixPolicy>
   concept LuDecompositionInPlaceConcept = requires(T t) {
-    { t.GetLUMatrix(SparseMatrixPolicy{}, 0.0, 1) };
+    { t.GetLUMatrix(SparseMatrixPolicy{}, 0.0, 1, true) };
     { t.Decompose(std::declval<SparseMatrixPolicy&>()) };
   };
   static_assert(

--- a/include/micm/solver/lu_decomposition.hpp
+++ b/include/micm/solver/lu_decomposition.hpp
@@ -16,7 +16,7 @@ namespace micm
   /// @brief Concept for in-place LU decomposition algorithms
   template<class T, class SparseMatrixPolicy>
   concept LuDecompositionInPlaceConcept = requires(T t) {
-    { t.GetLUMatrix(SparseMatrixPolicy{}, 0.0, 1, true) };
+    { t.GetLUMatrix(SparseMatrixPolicy{}, 0.0, true) };
     { t.Decompose(std::declval<SparseMatrixPolicy&>()) };
   };
   static_assert(

--- a/include/micm/solver/lu_decomposition_doolittle.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle.hpp
@@ -108,7 +108,8 @@ namespace micm
       requires(SparseMatrixConcept<SparseMatrixPolicy>)
     static std::pair<LMatrixPolicy, UMatrixPolicy> GetLUMatrices(
         const SparseMatrixPolicy& A,
-        typename SparseMatrixPolicy::value_type initial_value);
+        typename SparseMatrixPolicy::value_type initial_value,
+        std::size_t number_of_grid_cells);
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose

--- a/include/micm/solver/lu_decomposition_doolittle.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle.hpp
@@ -109,7 +109,6 @@ namespace micm
     static std::pair<LMatrixPolicy, UMatrixPolicy> GetLUMatrices(
         const SparseMatrixPolicy& A,
         typename SparseMatrixPolicy::value_type initial_value,
-        std::size_t number_of_grid_cells,
         bool indexing_only = false);
 
     /// @brief Perform an LU decomposition on a given A matrix

--- a/include/micm/solver/lu_decomposition_doolittle.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle.hpp
@@ -109,7 +109,8 @@ namespace micm
     static std::pair<LMatrixPolicy, UMatrixPolicy> GetLUMatrices(
         const SparseMatrixPolicy& A,
         typename SparseMatrixPolicy::value_type initial_value,
-        std::size_t number_of_grid_cells);
+        std::size_t number_of_grid_cells,
+        bool empty_matrix = false);
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose

--- a/include/micm/solver/lu_decomposition_doolittle.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle.hpp
@@ -110,7 +110,7 @@ namespace micm
         const SparseMatrixPolicy& A,
         typename SparseMatrixPolicy::value_type initial_value,
         std::size_t number_of_grid_cells,
-        bool empty_matrix = false);
+        bool indexing_only = false);
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -32,7 +32,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     std::size_t n = matrix.NumRows();
-    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks());
+    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks(), true);
     for (std::size_t i = 0; i < matrix.NumRows(); ++i)
     {
       std::pair<std::size_t, std::size_t> iLU(0, 0);
@@ -98,7 +98,8 @@ namespace micm
   inline std::pair<LMatrixPolicy, UMatrixPolicy> LuDecompositionDoolittle::GetLUMatrices(
       const SparseMatrixPolicy& A,
       typename SparseMatrixPolicy::value_type initial_value,
-      std::size_t number_of_grid_cells)
+      std::size_t number_of_grid_cells,
+      bool empty_matrix)
   {
     MICM_PROFILE_FUNCTION();
 

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -32,7 +32,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     std::size_t n = matrix.NumRows();
-    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value);
+    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks());
     for (std::size_t i = 0; i < matrix.NumRows(); ++i)
     {
       std::pair<std::size_t, std::size_t> iLU(0, 0);
@@ -97,7 +97,8 @@ namespace micm
     requires(SparseMatrixConcept<SparseMatrixPolicy>)
   inline std::pair<LMatrixPolicy, UMatrixPolicy> LuDecompositionDoolittle::GetLUMatrices(
       const SparseMatrixPolicy& A,
-      typename SparseMatrixPolicy::value_type initial_value)
+      typename SparseMatrixPolicy::value_type initial_value,
+      std::size_t number_of_grid_cells)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -140,12 +141,12 @@ namespace micm
         }
       }
     }
-    auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
+    auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(number_of_grid_cells).InitialValue(initial_value);
     for (auto& pair : L_ids)
     {
       L_builder = L_builder.WithElement(pair.first, pair.second);
     }
-    auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
+    auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(number_of_grid_cells).InitialValue(initial_value);
     for (auto& pair : U_ids)
     {
       U_builder = U_builder.WithElement(pair.first, pair.second);

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -32,7 +32,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     std::size_t n = matrix.NumRows();
-    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks(), true);
+    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, true);
     for (std::size_t i = 0; i < matrix.NumRows(); ++i)
     {
       std::pair<std::size_t, std::size_t> iLU(0, 0);
@@ -98,7 +98,6 @@ namespace micm
   inline std::pair<LMatrixPolicy, UMatrixPolicy> LuDecompositionDoolittle::GetLUMatrices(
       const SparseMatrixPolicy& A,
       typename SparseMatrixPolicy::value_type initial_value,
-      std::size_t number_of_grid_cells,
       bool indexing_only)
   {
     MICM_PROFILE_FUNCTION();
@@ -142,12 +141,12 @@ namespace micm
         }
       }
     }
-    auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(number_of_grid_cells).InitialValue(initial_value);
+    auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
     for (auto& pair : L_ids)
     {
       L_builder = L_builder.WithElement(pair.first, pair.second);
     }
-    auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(number_of_grid_cells).InitialValue(initial_value);
+    auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
     for (auto& pair : U_ids)
     {
       U_builder = U_builder.WithElement(pair.first, pair.second);

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -99,7 +99,7 @@ namespace micm
       const SparseMatrixPolicy& A,
       typename SparseMatrixPolicy::value_type initial_value,
       std::size_t number_of_grid_cells,
-      bool empty_matrix)
+      bool indexing_only)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -152,7 +152,7 @@ namespace micm
     {
       U_builder = U_builder.WithElement(pair.first, pair.second);
     }
-    std::pair<LMatrixPolicy, UMatrixPolicy> LU(L_builder, U_builder);
+    std::pair<LMatrixPolicy, UMatrixPolicy> LU(LMatrixPolicy(L_builder, indexing_only), UMatrixPolicy(U_builder, indexing_only));
     return LU;
   }
 

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
@@ -80,7 +80,8 @@ namespace micm
       requires(SparseMatrixConcept<SparseMatrixPolicy>)
     static SparseMatrixPolicy GetLUMatrix(
         const SparseMatrixPolicy& A,
-        typename SparseMatrixPolicy::value_type initial_value);
+        typename SparseMatrixPolicy::value_type initial_value,
+        std::size_t number_of_grid_cells);
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
@@ -81,7 +81,6 @@ namespace micm
     static SparseMatrixPolicy GetLUMatrix(
         const SparseMatrixPolicy& A,
         typename SparseMatrixPolicy::value_type initial_value,
-        std::size_t number_of_grid_cells,
         bool indexing_only = false);
 
     /// @brief Perform an LU decomposition on a given A matrix

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
@@ -82,7 +82,7 @@ namespace micm
         const SparseMatrixPolicy& A,
         typename SparseMatrixPolicy::value_type initial_value,
         std::size_t number_of_grid_cells,
-        bool empty_matrix = false);
+        bool indexing_only = false);
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.hpp
@@ -81,7 +81,8 @@ namespace micm
     static SparseMatrixPolicy GetLUMatrix(
         const SparseMatrixPolicy& A,
         typename SparseMatrixPolicy::value_type initial_value,
-        std::size_t number_of_grid_cells);
+        std::size_t number_of_grid_cells,
+        bool empty_matrix = false);
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -31,7 +31,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     std::size_t n = matrix.NumRows();
-    auto ALU = GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks());
+    auto ALU = GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks(), true);
     for (std::size_t i = 0; i < n; ++i)
     {
       if (ALU.IsZero(i, i))
@@ -78,7 +78,8 @@ namespace micm
   inline SparseMatrixPolicy LuDecompositionDoolittleInPlace::GetLUMatrix(
       const SparseMatrixPolicy& A,
       typename SparseMatrixPolicy::value_type initial_value,
-      std::size_t number_of_grid_cells)
+      std::size_t number_of_grid_cells,
+      bool empty_matrix)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -126,7 +127,7 @@ namespace micm
     {
       ALU_builder = ALU_builder.WithElement(pair.first, pair.second);
     }
-    return SparseMatrixPolicy(ALU_builder);
+    return SparseMatrixPolicy(ALU_builder, empty_matrix);
   }
 
   template<class SparseMatrixPolicy>

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -121,7 +121,7 @@ namespace micm
         }
       }
     }
-    auto ALU_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
+    auto ALU_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(number_of_grid_cells).InitialValue(initial_value);
     for (auto& pair : ALU_ids)
     {
       ALU_builder = ALU_builder.WithElement(pair.first, pair.second);

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -79,7 +79,7 @@ namespace micm
       const SparseMatrixPolicy& A,
       typename SparseMatrixPolicy::value_type initial_value,
       std::size_t number_of_grid_cells,
-      bool empty_matrix)
+      bool indexing_only)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -127,7 +127,7 @@ namespace micm
     {
       ALU_builder = ALU_builder.WithElement(pair.first, pair.second);
     }
-    return SparseMatrixPolicy(ALU_builder, empty_matrix);
+    return SparseMatrixPolicy(ALU_builder, indexing_only);
   }
 
   template<class SparseMatrixPolicy>

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -31,7 +31,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     std::size_t n = matrix.NumRows();
-    auto ALU = GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks(), true);
+    auto ALU = GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, true);
     for (std::size_t i = 0; i < n; ++i)
     {
       if (ALU.IsZero(i, i))
@@ -78,7 +78,6 @@ namespace micm
   inline SparseMatrixPolicy LuDecompositionDoolittleInPlace::GetLUMatrix(
       const SparseMatrixPolicy& A,
       typename SparseMatrixPolicy::value_type initial_value,
-      std::size_t number_of_grid_cells,
       bool indexing_only)
   {
     MICM_PROFILE_FUNCTION();
@@ -122,7 +121,7 @@ namespace micm
         }
       }
     }
-    auto ALU_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(number_of_grid_cells).InitialValue(initial_value);
+    auto ALU_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
     for (auto& pair : ALU_ids)
     {
       ALU_builder = ALU_builder.WithElement(pair.first, pair.second);

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -31,7 +31,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     std::size_t n = matrix.NumRows();
-    auto ALU = GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value);
+    auto ALU = GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks());
     for (std::size_t i = 0; i < n; ++i)
     {
       if (ALU.IsZero(i, i))
@@ -77,7 +77,8 @@ namespace micm
     requires(SparseMatrixConcept<SparseMatrixPolicy>)
   inline SparseMatrixPolicy LuDecompositionDoolittleInPlace::GetLUMatrix(
       const SparseMatrixPolicy& A,
-      typename SparseMatrixPolicy::value_type initial_value)
+      typename SparseMatrixPolicy::value_type initial_value,
+      std::size_t number_of_grid_cells)
   {
     MICM_PROFILE_FUNCTION();
 

--- a/include/micm/solver/lu_decomposition_mozart.hpp
+++ b/include/micm/solver/lu_decomposition_mozart.hpp
@@ -121,7 +121,6 @@ namespace micm
     static std::pair<LMatrixPolicy, UMatrixPolicy> GetLUMatrices(
         const SparseMatrixPolicy& A,
         typename SparseMatrixPolicy::value_type initial_value,
-        std::size_t number_of_grid_cells,
         bool indexing_only = false);
 
     /// @brief Perform an LU decomposition on a given A matrix

--- a/include/micm/solver/lu_decomposition_mozart.hpp
+++ b/include/micm/solver/lu_decomposition_mozart.hpp
@@ -121,7 +121,8 @@ namespace micm
     static std::pair<LMatrixPolicy, UMatrixPolicy> GetLUMatrices(
         const SparseMatrixPolicy& A,
         typename SparseMatrixPolicy::value_type initial_value,
-        std::size_t number_of_grid_cells);
+        std::size_t number_of_grid_cells,
+        bool empty_matrix = false);
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose

--- a/include/micm/solver/lu_decomposition_mozart.hpp
+++ b/include/micm/solver/lu_decomposition_mozart.hpp
@@ -122,7 +122,7 @@ namespace micm
         const SparseMatrixPolicy& A,
         typename SparseMatrixPolicy::value_type initial_value,
         std::size_t number_of_grid_cells,
-        bool empty_matrix = false);
+        bool indexing_only = false);
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose

--- a/include/micm/solver/lu_decomposition_mozart.hpp
+++ b/include/micm/solver/lu_decomposition_mozart.hpp
@@ -120,7 +120,8 @@ namespace micm
       requires(SparseMatrixConcept<SparseMatrixPolicy>)
     static std::pair<LMatrixPolicy, UMatrixPolicy> GetLUMatrices(
         const SparseMatrixPolicy& A,
-        typename SparseMatrixPolicy::value_type initial_value);
+        typename SparseMatrixPolicy::value_type initial_value,
+        std::size_t number_of_grid_cells);
 
     /// @brief Perform an LU decomposition on a given A matrix
     /// @param A Sparse matrix to decompose

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -32,7 +32,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     std::size_t n = matrix.NumRows();
-    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value);
+    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks());
     for (std::size_t i = 0; i < n; ++i)
     {
       std::tuple<std::size_t, std::size_t, std::size_t> lii_nuji_nlji(0, 0, 0);
@@ -115,7 +115,8 @@ namespace micm
     requires(SparseMatrixConcept<SparseMatrixPolicy>)
   inline std::pair<LMatrixPolicy, UMatrixPolicy> LuDecompositionMozart::GetLUMatrices(
       const SparseMatrixPolicy& A,
-      typename SparseMatrixPolicy::value_type initial_value)
+      typename SparseMatrixPolicy::value_type initial_value,
+      std::size_t number_of_grid_cells)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -150,12 +151,12 @@ namespace micm
             L_ids.insert(std::make_pair(j, k));
       }
     }
-    auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
+    auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(number_of_grid_cells).InitialValue(initial_value);
     for (auto& pair : L_ids)
     {
       L_builder = L_builder.WithElement(pair.first, pair.second);
     }
-    auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
+    auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(number_of_grid_cells).InitialValue(initial_value);
     for (auto& pair : U_ids)
     {
       U_builder = U_builder.WithElement(pair.first, pair.second);

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -32,7 +32,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     std::size_t n = matrix.NumRows();
-    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks(), true);
+    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, true);
     for (std::size_t i = 0; i < n; ++i)
     {
       std::tuple<std::size_t, std::size_t, std::size_t> lii_nuji_nlji(0, 0, 0);
@@ -116,7 +116,6 @@ namespace micm
   inline std::pair<LMatrixPolicy, UMatrixPolicy> LuDecompositionMozart::GetLUMatrices(
       const SparseMatrixPolicy& A,
       typename SparseMatrixPolicy::value_type initial_value,
-      std::size_t number_of_grid_cells,
       bool indexing_only)
   {
     MICM_PROFILE_FUNCTION();
@@ -152,12 +151,12 @@ namespace micm
             L_ids.insert(std::make_pair(j, k));
       }
     }
-    auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(number_of_grid_cells).InitialValue(initial_value);
+    auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
     for (auto& pair : L_ids)
     {
       L_builder = L_builder.WithElement(pair.first, pair.second);
     }
-    auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(number_of_grid_cells).InitialValue(initial_value);
+    auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
     for (auto& pair : U_ids)
     {
       U_builder = U_builder.WithElement(pair.first, pair.second);

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -117,7 +117,7 @@ namespace micm
       const SparseMatrixPolicy& A,
       typename SparseMatrixPolicy::value_type initial_value,
       std::size_t number_of_grid_cells,
-      bool empty_matrix)
+      bool indexing_only)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -162,7 +162,7 @@ namespace micm
     {
       U_builder = U_builder.WithElement(pair.first, pair.second);
     }
-    std::pair<LMatrixPolicy, UMatrixPolicy> LU(L_builder, U_builder);
+    std::pair<LMatrixPolicy, UMatrixPolicy> LU(LMatrixPolicy(L_builder, indexing_only), UMatrixPolicy(U_builder, indexing_only));
     return LU;
   }
 

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -32,7 +32,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     std::size_t n = matrix.NumRows();
-    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks());
+    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks(), true);
     for (std::size_t i = 0; i < n; ++i)
     {
       std::tuple<std::size_t, std::size_t, std::size_t> lii_nuji_nlji(0, 0, 0);
@@ -116,7 +116,8 @@ namespace micm
   inline std::pair<LMatrixPolicy, UMatrixPolicy> LuDecompositionMozart::GetLUMatrices(
       const SparseMatrixPolicy& A,
       typename SparseMatrixPolicy::value_type initial_value,
-      std::size_t number_of_grid_cells)
+      std::size_t number_of_grid_cells,
+      bool empty_matrix)
   {
     MICM_PROFILE_FUNCTION();
 

--- a/include/micm/solver/lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.hpp
@@ -80,7 +80,7 @@ namespace micm
         const SparseMatrixPolicy& A,
         typename SparseMatrixPolicy::value_type initial_value,
         std::size_t number_of_grid_cells,
-        bool empty_matrix = false);
+        bool indexing_only = false);
 
     /// @brief Perform an LU decomposition on a given A matrix.
     ///        All elements of L and U that are zero in A should be set to zero before calling this function.

--- a/include/micm/solver/lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.hpp
@@ -78,7 +78,8 @@ namespace micm
       requires(SparseMatrixConcept<SparseMatrixPolicy>)
     static SparseMatrixPolicy GetLUMatrix(
         const SparseMatrixPolicy& A,
-        typename SparseMatrixPolicy::value_type initial_value);
+        typename SparseMatrixPolicy::value_type initial_value,
+        std::size_t number_of_grid_cells);
 
     /// @brief Perform an LU decomposition on a given A matrix.
     ///        All elements of L and U that are zero in A should be set to zero before calling this function.

--- a/include/micm/solver/lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.hpp
@@ -79,7 +79,6 @@ namespace micm
     static SparseMatrixPolicy GetLUMatrix(
         const SparseMatrixPolicy& A,
         typename SparseMatrixPolicy::value_type initial_value,
-        std::size_t number_of_grid_cells,
         bool indexing_only = false);
 
     /// @brief Perform an LU decomposition on a given A matrix.

--- a/include/micm/solver/lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.hpp
@@ -79,7 +79,8 @@ namespace micm
     static SparseMatrixPolicy GetLUMatrix(
         const SparseMatrixPolicy& A,
         typename SparseMatrixPolicy::value_type initial_value,
-        std::size_t number_of_grid_cells);
+        std::size_t number_of_grid_cells,
+        bool empty_matrix = false);
 
     /// @brief Perform an LU decomposition on a given A matrix.
     ///        All elements of L and U that are zero in A should be set to zero before calling this function.

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -31,7 +31,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     std::size_t n = matrix.NumRows();
-    auto ALU = GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks());
+    auto ALU = GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, true);
     for (std::size_t i = 0; i < n; ++i)
     {
       if (ALU.IsZero(i, i))
@@ -71,7 +71,6 @@ namespace micm
   inline SparseMatrixPolicy LuDecompositionMozartInPlace::GetLUMatrix(
       const SparseMatrixPolicy& A,
       typename SparseMatrixPolicy::value_type initial_value,
-      std::size_t number_of_grid_cells,
       bool indexing_only)
   {
     MICM_PROFILE_FUNCTION();
@@ -95,7 +94,7 @@ namespace micm
             if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(j, i)) != ALU_ids.end())
               ALU_ids.insert(std::make_pair(j, k));
     }
-    auto ALU_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(number_of_grid_cells).InitialValue(initial_value);
+    auto ALU_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
     for (auto& pair : ALU_ids)
     {
       ALU_builder = ALU_builder.WithElement(pair.first, pair.second);

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -71,7 +71,8 @@ namespace micm
   inline SparseMatrixPolicy LuDecompositionMozartInPlace::GetLUMatrix(
       const SparseMatrixPolicy& A,
       typename SparseMatrixPolicy::value_type initial_value,
-      std::size_t number_of_grid_cells)
+      std::size_t number_of_grid_cells,
+      bool empty_matrix)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -99,7 +100,7 @@ namespace micm
     {
       ALU_builder = ALU_builder.WithElement(pair.first, pair.second);
     }
-    return SparseMatrixPolicy(ALU_builder);
+    return SparseMatrixPolicy(ALU_builder, empty_matrix);
   }
 
   template<class SparseMatrixPolicy>

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -72,7 +72,7 @@ namespace micm
       const SparseMatrixPolicy& A,
       typename SparseMatrixPolicy::value_type initial_value,
       std::size_t number_of_grid_cells,
-      bool empty_matrix)
+      bool indexing_only)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -100,7 +100,7 @@ namespace micm
     {
       ALU_builder = ALU_builder.WithElement(pair.first, pair.second);
     }
-    return SparseMatrixPolicy(ALU_builder, empty_matrix);
+    return SparseMatrixPolicy(ALU_builder, indexing_only);
   }
 
   template<class SparseMatrixPolicy>

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -31,7 +31,7 @@ namespace micm
     MICM_PROFILE_FUNCTION();
 
     std::size_t n = matrix.NumRows();
-    auto ALU = GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value);
+    auto ALU = GetLUMatrix<SparseMatrixPolicy>(matrix, initial_value, matrix.NumberOfBlocks());
     for (std::size_t i = 0; i < n; ++i)
     {
       if (ALU.IsZero(i, i))
@@ -70,7 +70,8 @@ namespace micm
     requires(SparseMatrixConcept<SparseMatrixPolicy>)
   inline SparseMatrixPolicy LuDecompositionMozartInPlace::GetLUMatrix(
       const SparseMatrixPolicy& A,
-      typename SparseMatrixPolicy::value_type initial_value)
+      typename SparseMatrixPolicy::value_type initial_value,
+      std::size_t number_of_grid_cells)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -93,7 +94,7 @@ namespace micm
             if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(j, i)) != ALU_ids.end())
               ALU_ids.insert(std::make_pair(j, k));
     }
-    auto ALU_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
+    auto ALU_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(number_of_grid_cells).InitialValue(initial_value);
     for (auto& pair : ALU_ids)
     {
       ALU_builder = ALU_builder.WithElement(pair.first, pair.second);

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -375,7 +375,7 @@ namespace micm
     LinearSolverPolicy linear_solver(jacobian, 0);
     if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
     {
-      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian, 0, 1, true);
+      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian, 0, true);
       jacobian = std::move(lu);
     }
     rates.SetJacobianFlatIds(jacobian);

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -375,7 +375,7 @@ namespace micm
     LinearSolverPolicy linear_solver(jacobian, 0);
     if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
     {
-      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian, 0, 1);
+      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian, 0, 1, true);
       jacobian = std::move(lu);
     }
     rates.SetJacobianFlatIds(jacobian);

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -375,7 +375,7 @@ namespace micm
     LinearSolverPolicy linear_solver(jacobian, 0);
     if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
     {
-      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian, 0);
+      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian, 0, 1);
       jacobian = std::move(lu);
     }
     rates.SetJacobianFlatIds(jacobian);

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -370,7 +370,7 @@ namespace micm
     RatesPolicy rates(this->reactions_, species_map);
     auto nonzero_elements = rates.NonZeroJacobianElements();
     // The actual number of grid cells is not needed to construct the various solver objects
-    auto jacobian = BuildJacobian<SparseMatrixPolicy>(nonzero_elements, 1, number_of_species);
+    auto jacobian = BuildJacobian<SparseMatrixPolicy>(nonzero_elements, 1, number_of_species, true);
 
     LinearSolverPolicy linear_solver(jacobian, 0);
     if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -117,7 +117,7 @@ namespace micm
 
     if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
     {
-      jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, 1, state_size_, true);
+      jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, number_of_grid_cells, state_size_, true);
       auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian_, 0, number_of_grid_cells, false);
       jacobian_ = std::move(lu);
     }

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -115,15 +115,15 @@ namespace micm
     for (auto& label : parameters.custom_rate_parameter_labels_)
       custom_rate_parameter_map_[label] = index++;
 
-    jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, 1, state_size_);
-
     if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
     {
+      jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, 1, state_size_);
       auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian_, 0, number_of_grid_cells);
       jacobian_ = std::move(lu);
     }
     else
     {
+      jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, number_of_grid_cells, state_size_);
       auto lu =
           LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(jacobian_, 0, number_of_grid_cells);
       auto lower_matrix = std::move(lu.first);

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -118,14 +118,14 @@ namespace micm
     if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
     {
       jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, 1, state_size_, true);
-      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian_, 0, number_of_grid_cells);
+      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian_, 0, number_of_grid_cells, false);
       jacobian_ = std::move(lu);
     }
     else
     {
       jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, number_of_grid_cells, state_size_, false);
       auto lu =
-          LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(jacobian_, 0, number_of_grid_cells);
+          LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(jacobian_, 0, number_of_grid_cells, false);
       auto lower_matrix = std::move(lu.first);
       auto upper_matrix = std::move(lu.second);
       lower_matrix_ = lower_matrix;

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -117,13 +117,13 @@ namespace micm
 
     if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
     {
-      jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, 1, state_size_);
+      jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, 1, state_size_, true);
       auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian_, 0, number_of_grid_cells);
       jacobian_ = std::move(lu);
     }
     else
     {
-      jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, number_of_grid_cells, state_size_);
+      jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, number_of_grid_cells, state_size_, false);
       auto lu =
           LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(jacobian_, 0, number_of_grid_cells);
       auto lower_matrix = std::move(lu.first);
@@ -131,7 +131,6 @@ namespace micm
       lower_matrix_ = lower_matrix;
       upper_matrix_ = upper_matrix;
     }
-
     jacobian_diagonal_elements_ = jacobian_.DiagonalIndices(0);
   }
 

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -115,17 +115,17 @@ namespace micm
     for (auto& label : parameters.custom_rate_parameter_labels_)
       custom_rate_parameter_map_[label] = index++;
 
-    jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, number_of_grid_cells, state_size_);
+    jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, 1, state_size_);
 
     if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
     {
-      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian_, 0);
+      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian_, 0, number_of_grid_cells);
       jacobian_ = std::move(lu);
     }
     else
     {
       auto lu =
-          LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(jacobian_, 0);
+          LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(jacobian_, 0, number_of_grid_cells);
       auto lower_matrix = std::move(lu.first);
       auto upper_matrix = std::move(lu.second);
       lower_matrix_ = lower_matrix;

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -118,14 +118,14 @@ namespace micm
     if constexpr (LuDecompositionInPlaceConcept<LuDecompositionPolicy, SparseMatrixPolicy>)
     {
       jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, number_of_grid_cells, state_size_, true);
-      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian_, 0, number_of_grid_cells, false);
+      auto lu = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(jacobian_, 0, false);
       jacobian_ = std::move(lu);
     }
     else
     {
       jacobian_ = BuildJacobian<SparseMatrixPolicy>(parameters.nonzero_jacobian_elements_, number_of_grid_cells, state_size_, false);
       auto lu =
-          LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(jacobian_, 0, number_of_grid_cells, false);
+          LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(jacobian_, 0, false);
       auto lower_matrix = std::move(lu.first);
       auto upper_matrix = std::move(lu.second);
       lower_matrix_ = lower_matrix;

--- a/include/micm/util/jacobian.hpp
+++ b/include/micm/util/jacobian.hpp
@@ -15,7 +15,8 @@ namespace micm
   SparseMatrixPolicy BuildJacobian(
       const std::set<std::pair<std::size_t, std::size_t>>& nonzero_jacobian_elements,
       std::size_t number_of_grid_cells,
-      std::size_t state_size)
+      std::size_t state_size,
+      bool empty_matrix)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -27,6 +28,6 @@ namespace micm
     {
       builder = builder.WithElement(i, i);
     }
-    return SparseMatrixPolicy(builder);
+    return SparseMatrixPolicy(builder, empty_matrix);
   }
 }  // namespace micm

--- a/include/micm/util/jacobian.hpp
+++ b/include/micm/util/jacobian.hpp
@@ -16,7 +16,7 @@ namespace micm
       const std::set<std::pair<std::size_t, std::size_t>>& nonzero_jacobian_elements,
       std::size_t number_of_grid_cells,
       std::size_t state_size,
-      bool empty_matrix)
+      bool indexing_only)
   {
     MICM_PROFILE_FUNCTION();
 
@@ -28,6 +28,6 @@ namespace micm
     {
       builder = builder.WithElement(i, i);
     }
-    return SparseMatrixPolicy(builder, empty_matrix);
+    return SparseMatrixPolicy(builder, indexing_only);
   }
 }  // namespace micm

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -170,12 +170,12 @@ namespace micm
 
     SparseMatrix() = default;
 
-    SparseMatrix(const SparseMatrixBuilder<T, OrderingPolicy>& builder)
+    SparseMatrix(const SparseMatrixBuilder<T, OrderingPolicy>& builder, bool empty_matrix = false)
         : OrderingPolicy(builder.number_of_blocks_, builder.block_size_, builder.non_zero_elements_),
           number_of_blocks_(builder.number_of_blocks_),
           block_size_(builder.block_size_),
           number_of_non_zero_elements_per_block_(builder.non_zero_elements_.size()),
-          data_(OrderingPolicy::VectorSize(number_of_blocks_), builder.initial_value_)
+          data_((empty_matrix ? 0 : OrderingPolicy::VectorSize(number_of_blocks_)), builder.initial_value_)
     {
     }
 

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -170,12 +170,21 @@ namespace micm
 
     SparseMatrix() = default;
 
-    SparseMatrix(const SparseMatrixBuilder<T, OrderingPolicy>& builder, bool empty_matrix = false)
+    
+    /// @brief Constructs a SparseMatrix from a given builder and optional indexing mode.
+    ///        Initializes the SparseMatrix using the provided SparseMatrixBuilder, which defines
+    ///        the matrix structure, block size, and non-zero elements. Optionally, the constructor
+    ///        can be used in "indexing only" mode, where the data storage is not allocated.
+    /// @tparam T The type of the matrix elements.
+    /// @tparam OrderingPolicy The policy class that defines the ordering and storage of elements.
+    /// @param builder The builder object containing matrix configuration and initial values.
+    /// @param indexing_only If true, only indexing structures are initialized and data storage is omitted.
+    SparseMatrix(const SparseMatrixBuilder<T, OrderingPolicy>& builder, bool indexing_only = false)
         : OrderingPolicy(builder.number_of_blocks_, builder.block_size_, builder.non_zero_elements_),
           number_of_blocks_(builder.number_of_blocks_),
           block_size_(builder.block_size_),
           number_of_non_zero_elements_per_block_(builder.non_zero_elements_.size()),
-          data_((empty_matrix ? 0 : OrderingPolicy::VectorSize(number_of_blocks_)), builder.initial_value_)
+          data_((indexing_only ? 0 : OrderingPolicy::VectorSize(number_of_blocks_)), builder.initial_value_)
     {
     }
 

--- a/test/unit/solver/test_linear_solver_in_place_policy.hpp
+++ b/test/unit/solver/test_linear_solver_in_place_policy.hpp
@@ -122,7 +122,7 @@ void testDenseMatrix()
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, A.NumberOfBlocks());
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   alu.Fill(0);
   for (std::size_t i = 0; i < A.NumRows(); ++i)
     for (std::size_t j = 0; j < A.NumColumns(); ++j)
@@ -176,7 +176,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, number_of_blocks);
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   alu.Fill(0);
   for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
     for (std::size_t i = 0; i < A.NumRows(); ++i)
@@ -243,7 +243,7 @@ void testExtremeInitialValue(std::size_t number_of_blocks, double initial_value)
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, initial_value);
-  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, initial_value, number_of_blocks);
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, initial_value, false);
   for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
     for (std::size_t i = 0; i < A.NumRows(); ++i)
       for (std::size_t j = 0; j < A.NumColumns(); ++j)
@@ -298,7 +298,7 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, number_of_blocks);
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   alu.Fill(0);
   for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
     for (std::size_t i = 0; i < A.NumRows(); ++i)
@@ -349,8 +349,8 @@ void testMarkowitzReordering()
   auto orig_LU_calc = micm::LuDecompositionInPlace::Create<SparseMatrixPolicy>(orig_jac);
   auto reordered_LU_calc = micm::LuDecompositionInPlace::Create<SparseMatrixPolicy>(reordered_jac);
 
-  auto orig_LU = orig_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(orig_jac, 0.0, orig_jac.NumberOfBlocks());
-  auto reordered_LU = reordered_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(reordered_jac, 0.0, reordered_jac.NumberOfBlocks());
+  auto orig_LU = orig_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(orig_jac, 0.0, false);
+  auto reordered_LU = reordered_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(reordered_jac, 0.0, false);
 
   std::size_t sum_orig = 0;
   std::size_t sum_reordered = 0;

--- a/test/unit/solver/test_linear_solver_in_place_policy.hpp
+++ b/test/unit/solver/test_linear_solver_in_place_policy.hpp
@@ -122,7 +122,7 @@ void testDenseMatrix()
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0);
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, 1);
   alu.Fill(0);
   for (std::size_t i = 0; i < A.NumRows(); ++i)
     for (std::size_t j = 0; j < A.NumColumns(); ++j)
@@ -176,7 +176,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0);
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, number_of_blocks);
   alu.Fill(0);
   for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
     for (std::size_t i = 0; i < A.NumRows(); ++i)
@@ -243,7 +243,7 @@ void testExtremeInitialValue(std::size_t number_of_blocks, double initial_value)
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, initial_value);
-  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, initial_value);
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, initial_value, number_of_blocks);
   for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
     for (std::size_t i = 0; i < A.NumRows(); ++i)
       for (std::size_t j = 0; j < A.NumColumns(); ++j)
@@ -298,7 +298,7 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0);
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, number_of_blocks);
   alu.Fill(0);
   for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
     for (std::size_t i = 0; i < A.NumRows(); ++i)
@@ -349,8 +349,8 @@ void testMarkowitzReordering()
   auto orig_LU_calc = micm::LuDecompositionInPlace::Create<SparseMatrixPolicy>(orig_jac);
   auto reordered_LU_calc = micm::LuDecompositionInPlace::Create<SparseMatrixPolicy>(reordered_jac);
 
-  auto orig_LU = orig_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(orig_jac, 0.0);
-  auto reordered_LU = reordered_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(reordered_jac, 0.0);
+  auto orig_LU = orig_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(orig_jac, 0.0, 1);
+  auto reordered_LU = reordered_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(reordered_jac, 0.0, 1);
 
   std::size_t sum_orig = 0;
   std::size_t sum_reordered = 0;

--- a/test/unit/solver/test_linear_solver_in_place_policy.hpp
+++ b/test/unit/solver/test_linear_solver_in_place_policy.hpp
@@ -122,7 +122,7 @@ void testDenseMatrix()
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, 1);
+  auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, A.NumberOfBlocks());
   alu.Fill(0);
   for (std::size_t i = 0; i < A.NumRows(); ++i)
     for (std::size_t j = 0; j < A.NumColumns(); ++j)
@@ -349,8 +349,8 @@ void testMarkowitzReordering()
   auto orig_LU_calc = micm::LuDecompositionInPlace::Create<SparseMatrixPolicy>(orig_jac);
   auto reordered_LU_calc = micm::LuDecompositionInPlace::Create<SparseMatrixPolicy>(reordered_jac);
 
-  auto orig_LU = orig_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(orig_jac, 0.0, 1);
-  auto reordered_LU = reordered_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(reordered_jac, 0.0, 1);
+  auto orig_LU = orig_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(orig_jac, 0.0, orig_jac.NumberOfBlocks());
+  auto reordered_LU = reordered_LU_calc.template GetLUMatrix<SparseMatrixPolicy>(reordered_jac, 0.0, reordered_jac.NumberOfBlocks());
 
   std::size_t sum_orig = 0;
   std::size_t sum_reordered = 0;

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -123,7 +123,7 @@ void testDenseMatrix()
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, A.NumberOfBlocks());
+  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, false);
   auto lower_matrix = std::move(lu.first);
   auto upper_matrix = std::move(lu.second);
 
@@ -176,7 +176,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, number_of_blocks);
+  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, false);
   auto lower_matrix = std::move(lu.first);
   auto upper_matrix = std::move(lu.second);
 
@@ -242,7 +242,7 @@ void testExtremeInitialValue(std::size_t number_of_blocks, double initial_value)
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, initial_value);
   auto lu =
-      micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, initial_value, number_of_blocks);
+      micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, initial_value, false);
   auto lower_matrix = std::move(lu.first);
   auto upper_matrix = std::move(lu.second);
 
@@ -295,7 +295,7 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, number_of_blocks);
+  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, false);
   auto lower_matrix = std::move(lu.first);
   auto upper_matrix = std::move(lu.second);
 
@@ -345,9 +345,9 @@ void testMarkowitzReordering()
       micm::LuDecomposition::Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(reordered_jac);
 
   auto orig_LU =
-      orig_LU_calc.template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(orig_jac, 0.0, orig_jac.NumberOfBlocks());
+      orig_LU_calc.template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(orig_jac, 0.0, false);
   auto reordered_LU = reordered_LU_calc.template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(
-      reordered_jac, 0.0, reordered_jac.NumberOfBlocks());
+      reordered_jac, 0.0, false);
 
   std::size_t sum_orig = 0;
   std::size_t sum_reordered = 0;

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -123,7 +123,7 @@ void testDenseMatrix()
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, 1);
+  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, A.NumberOfBlocks());
   auto lower_matrix = std::move(lu.first);
   auto upper_matrix = std::move(lu.second);
 
@@ -345,9 +345,9 @@ void testMarkowitzReordering()
       micm::LuDecomposition::Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(reordered_jac);
 
   auto orig_LU =
-      orig_LU_calc.template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(orig_jac, 0.0, 1);
+      orig_LU_calc.template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(orig_jac, 0.0, orig_jac.NumberOfBlocks());
   auto reordered_LU = reordered_LU_calc.template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(
-      reordered_jac, 0.0, 1);
+      reordered_jac, 0.0, reordered_jac.NumberOfBlocks());
 
   std::size_t sum_orig = 0;
   std::size_t sum_reordered = 0;

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -123,7 +123,7 @@ void testDenseMatrix()
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0);
+  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, 1);
   auto lower_matrix = std::move(lu.first);
   auto upper_matrix = std::move(lu.second);
 
@@ -176,7 +176,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0);
+  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, number_of_blocks);
   auto lower_matrix = std::move(lu.first);
   auto upper_matrix = std::move(lu.second);
 
@@ -242,7 +242,7 @@ void testExtremeInitialValue(std::size_t number_of_blocks, double initial_value)
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, initial_value);
   auto lu =
-      micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, initial_value);
+      micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, initial_value, number_of_blocks);
   auto lower_matrix = std::move(lu.first);
   auto upper_matrix = std::move(lu.second);
 
@@ -295,7 +295,7 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   CopyToDeviceDense<MatrixPolicy>(x);
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
-  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0);
+  auto lu = micm::LuDecomposition::GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, number_of_blocks);
   auto lower_matrix = std::move(lu.first);
   auto upper_matrix = std::move(lu.second);
 
@@ -345,9 +345,9 @@ void testMarkowitzReordering()
       micm::LuDecomposition::Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(reordered_jac);
 
   auto orig_LU =
-      orig_LU_calc.template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(orig_jac, 0.0);
+      orig_LU_calc.template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(orig_jac, 0.0, 1);
   auto reordered_LU = reordered_LU_calc.template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(
-      reordered_jac, 0.0);
+      reordered_jac, 0.0, 1);
 
   std::size_t sum_orig = 0;
   std::size_t sum_reordered = 0;

--- a/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
@@ -110,7 +110,7 @@ void testDenseMatrix()
   A[0][2][2] = 8;
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
-  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, A.NumberOfBlocks());
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   ALU.Fill(0);
   for (std::size_t i = 0; i < 3; ++i)
     for (std::size_t j = 0; j < 3; ++j)
@@ -150,7 +150,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
       }
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
-  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, number_of_blocks);
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   for (std::size_t i = 0; i < size; ++i)
     for (std::size_t j = 0; j < size; ++j)
       if (!A.IsZero(i, j))
@@ -196,7 +196,7 @@ void testExtremeValueInitialization(std::size_t number_of_blocks, double initial
       }
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
-  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, initial_value, number_of_blocks);
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, initial_value, false);
   for (std::size_t i = 0; i < size; ++i)
     for (std::size_t j = 0; j < size; ++j)
       if (!A.IsZero(i, j))
@@ -237,7 +237,7 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
       A[i_block][i][i] = get_double();
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
-  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, number_of_blocks);
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   ALU.Fill(0);
   for (std::size_t i = 0; i < 6; ++i)
     for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)

--- a/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
@@ -110,7 +110,7 @@ void testDenseMatrix()
   A[0][2][2] = 8;
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
-  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, 1);
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, A.NumberOfBlocks());
   ALU.Fill(0);
   for (std::size_t i = 0; i < 3; ++i)
     for (std::size_t j = 0; j < 3; ++j)

--- a/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
@@ -110,7 +110,7 @@ void testDenseMatrix()
   A[0][2][2] = 8;
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
-  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0);
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, 1);
   ALU.Fill(0);
   for (std::size_t i = 0; i < 3; ++i)
     for (std::size_t j = 0; j < 3; ++j)
@@ -150,7 +150,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
       }
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
-  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0);
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, number_of_blocks);
   for (std::size_t i = 0; i < size; ++i)
     for (std::size_t j = 0; j < size; ++j)
       if (!A.IsZero(i, j))
@@ -196,7 +196,7 @@ void testExtremeValueInitialization(std::size_t number_of_blocks, double initial
       }
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
-  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, initial_value);
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, initial_value, number_of_blocks);
   for (std::size_t i = 0; i < size; ++i)
     for (std::size_t j = 0; j < size; ++j)
       if (!A.IsZero(i, j))
@@ -237,7 +237,7 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
       A[i_block][i][i] = get_double();
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
-  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0);
+  auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, number_of_blocks);
   ALU.Fill(0);
   for (std::size_t i = 0; i < 6; ++i)
     for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)

--- a/test/unit/solver/test_lu_decomposition_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_policy.hpp
@@ -115,7 +115,7 @@ void testDenseMatrix()
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
-  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0);
+  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, 1);
   lud.template Decompose<SparseMatrixPolicy>(A, LU.first, LU.second);
   check_results<double, SparseMatrixPolicy>(
       A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });
@@ -143,7 +143,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
-  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0);
+  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, number_of_blocks);
   lud.template Decompose<SparseMatrixPolicy>(A, LU.first, LU.second);
   check_results<double, SparseMatrixPolicy>(
       A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-9); });
@@ -181,7 +181,7 @@ void testExtremeValueInitialization(std::size_t number_of_blocks, double initial
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
 
   auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(
-      A, initial_value);
+      A, initial_value, number_of_blocks);
 
   CopyToDevice<SparseMatrixPolicy>(A);
   CopyToDevice<SparseMatrixPolicy>(LU.first);
@@ -213,7 +213,7 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
-  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0);
+  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, number_of_blocks);
   lud.template Decompose<SparseMatrixPolicy>(A, LU.first, LU.second);
   check_results<double, SparseMatrixPolicy>(
       A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });

--- a/test/unit/solver/test_lu_decomposition_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_policy.hpp
@@ -115,7 +115,7 @@ void testDenseMatrix()
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
-  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, A.NumberOfBlocks());
+  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, false);
   lud.template Decompose<SparseMatrixPolicy>(A, LU.first, LU.second);
   check_results<double, SparseMatrixPolicy>(
       A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });
@@ -143,7 +143,7 @@ void testRandomMatrix(std::size_t number_of_blocks)
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
-  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, number_of_blocks);
+  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, false);
   lud.template Decompose<SparseMatrixPolicy>(A, LU.first, LU.second);
   check_results<double, SparseMatrixPolicy>(
       A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-9); });
@@ -181,7 +181,7 @@ void testExtremeValueInitialization(std::size_t number_of_blocks, double initial
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
 
   auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(
-      A, initial_value, number_of_blocks);
+      A, initial_value, false);
 
   CopyToDevice<SparseMatrixPolicy>(A);
   CopyToDevice<SparseMatrixPolicy>(LU.first);
@@ -213,7 +213,7 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
-  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, number_of_blocks);
+  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, false);
   lud.template Decompose<SparseMatrixPolicy>(A, LU.first, LU.second);
   check_results<double, SparseMatrixPolicy>(
       A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });

--- a/test/unit/solver/test_lu_decomposition_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_policy.hpp
@@ -115,7 +115,7 @@ void testDenseMatrix()
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
-  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, 1);
+  auto LU = LuDecompositionPolicy::template GetLUMatrices<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A, 0, A.NumberOfBlocks());
   lud.template Decompose<SparseMatrixPolicy>(A, LU.first, LU.second);
   check_results<double, SparseMatrixPolicy>(
       A, LU.first, LU.second, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });


### PR DESCRIPTION
This pull request
- avoids the allocation of two separate large sparse matrices when generating the Jacobian matrix and ALU matrix.
- avoids the undesired allocation of a Jacobian matrix on the GPU with `number_of_grid_cells` dimension when calling the `BuildJacobian` function.
- removes the `number of grid cells` argument from the `GetLuMatrix` function since we can always derive it from the matrix argument now and use the `indexing_only` flag to control the actual allocation.

It passes all the unit tests on Derecho's A100 GPUs and it runs with 1.6 million grid cells on Casper's A100 80GB GPU. 

Thanks @K20shores and @mattldawson for your help.

fix #776 
fix #782 