### PR TITLE
bumping nvida image version to fix build failure

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -15,7 +15,7 @@ jobs:
   cuda_tests:
     runs-on: gha-runner-micm
     container:
-      image: nvcr.io/nvidia/nvhpc:25.9-devel-cuda13.0-ubuntu24.04
+      image: nvcr.io/nvidia/nvhpc:25.1-devel-cuda12.6-ubuntu24.04
       options: --gpus all
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
       
       - name: Copy cublas headers
         run: |
-          cp -r /opt/nvidia/hpc_sdk/*/25.9/cuda/include/* /usr/include/
+          cp -r /opt/nvidia/hpc_sdk/*/25.1/cuda/include/* /usr/include/
 
       - name: Build
         run: cmake --build build --parallel 10

--- a/docker/Dockerfile.nvhpc
+++ b/docker/Dockerfile.nvhpc
@@ -4,7 +4,7 @@
 #
 # Container versions, and sizes, can be found at https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvhpc/tags
 #
-from nvcr.io/nvidia/nvhpc:25.9-devel-cuda13.0-ubuntu24.04
+from nvcr.io/nvidia/nvhpc:25.1-devel-cuda12.6-ubuntu24.04
 
 RUN apt update \
     && apt -y install \
@@ -29,7 +29,7 @@ ENV FC=nvfortran
 COPY . /micm/
 
 # copy headers needed for cublas to /usr/include
-RUN cp -r /opt/nvidia/hpc_sdk/*/25.9/cuda/include/* /usr/include/
+RUN cp -r /opt/nvidia/hpc_sdk/*/25.1/cuda/include/* /usr/include/
 
 # build the library and run the tests
 RUN mkdir /build \


### PR DESCRIPTION
Fix the designated GPU runner

In #864, I noticed that the gpu runner failed. It did because cmake couldn't clone our dependencies. Every time I've seen that error, updating the cmake version fixes it. This is probably caused by #856, where we added find package support, according to [this cmake issue](https://gitlab.kitware.com/cmake/cmake/-/issues/24909). This is the error that showed up.

```
-- The CXX compiler identification is GNU 11.4.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- CMake build configuration for micm(Release) 3.10.0
-- Configuring incomplete, errors occurred!
See also "/__w/micm/micm/build/CMakeFiles/CMakeOutput.log".
[ 11%] Creating directories for 'googletest-populate'
[ 22%] Performing download step (git clone) for 'googletest-populate'
fatal: could not create work tree dir '': No such file or directory
fatal: could not create work tree dir '': No such file or directory
fatal: could not create work tree dir '': No such file or directory
-- Had to git clone more than once:
          3 times.
CMake Error at googletest-subbuild/googletest-populate-prefix/tmp/googletest-populate-gitclone.cmake:31 (message):
  Failed to clone repository: 'https://github.com/google/googletest.git'


gmake[2]: *** [CMakeFiles/googletest-populate.dir/build.make:102: googletest-populate-prefix/src/googletest-populate-stamp/googletest-populate-download] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/googletest-populate.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2

CMake Error at /usr/share/cmake-3.22/Modules/FetchContent.cmake:1087 (message):
  Build step for googletest failed: 2
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FetchContent.cmake:1216:EVAL:2 (__FetchContent_directPopulate)
  /usr/share/cmake-3.22/Modules/FetchContent.cmake:1216 (cmake_language)
  /usr/share/cmake-3.22/Modules/FetchContent.cmake:1259 (FetchContent_Populate)
  cmake/dependencies.cmake:86 (FetchContent_MakeAvailable)
  CMakeLists.txt:54 (include)

```