### PR TITLE
Update CUDA dense matrix tests with user-defined vector length

### DIFF
--- a/test/unit/cuda/util/cuda_matrix_utils.cu
+++ b/test/unit/cuda/util/cuda_matrix_utils.cu
@@ -29,13 +29,25 @@ namespace micm
       }
     }
 
-    __global__ void AddOneElement(double* d_data, const std::size_t number_of_non_zeros, std::size_t elem_id, std::size_t grid_id, const std::size_t cuda_matrix_vector_length)
+    __global__ void SparseMatrixAddOneElement(double* d_data, const std::size_t number_of_grid_cells, const std::size_t number_of_non_zeros, std::size_t elem_id, std::size_t grid_id, const std::size_t cuda_matrix_vector_length)
     {
       std::size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
       std::size_t local_tid = tid % cuda_matrix_vector_length;
       std::size_t group_id = std::floor(static_cast<double>(tid) / cuda_matrix_vector_length);
-      const std::size_t offset = group_id * number_of_non_zeros * cuda_matrix_vector_length + elem_id * cuda_matrix_vector_length + local_tid;
+      std::size_t offset = group_id * number_of_non_zeros * cuda_matrix_vector_length + elem_id * cuda_matrix_vector_length + local_tid;
       if (tid == grid_id)
+      {
+        d_data[offset] += 1;
+      }
+    }
+
+    __global__ void DenseMatrixAddOneElement(double* d_data, const std::size_t number_of_columns, std::size_t row_id, std::size_t col_id, const std::size_t cuda_matrix_vector_length)
+    {
+      std::size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+      std::size_t local_tid = tid % cuda_matrix_vector_length;
+      std::size_t group_id = std::floor(static_cast<double>(tid) / cuda_matrix_vector_length);
+      const std::size_t offset = group_id * number_of_columns * cuda_matrix_vector_length + local_tid * col_id + local_tid;
+      if (tid == row_id)
       {
         d_data[offset] += 1;
       }
@@ -46,11 +58,22 @@ namespace micm
       AddOne<<<param.number_of_elements_, BLOCK_SIZE>>>(param.d_data_, param.number_of_elements_);
     }
 
-    void AddOneElementDriver(CudaMatrixParam& param, std::size_t elem_id, std::size_t grid_id, const std::size_t cuda_matrix_vector_length)
+    void SparseMatrixAddOneElementDriver(CudaMatrixParam& param, std::size_t elem_id, std::size_t grid_id, const std::size_t cuda_matrix_vector_length)
     {
-      const std::size_t number_of_non_zeros = param.number_of_elements_ / param.number_of_grid_cells_; 
-      AddOneElement<<<param.number_of_grid_cells_, 32>>>(param.d_data_, number_of_non_zeros, elem_id, grid_id, cuda_matrix_vector_length);
+      const std::size_t number_of_groups = std::ceil(static_cast<double>(param.number_of_grid_cells_) / cuda_matrix_vector_length);
+      const std::size_t number_of_non_zeros = param.number_of_elements_ / number_of_groups / cuda_matrix_vector_length;
+      const std::size_t number_of_blocks = (param.number_of_grid_cells_ + 31) / 32;
+      SparseMatrixAddOneElement<<<number_of_blocks, 32>>>(param.d_data_, param.number_of_grid_cells_, number_of_non_zeros, elem_id, grid_id, cuda_matrix_vector_length);
     }
 
+    void DenseMatrixAddOneElementDriver(CudaMatrixParam& param, std::size_t row_id, std::size_t col_id, const std::size_t cuda_matrix_vector_length)
+    {
+      if (row_id >= param.number_of_grid_cells_)
+      {
+        throw std::runtime_error("row_id out of bounds in DenseMatrixAddOneElementDriver");
+      }
+      const std::size_t number_of_columns = param.number_of_elements_ / param.number_of_grid_cells_;
+      DenseMatrixAddOneElement<<<param.number_of_grid_cells_, 32>>>(param.d_data_, number_of_columns, row_id, col_id, cuda_matrix_vector_length);
+    }
   }  // namespace cuda
 }  // namespace micm

