### PR TITLE
Update CUDA linear solver unit tests with user-defined vector length

### DIFF
--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
@@ -66,6 +66,10 @@ namespace micm
       hoststruct.nUij_Uii_size_ = this->nUij_Uii_.size();
       hoststruct.Uij_xj_size_ = this->Uij_xj_.size();
 
+      /// Create the ALU matrix with all the fill-ins for the non-zero values
+      auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(matrix, 0, true);
+      hoststruct.number_of_non_zeros_ = ALU.GroupSize() / SparseMatrixPolicy::GroupVectorSize();
+
       /// Copy the data from host struct to device struct
       this->devstruct_ = micm::cuda::CopyConstData(hoststruct);
     }

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -77,6 +77,7 @@ struct LinearSolverInPlaceParam
   std::size_t Lij_yj_size_;
   std::size_t nUij_Uii_size_;
   std::size_t Uij_xj_size_;
+  std::size_t number_of_non_zeros_;
 };
 
 /// This struct holds (1) pointer to, and (2) size of

--- a/src/solver/linear_solver_in_place.cu
+++ b/src/solver/linear_solver_in_place.cu
@@ -14,7 +14,7 @@ namespace micm
     SolveKernel(CudaMatrixParam x_param, const CudaMatrixParam ALU_param, const LinearSolverInPlaceParam devstruct)
     {
       // Calculate global thread ID
-      size_t tid = blockIdx.x * BLOCK_SIZE + threadIdx.x;
+      std::size_t tid = blockIdx.x * BLOCK_SIZE + threadIdx.x;
 
       // Local device variables
       const std::size_t* const __restrict__ d_nLij = devstruct.nLij_;
@@ -24,11 +24,19 @@ namespace micm
       const std::size_t d_nLij_size = devstruct.nLij_size_;
       const std::size_t d_nUij_Uii_size = devstruct.nUij_Uii_size_;
 
-      const double* const __restrict__ d_ALU = ALU_param.d_data_;
-      double* const d_x = x_param.d_data_;
-      double* d_y = d_x;  // Alias d_x for consistency with equation, but to reuse memory
+      double* __restrict__ d_ALU = ALU_param.d_data_;
+      double* d_x = x_param.d_data_;
       const std::size_t number_of_grid_cells = x_param.number_of_grid_cells_;
       const std::size_t number_of_elements = x_param.number_of_elements_;
+      const std::size_t cuda_matrix_vector_length = ALU_param.vector_length_;
+      const std::size_t number_of_groups = std::ceil(static_cast<double>(number_of_grid_cells) / cuda_matrix_vector_length);
+      const std::size_t local_tid = tid % cuda_matrix_vector_length;
+      const std::size_t group_id = std::floor(static_cast<double>(tid) / cuda_matrix_vector_length);
+
+      // Shift the index for different groups
+      d_ALU = d_ALU + group_id * ALU_param.number_of_elements_ / number_of_groups;
+      d_x = d_x + group_id * x_param.number_of_elements_ / number_of_groups;
+      double* d_y = d_x;  // Alias d_x for consistency with equation, but to reuse memory
 
       if (tid < number_of_grid_cells)
       {
@@ -40,32 +48,32 @@ namespace micm
             for (auto j = 0; j < j_lim; ++j)
             {
               const std::size_t d_Lij_yj_first = (*d_Lij_yj).first;
-              const std::size_t d_Lij_yj_second_times_ncells = (*d_Lij_yj).second * number_of_grid_cells;
+              const std::size_t d_Lij_yj_second_times_vlens = (*d_Lij_yj).second * cuda_matrix_vector_length;
               auto d_ALU_ptr = d_ALU + d_Lij_yj_first;
-              auto d_x_ptr = d_x + d_Lij_yj_second_times_ncells;
-              d_y[tid] -= d_ALU_ptr[tid] * d_x_ptr[tid];
+              auto d_x_ptr = d_x + d_Lij_yj_second_times_vlens;
+              d_y[local_tid] -= d_ALU_ptr[local_tid] * d_x_ptr[local_tid];
               ++d_Lij_yj;
             }
-            d_y += number_of_grid_cells;
+            d_y += cuda_matrix_vector_length;
           }
         }
         // Backward Substitution
         {
           // d_y will be x_elem in the CPU implementation
-          d_y = d_x + number_of_elements - number_of_grid_cells;
+          d_y = d_x + x_param.number_of_elements_ / number_of_groups - cuda_matrix_vector_length;
           for (auto i = 0; i < d_nUij_Uii_size; ++i)
           {
             const std::size_t j_lim = d_nUij_Uii[i].first;
             for (auto j = 0; j < j_lim; ++j)
             {
               auto d_ALU_ptr = d_ALU + (*d_Uij_xj).first;
-              auto d_x_ptr = d_x + (*d_Uij_xj).second * number_of_grid_cells;
-              d_y[tid] -= d_ALU_ptr[tid] * d_x_ptr[tid];
+              auto d_x_ptr = d_x + (*d_Uij_xj).second * cuda_matrix_vector_length;
+              d_y[local_tid] -= d_ALU_ptr[local_tid] * d_x_ptr[local_tid];
               ++d_Uij_xj;
             }
             auto d_ALU_ptr = d_ALU + d_nUij_Uii[i].second;
-            d_y[tid] /= d_ALU_ptr[tid];
-            d_y -= number_of_grid_cells;
+            d_y[local_tid] /= d_ALU_ptr[local_tid];
+            d_y -= cuda_matrix_vector_length;
           }
         }
       }
