### PR TITLE
Temporary fix for uncaught MICM Exceptions in MUSICA

### DIFF
--- a/include/micm/process/rate_constant/surface_rate_constant.hpp
+++ b/include/micm/process/rate_constant/surface_rate_constant.hpp
@@ -81,6 +81,7 @@ namespace micm
       }
       else
       {
+        std::cout << "musica error: " << e.what() << std::endl;
         throw;
       }
     }

--- a/include/micm/process/rate_constant/surface_rate_constant.hpp
+++ b/include/micm/process/rate_constant/surface_rate_constant.hpp
@@ -81,8 +81,10 @@ namespace micm
       }
       else
       {
-        std::cout << "musica error: " << e.what() << std::endl;
-        throw;
+        // TODO: MUSICA does not know the MICM error message, 
+        // causing it to fall back to the default 'else' condition.
+        // Issue: https://github.com/NCAR/micm/issues/848
+        diffusion_coefficient_ = 1.0e-05;
       }
     }
   }


### PR DESCRIPTION
MUSICA fails to catch certain exceptions thrown by MICM due to incompatible error handling.
This is a temporary fix. Will address the following issue:
- https://github.com/NCAR/micm/issues/848