--- a/test/unit/cuda/util/cuda_matrix_utils.cuh
+++ b/test/unit/cuda/util/cuda_matrix_utils.cuh
@@ -6,6 +6,7 @@ namespace micm
   {
     void SquareDriver(CudaMatrixParam& param);
     void AddOneDriver(CudaMatrixParam& param);
-    void AddOneElementDriver(CudaMatrixParam& param, std::size_t elem_id, std::size_t grid_id, const std::size_t cuda_matrix_vector_length);
+    void SparseMatrixAddOneElementDriver(CudaMatrixParam& param, std::size_t elem_id, std::size_t grid_id, const std::size_t cuda_matrix_vector_length);
+    void DenseMatrixAddOneElementDriver(CudaMatrixParam& param, std::size_t row_id, std::size_t col_id, const std::size_t cuda_matrix_vector_length);
   }  // namespace cuda
 }  // namespace micm

--- a/test/unit/cuda/util/test_cuda_dense_matrix.cpp
+++ b/test/unit/cuda/util/test_cuda_dense_matrix.cpp
@@ -709,12 +709,11 @@ TEST(CudaDenseMatrix, TestMin)
   EXPECT_EQ(matrix[1][2], 1.0);
 }
 
-TEST(CudaDenseMatrix, SingleBlockMatrixAddOneElement)
+template <std::size_t cuda_matrix_vector_length>
+void TestSingleBlockMatrixAddOneElement()
 {
-  const std::size_t cuda_matrix_vector_length = 37;
   const std::size_t number_of_grid_cells = 1;
   const std::size_t number_of_columns = 43;
-  // For MICM vector matrix class, the first dimension is the fast-varying one regardless dense/sparse, CSR/CSC, etc
   auto matrix = micm::CudaDenseMatrix<double, cuda_matrix_vector_length>(number_of_grid_cells, number_of_columns, 79.0);
 
   EXPECT_EQ(matrix.GroupVectorSize(), cuda_matrix_vector_length);
@@ -731,9 +730,18 @@ TEST(CudaDenseMatrix, SingleBlockMatrixAddOneElement)
   EXPECT_EQ(matrix[row_id][col_id], 80);
 }
 
-TEST(CudaDenseMatrix, MultiBlockMatrixAddOneElement)
+TEST(CudaDenseMatrix, SingleBlockMatrixAddOneElement)
 {
-  const std::size_t cuda_matrix_vector_length = 37;
+  TestSingleBlockMatrixAddOneElement<1>();
+  TestSingleBlockMatrixAddOneElement<4>();
+  TestSingleBlockMatrixAddOneElement<32>();
+  TestSingleBlockMatrixAddOneElement<37>();
+  TestSingleBlockMatrixAddOneElement<65>();
+}
+
+template <std::size_t cuda_matrix_vector_length>
+void TestMultiBlockMatrixAddOneElement()
+{
   const std::size_t number_of_grid_cells = 79;
   const std::size_t number_of_columns = 13;
   // For MICM vector matrix class, the first dimension is the fast-varying one regardless dense/sparse, CSR/CSC, etc
@@ -751,4 +759,13 @@ TEST(CudaDenseMatrix, MultiBlockMatrixAddOneElement)
   matrix.CopyToHost();
 
   EXPECT_EQ(matrix[row_id][col_id], 55);
+}
+
+TEST(CudaDenseMatrix, MultiBlockMatrixAddOneElement)
+{
+  TestMultiBlockMatrixAddOneElement<4>();
+  TestMultiBlockMatrixAddOneElement<32>();
+  TestMultiBlockMatrixAddOneElement<37>();
+  TestMultiBlockMatrixAddOneElement<65>();
+  TestMultiBlockMatrixAddOneElement<87>();
 }

--- a/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_column.cpp
+++ b/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_column.cpp
@@ -7,29 +7,29 @@
 
 /* Below are the policy tests on the CPU */
 
-TEST(SparseVectorCompressedRowMatrix, ZeroMatrix)
+TEST(SparseVectorCompressedColumnMatrix, ZeroMatrix)
 {
   testZeroMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<2>>();
 }
 
