### PR TITLE
Update CUDA LU decomposition with user-defined vector length

### DIFF
--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
@@ -58,6 +58,7 @@ namespace micm
       hoststruct.aji_size_ = this->aji_.size();
       hoststruct.aik_njk_size_ = this->aik_njk_.size();
       hoststruct.ajk_aji_size_ = this->ajk_aji_.size();
+      hoststruct.number_of_non_zeros_ = matrix.GroupSize() / SparseMatrixPolicy::GroupVectorSize();
 
       // Copy the data from host struct to device struct
       this->devstruct_ = micm::cuda::CopyConstData(hoststruct);

--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
@@ -58,7 +58,10 @@ namespace micm
       hoststruct.aji_size_ = this->aji_.size();
       hoststruct.aik_njk_size_ = this->aik_njk_.size();
       hoststruct.ajk_aji_size_ = this->ajk_aji_.size();
-      hoststruct.number_of_non_zeros_ = matrix.GroupSize() / SparseMatrixPolicy::GroupVectorSize();
+
+      /// Create the ALU matrix with all the fill-ins for the non-zero values
+      auto ALU = GetLUMatrix<SparseMatrixPolicy>(matrix, 0, true);
+      hoststruct.number_of_non_zeros_ = ALU.GroupSize() / SparseMatrixPolicy::GroupVectorSize();
 
       // Copy the data from host struct to device struct
       this->devstruct_ = micm::cuda::CopyConstData(hoststruct);

--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -66,6 +66,7 @@ namespace micm
     {
       this->param_.number_of_grid_cells_ = 0;
       this->param_.number_of_elements_ = this->data_.size();
+      this->param_.vector_length_ = L;
       if (this->param_.number_of_elements_ != 0)
         CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
     }
@@ -75,6 +76,7 @@ namespace micm
     {
       this->param_.number_of_elements_ = this->data_.size();
       this->param_.number_of_grid_cells_ = x_dim;
+      this->param_.vector_length_ = L;
       if (this->param_.number_of_elements_ != 0)
         CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
     }
@@ -84,6 +86,7 @@ namespace micm
     {
       this->param_.number_of_elements_ = this->data_.size();
       this->param_.number_of_grid_cells_ = x_dim;
+      this->param_.vector_length_ = L;
       if (this->param_.number_of_elements_ != 0)
       {
         CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
@@ -96,6 +99,7 @@ namespace micm
     {
       this->param_.number_of_grid_cells_ = 0;
       this->param_.number_of_elements_ = 0;
+      this->param_.vector_length_ = L;
       for (const auto& inner_vector : other)
       {
         this->param_.number_of_elements_ += inner_vector.size();
@@ -111,6 +115,7 @@ namespace micm
       this->param_.d_data_ = nullptr;
       this->param_.number_of_elements_ = other.param_.number_of_elements_;
       this->param_.number_of_grid_cells_ = other.param_.number_of_grid_cells_;
+      this->param_.vector_length_ = other.param_.vector_length_;
       CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
       CHECK_CUDA_ERROR(micm::cuda::CopyToDeviceFromDevice<T>(this->param_, other.param_), "cudaMemcpyDeviceToDevice");
     }

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -58,6 +58,7 @@ struct LuDecomposeMozartInPlaceParam
   std::size_t aji_size_;
   std::size_t aik_njk_size_;
   std::size_t ajk_aji_size_;
+  std::size_t number_of_non_zeros_;
 };
 
 /// Alias for the default LU decomposition parameter struct
@@ -85,6 +86,7 @@ struct CudaMatrixParam
   double* d_data_ = nullptr;
   std::size_t number_of_elements_;
   std::size_t number_of_grid_cells_;
+  std::size_t vector_length_;
 };
 
 /// This struct holds (1) pointer to, and (2) size of

--- a/include/micm/cuda/util/cuda_sparse_matrix.hpp
+++ b/include/micm/cuda/util/cuda_sparse_matrix.hpp
@@ -21,6 +21,8 @@ namespace micm
     // Diagonal markowitz reordering requires an int argument, make sure one is always accessible
     using IntMatrix = CudaSparseMatrix<int, OrderingPolicy>;
     using value_type = T;
+    // Access vector length via OrderingPolicy::GroupVectorSize()
+    static constexpr std::size_t vector_length_ = OrderingPolicy::GroupVectorSize();
 
    private:
     CudaMatrixParam param_;
@@ -36,6 +38,7 @@ namespace micm
         : SparseMatrix<T, OrderingPolicy>(builder, indexing_only)
     {
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
+      this->param_.vector_length_ = this->vector_length_;
       if (!indexing_only)
         CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->data_.size()), "cudaMalloc");
     }
