### PR TITLE
Add PhaseSpecies class

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ int main(const int argc, const char *argv[])
   auto bar = Species{ "Bar" };
   auto baz = Species{ "Baz" };
 
-  Phase gas_phase{ std::vector<Species>{ foo, bar, baz } };
+  Phase gas_phase{ "gas", std::vector<PhaseSpecies>{ foo, bar, baz } };
 
   System chemical_system{ SystemParameters{ .gas_phase_ = gas_phase } };
 

--- a/include/micm/process/rate_constant/surface_rate_constant.hpp
+++ b/include/micm/process/rate_constant/surface_rate_constant.hpp
@@ -4,7 +4,7 @@
 
 #define _USE_MATH_DEFINES
 #include <micm/process/rate_constant/rate_constant.hpp>
-#include <micm/system/species.hpp>
+#include <micm/system/phase.hpp>
 #include <micm/util/constants.hpp>
 #include <micm/util/property_keys.hpp>
 
@@ -19,7 +19,7 @@ namespace micm
     /// @brief Label for the reaction used to identify user-defined parameters
     std::string label_;
     /// @brief Gas-phase species reacting on surface
-    Species species_;
+    PhaseSpecies phase_species_;
     /// @brief Reaction probability (0-1) [unitless]
     double reaction_probability_{ 1.0 };
   };
@@ -32,8 +32,9 @@ namespace micm
     double diffusion_coefficient_;   // [m2 s-1]
     double mean_free_speed_factor_;  // 8 * gas_constant / ( pi * molecular_weight )  [K-1]
 
-    /// @brief
-    /// @param parameters The data required to build this class
+    /// @brief Constructs a SurfaceRateConstant by initializing the diffusion coefficient 
+    ///        and mean free speed factor from the provided parameters
+    /// @throws std::system_error if required properties (diffusion coefficient or molecular weight) are missing
     SurfaceRateConstant(const SurfaceRateConstantParameters& parameters);
 
     /// @brief Deep copy
@@ -62,22 +63,28 @@ namespace micm
   };
 
   inline SurfaceRateConstant::SurfaceRateConstant(const SurfaceRateConstantParameters& parameters)
