### PR TITLE
Replace typedef Yield with struct Yield 

### DIFF
--- a/docs/source/user_guide/rate_constant_tutorial.rst
+++ b/docs/source/user_guide/rate_constant_tutorial.rst
@@ -81,9 +81,8 @@ and our reactions, which will be a vector of :cpp:class:`micm::Process` We will 
 
         Now that we have a gas phase and our species, we can start building the reactions. Two things to note are that
         stoichiemtric coefficients for reactants are represented by repeating that product as many times as you need.
-        To specify the yield of a product, we've created a typedef :cpp:type:`micm::Yield` 
-        and a function :cpp:func:`micm::Yields` that produces these. Note that we add a conversion for
-        some rate constant parameters to be consistent with the configuration file that expects rate constants
+        To specify the yield of a product, we've created a struct :cpp:type:`micm::Yield`. Note that we add a conversion
+        for some rate constant parameters to be consistent with the configuration file that expects rate constants
         to be in cm^3/molecule/s. (All units will be mks in the next version of the configuration file format.)
 
         .. literalinclude:: ../../../test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp

--- a/docs/source/user_guide/user_defined_rate_constant_tutorial.rst
+++ b/docs/source/user_guide/user_defined_rate_constant_tutorial.rst
@@ -63,18 +63,18 @@ Then setup the reaction which will use this rate constant:
 
       Process r7 = Process::Create()
                       .SetReactants({ f })
-                      .SetProducts({ Yields(g, 1) })
+                      .SetProducts({ Yield(g, 1) })
                       .SetRateConstant(TunnelingRateConstant({ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 }))
                       .SetPhase(gas_phase);
 
       + Process r8 = Process::Create()
       +                 .SetReactants({ c })
-      +                 .SetProducts({ Yields(g, 1) })
+      +                 .SetProducts({ Yield(g, 1) })
       +                 .SetRateConstant(UserDefinedRateConstant({.label_="my rate"}))
       +                 .SetPhase(gas_phase);
 
       + Process r9 = Process::Create()
-      +                 .SetProducts({ Yields(a, 1) })
+      +                 .SetProducts({ Yield(a, 1) })
       +                 .SetRateConstant(UserDefinedRateConstant({.label_="my emission rate"}))
       +                 .SetPhase(gas_phase);
 

--- a/include/micm/Process.hpp
+++ b/include/micm/Process.hpp
@@ -9,6 +9,7 @@
 #include <micm/process/process.hpp>
 #include <micm/process/process_set.hpp>
 #include <micm/process/rate_constant.hpp>
+#include <micm/process/reaction_types.hpp>
 #include <micm/process/surface_rate_constant.hpp>
 #include <micm/process/taylor_series_rate_constant.hpp>
 #include <micm/process/ternary_chemical_activation_rate_constant.hpp>

--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -5,6 +5,7 @@
 #include <micm/process/arrhenius_rate_constant.hpp>
 #include <micm/process/branched_rate_constant.hpp>
 #include <micm/process/rate_constant.hpp>
+#include <micm/process/reaction_types.hpp>
 #include <micm/process/surface_rate_constant.hpp>
 #include <micm/process/ternary_chemical_activation_rate_constant.hpp>
 #include <micm/process/troe_rate_constant.hpp>
@@ -63,14 +64,6 @@ inline std::error_code make_error_code(MicmProcessErrc e)
 
 namespace micm
 {
-
-  /// @brief An alias that allows making products easily
-  using Yield = std::pair<Species, double>;
-
-  inline Yield Yields(const Species& species, double yield)
-  {
-    return Yield(species, yield);
-  };
 
   class ProcessBuilder;
 

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -178,12 +178,12 @@ namespace micm
       // Store product indices and yields
       for (const auto& product : process.products_)
       {
-        if (product.first.IsParameterized())
+        if (product.species_.IsParameterized())
           continue;  // Skip products that are parameterizations
-        if (variable_map.count(product.first.name_) < 1)
-          throw std::system_error(make_error_code(MicmProcessSetErrc::ProductDoesNotExist), product.first.name_);
-        product_ids_.push_back(variable_map.at(product.first.name_));
-        yields_.push_back(product.second);
+        if (variable_map.count(product.species_.name_) < 1)
+          throw std::system_error(make_error_code(MicmProcessSetErrc::ProductDoesNotExist), product.species_.name_);
+        product_ids_.push_back(variable_map.at(product.species_.name_));
+        yields_.push_back(product.coefficient_);
         ++number_of_products;
       }
       // Record how many reactants and products were processed for each process
@@ -232,12 +232,12 @@ namespace micm
           }
           for (const auto& product : process.products_)
           {
-            if (product.first.IsParameterized())
+            if (product.species_.IsParameterized())
               continue;  // Skip products that are parameterizations
-            if (variable_map.count(product.first.name_) < 1)
-              throw std::system_error(make_error_code(MicmProcessSetErrc::ProductDoesNotExist), product.first.name_);
-            jacobian_product_ids_.push_back(variable_map.at(product.first.name_));
-            jacobian_yields_.push_back(product.second);
+            if (variable_map.count(product.species_.name_) < 1)
+              throw std::system_error(make_error_code(MicmProcessSetErrc::ProductDoesNotExist), product.species_.name_);
+            jacobian_product_ids_.push_back(variable_map.at(product.species_.name_));
+            jacobian_yields_.push_back(product.coefficient_);
             ++info.number_of_products_;
           }
           jacobian_process_info_.push_back(info);
@@ -511,7 +511,7 @@ namespace micm
       for (const auto& reactant : process.reactants_)
         used_species.insert(reactant.name_);
       for (const auto& product : process.products_)
-        used_species.insert(product.first.name_);
+        used_species.insert(product.species_.name_);
     }
     return used_species;
   }

--- a/include/micm/process/reaction_types.hpp
+++ b/include/micm/process/reaction_types.hpp
@@ -25,10 +25,16 @@ namespace micm
           coefficient_(coefficient)
     {
     }
+
+    Yield(const Species& species)
+        : species_(species),
+          coefficient_(1.0)
+    {
+    }
   };
 
   /// @brief Represents a homogeneous or single-phase reaction with phase-specific
