### PR TITLE
Fix CUDA gtest runtime error on Derecho

### DIFF
--- a/test/unit/cuda/util/CMakeLists.txt
+++ b/test/unit/cuda/util/CMakeLists.txt
@@ -8,7 +8,7 @@ set_target_properties(micm_cuda_test_utils PROPERTIES LINKER_LANGUAGE CXX)
 
 # add a library to use customized GTest main function for CUDA tests
 add_library(cuda_gtest_main STATIC cuda_gtest_main.cpp)
-target_link_libraries(cuda_gtest_main PUBLIC gtest micm)
+target_link_libraries(cuda_gtest_main PUBLIC GTest::gtest micm)
 
 create_standard_test(NAME cuda_dense_matrix SOURCES test_cuda_dense_matrix.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils IS_CUDA_TEST)
 create_standard_test(NAME cuda_sparse_matrix_vector_ordering_row SOURCES test_cuda_sparse_matrix_vector_ordering_row.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils IS_CUDA_TEST)


### PR DESCRIPTION
On Derecho, after upgrading to the `ncarenv/25.10` environment, I got the following runtime error for CUDA unit tests:
```
error while loading shared libraries: libgtest.so.1.17.0: cannot open shared object file: No such file or directory
```
The fix is to change the `CMakeLists.txt` for CUDA utility so that the `cuda_gtest_main` library links against `GTest::gtest` instead of bare `gtest`. The bare `gtest` causes CMake to emit `-lgtest` without proper RPATH, while the `GTest::gtest` carries the full library path and RPATH.