-      : parameters_(parameters),
-        mean_free_speed_factor_(
-            8.0 * constants::GAS_CONSTANT /
-            (M_PI * parameters.species_.GetProperty<double>(property_keys::MOLECULAR_WEIGHT)))
+      : parameters_(parameters)
   {
-    // TODO - Diffusion coefficient should be avalialbe from PhaseSpecies
-    // Will address in the issue: https://github.com/NCAR/micm/issues/845
+    if (parameters.phase_species_.diffusion_coefficient_.has_value())
+    {
+      diffusion_coefficient_ = parameters.phase_species_.diffusion_coefficient_.value();
+    }
+    else
+    {
+      throw std::system_error(make_error_code(MicmSpeciesErrc::PropertyNotFound), 
+          "Diffusion coefficient for species " + parameters.phase_species_.species_.name_ + " is not defined");
+    }
     try
     {
-      diffusion_coefficient_ = parameters.species_.GetProperty<double>(property_keys::DIFFUSION_COEFFICIENT);
+      double molecular_weight = parameters.phase_species_.species_.GetProperty<double>(property_keys::MOLECULAR_WEIGHT);
+      mean_free_speed_factor_ = 8.0 * constants::GAS_CONSTANT / (M_PI * molecular_weight);
     }
     catch (const std::system_error& e)
     {
       if (e.code() == make_error_code(MicmSpeciesErrc::PropertyNotFound))
       {
-        diffusion_coefficient_ = 1.0e-05;
+        throw std::system_error(make_error_code(MicmSpeciesErrc::PropertyNotFound), 
+          "Molecular weight for species " + parameters.phase_species_.species_.name_ + " is not defined");
       }
       else
       {

--- a/include/micm/process/rate_constant/surface_rate_constant.hpp
+++ b/include/micm/process/rate_constant/surface_rate_constant.hpp
@@ -72,7 +72,7 @@ namespace micm
     else
     {
       throw std::system_error(make_error_code(MicmSpeciesErrc::PropertyNotFound), 
-          "Diffusion coefficient for species " + parameters.phase_species_.species_.name_ + " is not defined");
+          "Diffusion coefficient for species '" + parameters.phase_species_.species_.name_ + "' is not defined");
     }
     try
     {
@@ -84,7 +84,7 @@ namespace micm
       if (e.code() == make_error_code(MicmSpeciesErrc::PropertyNotFound))
       {
         throw std::system_error(make_error_code(MicmSpeciesErrc::PropertyNotFound), 
-          "Molecular weight for species " + parameters.phase_species_.species_.name_ + " is not defined");
+          "Molecular weight for species '" + parameters.phase_species_.species_.name_ + "' is not defined");
       }
       else
       {

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -228,8 +228,9 @@ namespace micm
       SetAbsoluteTolerances(std::vector<double>& tolerances, const std::map<std::string, std::size_t>& species_map) const
   {
     tolerances = std::vector<double>(species_map.size(), 1e-3);
-    for (auto& species : system_.gas_phase_.species_)
+    for (auto& phase_species : system_.gas_phase_.phase_species_)
     {
+      auto& species = phase_species.species_;
       if (species.HasProperty("absolute tolerance"))
       {
         tolerances[species_map.at(species.name_)] = species.template GetProperty<double>("absolute tolerance");
@@ -237,8 +238,9 @@ namespace micm
     }
     for (auto& phase : system_.phases_)
     {
-      for (auto& species : phase.second.species_)
+      for (auto& phase_species : phase.second.phase_species_)
       {
+        auto& species = phase_species.species_;
         if (species.HasProperty("absolute tolerance"))
         {
           tolerances[species_map.at(species.name_)] = species.template GetProperty<double>("absolute tolerance");

--- a/include/micm/system/phase.hpp
+++ b/include/micm/system/phase.hpp
@@ -18,9 +18,18 @@ namespace micm
     Species species_;
     std::optional<double> diffusion_coefficient_;
 
-    PhaseSpecies(const Species& species, double diffusion)
-      : species_(species), diffusion_coefficient_(diffusion) 
+    PhaseSpecies(const Species& species)
+      : species_(species)
     {}
+
+    PhaseSpecies(const Species& species, double diffusion_coefficient)
+      : species_(species), diffusion_coefficient_(diffusion_coefficient) 
+    {}
+
+    void SetDiffusionCoefficient(double diffusion_coefficient)
+    {
+      diffusion_coefficient_ = diffusion_coefficient;
+    }
   };
 
   /// @brief Represents a chemical phase (e.g., gaseous, aqueous)
@@ -30,7 +39,7 @@ namespace micm
   {
    public:
     std::string name_;
-    /// @brief The list of species
+    /// @brief The list of phase-specific species
     std::vector<PhaseSpecies> phase_species_;
 
     /// @brief Defaulted constructors and assignment operators
@@ -39,13 +48,6 @@ namespace micm
     Phase(Phase&&) noexcept = default;
     Phase& operator=(const Phase&) = default;
     Phase& operator=(Phase&&) noexcept = default;
-
-    /// @brief Create a phase with a set of species
-    Phase(const std::vector<PhaseSpecies>& phase_species)
-        : name_(),
-          phase_species_(phase_species)
-    {
-    }
 
     /// @brief Create a phase with a name and a set of species
     Phase(const std::string& name, const std::vector<PhaseSpecies>& phase_species)

--- a/include/micm/system/phase.hpp
+++ b/include/micm/system/phase.hpp
@@ -10,6 +10,19 @@
 namespace micm
 {
 
+  /// @brief Represents a chemical species within a specific phase, 
+  ///        storing the species information and its optional diffusion coefficient
+  class PhaseSpecies
+  {
+  public:
+    Species species_;
+    std::optional<double> diffusion_coefficient_;
+
+    PhaseSpecies(const Species& species, double diffusion)
+      : species_(species), diffusion_coefficient_(diffusion) 
+    {}
+  };
+
   /// @brief Represents a chemical phase (e.g., gaseous, aqueous)
   ///        Each phase defines a set of species that participate in chemical
   ///        reactions within that phase.
@@ -18,7 +31,7 @@ namespace micm
    public:
     std::string name_;
     /// @brief The list of species
-    std::vector<Species> species_;
+    std::vector<PhaseSpecies> phase_species_;
 
     /// @brief Defaulted constructors and assignment operators
     Phase() = default;
@@ -28,32 +41,32 @@ namespace micm
     Phase& operator=(Phase&&) noexcept = default;
 
     /// @brief Create a phase with a set of species
-    Phase(const std::vector<Species>& species)
+    Phase(const std::vector<PhaseSpecies>& phase_species)
         : name_(),
-          species_(species)
+          phase_species_(phase_species)
     {
     }
 
     /// @brief Create a phase with a name and a set of species
-    Phase(const std::string& name, const std::vector<Species>& species)
+    Phase(const std::string& name, const std::vector<PhaseSpecies>& phase_species)
         : name_(name),
-          species_(species)
+          phase_species_(phase_species)
     {
     }
 
     /// @brief Returns the number of non-parameterized species
     std::size_t StateSize() const
     {
-      return std::count_if(species_.begin(), species_.end(), [](const Species& s) { return !s.IsParameterized(); });
+      return std::count_if(phase_species_.begin(), phase_species_.end(), [](const PhaseSpecies& ps) { return !ps.species_.IsParameterized(); });
     }
 
     /// @brief Returns a set of unique names for each non-parameterized species
     std::vector<std::string> UniqueNames() const
     {
       std::vector<std::string> names{};
-      for (const auto& species : species_)
-        if (!species.IsParameterized())
-          names.push_back(species.name_);
+      for (const auto& phase_species : phase_species_)
+        if (!phase_species.species_.IsParameterized())
+          names.push_back(phase_species.species_.name_);
       return names;
     }
   };

--- a/include/micm/system/phase.hpp
+++ b/include/micm/system/phase.hpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <optional>
 
 namespace micm
 {

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -2,10 +2,10 @@
 # Tests
 
 create_standard_test(NAME chapman_integration SOURCES test_chapman_integration.cpp)
-# create_standard_test(NAME analytical_rosenbrock_integration SOURCES test_analytical_rosenbrock.cpp)
-# create_standard_test(NAME analytical_backward_euler SOURCES test_analytical_backward_euler.cpp)
-# create_standard_test(NAME terminator SOURCES test_terminator.cpp)
-# create_standard_test(NAME integrated_reaction_rates SOURCES test_integrated_reaction_rates.cpp)
+create_standard_test(NAME analytical_rosenbrock_integration SOURCES test_analytical_rosenbrock.cpp)
+create_standard_test(NAME analytical_backward_euler SOURCES test_analytical_backward_euler.cpp)
+create_standard_test(NAME terminator SOURCES test_terminator.cpp)
+create_standard_test(NAME integrated_reaction_rates SOURCES test_integrated_reaction_rates.cpp)
 
 if(MICM_ENABLE_LLVM)
   add_subdirectory(jit)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -2,10 +2,10 @@
 # Tests
 
 create_standard_test(NAME chapman_integration SOURCES test_chapman_integration.cpp)
-create_standard_test(NAME analytical_rosenbrock_integration SOURCES test_analytical_rosenbrock.cpp)
-create_standard_test(NAME analytical_backward_euler SOURCES test_analytical_backward_euler.cpp)
-create_standard_test(NAME terminator SOURCES test_terminator.cpp)
-create_standard_test(NAME integrated_reaction_rates SOURCES test_integrated_reaction_rates.cpp)
+# create_standard_test(NAME analytical_rosenbrock_integration SOURCES test_analytical_rosenbrock.cpp)
+# create_standard_test(NAME analytical_backward_euler SOURCES test_analytical_backward_euler.cpp)
+# create_standard_test(NAME terminator SOURCES test_terminator.cpp)
+# create_standard_test(NAME integrated_reaction_rates SOURCES test_integrated_reaction_rates.cpp)
 
 if(MICM_ENABLE_LLVM)
   add_subdirectory(jit)

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -380,7 +380,7 @@ void test_analytical_troe(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })
@@ -453,7 +453,7 @@ void test_analytical_stiff_troe(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a1, a2, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a1 })
@@ -544,7 +544,7 @@ void test_analytical_photolysis(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })
@@ -609,7 +609,7 @@ void test_analytical_stiff_photolysis(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a1, a2, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a1 })
@@ -695,7 +695,7 @@ void test_analytical_ternary_chemical_activation(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })
@@ -768,7 +768,7 @@ void test_analytical_stiff_ternary_chemical_activation(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a1, a2, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a1 })
@@ -860,7 +860,7 @@ void test_analytical_tunneling(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })
@@ -922,7 +922,7 @@ void test_analytical_stiff_tunneling(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a1, a2, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a1 })
@@ -1001,7 +1001,7 @@ void test_analytical_arrhenius(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })
@@ -1064,7 +1064,7 @@ void test_analytical_stiff_arrhenius(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a1, a2, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a1 })
@@ -1145,7 +1145,7 @@ void test_analytical_branched(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 =
       micm::ChemicalReactionBuilder()
@@ -1235,7 +1235,7 @@ void test_analytical_stiff_branched(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a1, a2, b, c } };
 
   micm::Process r1 =
       micm::ChemicalReactionBuilder()
@@ -1354,7 +1354,7 @@ void test_analytical_robertson(
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })
@@ -1524,7 +1524,7 @@ void test_analytical_oregonator(
   auto P = micm::Species("P");
   auto Q = micm::Species("Q");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ X, Y, Z, P, Q } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ X, Y, Z, P, Q } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ Y })
@@ -1703,7 +1703,7 @@ void test_analytical_hires(
   auto y6 = micm::Species("Y6");
   auto y7 = micm::Species("Y7");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ y0, y1, y2, y3, y4, y5, y6, y7 } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ y0, y1, y2, y3, y4, y5, y6, y7 } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ y0 })