-TEST(SparseVectorCompressedRowMatrix, ConstZeroMatrix)
+TEST(SparseVectorCompressedColumnMatrix, ConstZeroMatrix)
 {
   testConstZeroMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<3>>();
 }
 
-TEST(SparseVectorCompressedRowMatrix, SetScalar)
+TEST(SparseVectorCompressedColumnMatrix, SetScalar)
 {
   testSetScalar<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<3>>();
 }
 
-TEST(SparseVectorCompressedRowMatrix, AddToDiagonal)
+TEST(SparseVectorCompressedColumnMatrix, AddToDiagonal)
 {
   testAddToDiagonal<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<1>>();
   testAddToDiagonal<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<3>>();
   testAddToDiagonal<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<4>>();
 }
 
-TEST(SparseVectorCompressedRowMatrix, Print)
+TEST(SparseVectorCompressedColumnMatrix, Print)
 {
   testPrint<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<1>>();
   testPrint<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<2>>();
@@ -37,7 +37,7 @@ TEST(SparseVectorCompressedRowMatrix, Print)
   testPrint<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<4>>();
 }
 
-TEST(SparseVectorCompressedRowMatrix, PrintNonZero)
+TEST(SparseVectorCompressedColumnMatrix, PrintNonZero)
 {
   testPrintNonZero<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<1>>();
   testPrintNonZero<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<2>>();
@@ -224,10 +224,12 @@ TEST(CudaSparseMatrix, MoveAssignmentZeroMatrixAddOne)
   }
 }
 
