### PR TITLE
Set the temporary value for diffusion coefficient

### DIFF
--- a/include/micm/process/rate_constant/surface_rate_constant.hpp
+++ b/include/micm/process/rate_constant/surface_rate_constant.hpp
@@ -63,13 +63,27 @@ namespace micm
 
   inline SurfaceRateConstant::SurfaceRateConstant(const SurfaceRateConstantParameters& parameters)
       : parameters_(parameters),
-        // TODO - Diffusion coefficient should be avalialbe from PhaseSpecies
-        // Will address in the issue: https://github.com/NCAR/micm/issues/845
-        diffusion_coefficient_(1.0),
         mean_free_speed_factor_(
             8.0 * constants::GAS_CONSTANT /
             (M_PI * parameters.species_.GetProperty<double>(property_keys::MOLECULAR_WEIGHT)))
   {
+    // TODO - Diffusion coefficient should be avalialbe from PhaseSpecies
+    // Will address in the issue: https://github.com/NCAR/micm/issues/845
+    try
+    {
+      diffusion_coefficient_ = parameters.species_.GetProperty<double>(property_keys::DIFFUSION_COEFFICIENT);
+    }
+    catch (const std::system_error& e)
+    {
+      if (e.code() == make_error_code(MicmSpeciesErrc::PropertyNotFound))
+      {
+        diffusion_coefficient_ = 1.0e-05;
+      }
+      else
+      {
+        throw;
+      }
+    }
   }
 
   inline std::unique_ptr<RateConstant> SurfaceRateConstant::Clone() const

--- a/include/micm/process/rate_constant/surface_rate_constant.hpp
+++ b/include/micm/process/rate_constant/surface_rate_constant.hpp
@@ -63,7 +63,9 @@ namespace micm
 
   inline SurfaceRateConstant::SurfaceRateConstant(const SurfaceRateConstantParameters& parameters)
       : parameters_(parameters),
-        diffusion_coefficient_(parameters.species_.GetProperty<double>(property_keys::GAS_DIFFUSION_COEFFICIENT)),
+        // TODO - Diffusion coefficient should be avalialbe from PhaseSpecies
+        // Will address in the issue: https://github.com/NCAR/micm/issues/845
+        diffusion_coefficient_(1.0),
         mean_free_speed_factor_(
             8.0 * constants::GAS_CONSTANT /
             (M_PI * parameters.species_.GetProperty<double>(property_keys::MOLECULAR_WEIGHT)))

--- a/include/micm/util/property_keys.hpp
+++ b/include/micm/util/property_keys.hpp
@@ -8,7 +8,7 @@ namespace micm
 {
   namespace property_keys
   {
-    static constexpr const char* GAS_DIFFUSION_COEFFICIENT = "diffusion coefficient [m2 s-1]";
+    static constexpr const char* DIFFUSION_COEFFICIENT = "diffusion coefficient [m2 s-1]";
     static constexpr const char* MOLECULAR_WEIGHT = "molecular weight [kg mol-1]";
   }  // namespace property_keys
 }  // namespace micm


### PR DESCRIPTION
This PR adds temporary workaround to read diffusion coefficients.
Some tests use manually created species with specified diffusion coefficients, which led to test failures. This will be addressed in the following issue. 
- #845