@@ -1909,7 +1909,7 @@ void test_analytical_e5(
   auto a5 = micm::Species("A5");
   auto a6 = micm::Species("A6");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a1, a2, a3, a4, a5, a6 } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a1, a2, a3, a4, a5, a6 } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a1 })

--- a/test/integration/analytical_surface_rxn_policy.hpp
+++ b/test/integration/analytical_surface_rxn_policy.hpp
@@ -44,7 +44,7 @@ void test_analytical_surface_rxn(
   micm::Species baz("baz");
 
   // Phase
-  micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar, baz } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ foo, bar, baz } };
 
   // System
   micm::System chemical_system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });

--- a/test/integration/analytical_surface_rxn_policy.hpp
+++ b/test/integration/analytical_surface_rxn_policy.hpp
@@ -39,18 +39,21 @@ void test_analytical_surface_rxn(
                        (M_PI * std::pow(mode_GMD, 3.0) * std::exp(9.0 / 2.0 * std::log(mode_GSD) * std::log(mode_GSD))) *
                        (conc_stuff / DENSITY_stuff + conc_more_stuff / DENSITY_more_stuff);
 
-  micm::Species foo("foo", { { "molecular weight [kg mol-1]", MW_foo }, { "diffusion coefficient [m2 s-1]", Dg_foo } });
+  micm::Species foo("foo", { { "molecular weight [kg mol-1]", MW_foo } });
   micm::Species bar("bar");
   micm::Species baz("baz");
+  micm::PhaseSpecies gas_foo(foo, Dg_foo);
+  micm::PhaseSpecies gas_bar(bar);
+  micm::PhaseSpecies gas_baz(baz);
 
   // Phase
-  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ foo, bar, baz } };
+  micm::Phase gas_phase{ "gas", { gas_foo, gas_bar, gas_baz } };
 
   // System
   micm::System chemical_system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });
 
   // Rate
-  micm::SurfaceRateConstant surface{ { .label_ = "foo", .species_ = foo, .reaction_probability_ = rxn_gamma } };
+  micm::SurfaceRateConstant surface{ { .label_ = "foo", .phase_species_ = gas_foo, .reaction_probability_ = rxn_gamma } };
 
   // Process
   micm::Process surface_process = micm::ChemicalReactionBuilder()

--- a/test/integration/terminator.hpp
+++ b/test/integration/terminator.hpp
@@ -22,7 +22,7 @@ void TestTerminator(BuilderPolicy& builder, std::size_t number_of_grid_cells)
   cl.SetProperty("absolute tolerance", 1.0e-20);
   cl2.SetProperty("absolute tolerance", 1.0e-20);
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ cl2, cl } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ cl2, cl } };
 
   micm::Process toy_r1 = micm::ChemicalReactionBuilder()
                              .SetReactants({ cl2 })

--- a/test/integration/test_chapman_integration.cpp
+++ b/test/integration/test_chapman_integration.cpp
@@ -19,7 +19,7 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
   auto h2o = micm::Species("H2O");
   auto co2 = micm::Species("CO2");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ o, o1d, o2, o3, m, ar, n2, h2o, co2 } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ o, o1d, o2, o3, m, ar, n2, h2o, co2 } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ o1d, n2 })

--- a/test/integration/test_integrated_reaction_rates.cpp
+++ b/test/integration/test_integrated_reaction_rates.cpp
@@ -15,7 +15,7 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
   auto irr_1 = micm::Species("irr_1");
   auto irr_2 = micm::Species("irr_2");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c, irr_1, irr_2 } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c, irr_1, irr_2 } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })

--- a/test/regression/RosenbrockChapman/util.hpp
+++ b/test/regression/RosenbrockChapman/util.hpp
@@ -19,7 +19,7 @@ micm::Phase createGasPhase()
   auto h2o = micm::Species("H2O");
   auto co2 = micm::Species("CO2");
 
-  return micm::Phase{ std::vector<micm::Species>{ m, ar, co2, h2o, n2, o1d, o, o2, o3 } };
+  return micm::Phase{ "gas", std::vector<micm::PhaseSpecies>{ m, ar, co2, h2o, n2, o1d, o, o2, o3 } };
 }
 
 std::vector<micm::Process> createProcesses(const micm::Phase& gas_phase)

--- a/test/regression/regression_policy.hpp
+++ b/test/regression/regression_policy.hpp
@@ -124,7 +124,7 @@ void test_flow_tube(
 
   double MOLES_M3_TO_MOLECULES_CM3 = 1.0e-6 * 6.02214076e23;
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ soa1, soa2, apinene, o3 } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ soa1, soa2, apinene, o3 } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ soa1 })

--- a/test/tutorial/test_README_example.cpp
+++ b/test/tutorial/test_README_example.cpp
@@ -11,7 +11,7 @@ int main(const int argc, const char *argv[])
   auto bar = Species{ "Bar" };
   auto baz = Species{ "Baz" };
 
-  Phase gas_phase{ std::vector<Species>{ foo, bar, baz } };
+  Phase gas_phase{ "gas", std::vector<PhaseSpecies>{ foo, bar, baz } };
 
   System chemical_system{ SystemParameters{ .gas_phase_ = gas_phase } };
 

--- a/test/tutorial/test_jit_tutorial.cpp
+++ b/test/tutorial/test_jit_tutorial.cpp
@@ -69,7 +69,7 @@ int main(const int argc, const char* argv[])
   auto bar = Species{ "Bar" };
   auto baz = Species{ "Baz" };
 
-  Phase gas_phase{ std::vector<Species>{ foo, bar, baz } };
+  Phase gas_phase{ "gas", std::vector<PhaseSpecies>{ foo, bar, baz } };
 
   System chemical_system{ SystemParameters{ .gas_phase_ = gas_phase } };
 

--- a/test/tutorial/test_multiple_grid_cells.cpp
+++ b/test/tutorial/test_multiple_grid_cells.cpp
@@ -12,7 +12,7 @@ int main()
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })

--- a/test/tutorial/test_openmp.cpp
+++ b/test/tutorial/test_openmp.cpp
@@ -69,7 +69,7 @@ int main()
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })

--- a/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
@@ -32,7 +32,7 @@ int main(const int argc, const char* argv[])
   if (it == phase_species_list.end())
   {
     std::cout << "Species not found\n";
-    return 1;
+    return 1; // Failure
   }
 
   double c_diffusion_coefficient = 2.3e2;

--- a/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
@@ -17,14 +17,27 @@ int main(const int argc, const char* argv[])
   auto b = Species("B");
   auto c = Species(
       "C",
-      std::map<std::string, double>{ { "molecular weight [kg mol-1]", 0.025 },
-                                     { "diffusion coefficient [m2 s-1]", 2.3e2 } });
+      std::map<std::string, double>{ { "molecular weight [kg mol-1]", 0.025 }});
   auto d = Species("D");
   auto e = Species("E");
   auto f = Species("F");
   auto g = Species("G");