-TEST(CudaSparseMatrix, SingleBlockMatrixAddOneElement)
+template <std::size_t cuda_matrix_vector_length>
+void TestSingleBlockMatrixAddOneElement()
 {
-  const std::size_t cuda_matrix_vector_length = 37; // 4, 32, 37, 65
-  auto matrix = testSingleBlockMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<cuda_matrix_vector_length>>();
+  auto matrix = testSingleBlockMatrix<
+      micm::CudaSparseMatrix,
+      micm::SparseMatrixVectorOrderingCompressedSparseColumn<cuda_matrix_vector_length>>();
 
   {
     std::size_t elem = matrix.VectorIndex(3, 2);
@@ -254,10 +256,20 @@ TEST(CudaSparseMatrix, SingleBlockMatrixAddOneElement)
   EXPECT_EQ(matrix[0][2][1], 46);
 }
 
-TEST(CudaSparseMatrix, MultiBlockMatrixAddOneElement)
+TEST(CudaSparseMatrix, SingleBlockMatrixAddOneElement)
 {
-  const std::size_t cuda_matrix_vector_length = 37;
-  auto matrix = testMultiBlockMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<cuda_matrix_vector_length>>();
+  TestSingleBlockMatrixAddOneElement<3>();
+  TestSingleBlockMatrixAddOneElement<32>();
+  TestSingleBlockMatrixAddOneElement<37>();
+  TestSingleBlockMatrixAddOneElement<65>();
+}
+
+template <std::size_t cuda_matrix_vector_length>
+void TestMultiBlockMatrixAddOneElement()
+{
+  auto matrix = testMultiBlockMatrix<
+      micm::CudaSparseMatrix,
+      micm::SparseMatrixVectorOrderingCompressedSparseColumn<cuda_matrix_vector_length>>();
 
   {
     std::size_t elem = matrix.VectorIndex(0, 2, 3);
@@ -281,4 +293,12 @@ TEST(CudaSparseMatrix, MultiBlockMatrixAddOneElement)
   matrix.CopyToHost();
 
   EXPECT_EQ(matrix[grid_id][2][3], 80);
+}
+
+TEST(CudaSparseMatrix, MultiBlockMatrixAddOneElement)
+{
+  TestMultiBlockMatrixAddOneElement<3>();
+  TestMultiBlockMatrixAddOneElement<32>();
+  TestMultiBlockMatrixAddOneElement<37>();
+  TestMultiBlockMatrixAddOneElement<65>();
 }

--- a/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_column.cpp
+++ b/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_column.cpp
@@ -226,7 +226,7 @@ TEST(CudaSparseMatrix, MoveAssignmentZeroMatrixAddOne)
 
 TEST(CudaSparseMatrix, SingleBlockMatrixAddOneElement)
 {
-  const std::size_t cuda_matrix_vector_length = 37;
+  const std::size_t cuda_matrix_vector_length = 37; // 4, 32, 37, 65
   auto matrix = testSingleBlockMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<cuda_matrix_vector_length>>();
 
   {
@@ -247,8 +247,8 @@ TEST(CudaSparseMatrix, SingleBlockMatrixAddOneElement)
 
   matrix.CopyToDevice();
   auto param = matrix.AsDeviceParam();
-  std::size_t elem_id = 2; // in this example, 2 refers to matrix[2,1] which is non-zero
-  micm::cuda::AddOneElementDriver(param, elem_id, 0, cuda_matrix_vector_length);
+  std::size_t elem_id = 2; // in this example, 2 refers to matrix[2][1] which is non-zero
+  micm::cuda::SparseMatrixAddOneElementDriver(param, elem_id, 0, cuda_matrix_vector_length);
   matrix.CopyToHost();
 
   EXPECT_EQ(matrix[0][2][1], 46);
@@ -256,7 +256,7 @@ TEST(CudaSparseMatrix, SingleBlockMatrixAddOneElement)
 
 TEST(CudaSparseMatrix, MultiBlockMatrixAddOneElement)
 {
-  const std::size_t cuda_matrix_vector_length = 1;
+  const std::size_t cuda_matrix_vector_length = 37;
   auto matrix = testMultiBlockMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseColumn<cuda_matrix_vector_length>>();
 
   {
@@ -265,7 +265,7 @@ TEST(CudaSparseMatrix, MultiBlockMatrixAddOneElement)
     auto idx = 40;
     elem = matrix.VectorIndex(idx, 2, 3);
     auto a = std::floor(static_cast<double>(idx) / cuda_matrix_vector_length);
-    auto b = matrix.VectorIndex(0, 2, 3);
+    auto b = matrix.VectorIndex(0, 2, 3) / cuda_matrix_vector_length;
     auto c = idx % cuda_matrix_vector_length;
     EXPECT_EQ(elem, 5 * cuda_matrix_vector_length * a + b * cuda_matrix_vector_length + c);
   }
@@ -277,7 +277,7 @@ TEST(CudaSparseMatrix, MultiBlockMatrixAddOneElement)
   auto param = matrix.AsDeviceParam();
   std::size_t elem_id = 4; // in this example, 4 refers to matrix[2,3] which is non-zero
   std::size_t grid_id = 33;
-  micm::cuda::AddOneElementDriver(param, elem_id, grid_id, cuda_matrix_vector_length);
+  micm::cuda::SparseMatrixAddOneElementDriver(param, elem_id, grid_id, cuda_matrix_vector_length);
   matrix.CopyToHost();
 
   EXPECT_EQ(matrix[grid_id][2][3], 80);

--- a/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_row.cpp
+++ b/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_row.cpp
@@ -224,9 +224,9 @@ TEST(CudaSparseMatrix, MoveAssignmentZeroMatrixAddOne)
   }
 }
 
-TEST(CudaSparseMatrix, SingleBlockMatrixAddOneElement)
+template <std::size_t cuda_matrix_vector_length>
+void TestSingleBlockMatrixAddOneElement()
 {
-  const std::size_t cuda_matrix_vector_length = 37;
   auto matrix = testSingleBlockMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseRow<cuda_matrix_vector_length>>();
 
   {
@@ -254,9 +254,17 @@ TEST(CudaSparseMatrix, SingleBlockMatrixAddOneElement)
   EXPECT_EQ(matrix[0][2][1], 46);
 }
 
-TEST(CudaSparseMatrix, MultiBlockMatrixAddOneElement)
+TEST(CudaSparseMatrix, SingleBlockMatrixAddOneElement)
 {
-  const std::size_t cuda_matrix_vector_length = 37;
+  TestSingleBlockMatrixAddOneElement<3>();
+  TestSingleBlockMatrixAddOneElement<32>();
+  TestSingleBlockMatrixAddOneElement<37>();
+  TestSingleBlockMatrixAddOneElement<65>();
+}
+
+template <std::size_t cuda_matrix_vector_length>
+void TestMultiBlockMatrixAddOneElement()
+{
   auto matrix = testMultiBlockMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseRow<cuda_matrix_vector_length>>();
 
   {
@@ -281,4 +289,12 @@ TEST(CudaSparseMatrix, MultiBlockMatrixAddOneElement)
   matrix.CopyToHost();
 
   EXPECT_EQ(matrix[grid_id][3][2], 30);
+}
+
+TEST(CudaSparseMatrix, MultiBlockMatrixAddOneElement)
+{
+  TestMultiBlockMatrixAddOneElement<3>();
+  TestMultiBlockMatrixAddOneElement<32>();
+  TestMultiBlockMatrixAddOneElement<37>();
+  TestMultiBlockMatrixAddOneElement<65>();
 }

--- a/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_row.cpp
+++ b/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_row.cpp
@@ -248,7 +248,7 @@ TEST(CudaSparseMatrix, SingleBlockMatrixAddOneElement)
   matrix.CopyToDevice();
   auto param = matrix.AsDeviceParam();
   std::size_t elem_id = 2; // in this example, 2 refers to matrix[2,1] which is non-zero
-  micm::cuda::AddOneElementDriver(param, elem_id, 0, cuda_matrix_vector_length);
+  micm::cuda::SparseMatrixAddOneElementDriver(param, elem_id, 0, cuda_matrix_vector_length);
   matrix.CopyToHost();
 
   EXPECT_EQ(matrix[0][2][1], 46);
@@ -256,7 +256,7 @@ TEST(CudaSparseMatrix, SingleBlockMatrixAddOneElement)
 
 TEST(CudaSparseMatrix, MultiBlockMatrixAddOneElement)
 {
-  const std::size_t cuda_matrix_vector_length = 1;
+  const std::size_t cuda_matrix_vector_length = 37;
   auto matrix = testMultiBlockMatrix<micm::CudaSparseMatrix, micm::SparseMatrixVectorOrderingCompressedSparseRow<cuda_matrix_vector_length>>();
 
   {
@@ -265,7 +265,7 @@ TEST(CudaSparseMatrix, MultiBlockMatrixAddOneElement)
     auto idx = 40;
     elem = matrix.VectorIndex(idx, 2, 3);
     auto a = std::floor(static_cast<double>(idx) / cuda_matrix_vector_length);
-    auto b = matrix.VectorIndex(0, 2, 3);
+    auto b = matrix.VectorIndex(0, 2, 3) / cuda_matrix_vector_length;
     auto c = idx % cuda_matrix_vector_length;
     EXPECT_EQ(elem, 5 * cuda_matrix_vector_length * a + b * cuda_matrix_vector_length + c);
   }
@@ -275,9 +275,9 @@ TEST(CudaSparseMatrix, MultiBlockMatrixAddOneElement)
 
   matrix.CopyToDevice();
   auto param = matrix.AsDeviceParam();
-  std::size_t elem_id = 4; // in this example, 4 refers to matrix[3,2] which is non-zero
+  std::size_t elem_id = 4; // in this example, 4 refers to matrix[3][2] which is non-zero
   std::size_t grid_id = 43;
-  micm::cuda::AddOneElementDriver(param, elem_id, grid_id, cuda_matrix_vector_length);
+  micm::cuda::SparseMatrixAddOneElementDriver(param, elem_id, grid_id, cuda_matrix_vector_length);
   matrix.CopyToHost();
 
   EXPECT_EQ(matrix[grid_id][3][2], 30);


### PR DESCRIPTION
This pull request updates the CUDA dense matrix unit tests with user-defined vector length.

It also fixes a few bugs for the CUDA sparse matrix unit tests introduced in my previous PR (#814).

fix #816 