### PR TITLE
public linkage

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,17 +49,9 @@ if(NOT ${MICM_GPU_TYPE} STREQUAL "None")
     PRIVATE micm
   )
   
-  # For SHARED builds, CUDA dependencies are PRIVATE to avoid forcing consumers to link CUDA libs
-  # For STATIC builds, CUDA dependencies are PUBLIC so consumers get required link flags
-  if(MICM_BUILD_SHARED_LIBS)
-    target_link_libraries(micm_cuda 
-      PRIVATE CUDA::cudart CUDA::cublas
-    )
-  else()
-    target_link_libraries(micm_cuda 
-      PUBLIC CUDA::cudart CUDA::cublas
-    )
-  endif()
+  target_link_libraries(micm_cuda 
+    PUBLIC CUDA::cudart CUDA::cublas
+  )
   
   target_compile_options(micm_cuda PRIVATE --expt-relaxed-constexpr)
   set_property(TARGET micm_cuda PROPERTY CUDA_STANDARD 20)


### PR DESCRIPTION
When building shared library, this wasn't propagating the links to musica and musica couldn't include `micm/GPU.hpp` because it eventually includes "cuda_runtime.h"

This is the easy fix.

The harder fix would be to refactor the GPU code so that including `GPU.hpp` wouldn't require linking to nvidia libraries