### PR TITLE
add intersphinx linking to MICM

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ extensions = [
   'sphinx_copybutton',
   'sphinx_design',
   'sphinxcontrib.bibtex',
+  'sphinx.ext.intersphinx'
 ]
 
 bibtex_bibfiles = ['references.bib']
@@ -59,6 +60,13 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+# -- Link to Intersphinx Mappings ---
+
+intersphinx_mapping = {
+    'musica': ('https://ncar.github.io/musica/', None),
+    'mc': ('https://ncar.github.io/MechanismConfiguration/', None),
+    'mb': ('https://ncar.github.io/music-box/',None)
+}
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,7 +65,8 @@ exclude_patterns = []
 intersphinx_mapping = {
     'musica': ('https://ncar.github.io/musica/', None),
     'mc': ('https://ncar.github.io/MechanismConfiguration/', None),
-    'mb': ('https://ncar.github.io/music-box/',None)
+    'mb': ('https://ncar.github.io/music-box/',None),
+    'temp': ('http://localhost:8000/', None)
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,8 +65,7 @@ exclude_patterns = []
 intersphinx_mapping = {
     'musica': ('https://ncar.github.io/musica/', None),
     'mc': ('https://ncar.github.io/MechanismConfiguration/', None),
-    'mb': ('https://ncar.github.io/music-box/',None),
-    'temp': ('http://localhost:8000/', None)
+    'mb': ('https://ncar.github.io/music-box/',None)
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -2,10 +2,6 @@
 User Guide
 ##########
 
-:ref:`temp:contributing`
-:class:`mb:acom_music_box.music_box.MusicBox`
-
-
 MICM is quite expansive in its capabilities. We've written examples showing many different use cases.
 Hopefully our examples are exhaustive enough to provide you with the tools you need to solve some atmospheric chemistry.
 

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -2,6 +2,10 @@
 User Guide
 ##########
 
+:ref:`temp:contributing`
+:class:`mb:acom_music_box.music_box.MusicBox`
+
+
 MICM is quite expansive in its capabilities. We've written examples showing many different use cases.
 Hopefully our examples are exhaustive enough to provide you with the tools you need to solve some atmospheric chemistry.
 


### PR DESCRIPTION
intersphinx extension sets up an objects.inv file to be referenced from other documentation.  References to MICM are not currently used in MUSICA/MusicBox, but I set up links to MUSICA, MusicBox, and Mechanism Configuration for future use.

closes #791 