### PR TITLE
Correct the data type for storing gas species in PhaseTransferProcess

### DIFF
--- a/include/micm/process/phase_transfer_process.hpp
+++ b/include/micm/process/phase_transfer_process.hpp
@@ -23,7 +23,7 @@ namespace micm
     Phase gas_phase_;
     Phase condensed_phase_;
     Phase solvent_phase_;
-    std::vector<Species> gas_species_;
+    Species gas_species_;
     std::vector<Yield> condensed_species_;
     Species solvent_;
     std::unique_ptr<TransferCoefficient> coefficient_;
@@ -35,7 +35,7 @@ namespace micm
         const Phase& gas_phase,
         const Phase& condensed_phase,
         const Phase& solvent_phase,
-        std::vector<Species> gas_species,
+        Species gas_species,
         std::vector<Yield> condensed_species,
         Species solvent,
         std::unique_ptr<TransferCoefficient> coefficient)

--- a/include/micm/process/phase_transfer_process_builder.hpp
+++ b/include/micm/process/phase_transfer_process_builder.hpp
@@ -31,7 +31,7 @@ namespace micm
    public:
     /// @brief Sets the species in the gas phase
     /// @param phase Phase object representing the gas phase
-    /// @param species A vector of Species representing the species in the gas phase
+    /// @param species Species object in the gas phase
     /// @return Reference to the builder
     PhaseTransferProcessBuilder& SetGasSpecies(const Phase& phase, Species species)
     {

--- a/include/micm/process/phase_transfer_process_builder.hpp
+++ b/include/micm/process/phase_transfer_process_builder.hpp
@@ -23,7 +23,7 @@ namespace micm
     Phase gas_phase_;
     Phase condensed_phase_;
     Phase solvent_phase_;
-    std::vector<Species> gas_species_;
+    Species gas_species_;
     std::vector<Yield> condensed_species_;
     Species solvent_;
     std::unique_ptr<TransferCoefficient> coefficient_;
@@ -33,7 +33,7 @@ namespace micm
     /// @param phase Phase object representing the gas phase
     /// @param species A vector of Species representing the species in the gas phase
     /// @return Reference to the builder
-    PhaseTransferProcessBuilder& SetGasSpecies(const Phase& phase, std::vector<Species> species)
+    PhaseTransferProcessBuilder& SetGasSpecies(const Phase& phase, Species species)
     {
       gas_phase_ = phase;
       gas_species_ = std::move(species);

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -131,7 +131,7 @@ TEST(Process, BuildsChemicalReactionAndPhaseTransferProcess)
 
   // Build a PhaseTransferProcess
   Process phase_transfer = PhaseTransferProcessBuilder()
-                               .SetGasSpecies(gas_phase, { CO2 })
+                               .SetGasSpecies(gas_phase, CO2)
                                .SetCondensedSpecies(aqueous_phase, { Yield(Hplus, 2.0), Yield(CO32minus) })
                                .SetSolvent(aqueous_phase, H2O)
                                .SetTransferCoefficient(PhaseTransferCoefficient())
@@ -165,7 +165,7 @@ TEST(Process, BuildsChemicalReactionAndPhaseTransferProcess)
           EXPECT_EQ(value.gas_phase_.name_, "gas");
           EXPECT_EQ(value.condensed_phase_.name_, "aqueous");
           EXPECT_EQ(value.solvent_phase_.name_, "aqueous");
-          EXPECT_EQ(value.gas_species_.size(), 1);
+          EXPECT_EQ(value.gas_species_.name_, "CO2");
           EXPECT_EQ(value.condensed_species_.size(), 2);
           EXPECT_EQ(value.solvent_.name_, "H2O");
           EXPECT_EQ(value.condensed_species_[0].coefficient_, 2.0);
@@ -248,7 +248,7 @@ TEST(Process, PhaseTransferProcessCopyAssignmentSucceeds)
           EXPECT_EQ(copy.gas_phase_.name_, original.gas_phase_.name_);
           EXPECT_EQ(copy.condensed_phase_.name_, original.condensed_phase_.name_);
           EXPECT_EQ(copy.solvent_phase_.name_, original.solvent_phase_.name_);
-          EXPECT_EQ(copy.gas_species_[0].name_, original.gas_species_[0].name_);
+          EXPECT_EQ(copy.gas_species_.name_, original.gas_species_.name_);
           EXPECT_EQ(copy.condensed_species_[1].species_.name_, original.condensed_species_[1].species_.name_);
           EXPECT_EQ(copy.solvent_.name_, original.solvent_.name_);
           EXPECT_NE(copy.coefficient_.get(), original.coefficient_.get());


### PR DESCRIPTION
In `PhaseTransferProcess` there will only ever be one gas-phase species. This PR corrects the data type for it

```C++
// previous
std::vector<Species> gas_species_;

// this PR
Species gas_species_;
```