### PR TITLE
Add a new print function to print non-zero elements of a sparse matrix

### DIFF
--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -290,7 +290,7 @@ namespace micm
 
     /// @brief Print the sparse matrix with row index, column index, and non-zero value; useful to test other linear algebra libraries
     /// @param os Output stream to print to, defaults to std::cout
-    void PrintNonZeroElement(std::ostream& os) const
+    void PrintNonZeroElements(std::ostream& os) const
     {
       for (std::size_t i = 0; i < number_of_blocks_; ++i)
       {

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -290,7 +290,7 @@ namespace micm
 
     /// @brief Print the sparse matrix with row index, column index, and non-zero value; useful to test other linear algebra libraries
     /// @param os Output stream to print to, defaults to std::cout
-    void PrintNonZeroElement(std::ostream& os = std::cout) const
+    void PrintNonZeroElement(std::ostream& os) const
     {
       for (std::size_t i = 0; i < number_of_blocks_; ++i)
       {

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -287,6 +287,20 @@ namespace micm
       }
       return os;
     }
+
+    /// @brief Print the sparse matrix with row index, column index, and non-zero value; useful to test other linear algebra libraries
+    /// @param os Output stream to print to, defaults to std::cout
+    void PrintNonZeroElement(std::ostream& os = std::cout) const
+    {
+      for (std::size_t i = 0; i < number_of_blocks_; ++i)
+      {
+        os << "Block " << i << std::endl;
+        for (std::size_t j = 0; j < block_size_; ++j)
+          for (std::size_t k = 0; k < block_size_; ++k)
+            if (!this->IsZero(j, k)) os << j << ", " << k << ", " << (*this)[i][j][k] << std::endl;
+          
+      }
+    }
   };
 
   template<class T, class OrderingPolicy = SparseMatrixStandardOrdering>

--- a/test/unit/util/test_sparse_matrix_policy.hpp
+++ b/test/unit/util/test_sparse_matrix_policy.hpp
@@ -468,7 +468,7 @@ MatrixPolicy<int, OrderingPolicy> testAddToDiagonal()
 }
 
 template<template<class, class> class MatrixPolicy, class OrderingPolicy>
-MatrixPolicy<int, OrderingPolicy> testPrintNonZero()
+void testPrintNonZero()
 {
   auto builder = MatrixPolicy<int, OrderingPolicy>::Create(4)
                      .WithElement(0, 1)
@@ -490,7 +490,7 @@ MatrixPolicy<int, OrderingPolicy> testPrintNonZero()
 
   matrix.AddToDiagonal(5);
 
-  std::stringstream ss, endline;
+  std::stringstream ss;
   matrix.PrintNonZeroElement(ss);
 
   std::string expected_output =

--- a/test/unit/util/test_sparse_matrix_policy.hpp
+++ b/test/unit/util/test_sparse_matrix_policy.hpp
@@ -468,6 +468,55 @@ MatrixPolicy<int, OrderingPolicy> testAddToDiagonal()
 }
 
 template<template<class, class> class MatrixPolicy, class OrderingPolicy>
+MatrixPolicy<int, OrderingPolicy> testPrintNonZero()
+{
+  auto builder = MatrixPolicy<int, OrderingPolicy>::Create(4)
+                     .WithElement(0, 1)
+                     .WithElement(1, 1)
+                     .WithElement(2, 1)
+                     .WithElement(2, 3)
+                     .WithElement(3, 2)
+                     .InitialValue(32)
+                     .SetNumberOfBlocks(3);
+  // 0 X 0 0
+  // 0 X 0 0
+  // 0 X 0 X
+  // 0 0 X 0
+  MatrixPolicy<int, OrderingPolicy> matrix{ builder };
+
+  matrix[0][1][1] = 2;
+  matrix[1][1][1] = 4;
+  matrix[2][1][1] = 6;
+
+  matrix.AddToDiagonal(5);
+
+  std::stringstream ss, endline;
+  matrix.PrintNonZeroElement(ss);
+
+  std::string expected_output =
+    "Block 0\n"
+    "0, 1, 32\n"
+    "1, 1, 7\n"
+    "2, 1, 32\n"
+    "2, 3, 32\n"
+    "3, 2, 32\n"
+    "Block 1\n"
+    "0, 1, 32\n"
+    "1, 1, 9\n"
+    "2, 1, 32\n"
+    "2, 3, 32\n"
+    "3, 2, 32\n"
+    "Block 2\n"
+    "0, 1, 32\n"
+    "1, 1, 11\n"
+    "2, 1, 32\n"
+    "2, 3, 32\n"
+    "3, 2, 32\n";
+
+  EXPECT_EQ(ss.str(), expected_output);
+}
+
+template<template<class, class> class MatrixPolicy, class OrderingPolicy>
 MatrixPolicy<int, OrderingPolicy> testPrint()
 {
   auto builder = MatrixPolicy<int, OrderingPolicy>::Create(4)

--- a/test/unit/util/test_sparse_matrix_policy.hpp
+++ b/test/unit/util/test_sparse_matrix_policy.hpp
@@ -491,7 +491,7 @@ void testPrintNonZero()
   matrix.AddToDiagonal(5);
 
   std::stringstream ss;
-  matrix.PrintNonZeroElement(ss);
+  matrix.PrintNonZeroElements(ss);
 
   std::string expected_output =
     "Block 0\n"

--- a/test/unit/util/test_sparse_matrix_standard_ordering_column.cpp
+++ b/test/unit/util/test_sparse_matrix_standard_ordering_column.cpp
@@ -89,6 +89,11 @@ TEST(SparseCompressedColumnMatrix, Print)
   auto matrix = testPrint<micm::SparseMatrix, StandardOrdering>();
 }
 