@@ -44,6 +47,7 @@ namespace micm
     {
       SparseMatrix<T, OrderingPolicy>::operator=(builder);
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
+      this->param_.vector_length_ = this->vector_length_;
       if (this->data_.size() != 0)
         CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->data_.size()), "cudaMalloc");
       return *this;

--- a/src/solver/lu_decomposition_mozart_in_place.cu
+++ b/src/solver/lu_decomposition_mozart_in_place.cu
@@ -155,7 +155,6 @@ namespace micm
     {
       // Launch the CUDA kernel for LU decomposition
       std::size_t number_of_blocks = (ALU_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
-      std::size_t number_of_groups = std::ceil(static_cast<double>(ALU_param.number_of_grid_cells_) / ALU_param.vector_length_);
       DecomposeKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(
           ALU_param, devstruct);
     }  // end of DecomposeKernelDriver

--- a/src/solver/lu_decomposition_mozart_in_place.cu
+++ b/src/solver/lu_decomposition_mozart_in_place.cu
@@ -20,8 +20,13 @@ namespace micm
       const std::pair<std::size_t, std::size_t>* __restrict__ d_ajk_aji = devstruct.ajk_aji_;
       const std::size_t d_aii_nji_nki_size = devstruct.aii_nji_nki_size_;
 
-      double* const __restrict__ d_ALU = ALU_param.d_data_;
+      double* __restrict__ d_ALU = ALU_param.d_data_;
       const size_t number_of_grid_cells = ALU_param.number_of_grid_cells_;
+      const std::size_t local_tid = tid % ALU_param.vector_length_;
+      const std::size_t group_id = std::floor(static_cast<double>(tid) / ALU_param.vector_length_);
+
+      // Shift the index for different groups
+      d_ALU = d_ALU + group_id * devstruct.number_of_non_zeros_ * ALU_param.vector_length_;
 
       if (tid < number_of_grid_cells)
       {
@@ -29,10 +34,10 @@ namespace micm
         {
           auto& d_aii_nji_nki_elem = d_aii_nji_nki[i];
           auto d_Aii = d_ALU + std::get<0>(d_aii_nji_nki_elem);
-          auto d_Aii_inverse = 1.0 / d_Aii[tid];
+          auto d_Aii_inverse = 1.0 / d_Aii[local_tid];
           for (std::size_t ij = 0; ij < std::get<1>(d_aii_nji_nki_elem); ++ij)
           {
-            auto d_ALU_ji = d_ALU + *d_aji + tid;
+            auto d_ALU_ji = d_ALU + *d_aji + local_tid;
             *d_ALU_ji *= d_Aii_inverse;
             ++d_aji;
           }
@@ -42,9 +47,9 @@ namespace micm
             const std::size_t d_aik_njk_second = std::get<1>(*d_aik_njk);
             for (std::size_t ijk = 0; ijk < d_aik_njk_second; ++ijk)
             {
-              auto d_ALU_first = d_ALU + d_ajk_aji->first + tid;
-              auto d_ALU_second = d_ALU + d_ajk_aji->second + tid;
-              auto d_ALU_aik = d_ALU + d_aik_njk_first + tid;
+              auto d_ALU_first = d_ALU + d_ajk_aji->first + local_tid;
+              auto d_ALU_second = d_ALU + d_ajk_aji->second + local_tid;
+              auto d_ALU_aik = d_ALU + d_aik_njk_first + local_tid;
               *d_ALU_first -= *d_ALU_second * *d_ALU_aik;
               ++d_ajk_aji;
             }
@@ -121,6 +126,7 @@ namespace micm
       devstruct.aji_size_ = hoststruct.aji_size_;
       devstruct.aik_njk_size_ = hoststruct.aik_njk_size_;
       devstruct.ajk_aji_size_ = hoststruct.ajk_aji_size_;
+      devstruct.number_of_non_zeros_ = hoststruct.number_of_non_zeros_;
 
       return devstruct;
     }
@@ -147,7 +153,8 @@ namespace micm
     void DecomposeKernelDriver(CudaMatrixParam& ALU_param, const LuDecomposeParam& devstruct)
     {
       // Launch the CUDA kernel for LU decomposition
-      size_t number_of_blocks = (ALU_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
+      std::size_t number_of_blocks = (ALU_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
+      std::size_t number_of_groups = std::ceil(static_cast<double>(ALU_param.number_of_grid_cells_) / ALU_param.vector_length_);
       DecomposeKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(
           ALU_param, devstruct);
     }  // end of DecomposeKernelDriver

--- a/src/solver/lu_decomposition_mozart_in_place.cu
+++ b/src/solver/lu_decomposition_mozart_in_place.cu
@@ -22,11 +22,12 @@ namespace micm
 
       double* __restrict__ d_ALU = ALU_param.d_data_;
       const size_t number_of_grid_cells = ALU_param.number_of_grid_cells_;
-      const std::size_t local_tid = tid % ALU_param.vector_length_;
-      const std::size_t group_id = std::floor(static_cast<double>(tid) / ALU_param.vector_length_);
+      const size_t cuda_matrix_vector_length = ALU_param.vector_length_;
+      const std::size_t local_tid = tid % cuda_matrix_vector_length;
+      const std::size_t group_id = std::floor(static_cast<double>(tid) / cuda_matrix_vector_length);
 
       // Shift the index for different groups
-      d_ALU = d_ALU + group_id * devstruct.number_of_non_zeros_ * ALU_param.vector_length_;
+      d_ALU = d_ALU + group_id * devstruct.number_of_non_zeros_ * cuda_matrix_vector_length;
 
       if (tid < number_of_grid_cells)
       {

--- a/test/unit/cuda/solver/test_cuda_lu_decomposition_mozart_in_place.cpp
+++ b/test/unit/cuda/solver/test_cuda_lu_decomposition_mozart_in_place.cpp
@@ -32,9 +32,9 @@ TEST(CudaLuDecompositionMozartInPlace, AgnosticToInitialValue)
   double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
   for (auto& value : initial_values)
   {
-    testExtremeValueInitialization<Group1CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(1, value);
-    testExtremeValueInitialization<Group100CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(100, value);
-    testExtremeValueInitialization<Group1000CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(1000, value);
-    testExtremeValueInitialization<Group100000CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(100000, value);
+    testExtremeValueInitialization<Group1CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(2, value);
+    testExtremeValueInitialization<Group100CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(200, value);
+    testExtremeValueInitialization<Group1000CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(2000, value);
+    testExtremeValueInitialization<Group100000CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(200000, value);
   }
 }

--- a/test/unit/cuda/solver/test_cuda_lu_decomposition_mozart_in_place.cpp
+++ b/test/unit/cuda/solver/test_cuda_lu_decomposition_mozart_in_place.cpp
@@ -14,17 +14,33 @@
 #include <random>
 #include <vector>
 
-using Group1CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1>>;
-using Group100CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<100>>;
-using Group1000CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1000>>;
-using Group100000CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<100000>>;
+using Group1CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
+using Group27CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<27>>;
+using Group32CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<32>>;
+using Group43CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<43>>;
+using Group77CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<77>>;
+using Group113CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<113>>;
+using Group193CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<193>>;
+using Group281CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<281>>;
+using Group472CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<472>>;
+using Group512CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<512>>;
+using Group739CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<739>>;
+using Group1130CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<1130>>;
 
 TEST(CudaLuDecompositionMozartInPlace, RandomMatrixVectorOrdering)
 {
-  testRandomMatrix<Group1CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(1);
-  testRandomMatrix<Group100CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(100);
-  testRandomMatrix<Group1000CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(1000);
-  testRandomMatrix<Group100000CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(100000);
+  testRandomMatrix<Group1CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
+  testRandomMatrix<Group27CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
+  testRandomMatrix<Group32CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
+  testRandomMatrix<Group43CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
+  testRandomMatrix<Group77CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
+  testRandomMatrix<Group113CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
+  testRandomMatrix<Group193CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
+  testRandomMatrix<Group281CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
+  testRandomMatrix<Group472CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
+  testRandomMatrix<Group512CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
+  testRandomMatrix<Group739CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
+  testRandomMatrix<Group1130CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
 }
 
 TEST(CudaLuDecompositionMozartInPlace, AgnosticToInitialValue)
@@ -32,9 +48,17 @@ TEST(CudaLuDecompositionMozartInPlace, AgnosticToInitialValue)
   double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
   for (auto& value : initial_values)
   {
-    testExtremeValueInitialization<Group1CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(2, value);
-    testExtremeValueInitialization<Group100CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(200, value);
-    testExtremeValueInitialization<Group1000CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(2000, value);
-    testExtremeValueInitialization<Group100000CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(200000, value);
+    testExtremeValueInitialization<Group1CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
+    testExtremeValueInitialization<Group27CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
+    testExtremeValueInitialization<Group32CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
+    testExtremeValueInitialization<Group43CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
+    testExtremeValueInitialization<Group77CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
+    testExtremeValueInitialization<Group113CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
+    testExtremeValueInitialization<Group193CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
+    testExtremeValueInitialization<Group281CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
+    testExtremeValueInitialization<Group472CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
+    testExtremeValueInitialization<Group512CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
+    testExtremeValueInitialization<Group739CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
+    testExtremeValueInitialization<Group1130CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
   }
 }


### PR DESCRIPTION
This PR updates the CUDA LU decomposition kernel to allow a user-defined vector length.

All the unit tests pass on Derecho's A100 GPUs.

fix #825 