-  ///        reactants, products, and a rate constant
+  ///        reactants, products and a rate constant
   struct PhaseReaction
   {
     Phase phase_;

--- a/include/micm/process/reaction_types.hpp
+++ b/include/micm/process/reaction_types.hpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2023-2025 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <micm/process/rate_constant.hpp>
+#include <micm/system/phase.hpp>
+#include <micm/system/species.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace micm
+{
+  /// @brief Represents a product in a chemical reaction, associating a species with
+  ///        its stoichiometric coefficient
+  struct Yield
+  {
+    Species species_;
+    double coefficient_;
+
+    Yield() = default;
+
+    Yield(const Species& species, double coefficient)
+        : species_(species),
+          coefficient_(coefficient)
+    {
+    }
+  };
+
+  /// @brief Represents a homogeneous or single-phase reaction with phase-specific
+  ///        reactants, products, and a rate constant
+  struct PhaseReaction
+  {
+    Phase phase_;
+    std::vector<Species> reactants_;
+    std::vector<Yield> products_;
+    std::unique_ptr<RateConstant> rate_constant_;
+  };
+
+  /// @brief Represents a phase-transfer reaction where reactants move from one phase to another,
+  ///        producing products in the destination phase
+  struct PhaseTransferReaction
+  {
+    Phase source_phase_;
+    Phase destination_phase_;
+    std::vector<Species> reactants_;
+    std::vector<Yield> products_;
+    std::unique_ptr<RateConstant> rate_constant_;
+  };
+
+}  // namespace micm

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -123,8 +123,6 @@ double calculate_air_density_mol_m3(double pressure, double temperature)
   return pressure / (micm::constants::GAS_CONSTANT * temperature);
 }
 
-using yields = std::pair<micm::Species, double>;
-
 using SparseMatrixTest = micm::SparseMatrix<double>;
 
 // Test the analytical solution for a simple A -k1-> B -k2-> C system