+TEST(SparseCompressedColumnMatrix, PrintNonZero)
+{
+  auto matrix = testPrintNonZero<micm::SparseMatrix, StandardOrdering>();
+}
+
 TEST(SparseMatrixBuilder, BadConfiguration)
 {
   EXPECT_THROW(

--- a/test/unit/util/test_sparse_matrix_standard_ordering_column.cpp
+++ b/test/unit/util/test_sparse_matrix_standard_ordering_column.cpp
@@ -91,7 +91,7 @@ TEST(SparseCompressedColumnMatrix, Print)
 
 TEST(SparseCompressedColumnMatrix, PrintNonZero)
 {
-  auto matrix = testPrintNonZero<micm::SparseMatrix, StandardOrdering>();
+  testPrintNonZero<micm::SparseMatrix, StandardOrdering>();
 }
 
 TEST(SparseMatrixBuilder, BadConfiguration)

--- a/test/unit/util/test_sparse_matrix_standard_ordering_row.cpp
+++ b/test/unit/util/test_sparse_matrix_standard_ordering_row.cpp
@@ -89,6 +89,11 @@ TEST(SparseCompressedRowMatrix, Print)
   testPrint<micm::SparseMatrix, StandardOrdering>();
 }
 
+TEST(SparseCompressedRowMatrix, PrintNonZero)
+{
+  testPrintNonZero<micm::SparseMatrix, StandardOrdering>();
+}
+
 TEST(SparseMatrixBuilder, BadConfiguration)
 {
   EXPECT_THROW(

--- a/test/unit/util/test_sparse_matrix_vector_ordering_column.cpp
+++ b/test/unit/util/test_sparse_matrix_vector_ordering_column.cpp
@@ -95,3 +95,11 @@ TEST(SparseVectorCompressedColumnMatrix, Print)
   testPrint<micm::SparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<3>>();
   testPrint<micm::SparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<4>>();
 }
+
+TEST(SparseVectorCompressedColumnMatrix, PrintNonZero)
+{
+  testPrintNonZero<micm::SparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<1>>();
+  testPrintNonZero<micm::SparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<2>>();
+  testPrintNonZero<micm::SparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<3>>();
+  testPrintNonZero<micm::SparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<4>>();
+}

--- a/test/unit/util/test_sparse_matrix_vector_ordering_row.cpp
+++ b/test/unit/util/test_sparse_matrix_vector_ordering_row.cpp
@@ -95,3 +95,11 @@ TEST(SparseVectorCompressedRowMatrix, Print)
   testPrint<micm::SparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseRow<3>>();
   testPrint<micm::SparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseRow<4>>();
 }
+
+TEST(SparseVectorCompressedRowMatrix, PrintNonZero)
+{
+  testPrintNonZero<micm::SparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseRow<1>>();
+  testPrintNonZero<micm::SparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseRow<2>>();
+  testPrintNonZero<micm::SparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseRow<3>>();
+  testPrintNonZero<micm::SparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseRow<4>>();
+}


### PR DESCRIPTION
fix #778 

Thanks @mattldawson for the suggestions.