+  Phase gas_phase{ "gas", std::vector<PhaseSpecies>{ a, b, c, d, e, f, g } };
 
-  Phase gas_phase{ std::vector<Species>{ a, b, c, d, e, f, g } };
+  auto& phase_species_list = gas_phase.phase_species_;
+  auto it = std::find_if(phase_species_list.begin(), phase_species_list.end(),
+    [&c](const PhaseSpecies& ps) {
+      return ps.species_.name_ == c.name_; });
+
+  if (it == phase_species_list.end())
+  {
+    std::cout << "Species not found\n";
+    return 1;
+  }
+
+  double c_diffusion_coefficient = 2.3e2;
+  size_t surface_c_index = std::distance(phase_species_list.begin(), it);
+  phase_species_list[surface_c_index].SetDiffusionCoefficient(c_diffusion_coefficient);
 
   Process r1 = ChemicalReactionBuilder()
                    .SetReactants({ a })
@@ -58,7 +71,7 @@ int main(const int argc, const char* argv[])
   Process r4 = ChemicalReactionBuilder()
                    .SetReactants({ c })
                    .SetProducts({ Yield(e, 1) })
-                   .SetRateConstant(SurfaceRateConstant({ .label_ = "C", .species_ = c, .reaction_probability_ = 0.90 }))
+                   .SetRateConstant(SurfaceRateConstant({ .label_ = "C", .phase_species_ = phase_species_list[surface_c_index], .reaction_probability_ = 0.90 }))
                    .SetPhase(gas_phase)
                    .Build();
 

--- a/test/tutorial/test_rate_constants_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_user_defined_by_hand.cpp
@@ -32,7 +32,7 @@ int main(const int argc, const char* argv[])
   if (it == phase_species_list.end())
   {
     std::cout << "Species not found\n";
-    return 1;
+    return 1; // Failure
   }
 
   double c_diffusion_coefficient = 2.3e2;

--- a/test/tutorial/test_rate_constants_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_user_defined_by_hand.cpp
@@ -17,14 +17,27 @@ int main(const int argc, const char* argv[])
   auto b = Species("B");
   auto c = Species(
       "C",
-      std::map<std::string, double>{ { "molecular weight [kg mol-1]", 0.025 },
-                                     { "diffusion coefficient [m2 s-1]", 2.3e2 } });
+      std::map<std::string, double>{ { "molecular weight [kg mol-1]", 0.025 }});
   auto d = Species("D");
   auto e = Species("E");
   auto f = Species("F");
   auto g = Species("G");
+  Phase gas_phase{ "gas", std::vector<PhaseSpecies>{ a, b, c, d, e, f, g } };
 
-  Phase gas_phase{ std::vector<Species>{ a, b, c, d, e, f, g } };
+  auto& phase_species_list = gas_phase.phase_species_;
+  auto it = std::find_if(phase_species_list.begin(), phase_species_list.end(),
+    [&c](const PhaseSpecies& ps) {
+      return ps.species_.name_ == c.name_; });
+
+  if (it == phase_species_list.end())
+  {
+    std::cout << "Species not found\n";
+    return 1;
+  }
+
+  double c_diffusion_coefficient = 2.3e2;
+  size_t surface_c_index = std::distance(phase_species_list.begin(), it);
+  phase_species_list[surface_c_index].SetDiffusionCoefficient(c_diffusion_coefficient);
 
   Process r1 = ChemicalReactionBuilder()
                    .SetReactants({ a })
@@ -58,7 +71,7 @@ int main(const int argc, const char* argv[])
   Process r4 = ChemicalReactionBuilder()
                    .SetReactants({ c })
                    .SetProducts({ Yield(e, 1) })
-                   .SetRateConstant(SurfaceRateConstant({ .label_ = "C", .species_ = c, .reaction_probability_ = 0.90 }))
+                   .SetRateConstant(SurfaceRateConstant({ .label_ = "C", .phase_species_ = phase_species_list[surface_c_index], .reaction_probability_ = 0.90 }))
                    .SetPhase(gas_phase)
                    .Build();
 

--- a/test/tutorial/test_solver_configuration.cpp
+++ b/test/tutorial/test_solver_configuration.cpp
@@ -85,7 +85,7 @@ int main()
   auto b = Species("B");
   auto c = Species("C");
 
-  Phase gas_phase{ std::vector<Species>{ a, b, c } };
+  Phase gas_phase{ "gas", std::vector<PhaseSpecies>{ a, b, c } };
 
   Process r1 = ChemicalReactionBuilder()
                    .SetReactants({ a })

--- a/test/tutorial/test_solver_results.cpp
+++ b/test/tutorial/test_solver_results.cpp
@@ -13,7 +13,7 @@ int main()
   auto b = Species("B");
   auto c = Species("C");
 
-  Phase gas_phase{ std::vector<Species>{ a, b, c } };
+  Phase gas_phase{ "gas", std::vector<PhaseSpecies>{ a, b, c } };
 
   Process r1 = ChemicalReactionBuilder()
                    .SetReactants({ a })

--- a/test/tutorial/test_vectorized_matrix_solver.cpp
+++ b/test/tutorial/test_vectorized_matrix_solver.cpp
@@ -53,7 +53,7 @@ int main()
   auto b = Species("B");
   auto c = Species("C");
 
-  Phase gas_phase{ std::vector<Species>{ a, b, c } };
+  Phase gas_phase{ "gas", std::vector<PhaseSpecies>{ a, b, c } };
 
   Process r1 = ChemicalReactionBuilder()
                    .SetReactants({ a })

--- a/test/unit/cuda/solver/test_cuda_solver_builder.cpp
+++ b/test/unit/cuda/solver/test_cuda_solver_builder.cpp
@@ -17,7 +17,7 @@ namespace
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })

--- a/test/unit/jit/process/test_jit_forcing_calculation.cpp
+++ b/test/unit/jit/process/test_jit_forcing_calculation.cpp
@@ -31,7 +31,7 @@ TEST(JitProcessSet, ForcingFunction)
   auto e = micm::Species("E");
   auto f = micm::Species("F");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c, d, e, f } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c, d, e, f } };
   micm::ArrheniusRateConstant arrhenius_rate_constant({ .A_ = 12.2, .C_ = 300.0 });
 
   micm::State<ForcingTestVectorMatrix, ForcingTestSparseVectorMatrix> state(

--- a/test/unit/jit/solver/test_jit_rosenbrock.cpp
+++ b/test/unit/jit/solver/test_jit_rosenbrock.cpp
@@ -56,7 +56,7 @@ TEST(JitRosenbrockSolver, MultipleInstances)
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })

--- a/test/unit/jit/solver/test_jit_solver_builder.cpp
+++ b/test/unit/jit/solver/test_jit_solver_builder.cpp
@@ -22,7 +22,7 @@ namespace
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })

--- a/test/unit/openmp/test_openmp.cpp
+++ b/test/unit/openmp/test_openmp.cpp
@@ -18,7 +18,7 @@ TEST(OpenMP, OneSolverManyStates)
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })

--- a/test/unit/openmp/test_openmp_jit_solver.cpp
+++ b/test/unit/openmp/test_openmp_jit_solver.cpp
@@ -24,7 +24,7 @@ TEST(OpenMP, JITOneSolverManyStates)
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })

--- a/test/unit/process/rate_constant/test_surface_rate_constant.cpp
+++ b/test/unit/process/rate_constant/test_surface_rate_constant.cpp
@@ -4,24 +4,33 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+
 constexpr double TOLERANCE = 1e-13;
 
 TEST(SurfaceRateConstant, CalculateDefaultProbability)
 {
-  micm::Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }, { "diffusion coefficient [m2 s-1]", 2.3e2 } });
+  micm::Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }});
+  double foo_diffusion_coefficient = 2.3e2;
+  micm::PhaseSpecies foo_gas_species(foo, foo_diffusion_coefficient);
 
   auto state_parameters_ = micm::StateParameters{
     .number_of_rate_constants_ = 1,
     .variable_names_ = { "surface" },
     .custom_rate_parameter_labels_ = { "effective radius [m]", "particle number concentration [# m-3]" },
   };
-
   micm::State state{ state_parameters_, 1 };
   state.custom_rate_parameters_[0][0] = 1.0e-7;  // effective radius [m]
   state.custom_rate_parameters_[0][1] = 2.5e6;   // particle concentration [# m-3]
   state.conditions_[0].temperature_ = 273.65;    // K
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
-  micm::SurfaceRateConstant surface{ { .label_ = "foo", .species_ = foo } };
+
+  micm::SurfaceRateConstantParameters parameters{
+    .label_ = "foo",
+    .phase_species_ = foo_gas_species
+  };
+  micm::SurfaceRateConstant surface(parameters);
+
   EXPECT_EQ(surface.SizeCustomParameters(), 2);
   EXPECT_EQ(surface.CustomParameters()[0], "foo.effective radius [m]");
   EXPECT_EQ(surface.CustomParameters()[1], "foo.particle number concentration [# m-3]");
@@ -33,19 +42,27 @@ TEST(SurfaceRateConstant, CalculateDefaultProbability)
 
 TEST(SurfaceRateConstant, CalculateSpecifiedProbability)
 {
-  micm::Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }, { "diffusion coefficient [m2 s-1]", 2.3e2 } });
+  micm::Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }});
+  double foo_diffusion_coefficient = 2.3e2;
+  micm::PhaseSpecies foo_gas_species(foo, foo_diffusion_coefficient);
+
   auto state_parameters_ = micm::StateParameters{
     .number_of_rate_constants_ = 1,
     .variable_names_ = { "surface" },
     .custom_rate_parameter_labels_ = { "effective radius [m]", "particle number concentration [# m-3]" },
   };
-
   micm::State state{ state_parameters_, 1 };
   state.custom_rate_parameters_[0][0] = 1.0e-7;  // effective radius [m]
   state.custom_rate_parameters_[0][1] = 2.5e6;   // particle concentration [# m-3]
   state.conditions_[0].temperature_ = 273.65;    // K
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
-  micm::SurfaceRateConstant surface{ { .label_ = "foo", .species_ = foo, .reaction_probability_ = 0.74 } };
+  micm::SurfaceRateConstantParameters parameters{
+    .label_ = "foo",
+    .phase_species_ = foo_gas_species,
+    .reaction_probability_ = 0.74
+  };
+  micm::SurfaceRateConstant surface(parameters);
+
   EXPECT_EQ(surface.SizeCustomParameters(), 2);
   EXPECT_EQ(surface.CustomParameters()[0], "foo.effective radius [m]");
   EXPECT_EQ(surface.CustomParameters()[1], "foo.particle number concentration [# m-3]");
@@ -55,3 +72,5 @@ TEST(SurfaceRateConstant, CalculateSpecifiedProbability)
       (1.0e-7 / 2.3e2 + 4.0 / (std::sqrt(8.0 * micm::constants::GAS_CONSTANT * 273.65 / (M_PI * 0.025)) * 0.74));
   EXPECT_NEAR(k, expected, TOLERANCE * expected);
 }
+
+// TODO - Add test for failure case

--- a/test/unit/process/rate_constant/test_surface_rate_constant.cpp
+++ b/test/unit/process/rate_constant/test_surface_rate_constant.cpp
@@ -6,62 +6,64 @@
 
 #include <memory>
 
+using namespace micm;
+
 constexpr double TOLERANCE = 1e-13;
 
 TEST(SurfaceRateConstant, CalculateDefaultProbability)
 {
-  micm::Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }});
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }});
   double foo_diffusion_coefficient = 2.3e2;
-  micm::PhaseSpecies foo_gas_species(foo, foo_diffusion_coefficient);
+  PhaseSpecies foo_gas_species(foo, foo_diffusion_coefficient);
 
-  auto state_parameters_ = micm::StateParameters{
+  auto state_parameters_ = StateParameters{
     .number_of_rate_constants_ = 1,
     .variable_names_ = { "surface" },
     .custom_rate_parameter_labels_ = { "effective radius [m]", "particle number concentration [# m-3]" },
   };
-  micm::State state{ state_parameters_, 1 };
+  State state{ state_parameters_, 1 };
   state.custom_rate_parameters_[0][0] = 1.0e-7;  // effective radius [m]
   state.custom_rate_parameters_[0][1] = 2.5e6;   // particle concentration [# m-3]
   state.conditions_[0].temperature_ = 273.65;    // K
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
 
-  micm::SurfaceRateConstantParameters parameters{
+  SurfaceRateConstantParameters parameters{
     .label_ = "foo",
     .phase_species_ = foo_gas_species
   };
-  micm::SurfaceRateConstant surface(parameters);
+  SurfaceRateConstant surface(parameters);
 
   EXPECT_EQ(surface.SizeCustomParameters(), 2);
   EXPECT_EQ(surface.CustomParameters()[0], "foo.effective radius [m]");
   EXPECT_EQ(surface.CustomParameters()[1], "foo.particle number concentration [# m-3]");
   auto k = surface.Calculate(state.conditions_[0], params);
   double expected = 4.0 * 2.5e6 * M_PI * std::pow(1.0e-7, 2) /
-                    (1.0e-7 / 2.3e2 + 4.0 / (std::sqrt(8.0 * micm::constants::GAS_CONSTANT * 273.65 / (M_PI * 0.025))));
+                    (1.0e-7 / 2.3e2 + 4.0 / (std::sqrt(8.0 * constants::GAS_CONSTANT * 273.65 / (M_PI * 0.025))));
   EXPECT_NEAR(k, expected, TOLERANCE * expected);
 }
 
 TEST(SurfaceRateConstant, CalculateSpecifiedProbability)
 {
-  micm::Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }});
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }});
   double foo_diffusion_coefficient = 2.3e2;
-  micm::PhaseSpecies foo_gas_species(foo, foo_diffusion_coefficient);
+  PhaseSpecies foo_gas_species(foo, foo_diffusion_coefficient);
 