@@ -386,13 +384,13 @@ void test_analytical_troe(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::TroeRateConstant({ .k0_A_ = 4.0e-11 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b })
-                         .SetProducts({ Yields(c, 1) })
+                         .SetProducts({ micm::Yield(c, 1) })
                          .SetRateConstant(micm::TroeRateConstant({ .k0_A_ = 1.2e-3,
                                                                    .k0_B_ = 1.6,
                                                                    .k0_C_ = 3,
@@ -457,19 +455,19 @@ void test_analytical_stiff_troe(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a1 })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::TroeRateConstant({ .k0_A_ = 4.0e-11 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ a2 })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::TroeRateConstant({ .k0_A_ = 4.0e-11 }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ b })
-                         .SetProducts({ Yields(c, 1) })
+                         .SetProducts({ micm::Yield(c, 1) })
                          .SetRateConstant(micm::TroeRateConstant({ .k0_A_ = 1.2e-3,
                                                                    .k0_B_ = 1.6,
                                                                    .k0_C_ = 3,
@@ -482,13 +480,13 @@ void test_analytical_stiff_troe(
 
   micm::Process r4 = micm::Process::Create()
                          .SetReactants({ a1 })
-                         .SetProducts({ Yields(a2, 1) })
+                         .SetProducts({ micm::Yield(a2, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
                          .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
                          .SetReactants({ a2 })
-                         .SetProducts({ Yields(a1, 1) })
+                         .SetProducts({ micm::Yield(a1, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
                          .SetPhase(gas_phase);
 
@@ -543,13 +541,13 @@ void test_analytical_photolysis(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "photoA" }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b })
-                         .SetProducts({ Yields(c, 1) })
+                         .SetProducts({ micm::Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "photoB" }))
                          .SetPhase(gas_phase);
 
@@ -606,31 +604,31 @@ void test_analytical_stiff_photolysis(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a1 })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "photoA1B" }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ a2 })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "photoA2B" }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ b })
-                         .SetProducts({ Yields(c, 1) })
+                         .SetProducts({ micm::Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "photoB" }))
                          .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
                          .SetReactants({ a1 })
-                         .SetProducts({ Yields(a2, 1) })
+                         .SetProducts({ micm::Yield(a2, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
                          .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
                          .SetReactants({ a2 })
-                         .SetProducts({ Yields(a1, 1) })
+                         .SetProducts({ micm::Yield(a1, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
                          .SetPhase(gas_phase);
 
@@ -687,13 +685,13 @@ void test_analytical_ternary_chemical_activation(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 4.0e-5, .kinf_A_ = 1 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b })
-                         .SetProducts({ Yields(c, 1) })
+                         .SetProducts({ micm::Yield(c, 1) })
                          .SetRateConstant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2e-3,
                                                                                         .k0_B_ = 1.6,
                                                                                         .k0_C_ = 3,
@@ -758,19 +756,19 @@ void test_analytical_stiff_ternary_chemical_activation(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a1 })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 4.0e-5, .kinf_A_ = 1 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ a2 })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 4.0e-5, .kinf_A_ = 1 }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ b })
-                         .SetProducts({ Yields(c, 1) })
+                         .SetProducts({ micm::Yield(c, 1) })
                          .SetRateConstant(micm::TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2e-3,
                                                                                         .k0_B_ = 1.6,
                                                                                         .k0_C_ = 3,
@@ -783,13 +781,13 @@ void test_analytical_stiff_ternary_chemical_activation(
 
   micm::Process r4 = micm::Process::Create()
                          .SetReactants({ a1 })
-                         .SetProducts({ Yields(a2, 1) })
+                         .SetProducts({ micm::Yield(a2, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
                          .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
                          .SetReactants({ a2 })
-                         .SetProducts({ Yields(a1, 1) })
+                         .SetProducts({ micm::Yield(a1, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
                          .SetPhase(gas_phase);
 
@@ -845,13 +843,13 @@ void test_analytical_tunneling(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::TunnelingRateConstant({ .A_ = 4.0e-3 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b })
-                         .SetProducts({ Yields(c, 1) })
+                         .SetProducts({ micm::Yield(c, 1) })
                          .SetRateConstant(micm::TunnelingRateConstant({ .A_ = 1.2e-4, .B_ = 167, .C_ = 1.0e8 }))
                          .SetPhase(gas_phase);
 
@@ -905,31 +903,31 @@ void test_analytical_stiff_tunneling(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a1 })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::TunnelingRateConstant({ .A_ = 4.0e-3 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ a2 })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::TunnelingRateConstant({ .A_ = 4.0e-3 }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ b })
-                         .SetProducts({ Yields(c, 1) })
+                         .SetProducts({ micm::Yield(c, 1) })
                          .SetRateConstant(micm::TunnelingRateConstant({ .A_ = 1.2e-4, .B_ = 167, .C_ = 1.0e8 }))
                          .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
                          .SetReactants({ a1 })
-                         .SetProducts({ Yields(a2, 1) })
+                         .SetProducts({ micm::Yield(a2, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
                          .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
                          .SetReactants({ a2 })
-                         .SetProducts({ Yields(a1, 1) })
+                         .SetProducts({ micm::Yield(a1, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
                          .SetPhase(gas_phase);
 
@@ -979,14 +977,14 @@ void test_analytical_arrhenius(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e-3, .C_ = 50 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 =
       micm::Process::Create()
           .SetReactants({ b })
-          .SetProducts({ Yields(c, 1) })
+          .SetProducts({ micm::Yield(c, 1) })
           .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 1.2e-4, .B_ = 7, .C_ = 75, .D_ = 50, .E_ = 0.5 }))
           .SetPhase(gas_phase);
 
@@ -1040,32 +1038,32 @@ void test_analytical_stiff_arrhenius(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a1 })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e-3, .C_ = 50 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ a2 })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e-3, .C_ = 50 }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 =
       micm::Process::Create()
           .SetReactants({ b })
-          .SetProducts({ Yields(c, 1) })
+          .SetProducts({ micm::Yield(c, 1) })
           .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 1.2e-4, .B_ = 1.6, .C_ = 75, .D_ = 50, .E_ = 0.5 }))
           .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
                          .SetReactants({ a1 })
-                         .SetProducts({ Yields(a2, 1) })
+                         .SetProducts({ micm::Yield(a2, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
                          .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
                          .SetReactants({ a2 })
-                         .SetProducts({ Yields(a1, 1) })
+                         .SetProducts({ micm::Yield(a1, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
                          .SetPhase(gas_phase);
 
@@ -1117,7 +1115,7 @@ void test_analytical_branched(
   micm::Process r1 =
       micm::Process::Create()
           .SetReactants({ a })
-          .SetProducts({ Yields(b, 1) })
+          .SetProducts({ micm::Yield(b, 1) })
           .SetRateConstant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
                                                         .X_ = 1e-4,
                                                         .Y_ = 204.3,
@@ -1128,7 +1126,7 @@ void test_analytical_branched(
   micm::Process r2 =
       micm::Process::Create()
           .SetReactants({ b })
-          .SetProducts({ Yields(c, 1) })
+          .SetProducts({ micm::Yield(c, 1) })
           .SetRateConstant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate,
                                                         .X_ = 1e-4,
                                                         .Y_ = 204.3,
@@ -1205,7 +1203,7 @@ void test_analytical_stiff_branched(
   micm::Process r1 =
       micm::Process::Create()
           .SetReactants({ a1 })
-          .SetProducts({ Yields(b, 1) })
+          .SetProducts({ micm::Yield(b, 1) })
           .SetRateConstant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
                                                         .X_ = 1e-4,
                                                         .Y_ = 204.3,
@@ -1216,7 +1214,7 @@ void test_analytical_stiff_branched(
   micm::Process r2 =
       micm::Process::Create()
           .SetReactants({ a2 })
-          .SetProducts({ Yields(b, 1) })
+          .SetProducts({ micm::Yield(b, 1) })
           .SetRateConstant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
                                                         .X_ = 1e-4,
                                                         .Y_ = 204.3,
@@ -1227,7 +1225,7 @@ void test_analytical_stiff_branched(
   micm::Process r3 =
       micm::Process::Create()
           .SetReactants({ b })
-          .SetProducts({ Yields(c, 1) })
+          .SetProducts({ micm::Yield(c, 1) })
           .SetRateConstant(micm::BranchedRateConstant({ .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate,
                                                         .X_ = 1e-4,
                                                         .Y_ = 204.3,
@@ -1237,13 +1235,13 @@ void test_analytical_stiff_branched(
 
   micm::Process r4 = micm::Process::Create()
                          .SetReactants({ a1 })
-                         .SetProducts({ Yields(a2, 1) })
+                         .SetProducts({ micm::Yield(a2, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 4.0e10 }))
                          .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
                          .SetReactants({ a2 })
-                         .SetProducts({ Yields(a1, 1) })
+                         .SetProducts({ micm::Yield(a1, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 0.9 * 4.0e10 }))
                          .SetPhase(gas_phase);
 
@@ -1318,19 +1316,19 @@ void test_analytical_robertson(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b, b })
-                         .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                         .SetProducts({ micm::Yield(b, 1), micm::Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ b, c })
-                         .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                         .SetProducts({ micm::Yield(a, 1), micm::Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .SetPhase(gas_phase);
 
@@ -1485,31 +1483,31 @@ void test_analytical_oregonator(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ Y })
-                         .SetProducts({ Yields(X, 1) })
+                         .SetProducts({ micm::Yield(X, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ X, Y })
-                         .SetProducts({ Yields(P, 1) })
+                         .SetProducts({ micm::Yield(P, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ X })
-                         .SetProducts({ Yields(Z, 1), Yields(X, 2) })
+                         .SetProducts({ micm::Yield(Z, 1), micm::Yield(X, 2) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
                          .SetReactants({ X, X })
-                         .SetProducts({ Yields(Q, 1) })
+                         .SetProducts({ micm::Yield(Q, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r4" }))
                          .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
                          .SetReactants({ Z })
-                         .SetProducts({ Yields(Y, 1) })
+                         .SetProducts({ micm::Yield(Y, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r5" }))
                          .SetPhase(gas_phase);
 
@@ -1659,54 +1657,54 @@ void test_analytical_hires(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ y0 })
-                         .SetProducts({ Yields(y1, 1) })
+                         .SetProducts({ micm::Yield(y1, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ y1 })
-                         .SetProducts({ Yields(y0, 0.43 / 8.75), Yields(y3, 8.32 / 8.75) })
+                         .SetProducts({ micm::Yield(y0, 0.43 / 8.75), micm::Yield(y3, 8.32 / 8.75) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ y2 })
-                         .SetProducts({ Yields(y0, 8.32 / 10.03), Yields(y3, 1.71 / 10.03) })
+                         .SetProducts({ micm::Yield(y0, 8.32 / 10.03), micm::Yield(y3, 1.71 / 10.03) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
-                         .SetProducts({ Yields(y0, 1) })
+                         .SetProducts({ micm::Yield(y0, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r4" }))
                          .SetPhase(gas_phase);
 
   micm::Process r5 = micm::Process::Create()
                          .SetReactants({ y3 })
-                         .SetProducts({ Yields(y2, 0.43 / 1.12), Yields(y5, 0.69 / 1.12) })
+                         .SetProducts({ micm::Yield(y2, 0.43 / 1.12), micm::Yield(y5, 0.69 / 1.12) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r5" }))
                          .SetPhase(gas_phase);
 
   micm::Process r6 = micm::Process::Create()
                          .SetReactants({ y4 })
-                         .SetProducts({ Yields(y2, 0.035 / 1.745), Yields(y5, 1.71 / 1.745) })
+                         .SetProducts({ micm::Yield(y2, 0.035 / 1.745), micm::Yield(y5, 1.71 / 1.745) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r6" }))
                          .SetPhase(gas_phase);
 
   micm::Process r7 = micm::Process::Create()
                          .SetReactants({ y5 })
-                         .SetProducts({ Yields(y4, 1) })
+                         .SetProducts({ micm::Yield(y4, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r7" }))
                          .SetPhase(gas_phase);
 
   micm::Process r8 = micm::Process::Create()
                          .SetReactants({ y6 })
-                         .SetProducts({ Yields(y4, 0.43 / 1.81), Yields(y5, 0.69 / 1.81), Yields(y7, 1) })
+                         .SetProducts({ micm::Yield(y4, 0.43 / 1.81), micm::Yield(y5, 0.69 / 1.81), micm::Yield(y7, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r8" }))
                          .SetPhase(gas_phase);
 
   micm::Process r9 = micm::Process::Create()
                          .SetReactants({ y5, y7 })
-                         .SetProducts({ Yields(y6, 1) })
+                         .SetProducts({ micm::Yield(y6, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r9" }))
                          .SetPhase(gas_phase);
 
@@ -1856,25 +1854,25 @@ void test_analytical_e5(
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a1 })
-                         .SetProducts({ Yields(a2, 1), Yields(a3, 1) })
+                         .SetProducts({ micm::Yield(a2, 1), micm::Yield(a3, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ a2, a3 })
-                         .SetProducts({ Yields(a5, 1) })
+                         .SetProducts({ micm::Yield(a5, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ a1, a3 })
-                         .SetProducts({ Yields(a4, 1) })
+                         .SetProducts({ micm::Yield(a4, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
                          .SetReactants({ a4 })
-                         .SetProducts({ Yields(a3, 1), Yields(a6, 1) })
+                         .SetProducts({ micm::Yield(a3, 1), micm::Yield(a6, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r4" }))
                          .SetPhase(gas_phase);
 

--- a/test/integration/analytical_surface_rxn_policy.hpp
+++ b/test/integration/analytical_surface_rxn_policy.hpp
@@ -55,7 +55,7 @@ void test_analytical_surface_rxn(
   // Process
   micm::Process surface_process = micm::Process::Create()
                                       .SetReactants({ foo })
-                                      .SetProducts({ micm::Yields(bar, bar_yield), micm::Yields(baz, baz_yield) })
+                                      .SetProducts({ micm::Yield(bar, bar_yield), micm::Yield(baz, baz_yield) })
                                       .SetRateConstant(surface)
                                       .SetPhase(gas_phase);
 

--- a/test/integration/test_chapman_integration.cpp
+++ b/test/integration/test_chapman_integration.cpp
@@ -5,7 +5,6 @@
 #include <utility>
 #include <vector>
 
-using yields = std::pair<micm::Species, double>;
 using SparseMatrixTest = micm::SparseMatrix<double>;
 
 TEST(ChapmanIntegration, CanBuildChapmanSystem)
@@ -24,46 +23,46 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ o1d, n2 })
-                         .SetProducts({ Yields(o, 1), Yields(n2, 1) })
+                         .SetProducts({ micm::Yield(o, 1), micm::Yield(n2, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ o1d, o2 })
-                         .SetProducts({ Yields(o, 1), Yields(o2, 1) })
+                         .SetProducts({ micm::Yield(o, 1), micm::Yield(o2, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .B_ = 0, .C_ = 55 }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ o, o3 })
-                         .SetProducts({ Yields(o2, 2) })
+                         .SetProducts({ micm::Yield(o2, 2) })
                          .SetRateConstant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 8e-12, .B_ = 0, .C_ = -2060 }))
                          .SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
                          .SetReactants({ o, o2, m })
-                         .SetProducts({ Yields(o3, 1), Yields(m, 1) })
+                         .SetProducts({ micm::Yield(o3, 1), micm::Yield(m, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 6.0e-34, .B_ = 0, .C_ = 2.4 }))
                          .SetPhase(gas_phase);
 
   micm::Process photo_1 = micm::Process::Create()
                               .SetReactants({ o2 })
-                              .SetProducts({ Yields(o, 2) })
+                              .SetProducts({ micm::Yield(o, 2) })
                               .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "jO2" }))
                               .SetPhase(gas_phase);
 
   micm::Process photo_2 = micm::Process::Create()
                               .SetReactants({ o3 })
-                              .SetProducts({ Yields(o1d, 1), Yields(o2, 1) })
+                              .SetProducts({ micm::Yield(o1d, 1), micm::Yield(o2, 1) })
                               .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "jO3a" }))
                               .SetPhase(gas_phase);
 
   micm::Process photo_3 = micm::Process::Create()
                               .SetReactants({ o3 })
-                              .SetProducts({ Yields(o, 1), Yields(o2, 1) })
+                              .SetProducts({ micm::Yield(o, 1), micm::Yield(o2, 1) })
                               .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "jO3b" }))
                               .SetPhase(gas_phase);
 

--- a/test/integration/test_integrated_reaction_rates.cpp
+++ b/test/integration/test_integrated_reaction_rates.cpp
@@ -5,8 +5,6 @@
 #include <utility>
 #include <vector>
 
-using yields = std::pair<micm::Species, double>;
-
 using SparseMatrixTest = micm::SparseMatrix<double>;
 
 TEST(ChapmanIntegration, CanBuildChapmanSystem)
@@ -21,14 +19,14 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yields(b, 1), Yields(irr_1, 1) })
+                         .SetProducts({ micm::Yield(b, 1), micm::Yield(irr_1, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 =
       micm::Process::Create()
           .SetReactants({ b })
-          .SetProducts({ Yields(c, 1), Yields(irr_2, 1) })
+          .SetProducts({ micm::Yield(c, 1), micm::Yield(irr_2, 1) })
           .SetRateConstant(micm::UserDefinedRateConstant(micm::UserDefinedRateConstantParameters{ .label_ = "r2" }))
           .SetPhase(gas_phase);
 

--- a/test/regression/RosenbrockChapman/util.hpp
+++ b/test/regression/RosenbrockChapman/util.hpp
@@ -7,8 +7,6 @@
 #include <utility>
 #include <vector>
 
-using yields = std::pair<micm::Species, double>;
-
 micm::Phase createGasPhase()
 {
   auto o = micm::Species("O");
@@ -29,46 +27,46 @@ std::vector<micm::Process> createProcesses(const micm::Phase& gas_phase)
   micm::Process r1 =
       micm::Process::Create()
           .SetReactants({ micm::Species("O1D"), micm::Species("N2") })
-          .SetProducts({ Yields(micm::Species("O"), 1), Yields(micm::Species("N2"), 1) })
+          .SetProducts({ micm::Yield(micm::Species("O"), 1), micm::Yield(micm::Species("N2"), 1) })
           .SetRateConstant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 2.15e-11, .C_ = 110 }))
           .SetPhase(gas_phase);
 
   micm::Process r2 =
       micm::Process::Create()
           .SetReactants({ micm::Species("O1D"), micm::Species("O2") })
-          .SetProducts({ Yields(micm::Species("O"), 1), Yields(micm::Species("O2"), 1) })
+          .SetProducts({ micm::Yield(micm::Species("O"), 1), micm::Yield(micm::Species("O2"), 1) })
           .SetRateConstant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .C_ = 55 }))
           .SetPhase(gas_phase);
 
   micm::Process r3 =
       micm::Process::Create()
           .SetReactants({ micm::Species("O"), micm::Species("O3") })
-          .SetProducts({ Yields(micm::Species("O2"), 2) })
+          .SetProducts({ micm::Yield(micm::Species("O2"), 2) })
           .SetRateConstant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 8e-12, .C_ = -2060 }))
           .SetPhase(gas_phase);
 
   micm::Process r4 =
       micm::Process::Create()
           .SetReactants({ micm::Species("O"), micm::Species("O2"), micm::Species("M") })
-          .SetProducts({ Yields(micm::Species("O3"), 1), Yields(micm::Species("M"), 1) })
+          .SetProducts({ micm::Yield(micm::Species("O3"), 1), micm::Yield(micm::Species("M"), 1) })
           .SetRateConstant(micm::ArrheniusRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 6.0e-34, .B_ = 2.4 }))
           .SetPhase(gas_phase);
 
   micm::Process photo_1 = micm::Process::Create()
                               .SetReactants({ micm::Species("O2") })
-                              .SetProducts({ Yields(micm::Species("O"), 2) })
+                              .SetProducts({ micm::Yield(micm::Species("O"), 2) })
                               .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "jO2" }))
                               .SetPhase(gas_phase);
 
   micm::Process photo_2 = micm::Process::Create()
                               .SetReactants({ micm::Species("O3") })
-                              .SetProducts({ Yields(micm::Species("O1D"), 1), Yields(micm::Species("O2"), 1) })
+                              .SetProducts({ micm::Yield(micm::Species("O1D"), 1), micm::Yield(micm::Species("O2"), 1) })
                               .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "jO3a" }))
                               .SetPhase(gas_phase);
 
   micm::Process photo_3 = micm::Process::Create()
                               .SetReactants({ micm::Species("O3") })
-                              .SetProducts({ Yields(micm::Species("O"), 1), Yields(micm::Species("O2"), 1) })
+                              .SetProducts({ micm::Yield(micm::Species("O"), 1), micm::Yield(micm::Species("O2"), 1) })
                               .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "jO3b" }))
                               .SetPhase(gas_phase);
 

--- a/test/regression/regression_policy.hpp
+++ b/test/regression/regression_policy.hpp
@@ -138,7 +138,7 @@ void test_flow_tube(
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ apinene, o3 })
-                         .SetProducts({ Yields(soa1, 0.18), Yields(soa2, 0.09) })
+                         .SetProducts({ micm::Yield(soa1, 0.18), micm::Yield(soa2, 0.09) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 8.8e-17 * MOLES_M3_TO_MOLECULES_CM3 }))
                          .SetPhase(gas_phase);
 

--- a/test/tutorial/test_multiple_grid_cells.cpp
+++ b/test/tutorial/test_multiple_grid_cells.cpp
@@ -16,19 +16,19 @@ int main()
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b, b })
-                         .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                         .SetProducts({ micm::Yield(b, 1), micm::Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ b, c })
-                         .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                         .SetProducts({ micm::Yield(a, 1), micm::Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .SetPhase(gas_phase);
 

--- a/test/tutorial/test_openmp.cpp
+++ b/test/tutorial/test_openmp.cpp
@@ -73,19 +73,19 @@ int main()
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b, b })
-                         .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                         .SetProducts({ micm::Yield(b, 1), micm::Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ b, c })
-                         .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                         .SetProducts({ micm::Yield(a, 1), micm::Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .SetPhase(gas_phase);
 

--- a/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
@@ -28,7 +28,7 @@ int main(const int argc, const char* argv[])
 
   Process r1 = Process::Create()
                    .SetReactants({ a })
-                   .SetProducts({ Yields(b, 1) })
+                   .SetProducts({ Yield(b, 1) })
                    .SetRateConstant(ArrheniusRateConstant({ .A_ = 2.15e-4, .B_ = 0, .C_ = 110 }))
                    .SetPhase(gas_phase);
 
@@ -39,14 +39,14 @@ int main(const int argc, const char* argv[])
 
   Process r2 = Process::Create()
                    .SetReactants({ b })
-                   .SetProducts({ Yields(c, 1) })
+                   .SetProducts({ Yield(c, 1) })
                    .SetRateConstant(BranchedRateConstant(branched_params))
                    .SetPhase(gas_phase);
 
   branched_params.branch_ = BranchedRateConstantParameters::Branch::Nitrate;
   Process r3 = Process::Create()
                    .SetReactants({ b })
-                   .SetProducts({ Yields(d, 1) })
+                   .SetProducts({ Yield(d, 1) })
                    .SetRateConstant(BranchedRateConstant(branched_params))
                    .SetPhase(gas_phase);
 
@@ -54,13 +54,13 @@ int main(const int argc, const char* argv[])
   // we will set those later
   Process r4 = Process::Create()
                    .SetReactants({ c })
-                   .SetProducts({ Yields(e, 1) })
+                   .SetProducts({ Yield(e, 1) })
                    .SetRateConstant(SurfaceRateConstant({ .label_ = "C", .species_ = c, .reaction_probability_ = 0.90 }))
                    .SetPhase(gas_phase);
 
   Process r5 = Process::Create()
                    .SetReactants({ d })
-                   .SetProducts({ Yields(f, 2) })
+                   .SetProducts({ Yield(f, 2) })
                    .SetRateConstant(TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2,
                                                                           .k0_B_ = 2.3,
                                                                           .k0_C_ = 302.3,
@@ -75,7 +75,7 @@ int main(const int argc, const char* argv[])
   // list the reactant that many times
   Process r6 = Process::Create()
                    .SetReactants({ e, e })
-                   .SetProducts({ Yields(g, 1) })
+                   .SetProducts({ Yield(g, 1) })
                    .SetRateConstant(TroeRateConstant({ .k0_A_ = 1.2e4 * MOLES_M3_TO_MOLECULES_CM3 * MOLES_M3_TO_MOLECULES_CM3,
                                                      .k0_B_ = 167.0,
                                                      .k0_C_ = 3.0,
@@ -88,7 +88,7 @@ int main(const int argc, const char* argv[])
 
   Process r7 = Process::Create()
                    .SetReactants({ f })
-                   .SetProducts({ Yields(g, 1) })
+                   .SetProducts({ Yield(g, 1) })
                    .SetRateConstant(TunnelingRateConstant({ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 }))
                    .SetPhase(gas_phase);
 

--- a/test/tutorial/test_rate_constants_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_user_defined_by_hand.cpp
@@ -28,7 +28,7 @@ int main(const int argc, const char* argv[])
 
   Process r1 = Process::Create()
                    .SetReactants({ a })
-                   .SetProducts({ Yields(b, 1) })
+                   .SetProducts({ Yield(b, 1) })
                    .SetRateConstant(ArrheniusRateConstant({ .A_ = 2.15e-4, .B_ = 0, .C_ = 110 }))
                    .SetPhase(gas_phase);
 
@@ -39,14 +39,14 @@ int main(const int argc, const char* argv[])
 
   Process r2 = Process::Create()
                    .SetReactants({ b })
-                   .SetProducts({ Yields(c, 1) })
+                   .SetProducts({ Yield(c, 1) })
                    .SetRateConstant(BranchedRateConstant(branched_params))
                    .SetPhase(gas_phase);
 
   branched_params.branch_ = BranchedRateConstantParameters::Branch::Nitrate;
   Process r3 = Process::Create()
                    .SetReactants({ b })
-                   .SetProducts({ Yields(d, 1) })
+                   .SetProducts({ Yield(d, 1) })
                    .SetRateConstant(BranchedRateConstant(branched_params))
                    .SetPhase(gas_phase);
 
@@ -54,13 +54,13 @@ int main(const int argc, const char* argv[])
   // we will set those later
   Process r4 = Process::Create()
                    .SetReactants({ c })
-                   .SetProducts({ Yields(e, 1) })
+                   .SetProducts({ Yield(e, 1) })
                    .SetRateConstant(SurfaceRateConstant({ .label_ = "C", .species_ = c, .reaction_probability_ = 0.90 }))
                    .SetPhase(gas_phase);
 
   Process r5 = Process::Create()
                    .SetReactants({ d })
-                   .SetProducts({ Yields(f, 2) })
+                   .SetProducts({ Yield(f, 2) })
                    .SetRateConstant(TernaryChemicalActivationRateConstant({ .k0_A_ = 1.2,
                                                                           .k0_B_ = 2.3,
                                                                           .k0_C_ = 302.3,
@@ -75,7 +75,7 @@ int main(const int argc, const char* argv[])
   // list the reactant that many times
   Process r6 = Process::Create()
                    .SetReactants({ e, e })
-                   .SetProducts({ Yields(g, 1) })
+                   .SetProducts({ Yield(g, 1) })
                    .SetRateConstant(TroeRateConstant({ .k0_A_ = 1.2e4 * MOLES_M3_TO_MOLECULES_CM3 * MOLES_M3_TO_MOLECULES_CM3,
                                                      .k0_B_ = 167.0,
                                                      .k0_C_ = 3.0,
@@ -88,18 +88,18 @@ int main(const int argc, const char* argv[])
 
   Process r7 = Process::Create()
                    .SetReactants({ f })
-                   .SetProducts({ Yields(g, 1) })
+                   .SetProducts({ Yield(g, 1) })
                    .SetRateConstant(TunnelingRateConstant({ .A_ = 1.2, .B_ = 2.3, .C_ = 302.3 }))
                    .SetPhase(gas_phase);
 
   Process r8 = Process::Create()
                    .SetReactants({ c })
-                   .SetProducts({ Yields(g, 1) })
+                   .SetProducts({ Yield(g, 1) })
                    .SetRateConstant(UserDefinedRateConstant({ .label_ = "my photolysis rate" }))
                    .SetPhase(gas_phase);
 
   Process r9 = Process::Create()
-                   .SetProducts({ Yields(a, 1) })
+                   .SetProducts({ Yield(a, 1) })
                    .SetRateConstant(UserDefinedRateConstant({ .label_ = "my emission rate" }))
                    .SetPhase(gas_phase);
 

--- a/test/tutorial/test_solver_configuration.cpp
+++ b/test/tutorial/test_solver_configuration.cpp
@@ -89,19 +89,19 @@ int main()
 
   Process r1 = Process::Create()
                    .SetReactants({ a })
-                   .SetProducts({ Yields(b, 1) })
+                   .SetProducts({ Yield(b, 1) })
                    .SetRateConstant(UserDefinedRateConstant({ .label_ = "r1" }))
                    .SetPhase(gas_phase);
 
   Process r2 = Process::Create()
                    .SetReactants({ b, b })
-                   .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                   .SetProducts({ Yield(b, 1), Yield(c, 1) })
                    .SetRateConstant(UserDefinedRateConstant({ .label_ = "r2" }))
                    .SetPhase(gas_phase);
 
   Process r3 = Process::Create()
                    .SetReactants({ b, c })
-                   .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                   .SetProducts({ Yield(a, 1), Yield(c, 1) })
                    .SetRateConstant(UserDefinedRateConstant({ .label_ = "r3" }))
                    .SetPhase(gas_phase);
 

--- a/test/tutorial/test_solver_results.cpp
+++ b/test/tutorial/test_solver_results.cpp
@@ -17,19 +17,19 @@ int main()
 
   Process r1 = Process::Create()
                    .SetReactants({ a })
-                   .SetProducts({ Yields(b, 1) })
+                   .SetProducts({ Yield(b, 1) })
                    .SetRateConstant(UserDefinedRateConstant({ .label_ = "r1" }))
                    .SetPhase(gas_phase);
 
   Process r2 = Process::Create()
                    .SetReactants({ b, b })
-                   .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                   .SetProducts({ Yield(b, 1), Yield(c, 1) })
                    .SetRateConstant(UserDefinedRateConstant({ .label_ = "r2" }))
                    .SetPhase(gas_phase);
 
   Process r3 = Process::Create()
                    .SetReactants({ b, c })
-                   .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                   .SetProducts({ Yield(a, 1), Yield(c, 1) })
                    .SetRateConstant(UserDefinedRateConstant({ .label_ = "r3" }))
                    .SetPhase(gas_phase);
 

--- a/test/tutorial/test_vectorized_matrix_solver.cpp
+++ b/test/tutorial/test_vectorized_matrix_solver.cpp
@@ -57,19 +57,19 @@ int main()
 
   Process r1 = Process::Create()
                    .SetReactants({ a })
-                   .SetProducts({ Yields(b, 1) })
+                   .SetProducts({ Yield(b, 1) })
                    .SetRateConstant(UserDefinedRateConstant({ .label_ = "r1" }))
                    .SetPhase(gas_phase);
 
   Process r2 = Process::Create()
                    .SetReactants({ b, b })
-                   .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                   .SetProducts({ Yield(b, 1), Yield(c, 1) })
                    .SetRateConstant(UserDefinedRateConstant({ .label_ = "r2" }))
                    .SetPhase(gas_phase);
 
   Process r3 = Process::Create()
                    .SetReactants({ b, c })
-                   .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                   .SetProducts({ Yield(a, 1), Yield(c, 1) })
                    .SetRateConstant(UserDefinedRateConstant({ .label_ = "r3" }))
                    .SetPhase(gas_phase);
 

--- a/test/unit/cuda/process/test_cuda_process_set.cpp
+++ b/test/unit/cuda/process/test_cuda_process_set.cpp
@@ -67,7 +67,7 @@ void testRandomSystemAddForcingTerms(std::size_t n_cells, std::size_t n_reaction
     std::vector<micm::Yield> products{};
     for (std::size_t i_prod = 0; i_prod < n_product; ++i_prod)
     {
-      products.push_back(micm::Yields(std::to_string(get_species_id()), 1.2));
+      products.push_back(micm::Yield(std::to_string(get_species_id()), 1.2));
     }
     processes.push_back(micm::Process::Create().SetReactants(reactants).SetProducts(products).SetPhase(gas_phase));
   }
@@ -154,7 +154,7 @@ void testRandomSystemSubtractJacobianTerms(std::size_t n_cells, std::size_t n_re
     std::vector<micm::Yield> products{};
     for (std::size_t i_prod = 0; i_prod < n_product; ++i_prod)
     {
-      products.push_back(micm::Yields(std::to_string(get_species_id()), 1.2));
+      products.push_back(micm::Yield(std::to_string(get_species_id()), 1.2));
     }
     processes.push_back(micm::Process::Create().SetReactants(reactants).SetProducts(products).SetPhase(gas_phase));
   }

--- a/test/unit/cuda/solver/test_cuda_solver_builder.cpp
+++ b/test/unit/cuda/solver/test_cuda_solver_builder.cpp
@@ -20,13 +20,13 @@ namespace
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ micm::Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b })
-                         .SetProducts({ micm::Yields(c, 1) })
+                         .SetProducts({ micm::Yield(c, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .B_ = 0, .C_ = 55 }))
                          .SetPhase(gas_phase);

--- a/test/unit/jit/solver/test_jit_rosenbrock.cpp
+++ b/test/unit/jit/solver/test_jit_rosenbrock.cpp
@@ -59,19 +59,19 @@ TEST(JitRosenbrockSolver, MultipleInstances)
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ Yield(b, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b, b })
-                         .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                         .SetProducts({ Yield(b, 1), Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ b, c })
-                         .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                         .SetProducts({ Yield(a, 1), Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .SetPhase(gas_phase);
 

--- a/test/unit/jit/solver/test_jit_rosenbrock.cpp
+++ b/test/unit/jit/solver/test_jit_rosenbrock.cpp
@@ -5,6 +5,7 @@
 #include <micm/jit/solver/jit_solver_builder.hpp>
 #include <micm/jit/solver/jit_solver_parameters.hpp>
 #include <micm/process/arrhenius_rate_constant.hpp>
+#include <micm/process/reaction_types.hpp>
 #include <micm/solver/rosenbrock.hpp>
 #include <micm/util/matrix.hpp>
 #include <micm/util/sparse_matrix.hpp>
@@ -59,19 +60,19 @@ TEST(JitRosenbrockSolver, MultipleInstances)
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yield(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b, b })
-                         .SetProducts({ Yield(b, 1), Yield(c, 1) })
+                         .SetProducts({ micm::Yield(b, 1), micm::Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ b, c })
-                         .SetProducts({ Yield(a, 1), Yield(c, 1) })
+                         .SetProducts({ micm::Yield(a, 1), micm::Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .SetPhase(gas_phase);
 

--- a/test/unit/jit/solver/test_jit_solver_builder.cpp
+++ b/test/unit/jit/solver/test_jit_solver_builder.cpp
@@ -24,13 +24,13 @@ namespace
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ micm::Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b })
-                         .SetProducts({ micm::Yields(c, 1) })
+                         .SetProducts({ micm::Yield(c, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .B_ = 0, .C_ = 55 }))
                          .SetPhase(gas_phase);

--- a/test/unit/openmp/test_openmp.cpp
+++ b/test/unit/openmp/test_openmp.cpp
@@ -20,19 +20,19 @@ TEST(OpenMP, OneSolverManyStates)
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ Yield(b, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b, b })
-                         .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                         .SetProducts({ Yield(b, 1), Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ b, c })
-                         .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                         .SetProducts({ Yield(a, 1), Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .SetPhase(gas_phase);
 

--- a/test/unit/openmp/test_openmp_jit_solver.cpp
+++ b/test/unit/openmp/test_openmp_jit_solver.cpp
@@ -26,19 +26,19 @@ TEST(OpenMP, JITOneSolverManyStates)
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ Yields(b, 1) })
+                         .SetProducts({ Yield(b, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r1" }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b, b })
-                         .SetProducts({ Yields(b, 1), Yields(c, 1) })
+                         .SetProducts({ Yield(b, 1), Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r2" }))
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create()
                          .SetReactants({ b, c })
-                         .SetProducts({ Yields(a, 1), Yields(c, 1) })
+                         .SetProducts({ Yield(a, 1), Yield(c, 1) })
                          .SetRateConstant(micm::UserDefinedRateConstant({ .label_ = "r3" }))
                          .SetPhase(gas_phase);
 

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -101,7 +101,7 @@ TEST(Process, SurfaceRateConstantOnlyHasOneReactant)
   micm::Phase gas_phase({ c, e });
   EXPECT_ANY_THROW(micm::Process r = micm::Process::Create()
                                          .SetReactants({ c, c })
-                                         .SetProducts({ Yields(e, 1) })
+                                         .SetProducts({ micm::Yield(e, 1) })
                                          .SetRateConstant(micm::SurfaceRateConstant(
                                              { .label_ = "c", .species_ = c, .reaction_probability_ = 0.90 }))
                                          .SetPhase(gas_phase););

--- a/test/unit/process/test_process_set_policy.hpp
+++ b/test/unit/process/test_process_set_policy.hpp
@@ -4,7 +4,6 @@
 
 #include <random>
 
-using yields = std::pair<micm::Species, double>;
 using index_pair = std::pair<std::size_t, std::size_t>;
 
 void compare_pair(const index_pair& a, const index_pair& b)
@@ -34,19 +33,19 @@ void testProcessSet()
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ foo, baz })
-                         .SetProducts({ Yields(bar, 1), Yields(quuz, 2.4) })
+                         .SetProducts({ micm::Yield(bar, 1), micm::Yield(quuz, 2.4) })
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ bar, qux })
-                         .SetProducts({ Yields(foo, 1), Yields(quz, 1.4) })
+                         .SetProducts({ micm::Yield(foo, 1), micm::Yield(quz, 1.4) })
                          .SetPhase(gas_phase);
 
   micm::Process r3 = micm::Process::Create().SetReactants({ quz }).SetProducts({}).SetPhase(gas_phase);
 
   micm::Process r4 = micm::Process::Create()
                          .SetReactants({ baz, qux })
-                         .SetProducts({ Yields(bar, 1), Yields(quz, 2.5) })
+                         .SetProducts({ micm::Yield(bar, 1), micm::Yield(quz, 2.5) })
                          .SetPhase(gas_phase);
 
   auto used_species = RatesPolicy::SpeciesUsed(std::vector<micm::Process>{ r1, r2, r3, r4 });
@@ -177,10 +176,10 @@ void testRandomSystem(std::size_t n_cells, std::size_t n_reactions, std::size_t 
       reactants.push_back({ std::to_string(get_species_id()) });
     }
     auto n_product = get_n_product();
-    std::vector<yields> products{};
+    std::vector<micm::Yield> products{};
     for (std::size_t i_prod = 0; i_prod < n_product; ++i_prod)
     {
-      products.push_back(micm::Yields(std::to_string(get_species_id()), 1.2));
+      products.push_back(micm::Yield(std::to_string(get_species_id()), 1.2));
     }
     auto proc = micm::Process(micm::Process::Create().SetReactants(reactants).SetProducts(products).SetPhase(gas_phase));
     processes.push_back(proc);

--- a/test/unit/solver/test_backward_euler.cpp
+++ b/test/unit/solver/test_backward_euler.cpp
@@ -21,13 +21,13 @@ namespace
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ micm::Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b })
-                         .SetProducts({ micm::Yields(c, 1) })
+                         .SetProducts({ micm::Yield(c, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .B_ = 0, .C_ = 55 }))
                          .SetPhase(gas_phase);

--- a/test/unit/solver/test_rosenbrock.cpp
+++ b/test/unit/solver/test_rosenbrock.cpp
@@ -94,7 +94,7 @@ TEST(RosenbrockSolver, CanSetTolerances)
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ foo })
-                         .SetProducts({ Yields(bar, 1) })
+                         .SetProducts({ micm::Yield(bar, 1) })
                          .SetPhase(gas_phase)
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
 

--- a/test/unit/solver/test_rosenbrock_solver_policy.hpp
+++ b/test/unit/solver/test_rosenbrock_solver_policy.hpp
@@ -30,13 +30,13 @@ SolverBuilderPolicy getSolver(SolverBuilderPolicy builder)
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ foo, baz })
-                         .SetProducts({ Yields(bar, 1), Yields(quuz, 2.4) })
+                         .SetProducts({ micm::Yield(bar, 1), micm::Yield(quuz, 2.4) })
                          .SetPhase(gas_phase)
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.0e-11, .B_ = 0, .C_ = 110 }));
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ bar })
-                         .SetProducts({ Yields(foo, 1), Yields(quz, 1.4) })
+                         .SetProducts({ micm::Yield(foo, 1), micm::Yield(quz, 1.4) })
                          .SetPhase(gas_phase)
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 1.0e-6 }));
 

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -26,13 +26,13 @@ namespace
 
   micm::Process r1 = micm::Process::Create()
                          .SetReactants({ a })
-                         .SetProducts({ micm::Yields(b, 1) })
+                         .SetProducts({ micm::Yield(b, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant({ .A_ = 2.15e-11, .B_ = 0, .C_ = 110 }))
                          .SetPhase(gas_phase);
 
   micm::Process r2 = micm::Process::Create()
                          .SetReactants({ b })
-                         .SetProducts({ micm::Yields(c, 1) })
+                         .SetProducts({ micm::Yield(c, 1) })
                          .SetRateConstant(micm::ArrheniusRateConstant(
                              micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .B_ = 0, .C_ = 55 }))
                          .SetPhase(gas_phase);


### PR DESCRIPTION
This PR:
- Replaces `using Yield = std::pair<Species, double>` with `struct Yield` which contains the same data members. This avoids duplicate typedef or `using` statement.
- Uses the explicit variable names instead of generic name(`species`, `coefficient` vs. `first`, `second`)
- Adds preliminary support for multi-phase reactions through `PhaseReaction`, `PhaseTransferReaction` struct. This is a work in progress.
- is one of several small PRs for #804 for easier review. 
