### PR TITLE
Add default minimum time-step for Rosenbrock solver

### DIFF
--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -53,7 +53,8 @@ namespace micm
     LinearSolverPolicy linear_solver_;
     RatesPolicy rates_;
 
-    static constexpr double DELTA_MIN = 1.0e-6;
+    static constexpr double DEFAULT_H_MIN   = 1.0e-15; // Minimum internal time step relative to overall time step
+    static constexpr double DEFAULT_H_START = 1.0e-6;  // Default initial time step relative to overall time step
 
     /// @brief Solver parameters typename
     using ParametersType = RosenbrockSolverParameters;

--- a/include/micm/solver/rosenbrock_solver_parameters.hpp
+++ b/include/micm/solver/rosenbrock_solver_parameters.hpp
@@ -31,11 +31,11 @@ namespace micm
     double rejection_factor_decrease_{ 0.1 };                     // used to decrease the step after 2 successive rejections
     double safety_factor_{ 0.9 };                                 // safety factor in new step size computation
 
-    double h_min_{ 0.0 };  // step size min [s]
+    double h_min_{ 0.0 };  // step size min [s] (if zero, the solver will use DEFAULT_H_MIN * time_step)
     double h_max_{
       0.0
     };  // step size max [s] (if zero or greater than the solver time-step, the time-step passed to the solver will be used)
-    double h_start_{ 0.0 };  // step size start [s] (if zero, 1.0e-6 will be used, if greater than h_max, h_max will be used)
+    double h_start_{ 0.0 };  // step size start [s] (if zero, the solver will use DEFAULT_H_START * time_step)
 
     // Does the stage i require a new function evaluation (ros_NewF(i)=TRUE)
     // or does it re-use the function evaluation from stage i-1 (ros_NewF(i)=FALSE)

--- a/test/regression/RosenbrockChapman/regression_test_solve.cpp
+++ b/test/regression/RosenbrockChapman/regression_test_solve.cpp
@@ -20,7 +20,7 @@ TEST(RegressionRosenbrock, ThreeStageSolve)
   auto builder = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
       micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
   auto solver = getChapmanSolver(builder);
-  testSolve(solver);
+  testSolve(solver, 1.0e-4);
 }
 
 TEST(RegressionRosenbrock, FourStageSolve)
@@ -52,21 +52,21 @@ TEST(RegressionRosenbrock, VectorSolve)
   {
     auto builder = VectorBuilder<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
     auto solver = getChapmanSolver(builder);
-    testSolve(solver);
+    testSolve(solver, 1.0e-4);
   }
   {
     auto builder = VectorBuilder<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
     auto solver = getChapmanSolver(builder);
-    testSolve(solver);
+    testSolve(solver, 1.0e-4);
   }
   {
     auto builder = VectorBuilder<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
     auto solver = getChapmanSolver(builder);
-    testSolve(solver);
+    testSolve(solver, 1.0e-4);
   }
   {
     auto builder = VectorBuilder<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
     auto solver = getChapmanSolver(builder);
-    testSolve(solver);
+    testSolve(solver, 1.0e-4);
   }
 }

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -120,22 +120,22 @@ TEST(SolverBuilder, CanBuildBackwardEulerOverloadedSolverMethod)
   auto options = micm::BackwardEulerSolverParameters();
   auto solve = solver.Solve(5, state, options);
 
-  ASSERT_EQ(solve.final_time_, 5);
-  ASSERT_EQ(solve.stats_.function_calls_, 2);
-  ASSERT_EQ(solve.stats_.jacobian_updates_, 2);
-  ASSERT_EQ(solve.stats_.number_of_steps_, 2);
-  ASSERT_EQ(solve.stats_.solves_, 2);
+  EXPECT_EQ(solve.final_time_, 5);
+  EXPECT_EQ(solve.stats_.function_calls_, 2);
+  EXPECT_EQ(solve.stats_.jacobian_updates_, 2);
+  EXPECT_EQ(solve.stats_.number_of_steps_, 2);
+  EXPECT_EQ(solve.stats_.solves_, 2);
 
   options.small_ = 1.0;
   options.max_number_of_steps_ = 1.0;
 
   solve = solver.Solve(5, state, options);
 