-  auto state_parameters_ = micm::StateParameters{
+  auto state_parameters_ = StateParameters{
     .number_of_rate_constants_ = 1,
     .variable_names_ = { "surface" },
     .custom_rate_parameter_labels_ = { "effective radius [m]", "particle number concentration [# m-3]" },
   };
-  micm::State state{ state_parameters_, 1 };
+  State state{ state_parameters_, 1 };
   state.custom_rate_parameters_[0][0] = 1.0e-7;  // effective radius [m]
   state.custom_rate_parameters_[0][1] = 2.5e6;   // particle concentration [# m-3]
   state.conditions_[0].temperature_ = 273.65;    // K
   std::vector<double>::const_iterator params = state.custom_rate_parameters_[0].begin();
-  micm::SurfaceRateConstantParameters parameters{
+  SurfaceRateConstantParameters parameters{
     .label_ = "foo",
     .phase_species_ = foo_gas_species,
     .reaction_probability_ = 0.74
   };
-  micm::SurfaceRateConstant surface(parameters);
+  SurfaceRateConstant surface(parameters);
 
   EXPECT_EQ(surface.SizeCustomParameters(), 2);
   EXPECT_EQ(surface.CustomParameters()[0], "foo.effective radius [m]");
@@ -69,8 +71,51 @@ TEST(SurfaceRateConstant, CalculateSpecifiedProbability)
   auto k = surface.Calculate(state.conditions_[0], params);
   double expected =
       4.0 * 2.5e6 * M_PI * std::pow(1.0e-7, 2) /
-      (1.0e-7 / 2.3e2 + 4.0 / (std::sqrt(8.0 * micm::constants::GAS_CONSTANT * 273.65 / (M_PI * 0.025)) * 0.74));
+      (1.0e-7 / 2.3e2 + 4.0 / (std::sqrt(8.0 * constants::GAS_CONSTANT * 273.65 / (M_PI * 0.025)) * 0.74));
   EXPECT_NEAR(k, expected, TOLERANCE * expected);
 }
 
-// TODO - Add test for failure case
+TEST(SurfaceRateConstant, DiffusionCoefficientIsMissing)
+{
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 }});
+  PhaseSpecies foo_gas_species(foo);
+  SurfaceRateConstantParameters parameters{
+    .label_ = "foo",
+    .phase_species_ = foo_gas_species
+  };
+
+  try
+  {
+    SurfaceRateConstant surface_rate_constant(parameters);
+  }
+  catch (const std::system_error& e)
+  {
+    EXPECT_EQ(e.code(), make_error_code(MicmSpeciesErrc::PropertyNotFound));
+    EXPECT_NE(std::string(e.what()).find("Diffusion coefficient for species 'foo' is not defined"), std::string::npos);
+    return;
+  }
+  FAIL() << "Expected std::system_error to be thrown";
+}
+
+TEST(SurfaceRateConstant, MolecularWeightIsMissing)
+{
+  Species foo("foo");
+  double foo_diffusion_coefficient = 2.3e2;
+  PhaseSpecies foo_gas_species(foo, foo_diffusion_coefficient);
+  SurfaceRateConstantParameters parameters{
+    .label_ = "foo",
+    .phase_species_ = foo_gas_species
+  };
+
+  try
+  {
+    SurfaceRateConstant surface_rate_constant(parameters);
+  }
+  catch (const std::system_error& e)
+  {
+    EXPECT_EQ(e.code(), make_error_code(MicmSpeciesErrc::PropertyNotFound));
+    EXPECT_NE(std::string(e.what()).find("Molecular weight for species 'foo' is not defined"), std::string::npos);
+    return;
+  }
+  FAIL() << "Expected std::system_error to be thrown";
+}

--- a/test/unit/solver/test_backward_euler.cpp
+++ b/test/unit/solver/test_backward_euler.cpp
@@ -19,7 +19,7 @@ namespace
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })

--- a/test/unit/solver/test_rosenbrock.cpp
+++ b/test/unit/solver/test_rosenbrock.cpp
@@ -90,7 +90,7 @@ TEST(RosenbrockSolver, CanSetTolerances)
   foo.SetProperty("absolute tolerance", 1.0e-07);
   bar.SetProperty("absolute tolerance", 1.0e-08);
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ foo, bar } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ foo })

--- a/test/unit/solver/test_rosenbrock_solver_policy.hpp
+++ b/test/unit/solver/test_rosenbrock_solver_policy.hpp
@@ -28,7 +28,7 @@ SolverBuilderPolicy getSolver(SolverBuilderPolicy builder)
   auto quz = micm::Species("quz");
   auto quuz = micm::Species("quuz");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ foo, bar, baz, quz, quuz } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ foo, bar, baz, quz, quuz } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ foo, baz })

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -24,7 +24,7 @@ namespace
   auto b = micm::Species("B");
   auto c = micm::Species("C");
 
-  micm::Phase gas_phase{ std::vector<micm::Species>{ a, b, c } };
+  micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
   micm::Process r1 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a })
@@ -83,7 +83,7 @@ TEST(SolverBuilder, CanBuildBackwardEuler)
           .SetReactions(reactions)
           .Build();
   EXPECT_EQ(backward_euler_vector.GetSystem().gas_phase_.name_, the_system.gas_phase_.name_);
-  EXPECT_EQ(backward_euler_vector.GetSystem().gas_phase_.species_.size(), the_system.gas_phase_.species_.size());
+  EXPECT_EQ(backward_euler_vector.GetSystem().gas_phase_.phase_species_.size(), the_system.gas_phase_.phase_species_.size());
   EXPECT_EQ(backward_euler_vector.GetSystem().phases_.size(), the_system.phases_.size());
   EXPECT_GT(backward_euler.MaximumNumberOfGridCells(), 1e8);
   EXPECT_EQ(backward_euler_vector.MaximumNumberOfGridCells(), 4);
@@ -108,7 +108,7 @@ TEST(SolverBuilder, CanBuildRosenbrock)
                                .Build();
 
   EXPECT_EQ(rosenbrock_vector.GetSystem().gas_phase_.name_, the_system.gas_phase_.name_);
-  EXPECT_EQ(rosenbrock_vector.GetSystem().gas_phase_.species_.size(), the_system.gas_phase_.species_.size());
+  EXPECT_EQ(rosenbrock_vector.GetSystem().gas_phase_.phase_species_.size(), the_system.gas_phase_.phase_species_.size());
   EXPECT_EQ(rosenbrock_vector.GetSystem().phases_.size(), the_system.phases_.size());
   EXPECT_GT(rosenbrock.MaximumNumberOfGridCells(), 1e8);
   EXPECT_EQ(rosenbrock_vector.MaximumNumberOfGridCells(), 4);

--- a/test/unit/system/test_phase.cpp
+++ b/test/unit/system/test_phase.cpp
@@ -3,11 +3,46 @@
 
 #include <gtest/gtest.h>
 