@@ -137,6 +145,7 @@ namespace micm
       devstruct.Lij_yj_size_ = hoststruct.Lij_yj_size_;
       devstruct.nUij_Uii_size_ = hoststruct.nUij_Uii_size_;
       devstruct.Uij_xj_size_ = hoststruct.Uij_xj_size_;
+      devstruct.number_of_non_zeros_ = hoststruct.number_of_non_zeros_;
 
       return devstruct;
     }
@@ -162,7 +171,7 @@ namespace micm
     void
     SolveKernelDriver(CudaMatrixParam& x_param, const CudaMatrixParam& ALU_param, const LinearSolverInPlaceParam& devstruct)
     {
-      size_t number_of_blocks = (x_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
+      std::size_t number_of_blocks = (x_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
       SolveKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(
           x_param, ALU_param, devstruct);
     }

--- a/test/unit/cuda/solver/test_cuda_linear_solver_in_place.cpp
+++ b/test/unit/cuda/solver/test_cuda_linear_solver_in_place.cpp
@@ -19,57 +19,70 @@
 
 using FloatingPointType = double;
 
-using Group1CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 1>;
-using Group20CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 20>;
-using Group300CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 300>;
-using Group4000CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 4000>;
-using Group10000CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 10000>;
+using Group3CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 3>;
+using Group27CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 27>;
+using Group32CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 32>;
+using Group43CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 43>;
+using Group77CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 77>;
+using Group113CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 113>;
+using Group193CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 193>;
+using Group281CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 281>;
+using Group472CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 472>;
+using Group512CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 512>;
+using Group739CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 739>;
+using Group1130CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 1130>;
 
-using Group1CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<1>>;
-using Group20CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<20>>;
-using Group300CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<300>>;
-using Group4000CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<4000>>;
-using Group10000CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<10000>>;
+using Group3CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<3>>;
+using Group27CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<27>>;
+using Group32CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<32>>;
+using Group43CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<43>>;
+using Group77CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<77>>;
+using Group113CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<113>>;
+using Group193CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<193>>;
+using Group281CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<281>>;
+using Group472CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<472>>;
+using Group512CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<512>>;
+using Group739CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<739>>;
+using Group1130CudaSparseMatrix = micm::CudaSparseMatrix<FloatingPointType, micm::SparseMatrixVectorOrdering<1130>>;
 
 TEST(CudaLinearSolverInPlace, DenseMatrixVectorOrderingPolicy)
 {
   testDenseMatrix<
-      Group1CudaDenseMatrix,
-      Group1CudaSparseMatrix,
-      micm::CudaLinearSolverInPlace<Group1CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>>();
+      Group1130CudaDenseMatrix,
+      Group1130CudaSparseMatrix,
+      micm::CudaLinearSolverInPlace<Group1130CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>>();
 }
 
 TEST(CudaLinearSolverInPlace, RandomMatrixVectorOrderingPolicy)
 {
-  testRandomMatrix<Group1CudaDenseMatrix, Group1CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group1CudaSparseMatrix>>(1);
-  testRandomMatrix<Group20CudaDenseMatrix, Group20CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group20CudaSparseMatrix>>(
-      20);
-  testRandomMatrix<
-      Group300CudaDenseMatrix,
-      Group300CudaSparseMatrix,
-      micm::CudaLinearSolverInPlace<Group300CudaSparseMatrix>>(300);
-  testRandomMatrix<
-      Group4000CudaDenseMatrix,
-      Group4000CudaSparseMatrix,
-      micm::CudaLinearSolverInPlace<Group4000CudaSparseMatrix>>(4000);
+    testRandomMatrix<Group3CudaDenseMatrix, Group3CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group3CudaSparseMatrix>>(400);
+    testRandomMatrix<Group27CudaDenseMatrix, Group27CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group27CudaSparseMatrix>>(400);
+    testRandomMatrix<Group32CudaDenseMatrix, Group32CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group32CudaSparseMatrix>>(400);
+    testRandomMatrix<Group43CudaDenseMatrix, Group43CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group43CudaSparseMatrix>>(400);
+    testRandomMatrix<Group77CudaDenseMatrix, Group77CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group77CudaSparseMatrix>>(400);
+    testRandomMatrix<Group113CudaDenseMatrix, Group113CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group113CudaSparseMatrix>>(400);
+    testRandomMatrix<Group193CudaDenseMatrix, Group193CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group193CudaSparseMatrix>>(400);
+    testRandomMatrix<Group281CudaDenseMatrix, Group281CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group281CudaSparseMatrix>>(400);
+    testRandomMatrix<Group472CudaDenseMatrix, Group472CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group472CudaSparseMatrix>>(400);
+    testRandomMatrix<Group512CudaDenseMatrix, Group512CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group512CudaSparseMatrix>>(400);
+    testRandomMatrix<Group739CudaDenseMatrix, Group739CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group739CudaSparseMatrix>>(400);
+    testRandomMatrix<Group1130CudaDenseMatrix, Group1130CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group1130CudaSparseMatrix>>(400);
 }
 
 TEST(CudaLinearSolverInPlace, DiagonalMatrixVectorOrderingPolicy)
 {
-  testDiagonalMatrix<Group1CudaDenseMatrix, Group1CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group1CudaSparseMatrix>>(
-      1);
-  testDiagonalMatrix<
-      Group20CudaDenseMatrix,
-      Group20CudaSparseMatrix,
-      micm::CudaLinearSolverInPlace<Group20CudaSparseMatrix>>(20);
-  testDiagonalMatrix<
-      Group300CudaDenseMatrix,
-      Group300CudaSparseMatrix,
-      micm::CudaLinearSolverInPlace<Group300CudaSparseMatrix>>(300);
-  testDiagonalMatrix<
-      Group4000CudaDenseMatrix,
-      Group4000CudaSparseMatrix,
-      micm::CudaLinearSolverInPlace<Group4000CudaSparseMatrix>>(4000);
+    testDiagonalMatrix<Group3CudaDenseMatrix, Group3CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group3CudaSparseMatrix>>(400);
+    testDiagonalMatrix<Group27CudaDenseMatrix, Group27CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group27CudaSparseMatrix>>(400);
+    testDiagonalMatrix<Group32CudaDenseMatrix, Group32CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group32CudaSparseMatrix>>(400);
+    testDiagonalMatrix<Group43CudaDenseMatrix, Group43CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group43CudaSparseMatrix>>(400);
+    testDiagonalMatrix<Group77CudaDenseMatrix, Group77CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group77CudaSparseMatrix>>(400);
+    testDiagonalMatrix<Group113CudaDenseMatrix, Group113CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group113CudaSparseMatrix>>(400);
+    testDiagonalMatrix<Group193CudaDenseMatrix, Group193CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group193CudaSparseMatrix>>(400);
+    testDiagonalMatrix<Group281CudaDenseMatrix, Group281CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group281CudaSparseMatrix>>(400);
+    testDiagonalMatrix<Group472CudaDenseMatrix, Group472CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group472CudaSparseMatrix>>(400);
+    testDiagonalMatrix<Group512CudaDenseMatrix, Group512CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group512CudaSparseMatrix>>(400);
+    testDiagonalMatrix<Group739CudaDenseMatrix, Group739CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group739CudaSparseMatrix>>(400);
+    testDiagonalMatrix<Group1130CudaDenseMatrix, Group1130CudaSparseMatrix, micm::CudaLinearSolverInPlace<Group1130CudaSparseMatrix>>(400);
 }
 
 TEST(CudaLinearSolverInPlace, AgnosticToInitialValue)
@@ -78,20 +91,52 @@ TEST(CudaLinearSolverInPlace, AgnosticToInitialValue)
   for (auto initial_value : initial_values)
   {
     testExtremeInitialValue<
-        Group1CudaDenseMatrix,
-        Group1CudaSparseMatrix,
-        micm::CudaLinearSolverInPlace<Group1CudaSparseMatrix>>(1, initial_value);
+        Group3CudaDenseMatrix,
+        Group3CudaSparseMatrix,
+        micm::CudaLinearSolverInPlace<Group3CudaSparseMatrix>>(400, initial_value);
     testExtremeInitialValue<
-        Group20CudaDenseMatrix,
-        Group20CudaSparseMatrix,
-        micm::CudaLinearSolverInPlace<Group20CudaSparseMatrix>>(20, initial_value);
+        Group27CudaDenseMatrix,
+        Group27CudaSparseMatrix,
+        micm::CudaLinearSolverInPlace<Group27CudaSparseMatrix>>(400, initial_value);
     testExtremeInitialValue<
-        Group300CudaDenseMatrix,
-        Group300CudaSparseMatrix,
-        micm::CudaLinearSolverInPlace<Group300CudaSparseMatrix>>(300, initial_value);
+        Group32CudaDenseMatrix,
+        Group32CudaSparseMatrix,
+        micm::CudaLinearSolverInPlace<Group32CudaSparseMatrix>>(400, initial_value);
     testExtremeInitialValue<
-        Group4000CudaDenseMatrix,
-        Group4000CudaSparseMatrix,
-        micm::CudaLinearSolverInPlace<Group4000CudaSparseMatrix>>(4000, initial_value);
+        Group43CudaDenseMatrix,
+        Group43CudaSparseMatrix,
+        micm::CudaLinearSolverInPlace<Group43CudaSparseMatrix>>(400, initial_value);
+    testExtremeInitialValue<
+        Group77CudaDenseMatrix,
+        Group77CudaSparseMatrix,
+        micm::CudaLinearSolverInPlace<Group77CudaSparseMatrix>>(400, initial_value);
+    testExtremeInitialValue<
+        Group113CudaDenseMatrix,
+        Group113CudaSparseMatrix,
+        micm::CudaLinearSolverInPlace<Group113CudaSparseMatrix>>(400, initial_value);
+    testExtremeInitialValue<
+        Group193CudaDenseMatrix,
+        Group193CudaSparseMatrix,
+        micm::CudaLinearSolverInPlace<Group193CudaSparseMatrix>>(400, initial_value);
+    testExtremeInitialValue<
+        Group281CudaDenseMatrix,
+        Group281CudaSparseMatrix,
+        micm::CudaLinearSolverInPlace<Group281CudaSparseMatrix>>(400, initial_value);
+    testExtremeInitialValue<
+        Group472CudaDenseMatrix,
+        Group472CudaSparseMatrix,
+        micm::CudaLinearSolverInPlace<Group472CudaSparseMatrix>>(400, initial_value);
+    testExtremeInitialValue<
+        Group512CudaDenseMatrix,
+        Group512CudaSparseMatrix,
+        micm::CudaLinearSolverInPlace<Group512CudaSparseMatrix>>(400, initial_value);
+    testExtremeInitialValue<
+        Group739CudaDenseMatrix,
+        Group739CudaSparseMatrix,
+        micm::CudaLinearSolverInPlace<Group739CudaSparseMatrix>>(400, initial_value);
+    testExtremeInitialValue<
+        Group1130CudaDenseMatrix,
+        Group1130CudaSparseMatrix,
+        micm::CudaLinearSolverInPlace<Group1130CudaSparseMatrix>>(400, initial_value);
   }
 }

--- a/test/unit/cuda/solver/test_cuda_lu_decomposition_mozart_in_place.cpp
+++ b/test/unit/cuda/solver/test_cuda_lu_decomposition_mozart_in_place.cpp
@@ -14,7 +14,7 @@
 #include <random>
 #include <vector>
 
-using Group1CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
+using Group3CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<3>>;
 using Group27CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<27>>;
 using Group32CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<32>>;
 using Group43CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrdering<43>>;
@@ -29,7 +29,7 @@ using Group1130CudaSparseMatrix = micm::CudaSparseMatrix<double, micm::SparseMat
 
 TEST(CudaLuDecompositionMozartInPlace, RandomMatrixVectorOrdering)
 {
-  testRandomMatrix<Group1CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
+  testRandomMatrix<Group3CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
   testRandomMatrix<Group27CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
   testRandomMatrix<Group32CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
   testRandomMatrix<Group43CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400);
@@ -48,7 +48,7 @@ TEST(CudaLuDecompositionMozartInPlace, AgnosticToInitialValue)
   double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
   for (auto& value : initial_values)
   {
-    testExtremeValueInitialization<Group1CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
+    testExtremeValueInitialization<Group3CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
     testExtremeValueInitialization<Group27CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
     testExtremeValueInitialization<Group32CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);
     testExtremeValueInitialization<Group43CudaSparseMatrix, micm::CudaLuDecompositionMozartInPlace>(400, value);


### PR DESCRIPTION
This PR updates the CUDA linear solver unit tests with the user-defined vector length.

All the unit tests pass on Derecho's A100 GPU nodes.

fix #834 