-  ASSERT_EQ(solve.final_time_, 0.03125);
-  ASSERT_EQ(solve.stats_.function_calls_, 6);
-  ASSERT_EQ(solve.stats_.jacobian_updates_, 6);
-  ASSERT_EQ(solve.stats_.number_of_steps_, 6);
-  ASSERT_EQ(solve.stats_.solves_, 6);
+  EXPECT_EQ(solve.final_time_, 0.03125);
+  EXPECT_EQ(solve.stats_.function_calls_, 6);
+  EXPECT_EQ(solve.stats_.jacobian_updates_, 6);
+  EXPECT_EQ(solve.stats_.number_of_steps_, 6);
+  EXPECT_EQ(solve.stats_.solves_, 6);
 }
 
 TEST(SolverBuilder, CanBuildRosenbrockOverloadedSolveMethod)
@@ -150,11 +150,11 @@ TEST(SolverBuilder, CanBuildRosenbrockOverloadedSolveMethod)
 
   auto solve = solver.Solve(5, state);
 
-  ASSERT_EQ(solve.final_time_, 5);
-  ASSERT_EQ(solve.stats_.function_calls_, 20);
-  ASSERT_EQ(solve.stats_.jacobian_updates_, 10);
-  ASSERT_EQ(solve.stats_.number_of_steps_, 10);
-  ASSERT_EQ(solve.stats_.solves_, 30);
+  EXPECT_EQ(solve.final_time_, 5);
+  EXPECT_EQ(solve.stats_.function_calls_, 18);
+  EXPECT_EQ(solve.stats_.jacobian_updates_, 9);
+  EXPECT_EQ(solve.stats_.number_of_steps_, 9);
+  EXPECT_EQ(solve.stats_.solves_, 27);
 
   options.h_min_ = 15.0;
   options.max_number_of_steps_ = 6.0;
@@ -162,12 +162,12 @@ TEST(SolverBuilder, CanBuildRosenbrockOverloadedSolveMethod)
   state.variables_[0] = { 1.0, 0.0, 0.0 };
   solve = solver.Solve(5, state, options);
 
-  ASSERT_EQ(solve.final_time_, 5);
-  ASSERT_EQ(solve.stats_.function_calls_, 2);
-  ASSERT_EQ(solve.stats_.jacobian_updates_, 1);
-  ASSERT_EQ(solve.stats_.number_of_steps_, 1);
-  ASSERT_EQ(solve.stats_.solves_, 3);
+  EXPECT_EQ(solve.final_time_, 5);
+  EXPECT_EQ(solve.stats_.function_calls_, 2);
+  EXPECT_EQ(solve.stats_.jacobian_updates_, 1);
+  EXPECT_EQ(solve.stats_.number_of_steps_, 1);
+  EXPECT_EQ(solve.stats_.solves_, 3);
 
-  ASSERT_EQ(solver.solver_parameters_.h_min_, 15.0);
-  ASSERT_EQ(solver.solver_parameters_.max_number_of_steps_, 6.0);
+  EXPECT_EQ(solver.solver_parameters_.h_min_, 15.0);
+  EXPECT_EQ(solver.solver_parameters_.max_number_of_steps_, 6.0);
 }


### PR DESCRIPTION
The current Rosenbrock parameters let `h_min` to be 0 by default. This could lead to the internal convergence loop iterating until H was < `1.0e-324`. This PR introduces a default minimum value for `h_min` that is set to `1.0e-20 * time_step`, it also updates the default value for `h_start` to be `1.0e-6 * time_step` (instead of just `1.0e-6`).