-TEST(Phase, ConstructorWithVector)
-{
-  micm::Phase phase(std::vector<micm::Species>({ micm::Species("species1"), micm::Species("species2") }));
+using namespace micm;
 
-  EXPECT_EQ(phase.species_.size(), 2);
+TEST(PhaseSpecies, ConstructsWithoutDiffusionCoefficient)
+{
+  Species CO2("CO2");
+  PhaseSpecies gas_CO2(CO2);
+  EXPECT_EQ(gas_CO2.species_.name_, "CO2");
+  EXPECT_FALSE(gas_CO2.diffusion_coefficient_.has_value());
+}
+
+TEST(PhaseSpecies, ConstructsWithDiffusionCoefficient)
+{
+  Species CO2("CO2");
+  double diff_coeff = 1.23e-5;
+  PhaseSpecies gas_CO2(CO2, diff_coeff);
+  EXPECT_EQ(gas_CO2.species_.name_, "CO2");
+  ASSERT_TRUE(gas_CO2.diffusion_coefficient_.has_value());
+  EXPECT_DOUBLE_EQ(gas_CO2.diffusion_coefficient_.value(), diff_coeff);
+}
+
+TEST(PhaseSpecies, SetDiffusionCoefficient)
+{
+  Species CO2("CO2");
+  PhaseSpecies gas_CO2(CO2);
+  EXPECT_FALSE(gas_CO2.diffusion_coefficient_.has_value());
+
+  double diff_coeff = 2.5e-6;
+  gas_CO2.SetDiffusionCoefficient(diff_coeff);
+  ASSERT_TRUE(gas_CO2.diffusion_coefficient_.has_value());
+  EXPECT_DOUBLE_EQ(gas_CO2.diffusion_coefficient_.value(), diff_coeff);
+}
+
+TEST(Phase, Constructor)
+{
+  Phase phase("test_phase",
+        std::vector<PhaseSpecies>({
+        PhaseSpecies(Species("species1")),
+        PhaseSpecies(Species("species2"))}));
+  EXPECT_EQ(phase.name_, "test_phase");
+  EXPECT_EQ(phase.phase_species_.size(), 2);
   EXPECT_EQ(phase.StateSize(), 2);
 
   auto names = phase.UniqueNames();
@@ -17,55 +52,31 @@ TEST(Phase, ConstructorWithVector)
 
 TEST(Phase, ConstructorWithParameterizedSpecies)
 {
-  auto foo = micm::Species("foo");
-  auto bar = micm::Species("bar");
-  auto baz = micm::Species("baz");
+  Species foo("foo");
+  Species bar("bar");
+  Species baz("baz");
+  PhaseSpecies gas_foo(foo);
+  PhaseSpecies gas_bar(bar);
+  PhaseSpecies gas_baz(baz);
 
-  bar.parameterize_ = [](const micm::Conditions& c) { return 42.0; };
-  micm::Phase phase(std::vector<micm::Species>({ foo, bar, baz }));
+  gas_bar.species_.parameterize_ = [](const Conditions& c) { return 42.0; };
+  Phase phase("gas", std::vector<PhaseSpecies>({ gas_foo, gas_bar, gas_baz }));
 
-  EXPECT_EQ(phase.species_.size(), 3);
-  EXPECT_EQ(phase.StateSize(), 2);
-
-  auto names = phase.UniqueNames();
-  EXPECT_EQ(names[0], "foo");
-  EXPECT_EQ(names[1], "baz");
-}
-
-TEST(Phase, ConstructorWithNameAndVector)
-{
-  micm::Phase phase("test_phase", std::vector<micm::Species>({ micm::Species("species1"), micm::Species("species2") }));
-
-  EXPECT_EQ(phase.name_, "test_phase");
-  EXPECT_EQ(phase.species_.size(), 2);
-  EXPECT_EQ(phase.StateSize(), 2);
-
-  auto names = phase.UniqueNames();
-  EXPECT_EQ(names[0], "species1");
-  EXPECT_EQ(names[1], "species2");
-}
-
-TEST(Phase, StateSizeWithParameterizedSpecies)
-{
-  auto foo = micm::Species("foo");
-  auto bar = micm::Species("bar");
-  auto baz = micm::Species("baz");
-
-  bar.parameterize_ = [](const micm::Conditions& c) { return 42.0; };
-  micm::Phase phase(std::vector<micm::Species>({ foo, bar, baz }));
-
-  EXPECT_EQ(phase.species_.size(), 3);
+  EXPECT_EQ(phase.phase_species_.size(), 3);
   EXPECT_EQ(phase.StateSize(), 2);
 }
 
 TEST(Phase, UniqueNamesWithParameterizedSpecies)
 {
-  auto foo = micm::Species("foo");
-  auto bar = micm::Species("bar");
-  auto baz = micm::Species("baz");
+  Species foo("foo");
+  Species bar("bar");
+  Species baz("baz");
+  PhaseSpecies gas_foo(foo);
+  PhaseSpecies gas_bar(bar);
+  PhaseSpecies gas_baz(baz);
 
-  bar.parameterize_ = [](const micm::Conditions& c) { return 42.0; };
-  micm::Phase phase(std::vector<micm::Species>({ foo, bar, baz }));
+  gas_bar.species_.parameterize_ = [](const Conditions& c) { return 42.0; };
+  Phase phase("gas", std::vector<PhaseSpecies>({ gas_foo, gas_bar, gas_baz }));
 
   auto names = phase.UniqueNames();
   EXPECT_EQ(names.size(), 2);

--- a/test/unit/system/test_system.cpp
+++ b/test/unit/system/test_system.cpp
@@ -1,71 +1,90 @@
 #include <micm/system/species.hpp>
+#include <micm/system/phase.hpp>
 #include <micm/system/system.hpp>
 
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <set>
+
+using namespace micm;
 
 TEST(System, ConstructorWithAllParameters)
 {
-  std::vector<micm::Species> speciesA = { micm::Species("species1"), micm::Species("species2") };
-  std::vector<micm::Species> speciesB = { micm::Species("species3"), micm::Species("species4") };
+  Species foo("foo");
+  Species bar("bar");
+  Species baz("baz");
+  Species quiz("quiz");
+  PhaseSpecies gas_foo(foo);
+  PhaseSpecies gas_bar(bar);
+  PhaseSpecies organic_foo(foo);
+  PhaseSpecies organic_bar(bar);
+  PhaseSpecies aqueous_baz(baz);
+  PhaseSpecies aqueous_quiz(quiz);
 
-  micm::Phase phase = speciesA;
-  std::unordered_map<std::string, micm::Phase> phases = { { "phase1", speciesA }, { "phase2", speciesB } };
+  Phase gas_phase("gas", std::vector<PhaseSpecies>({ gas_foo, gas_bar }));
+  Phase organic_phase("organic", std::vector<PhaseSpecies>({ organic_foo, organic_bar }));
+  Phase aqueous_phase("aqueous", std::vector<PhaseSpecies>({ aqueous_baz, aqueous_quiz }));
+  std::unordered_map<std::string, Phase> phases = { { "organic", organic_phase }, { "aqueous", aqueous_phase }, };
+  System system = { SystemParameters{
+     .gas_phase_ = gas_phase,
+     .phases_ = phases } };
 
-  micm::System system = { micm::SystemParameters{ .gas_phase_ = phase, .phases_ = phases } };
-
-  EXPECT_EQ(system.gas_phase_.species_.size(), 2);
+  EXPECT_EQ(system.gas_phase_.phase_species_.size(), 2);
   EXPECT_EQ(system.phases_.size(), 2);
+  EXPECT_EQ(system.phases_["organic"].phase_species_.size(), 2);
+  EXPECT_EQ(system.phases_["aqueous"].phase_species_.size(), 2);
 
   auto names = system.UniqueNames();
+  std::vector<std::string> expected = {
+    "foo", "bar", "organic.foo", "organic.bar", "aqueous.baz", "aqueous.quiz" };
+  std::multiset<std::string> name_set(names.begin(), names.end());
+  std::multiset<std::string> expected_set(expected.begin(), expected.end());
 
-  EXPECT_EQ(names.size(), 6);
-  EXPECT_NE(std::find(names.begin(), names.end(), "species1"), names.end());
-  EXPECT_NE(std::find(names.begin(), names.end(), "species2"), names.end());
-  EXPECT_NE(std::find(names.begin(), names.end(), "phase1.species1"), names.end());
-  EXPECT_NE(std::find(names.begin(), names.end(), "phase1.species2"), names.end());
-  EXPECT_NE(std::find(names.begin(), names.end(), "phase2.species3"), names.end());
-  EXPECT_NE(std::find(names.begin(), names.end(), "phase2.species4"), names.end());
-
-  std::vector<int> reorder{ 3, 2, 1, 0, 5, 4 };
-  auto reordered_names = system.UniqueNames([&](const std::vector<std::string> variables, const std::size_t i)
-                                            { return variables[reorder[i]]; });
-  EXPECT_EQ(reordered_names.size(), 6);
-  EXPECT_EQ(reordered_names[0], names[3]);
-  EXPECT_EQ(reordered_names[1], names[2]);
-  EXPECT_EQ(reordered_names[2], names[1]);
-  EXPECT_EQ(reordered_names[3], names[0]);
-  EXPECT_EQ(reordered_names[4], names[5]);
-  EXPECT_EQ(reordered_names[5], names[4]);
+  EXPECT_EQ(names.size(), expected.size());
+  EXPECT_EQ(name_set, expected_set);
 }
 
 TEST(System, ConstructorWithParameterizedSpecies)
 {
-  std::vector<micm::Species> speciesA = { micm::Species("species1"), micm::Species("species2") };
-  std::vector<micm::Species> speciesB = { micm::Species("species3"), micm::Species("species4") };
-  auto param_species = micm::Species("paramSpecies");
-  param_species.parameterize_ = [](const micm::Conditions& c) { return 64.2; };
-  speciesA.push_back(param_species);
+  Species foo("foo");
+  Species bar("bar");
+  Species baz("baz");
+  Species quiz("quiz");
+  PhaseSpecies gas_foo(foo);
+  PhaseSpecies gas_bar(bar);
+  PhaseSpecies organic_foo(foo);
+  PhaseSpecies organic_bar(bar);
+  PhaseSpecies aqueous_baz(baz);
+  PhaseSpecies aqueous_quiz(quiz);
 
-  micm::Phase phase = speciesA;
-  std::unordered_map<std::string, micm::Phase> phases = { { "phase1", speciesA }, { "phase2", speciesB } };
+  // Parameterized species
+  Species param_species = Species("paramSpecies");
+  param_species.parameterize_ = [](const Conditions& c) { return 64.2; };
+  PhaseSpecies gas_param_species(param_species);
 
-  micm::System system = { micm::SystemParameters{ .gas_phase_ = phase, .phases_ = phases } };
+  Phase gas_phase("gas", std::vector<PhaseSpecies>({ gas_foo, gas_bar, gas_param_species }));
+  Phase organic_phase("organic", std::vector<PhaseSpecies>({ organic_foo, organic_bar }));
+  Phase aqueous_phase("aqueous", std::vector<PhaseSpecies>({ aqueous_baz, aqueous_quiz }));
+  std::unordered_map<std::string, Phase> phases = { { "organic", organic_phase }, { "aqueous", aqueous_phase }, };
+  System system = { SystemParameters{
+     .gas_phase_ = gas_phase,
+     .phases_ = phases } };
 
-  EXPECT_EQ(system.gas_phase_.species_.size(), 3);
+  EXPECT_EQ(system.gas_phase_.phase_species_.size(), 3);
   EXPECT_EQ(system.phases_.size(), 2);
+  EXPECT_EQ(system.phases_["organic"].phase_species_.size(), 2);
+  EXPECT_EQ(system.phases_["aqueous"].phase_species_.size(), 2);
   EXPECT_EQ(system.StateSize(), 6);
 
   auto names = system.UniqueNames();
+  std::vector<std::string> expected = {
+    "foo", "bar", "organic.foo", "organic.bar", "aqueous.baz", "aqueous.quiz" };
+  std::multiset<std::string> name_set(names.begin(), names.end());
+  std::multiset<std::string> expected_set(expected.begin(), expected.end());
 
-  EXPECT_EQ(names.size(), 6);
-  EXPECT_NE(std::find(names.begin(), names.end(), "species1"), names.end());
-  EXPECT_NE(std::find(names.begin(), names.end(), "species2"), names.end());
-  EXPECT_NE(std::find(names.begin(), names.end(), "phase1.species1"), names.end());
-  EXPECT_NE(std::find(names.begin(), names.end(), "phase1.species2"), names.end());
-  EXPECT_NE(std::find(names.begin(), names.end(), "phase2.species3"), names.end());
-  EXPECT_NE(std::find(names.begin(), names.end(), "phase2.species4"), names.end());
+  EXPECT_EQ(names.size(), expected.size());
+  EXPECT_EQ(name_set, expected_set);
 
   std::vector<int> reorder{ 3, 2, 1, 0, 5, 4 };
   auto reordered_names = system.UniqueNames([&](const std::vector<std::string> variables, const std::size_t i)
@@ -81,11 +100,11 @@ TEST(System, ConstructorWithParameterizedSpecies)
 
 TEST(System, OthersIsStoredAndAccessible)
 {
-  micm::SystemParameters params;
+  SystemParameters params;
   params.others_["modal.aitken"] = "number_concentration";
   params.others_["modal.accumulation"] = "number_concentration";
 
-  micm::System sys(params);
+  System sys(params);
 
   ASSERT_EQ(sys.others_.size(), 2);
   EXPECT_EQ(sys.others_.at("modal.aitken"), "number_concentration");


### PR DESCRIPTION
This PR is working in progress.

- Adds `micm::PhaseSpecies` class to support to phase-specific diffusion coefficient value 
- Updates the surface reaction class to read the diffusion coefficient from PhaseSpecies
- Updates the test
- Closes #845 
- Closes #847 