### PR TITLE
Calculate the chemistry reaction rates on the GPU

### DIFF
--- a/include/micm/cuda/process/cuda_process.cuh
+++ b/include/micm/cuda/process/cuda_process.cuh
@@ -1,0 +1,37 @@
+// Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <micm/cuda/util/cuda_param.hpp>
+
+namespace micm
+{
+  namespace cuda
+  {
+    /// @brief Copy rate constant descriptors to device memory
+    /// @param hoststruct Host-side struct with rate constant data pointers
+    /// @return Device-side struct with allocated and copied device memory
+    ProcessParam CopyProcessConstData(ProcessParam& hoststruct);
+
+    /// @brief Free device memory for rate constant descriptors
+    /// @param devstruct Device-side struct to free
+    void FreeProcessConstData(ProcessParam& devstruct);
+
+    /// @brief Launch CUDA kernel to calculate rate constants
+    /// @param d_temperature Device array of temperatures [K] (one per grid cell)
+    /// @param d_pressure Device array of pressures [Pa] (one per grid cell)
+    /// @param d_air_density Device array of air densities [mol m-3] (one per grid cell)
+    /// @param custom_rate_params Custom rate parameters matrix on device
+    /// @param d_fixed_reactants Device array of pre-computed parameterized reactant factors
+    /// @param rate_constants_param Output rate constants matrix on device
+    /// @param devstruct Device-side struct with rate constant descriptors
+    void CalculateRateConstantsKernelDriver(
+        const double* d_temperature,
+        const double* d_pressure,
+        const double* d_air_density,
+        const CudaMatrixParam& custom_rate_params,
+        const double* d_fixed_reactants,
+        CudaMatrixParam& rate_constants_param,
+        const ProcessParam& devstruct);
+  }  // namespace cuda
+}  // namespace micm

--- a/include/micm/cuda/process/cuda_process.hpp
+++ b/include/micm/cuda/process/cuda_process.hpp
@@ -1,0 +1,323 @@
+// Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <micm/cuda/process/cuda_process.cuh>
+#include <micm/cuda/util/cuda_dense_matrix.hpp>
+#include <micm/cuda/util/cuda_param.hpp>
+#include <micm/cuda/util/cuda_util.cuh>
+#include <micm/process/chemical_reaction.hpp>
+#include <micm/process/process.hpp>
+#include <micm/process/rate_constant/arrhenius_rate_constant.hpp>
+#include <micm/process/rate_constant/branched_rate_constant.hpp>
+#include <micm/process/rate_constant/reversible_rate_constant.hpp>
+#include <micm/process/rate_constant/surface_rate_constant.hpp>
+#include <micm/process/rate_constant/ternary_chemical_activation_rate_constant.hpp>
+#include <micm/process/rate_constant/troe_rate_constant.hpp>
+#include <micm/process/rate_constant/tunneling_rate_constant.hpp>
+#include <micm/process/rate_constant/user_defined_rate_constant.hpp>
+#include <micm/solver/state.hpp>
+
+#include <cassert>
+#include <stdexcept>
+#include <vector>
+
+namespace micm
+{
+  /// @brief A GPU-based implementation for calculating rate constants
+  /// @tparam DenseMatrixPolicy Policy for dense matrices (must satisfy CudaMatrix and VectorizableDense concepts)
+  template<typename DenseMatrixPolicy>
+    requires(CudaMatrix<DenseMatrixPolicy> && VectorizableDense<DenseMatrixPolicy>)
+  class CudaProcess
+  {
+   public:
+    ProcessParam devstruct_;
+    std::vector<CudaRateConstantData> h_rate_constants_;
+
+    CudaProcess() = default;
+
+    CudaProcess(const CudaProcess&) = delete;
+    CudaProcess& operator=(const CudaProcess&) = delete;
+
+    CudaProcess(CudaProcess&& other)
+        : h_rate_constants_(std::move(other.h_rate_constants_))
+    {
+      std::swap(this->devstruct_, other.devstruct_);
+    }
+
+    CudaProcess& operator=(CudaProcess&& other)
+    {
+      if (this != &other)
+      {
+        if (devstruct_.rate_constants_ != nullptr)
+          micm::cuda::FreeProcessConstData(devstruct_);
+        h_rate_constants_ = std::move(other.h_rate_constants_);
+        devstruct_ = {};
+        std::swap(this->devstruct_, other.devstruct_);
+      }
+      return *this;
+    }
+
+    ~CudaProcess()
+    {
+      micm::cuda::FreeProcessConstData(devstruct_);
+    }
+
+    /// @brief Construct from a vector of Process objects
+    /// @param processes The processes to build rate constant descriptors for
+    CudaProcess(const std::vector<Process>& processes);
+
+    /// @brief Calculate rate constants on GPU
+    /// @param processes The processes (needed for parameterized reactant evaluation on CPU)
+    /// @param state The solver state (conditions, custom params, rate constants output)
+    template<
+        class SparseMatrixPolicy,
+        class LuDecompositionPolicy,
+        class LMatrixPolicy,
+        class UMatrixPolicy>
+    void CalculateRateConstants(
+        const std::vector<Process>& processes,
+        State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>& state) const;
+
+   private:
+    /// @brief Pack a rate constant into a CudaRateConstantData descriptor
+    /// @param rate_constant The polymorphic rate constant to pack
+    /// @return The GPU-portable rate constant descriptor
+    static CudaRateConstantData PackRateConstant(const RateConstant* rate_constant);
+  };
+
+  // ==========================================================================
+  // Implementation
+  // ==========================================================================
+
+  template<typename DenseMatrixPolicy>
+    requires(CudaMatrix<DenseMatrixPolicy> && VectorizableDense<DenseMatrixPolicy>)
+  inline CudaProcess<DenseMatrixPolicy>::CudaProcess(const std::vector<Process>& processes)
+  {
+    // Extract ChemicalReaction objects and pack their rate constants
+    for (const auto& process : processes)
+    {
+      if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+      {
+        h_rate_constants_.push_back(PackRateConstant(reaction->rate_constant_.get()));
+      }
+    }
+
+    // Copy to device
+    ProcessParam hoststruct;
+    hoststruct.rate_constants_ = h_rate_constants_.data();
+    hoststruct.num_reactions_ = h_rate_constants_.size();
+
+    devstruct_ = micm::cuda::CopyProcessConstData(hoststruct);
+  }
+
+  template<typename DenseMatrixPolicy>
+    requires(CudaMatrix<DenseMatrixPolicy> && VectorizableDense<DenseMatrixPolicy>)
+  inline CudaRateConstantData CudaProcess<DenseMatrixPolicy>::PackRateConstant(const RateConstant* rate_constant)
+  {
+    CudaRateConstantData data{};
+    data.num_custom_params_ = rate_constant->SizeCustomParameters();
+
+    if (auto* rc = dynamic_cast<const ArrheniusRateConstant*>(rate_constant))
+    {
+      data.type_ = CudaRateConstantType::Arrhenius;
+      data.params_[0] = rc->parameters_.A_;
+      data.params_[1] = rc->parameters_.B_;
+      data.params_[2] = rc->parameters_.C_;
+      data.params_[3] = rc->parameters_.D_;
+      data.params_[4] = rc->parameters_.E_;
+    }
+    else if (auto* rc = dynamic_cast<const TroeRateConstant*>(rate_constant))
+    {
+      data.type_ = CudaRateConstantType::Troe;
+      data.params_[0] = rc->parameters_.k0_A_;
+      data.params_[1] = rc->parameters_.k0_B_;
+      data.params_[2] = rc->parameters_.k0_C_;
+      data.params_[3] = rc->parameters_.kinf_A_;
+      data.params_[4] = rc->parameters_.kinf_B_;
+      data.params_[5] = rc->parameters_.kinf_C_;
+      data.params_[6] = rc->parameters_.Fc_;
+      data.params_[7] = rc->parameters_.N_;
+    }
+    else if (auto* rc = dynamic_cast<const TunnelingRateConstant*>(rate_constant))
+    {
+      data.type_ = CudaRateConstantType::Tunneling;
+      data.params_[0] = rc->parameters_.A_;
+      data.params_[1] = rc->parameters_.B_;
+      data.params_[2] = rc->parameters_.C_;
+    }
+    else if (auto* rc = dynamic_cast<const BranchedRateConstant*>(rate_constant))
+    {
+      data.type_ = CudaRateConstantType::Branched;
+      data.params_[0] = rc->parameters_.X_;
+      data.params_[1] = rc->parameters_.Y_;
+      data.params_[2] = rc->k0_;  // precomputed
+      data.params_[3] = rc->z_;   // precomputed
+      data.params_[4] =
+          (rc->parameters_.branch_ == BranchedRateConstantParameters::Branch::Alkoxy) ? 0.0 : 1.0;
+    }
+    else if (auto* rc = dynamic_cast<const TernaryChemicalActivationRateConstant*>(rate_constant))
+    {
+      data.type_ = CudaRateConstantType::TernaryChemicalActivation;
+      data.params_[0] = rc->parameters_.k0_A_;
+      data.params_[1] = rc->parameters_.k0_B_;
+      data.params_[2] = rc->parameters_.k0_C_;
+      data.params_[3] = rc->parameters_.kinf_A_;
+      data.params_[4] = rc->parameters_.kinf_B_;
+      data.params_[5] = rc->parameters_.kinf_C_;
+      data.params_[6] = rc->parameters_.Fc_;
+      data.params_[7] = rc->parameters_.N_;
+    }
+    else if (auto* rc = dynamic_cast<const ReversibleRateConstant*>(rate_constant))
+    {
+      data.type_ = CudaRateConstantType::Reversible;
+      data.params_[0] = rc->parameters_.A_;
+      data.params_[1] = rc->parameters_.C_;
+      data.params_[2] = rc->parameters_.k_r_;
+    }
+    else if (auto* rc = dynamic_cast<const SurfaceRateConstant*>(rate_constant))
+    {
+      data.type_ = CudaRateConstantType::Surface;
+      data.params_[0] = rc->diffusion_coefficient_;
+      data.params_[1] = rc->mean_free_speed_factor_;
+      data.params_[2] = rc->parameters_.reaction_probability_;
+    }
+    else if (auto* rc = dynamic_cast<const UserDefinedRateConstant*>(rate_constant))
+    {
+      data.type_ = CudaRateConstantType::UserDefined;
+      data.params_[0] = rc->parameters_.scaling_factor_;
+    }
+    else
+    {
+      throw std::runtime_error(
+          "CudaProcess: Unsupported rate constant type. "
+          "Lambda and TaylorSeries rate constants cannot run on GPU.");
+    }
+
+    return data;
+  }
+
+  template<typename DenseMatrixPolicy>
+    requires(CudaMatrix<DenseMatrixPolicy> && VectorizableDense<DenseMatrixPolicy>)
+  template<
+      class SparseMatrixPolicy,
+      class LuDecompositionPolicy,
+      class LMatrixPolicy,
+      class UMatrixPolicy>
+  inline void CudaProcess<DenseMatrixPolicy>::CalculateRateConstants(
+      const std::vector<Process>& processes,
+      State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>& state) const
+  {
+    const std::size_t num_cells = state.conditions_.size();
+    const std::size_t num_reactions = h_rate_constants_.size();
+    constexpr std::size_t L = DenseMatrixPolicy::GroupVectorSize();
+
+    // Verify that the processes vector matches what was used at construction
+    std::size_t num_chemical_reactions = 0;
+    for (const auto& process : processes)
+      if (std::holds_alternative<ChemicalReaction>(process.process_))
+        ++num_chemical_reactions;
+    assert(num_chemical_reactions == num_reactions && "processes must match the vector used to construct CudaProcess");
+
+    if (num_reactions == 0)
+      return;
+
+    auto cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+
+    // 1. Extract conditions into SOA arrays and copy to device
+    std::vector<double> h_temperature(num_cells);
+    std::vector<double> h_pressure(num_cells);
+    std::vector<double> h_air_density(num_cells);
+
+    for (std::size_t i = 0; i < num_cells; ++i)
+    {
+      h_temperature[i] = state.conditions_[i].temperature_;
+      h_pressure[i] = state.conditions_[i].pressure_;
+      h_air_density[i] = state.conditions_[i].air_density_;
+    }
+
+    double* d_temperature = nullptr;
+    double* d_pressure = nullptr;
+    double* d_air_density = nullptr;
+
+    CHECK_CUDA_ERROR(cudaMallocAsync(&d_temperature, sizeof(double) * num_cells, cuda_stream_id), "cudaMalloc");
+    CHECK_CUDA_ERROR(cudaMallocAsync(&d_pressure, sizeof(double) * num_cells, cuda_stream_id), "cudaMalloc");
+    CHECK_CUDA_ERROR(cudaMallocAsync(&d_air_density, sizeof(double) * num_cells, cuda_stream_id), "cudaMalloc");
+
+    CHECK_CUDA_ERROR(
+        cudaMemcpyAsync(d_temperature, h_temperature.data(), sizeof(double) * num_cells, cudaMemcpyHostToDevice, cuda_stream_id),
+        "cudaMemcpy");
+    CHECK_CUDA_ERROR(
+        cudaMemcpyAsync(d_pressure, h_pressure.data(), sizeof(double) * num_cells, cudaMemcpyHostToDevice, cuda_stream_id),
+        "cudaMemcpy");
+    CHECK_CUDA_ERROR(
+        cudaMemcpyAsync(
+            d_air_density, h_air_density.data(), sizeof(double) * num_cells, cudaMemcpyHostToDevice, cuda_stream_id),
+        "cudaMemcpy");
+
+    // 2. Pre-compute parameterized reactant factors on CPU
+    //    Layout matches rate_constants_ vectorized layout: groups of L cells x num_reactions columns
+    std::vector<double> h_fixed_reactants(state.rate_constants_.AsVector().size(), 1.0);
+
+    // Collect chemical reactions
+    std::vector<const ChemicalReaction*> reactions;
+    for (const auto& process : processes)
+    {
+      if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+      {
+        reactions.push_back(reaction);
+      }
+    }
+
+    // Compute fixed_reactants in vectorized layout
+    for (std::size_t i_group = 0; i_group < state.rate_constants_.NumberOfGroups(); ++i_group)
+    {
+      std::size_t offset_rc = i_group * state.rate_constants_.GroupSize();
+      std::size_t rate_const_size = std::min(L, state.rate_constants_.NumRows() - (i_group * L));
+      for (std::size_t i_rxn = 0; i_rxn < num_reactions; ++i_rxn)
+      {
+        for (std::size_t i_cell = 0; i_cell < rate_const_size; ++i_cell)
+        {
+          double fixed = 1.0;
+          for (auto& reactant : reactions[i_rxn]->reactants_)
+          {
+            if (reactant.IsParameterized())
+              fixed *= reactant.parameterize_(state.conditions_[i_group * L + i_cell]);
+          }
+          h_fixed_reactants[offset_rc + i_cell] = fixed;
+        }
+        offset_rc += L;
+      }
+    }
+
+    // Copy fixed_reactants to device
+    double* d_fixed_reactants = nullptr;
+    CHECK_CUDA_ERROR(
+        cudaMallocAsync(&d_fixed_reactants, sizeof(double) * h_fixed_reactants.size(), cuda_stream_id), "cudaMalloc");
+    CHECK_CUDA_ERROR(
+        cudaMemcpyAsync(
+            d_fixed_reactants,
+            h_fixed_reactants.data(),
+            sizeof(double) * h_fixed_reactants.size(),
+            cudaMemcpyHostToDevice,
+            cuda_stream_id),
+        "cudaMemcpy");
+
+    // 3. Ensure custom_rate_parameters are on device
+    state.custom_rate_parameters_.CopyToDevice();
+
+    // 4. Launch kernel
+    auto rate_constants_param = state.rate_constants_.AsDeviceParam();
+    auto custom_rate_params = state.custom_rate_parameters_.AsDeviceParam();
+
+    micm::cuda::CalculateRateConstantsKernelDriver(
+        d_temperature, d_pressure, d_air_density, custom_rate_params, d_fixed_reactants, rate_constants_param, devstruct_);
+
+    // 5. Free temporary device memory
+    CHECK_CUDA_ERROR(cudaFreeAsync(d_temperature, cuda_stream_id), "cudaFree");
+    CHECK_CUDA_ERROR(cudaFreeAsync(d_pressure, cuda_stream_id), "cudaFree");
+    CHECK_CUDA_ERROR(cudaFreeAsync(d_air_density, cuda_stream_id), "cudaFree");
+    CHECK_CUDA_ERROR(cudaFreeAsync(d_fixed_reactants, cuda_stream_id), "cudaFree");
+  }
+
+}  // namespace micm

--- a/include/micm/cuda/process/cuda_process.hpp
+++ b/include/micm/cuda/process/cuda_process.hpp
@@ -115,6 +115,13 @@ namespace micm
     CudaRateConstantData data{};
     data.number_of_custom_parameters_ = rate_constant->SizeCustomParameters();
 
+    if (data.number_of_custom_parameters_ > MAX_CUSTOM_PARAMETERS)
+    {
+      throw std::runtime_error(
+          "CudaProcess: Rate constant requires " + std::to_string(data.number_of_custom_parameters_) +
+          " custom parameters, but the GPU kernel supports at most " + std::to_string(MAX_CUSTOM_PARAMETERS) + ".");
+    }
+
     if (auto* rc = dynamic_cast<const ArrheniusRateConstant*>(rate_constant))
     {
       data.type_ = CudaRateConstantType::Arrhenius;

--- a/include/micm/cuda/process/cuda_process.hpp
+++ b/include/micm/cuda/process/cuda_process.hpp
@@ -16,6 +16,7 @@
 #include <micm/process/rate_constant/troe_rate_constant.hpp>
 #include <micm/process/rate_constant/tunneling_rate_constant.hpp>
 #include <micm/process/rate_constant/user_defined_rate_constant.hpp>
+#include <micm/cuda/solver/cuda_state.hpp>
 #include <micm/solver/state.hpp>
 
 #include <cassert>
@@ -69,15 +70,11 @@ namespace micm
 
     /// @brief Calculate rate constants on GPU
     /// @param processes The processes (needed for parameterized reactant evaluation on CPU)
-    /// @param state The solver state (conditions, custom params, rate constants output)
-    template<
-        class SparseMatrixPolicy,
-        class LuDecompositionPolicy,
-        class LMatrixPolicy,
-        class UMatrixPolicy>
+    /// @param state The CUDA solver state (conditions must be synced to device beforehand via SyncConditionsToDevice())
+    template<class SparseMatrixPolicy, class LuDecompositionPolicy>
     void CalculateRateConstants(
         const std::vector<Process>& processes,
-        State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>& state) const;
+        CudaState<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy>& state) const;
 
    private:
     /// @brief Pack a rate constant into a CudaRateConstantData descriptor
@@ -199,14 +196,10 @@ namespace micm
 
   template<typename DenseMatrixPolicy>
     requires(CudaMatrix<DenseMatrixPolicy> && VectorizableDense<DenseMatrixPolicy>)
-  template<
-      class SparseMatrixPolicy,
-      class LuDecompositionPolicy,
-      class LMatrixPolicy,
-      class UMatrixPolicy>
+  template<class SparseMatrixPolicy, class LuDecompositionPolicy>
   inline void CudaProcess<DenseMatrixPolicy>::CalculateRateConstants(
       const std::vector<Process>& processes,
-      State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>& state) const
+      CudaState<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy>& state) const
   {
     const std::size_t num_cells = state.conditions_.size();
     const std::size_t num_reactions = h_rate_constants_.size();
@@ -224,40 +217,12 @@ namespace micm
 
     auto cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
 
-    // 1. Extract conditions into SOA arrays and copy to device
-    std::vector<double> h_temperature(num_cells);
-    std::vector<double> h_pressure(num_cells);
-    std::vector<double> h_air_density(num_cells);
-
-    for (std::size_t i = 0; i < num_cells; ++i)
-    {
-      h_temperature[i] = state.conditions_[i].temperature_;
-      h_pressure[i] = state.conditions_[i].pressure_;
-      h_air_density[i] = state.conditions_[i].air_density_;
-    }
-
-    double* d_temperature = nullptr;
-    double* d_pressure = nullptr;
-    double* d_air_density = nullptr;
-
-    CHECK_CUDA_ERROR(cudaMallocAsync(&d_temperature, sizeof(double) * num_cells, cuda_stream_id), "cudaMalloc");
-    CHECK_CUDA_ERROR(cudaMallocAsync(&d_pressure, sizeof(double) * num_cells, cuda_stream_id), "cudaMalloc");
-    CHECK_CUDA_ERROR(cudaMallocAsync(&d_air_density, sizeof(double) * num_cells, cuda_stream_id), "cudaMalloc");
-
-    CHECK_CUDA_ERROR(
-        cudaMemcpyAsync(d_temperature, h_temperature.data(), sizeof(double) * num_cells, cudaMemcpyHostToDevice, cuda_stream_id),
-        "cudaMemcpy");
-    CHECK_CUDA_ERROR(
-        cudaMemcpyAsync(d_pressure, h_pressure.data(), sizeof(double) * num_cells, cudaMemcpyHostToDevice, cuda_stream_id),
-        "cudaMemcpy");
-    CHECK_CUDA_ERROR(
-        cudaMemcpyAsync(
-            d_air_density, h_air_density.data(), sizeof(double) * num_cells, cudaMemcpyHostToDevice, cuda_stream_id),
-        "cudaMemcpy");
+    // 1. Conditions (temperature, pressure, air_density) are already on device
+    //    via state.SyncConditionsToDevice() called by the caller
 
     // 2. Pre-compute parameterized reactant factors on CPU
     //    Layout matches rate_constants_ vectorized layout: groups of L cells x num_reactions columns
-    std::vector<double> h_fixed_reactants(state.rate_constants_.AsVector().size(), 1.0);
+    std::vector<double> h_fixed_reactants(state.conditions_param_.fixed_reactants_size_, 1.0);
 
     // Collect chemical reactions
     std::vector<const ChemicalReaction*> reactions;
@@ -290,13 +255,10 @@ namespace micm
       }
     }
 
-    // Copy fixed_reactants to device
-    double* d_fixed_reactants = nullptr;
-    CHECK_CUDA_ERROR(
-        cudaMallocAsync(&d_fixed_reactants, sizeof(double) * h_fixed_reactants.size(), cuda_stream_id), "cudaMalloc");
+    // Copy fixed_reactants to pre-allocated device buffer
     CHECK_CUDA_ERROR(
         cudaMemcpyAsync(
-            d_fixed_reactants,
+            state.conditions_param_.d_fixed_reactants_,
             h_fixed_reactants.data(),
             sizeof(double) * h_fixed_reactants.size(),
             cudaMemcpyHostToDevice,
@@ -311,13 +273,13 @@ namespace micm
     auto custom_rate_params = state.custom_rate_parameters_.AsDeviceParam();
 
     micm::cuda::CalculateRateConstantsKernelDriver(
-        d_temperature, d_pressure, d_air_density, custom_rate_params, d_fixed_reactants, rate_constants_param, devstruct_);
-
-    // 5. Free temporary device memory
-    CHECK_CUDA_ERROR(cudaFreeAsync(d_temperature, cuda_stream_id), "cudaFree");
-    CHECK_CUDA_ERROR(cudaFreeAsync(d_pressure, cuda_stream_id), "cudaFree");
-    CHECK_CUDA_ERROR(cudaFreeAsync(d_air_density, cuda_stream_id), "cudaFree");
-    CHECK_CUDA_ERROR(cudaFreeAsync(d_fixed_reactants, cuda_stream_id), "cudaFree");
+        state.conditions_param_.d_temperature_,
+        state.conditions_param_.d_pressure_,
+        state.conditions_param_.d_air_density_,
+        custom_rate_params,
+        state.conditions_param_.d_fixed_reactants_,
+        rate_constants_param,
+        devstruct_);
   }
 
 }  // namespace micm

--- a/include/micm/cuda/process/cuda_process.hpp
+++ b/include/micm/cuda/process/cuda_process.hpp
@@ -103,7 +103,7 @@ namespace micm
     // Copy to device
     ProcessParam hoststruct;
     hoststruct.rate_constants_ = h_rate_constants_.data();
-    hoststruct.num_reactions_ = h_rate_constants_.size();
+    hoststruct.number_of_reactions_ = h_rate_constants_.size();
 
     devstruct_ = micm::cuda::CopyProcessConstData(hoststruct);
   }
@@ -113,7 +113,7 @@ namespace micm
   inline CudaRateConstantData CudaProcess<DenseMatrixPolicy>::PackRateConstant(const RateConstant* rate_constant)
   {
     CudaRateConstantData data{};
-    data.num_custom_params_ = rate_constant->SizeCustomParameters();
+    data.number_of_custom_parameters_ = rate_constant->SizeCustomParameters();
 
     if (auto* rc = dynamic_cast<const ArrheniusRateConstant*>(rate_constant))
     {
@@ -201,18 +201,20 @@ namespace micm
       const std::vector<Process>& processes,
       CudaState<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy>& state) const
   {
-    const std::size_t num_cells = state.conditions_.size();
-    const std::size_t num_reactions = h_rate_constants_.size();
+    const std::size_t number_of_grid_cells = state.conditions_.size();
+    const std::size_t number_of_reactions = h_rate_constants_.size();
     constexpr std::size_t L = DenseMatrixPolicy::GroupVectorSize();
 
     // Verify that the processes vector matches what was used at construction
-    std::size_t num_chemical_reactions = 0;
+    std::size_t number_of_chemical_reactions = 0;
     for (const auto& process : processes)
       if (std::holds_alternative<ChemicalReaction>(process.process_))
-        ++num_chemical_reactions;
-    assert(num_chemical_reactions == num_reactions && "processes must match the vector used to construct CudaProcess");
+        ++number_of_chemical_reactions;
+    assert(
+        number_of_chemical_reactions == number_of_reactions &&
+        "processes must match the vector used to construct CudaProcess");
 
-    if (num_reactions == 0)
+    if (number_of_reactions == 0)
       return;
 
     auto cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
@@ -221,8 +223,8 @@ namespace micm
     //    via state.SyncConditionsToDevice() called by the caller
 
     // 2. Pre-compute parameterized reactant factors on CPU
-    //    Layout matches rate_constants_ vectorized layout: groups of L cells x num_reactions columns
-    std::vector<double> h_fixed_reactants(state.conditions_param_.fixed_reactants_size_, 1.0);
+    //    Layout matches rate_constants_ vectorized layout
+    std::vector<double> h_fixed_reactants(state.conditions_param_.number_of_fixed_reactant_elements_, 1.0);
 
     // Collect chemical reactions
     std::vector<const ChemicalReaction*> reactions;
@@ -239,7 +241,7 @@ namespace micm
     {
       std::size_t offset_rc = i_group * state.rate_constants_.GroupSize();
       std::size_t rate_const_size = std::min(L, state.rate_constants_.NumRows() - (i_group * L));
-      for (std::size_t i_rxn = 0; i_rxn < num_reactions; ++i_rxn)
+      for (std::size_t i_rxn = 0; i_rxn < number_of_reactions; ++i_rxn)
       {
         for (std::size_t i_cell = 0; i_cell < rate_const_size; ++i_cell)
         {

--- a/include/micm/cuda/solver/cuda_state.hpp
+++ b/include/micm/cuda/solver/cuda_state.hpp
@@ -89,8 +89,8 @@ namespace micm
           "cudaMemcpy");
 
       // Allocate persistent device buffers for conditions
-      conditions_param_.num_cells_ = number_of_grid_cells;
-      conditions_param_.fixed_reactants_size_ = this->rate_constants_.AsVector().size();
+      conditions_param_.number_of_grid_cells_ = number_of_grid_cells;
+      conditions_param_.number_of_fixed_reactant_elements_ = this->rate_constants_.AsVector().size();
       CHECK_CUDA_ERROR(
           cudaMallocAsync(&conditions_param_.d_temperature_, sizeof(double) * number_of_grid_cells, cuda_stream), "cudaMalloc");
       CHECK_CUDA_ERROR(
@@ -100,7 +100,7 @@ namespace micm
       CHECK_CUDA_ERROR(
           cudaMallocAsync(
               &conditions_param_.d_fixed_reactants_,
-              sizeof(double) * conditions_param_.fixed_reactants_size_,
+              sizeof(double) * conditions_param_.number_of_fixed_reactant_elements_,
               cuda_stream),
           "cudaMalloc");
     };
@@ -148,11 +148,11 @@ namespace micm
     void SyncConditionsToDevice()
       requires(CudaMatrix<DenseMatrixPolicy> && VectorizableDense<DenseMatrixPolicy>)
     {
-      const std::size_t num_cells = conditions_param_.num_cells_;
-      std::vector<double> h_temperature(num_cells);
-      std::vector<double> h_pressure(num_cells);
-      std::vector<double> h_air_density(num_cells);
-      for (std::size_t i = 0; i < num_cells; ++i)
+      const std::size_t number_of_grid_cells = conditions_param_.number_of_grid_cells_;
+      std::vector<double> h_temperature(number_of_grid_cells);
+      std::vector<double> h_pressure(number_of_grid_cells);
+      std::vector<double> h_air_density(number_of_grid_cells);
+      for (std::size_t i = 0; i < number_of_grid_cells; ++i)
       {
         h_temperature[i] = this->conditions_[i].temperature_;
         h_pressure[i] = this->conditions_[i].pressure_;
@@ -161,15 +161,15 @@ namespace micm
       auto stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
       CHECK_CUDA_ERROR(
           cudaMemcpyAsync(
-              conditions_param_.d_temperature_, h_temperature.data(), sizeof(double) * num_cells, cudaMemcpyHostToDevice, stream),
+              conditions_param_.d_temperature_, h_temperature.data(), sizeof(double) * number_of_grid_cells, cudaMemcpyHostToDevice, stream),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
           cudaMemcpyAsync(
-              conditions_param_.d_pressure_, h_pressure.data(), sizeof(double) * num_cells, cudaMemcpyHostToDevice, stream),
+              conditions_param_.d_pressure_, h_pressure.data(), sizeof(double) * number_of_grid_cells, cudaMemcpyHostToDevice, stream),
           "cudaMemcpy");
       CHECK_CUDA_ERROR(
           cudaMemcpyAsync(
-              conditions_param_.d_air_density_, h_air_density.data(), sizeof(double) * num_cells, cudaMemcpyHostToDevice, stream),
+              conditions_param_.d_air_density_, h_air_density.data(), sizeof(double) * number_of_grid_cells, cudaMemcpyHostToDevice, stream),
           "cudaMemcpy");
     }
 

--- a/include/micm/cuda/solver/cuda_state.hpp
+++ b/include/micm/cuda/solver/cuda_state.hpp
@@ -10,7 +10,10 @@
 namespace micm
 {
   /// @brief Construct a state variable for CUDA tests
-  template<class DenseMatrixPolicy, class SparseMatrixPolicy, class LuDecompositionPolicy>
+  template<
+      class DenseMatrixPolicy = StandardDenseMatrix,
+      class SparseMatrixPolicy = StandardSparseMatrix,
+      class LuDecompositionPolicy = LuDecomposition>
   struct CudaState : public State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy>
   {
    public:
@@ -21,13 +24,23 @@ namespace micm
 
     CudaErrorParam errors_param_;
     CudaJacobianDiagonalElementsParam jacobian_diagonal_elements_param_;
+    CudaConditionsParam conditions_param_;
 
     ~CudaState()
     {
+      auto stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
       CHECK_CUDA_ERROR(micm::cuda::FreeVector(absolute_tolerance_param_), "cudaFree");
       CHECK_CUDA_ERROR(micm::cuda::FreeArray(errors_param_.errors_input_), "cudaFree");
       CHECK_CUDA_ERROR(micm::cuda::FreeArray(errors_param_.errors_output_), "cudaFree");
       CHECK_CUDA_ERROR(micm::cuda::FreeArray(jacobian_diagonal_elements_param_.data_), "cudaFree");
+      if (conditions_param_.d_temperature_ != nullptr)
+        CHECK_CUDA_ERROR(cudaFreeAsync(conditions_param_.d_temperature_, stream), "cudaFree");
+      if (conditions_param_.d_pressure_ != nullptr)
+        CHECK_CUDA_ERROR(cudaFreeAsync(conditions_param_.d_pressure_, stream), "cudaFree");
+      if (conditions_param_.d_air_density_ != nullptr)
+        CHECK_CUDA_ERROR(cudaFreeAsync(conditions_param_.d_air_density_, stream), "cudaFree");
+      if (conditions_param_.d_fixed_reactants_ != nullptr)
+        CHECK_CUDA_ERROR(cudaFreeAsync(conditions_param_.d_fixed_reactants_, stream), "cudaFree");
     }
 
     /// @brief Constructor which takes the state dimension information as input
@@ -64,14 +77,32 @@ namespace micm
           "cudaMalloc");
       CHECK_CUDA_ERROR(micm::cuda::CopyToDevice<double>(absolute_tolerance_param_, atol), "cudaMemcpyHostToDevice");
 
+      auto cuda_stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+
       CHECK_CUDA_ERROR(
           cudaMemcpyAsync(
               jacobian_diagonal_elements_param_.data_,
               diagonal_indices.data(),
               sizeof(std::size_t) * diagonal_indices.size(),
               cudaMemcpyHostToDevice,
-              micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)),
+              cuda_stream),
           "cudaMemcpy");
+
+      // Allocate persistent device buffers for conditions
+      conditions_param_.num_cells_ = number_of_grid_cells;
+      conditions_param_.fixed_reactants_size_ = this->rate_constants_.AsVector().size();
+      CHECK_CUDA_ERROR(
+          cudaMallocAsync(&conditions_param_.d_temperature_, sizeof(double) * number_of_grid_cells, cuda_stream), "cudaMalloc");
+      CHECK_CUDA_ERROR(
+          cudaMallocAsync(&conditions_param_.d_pressure_, sizeof(double) * number_of_grid_cells, cuda_stream), "cudaMalloc");
+      CHECK_CUDA_ERROR(
+          cudaMallocAsync(&conditions_param_.d_air_density_, sizeof(double) * number_of_grid_cells, cuda_stream), "cudaMalloc");
+      CHECK_CUDA_ERROR(
+          cudaMallocAsync(
+              &conditions_param_.d_fixed_reactants_,
+              sizeof(double) * conditions_param_.fixed_reactants_size_,
+              cuda_stream),
+          "cudaMalloc");
     };
 
     /// @brief Move constructor
@@ -84,6 +115,8 @@ namespace micm
       other.errors_param_ = {};
       jacobian_diagonal_elements_param_ = other.jacobian_diagonal_elements_param_;
       other.jacobian_diagonal_elements_param_ = {};
+      conditions_param_ = other.conditions_param_;
+      other.conditions_param_ = {};
     }
 
     /// @brief Move assignment operator
@@ -98,6 +131,8 @@ namespace micm
         other.errors_param_ = {};
         jacobian_diagonal_elements_param_ = other.jacobian_diagonal_elements_param_;
         other.jacobian_diagonal_elements_param_ = {};
+        conditions_param_ = other.conditions_param_;
+        other.conditions_param_ = {};
       }
       return *this;
     }
@@ -107,6 +142,35 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy>::SetAbsoluteTolerances(absoluteTolerance);
       CHECK_CUDA_ERROR(
           micm::cuda::CopyToDevice<double>(absolute_tolerance_param_, absoluteTolerance), "cudaMemcpyHostToDevice");
+    }
+
+    /// @brief Copy conditions (temperature, pressure, air_density) to the device
+    void SyncConditionsToDevice()
+      requires(CudaMatrix<DenseMatrixPolicy> && VectorizableDense<DenseMatrixPolicy>)
+    {
+      const std::size_t num_cells = conditions_param_.num_cells_;
+      std::vector<double> h_temperature(num_cells);
+      std::vector<double> h_pressure(num_cells);
+      std::vector<double> h_air_density(num_cells);
+      for (std::size_t i = 0; i < num_cells; ++i)
+      {
+        h_temperature[i] = this->conditions_[i].temperature_;
+        h_pressure[i] = this->conditions_[i].pressure_;
+        h_air_density[i] = this->conditions_[i].air_density_;
+      }
+      auto stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+      CHECK_CUDA_ERROR(
+          cudaMemcpyAsync(
+              conditions_param_.d_temperature_, h_temperature.data(), sizeof(double) * num_cells, cudaMemcpyHostToDevice, stream),
+          "cudaMemcpy");
+      CHECK_CUDA_ERROR(
+          cudaMemcpyAsync(
+              conditions_param_.d_pressure_, h_pressure.data(), sizeof(double) * num_cells, cudaMemcpyHostToDevice, stream),
+          "cudaMemcpy");
+      CHECK_CUDA_ERROR(
+          cudaMemcpyAsync(
+              conditions_param_.d_air_density_, h_air_density.data(), sizeof(double) * num_cells, cudaMemcpyHostToDevice, stream),
+          "cudaMemcpy");
     }
 
     /// @brief Copy input variables to the device

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -130,6 +130,10 @@ enum class CudaRateConstantType : uint8_t
   UserDefined = 7,
 };
 
+/// Maximum number of custom parameters per reaction supported by the GPU kernel
+/// (Surface uses 2: radius + number_concentration; UserDefined uses 1)
+const std::size_t MAX_CUSTOM_PARAMETERS = 2;
+
 /// GPU-portable rate constant descriptor
 /// Replaces virtual RateConstant::Calculate() dispatch with a tagged union
 struct CudaRateConstantData

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -113,8 +113,8 @@ struct CudaConditionsParam
   double* d_pressure_ = nullptr;
   double* d_air_density_ = nullptr;
   double* d_fixed_reactants_ = nullptr;  // pre-computed parameterized reactant factors
-  std::size_t num_cells_ = 0;
-  std::size_t fixed_reactants_size_ = 0;  // total elements in fixed_reactants (= rate_constants_.AsVector().size())
+  std::size_t number_of_grid_cells_ = 0;
+  std::size_t number_of_fixed_reactant_elements_ = 0;  // total elements in fixed_reactants (= rate_constants_.AsVector().size())
 };
 
 /// Tagged enum for GPU-portable rate constant types
@@ -136,12 +136,12 @@ struct CudaRateConstantData
 {
   CudaRateConstantType type_;
   double params_[10];              // fixed-size parameter block (max is 8 for Troe/TCA)
-  std::size_t num_custom_params_;  // number of custom params this reaction consumes from state
+  std::size_t number_of_custom_parameters_;  // number of custom params this reaction consumes from state
 };
 
 /// Device-side struct for CudaProcess rate constant computation
 struct ProcessParam
 {
   CudaRateConstantData* rate_constants_ = nullptr;
-  std::size_t num_reactions_ = 0;
+  std::size_t number_of_reactions_ = 0;
 };

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -106,6 +106,17 @@ struct CudaJacobianDiagonalElementsParam
   std::size_t size_;
 };
 
+/// Device-side struct for cached conditions (SOA layout)
+struct CudaConditionsParam
+{
+  double* d_temperature_ = nullptr;
+  double* d_pressure_ = nullptr;
+  double* d_air_density_ = nullptr;
+  double* d_fixed_reactants_ = nullptr;  // pre-computed parameterized reactant factors
+  std::size_t num_cells_ = 0;
+  std::size_t fixed_reactants_size_ = 0;  // total elements in fixed_reactants (= rate_constants_.AsVector().size())
+};
+
 /// Tagged enum for GPU-portable rate constant types
 enum class CudaRateConstantType : uint8_t
 {

--- a/include/micm/cuda/util/cuda_param.hpp
+++ b/include/micm/cuda/util/cuda_param.hpp
@@ -105,3 +105,32 @@ struct CudaJacobianDiagonalElementsParam
   std::size_t* data_ = nullptr;
   std::size_t size_;
 };
+
+/// Tagged enum for GPU-portable rate constant types
+enum class CudaRateConstantType : uint8_t
+{
+  Arrhenius = 0,
+  Troe = 1,
+  Tunneling = 2,
+  Branched = 3,
+  TernaryChemicalActivation = 4,
+  Reversible = 5,
+  Surface = 6,
+  UserDefined = 7,
+};
+
+/// GPU-portable rate constant descriptor
+/// Replaces virtual RateConstant::Calculate() dispatch with a tagged union
+struct CudaRateConstantData
+{
+  CudaRateConstantType type_;
+  double params_[10];              // fixed-size parameter block (max is 8 for Troe/TCA)
+  std::size_t num_custom_params_;  // number of custom params this reaction consumes from state
+};
+
+/// Device-side struct for CudaProcess rate constant computation
+struct ProcessParam
+{
+  CudaRateConstantData* rate_constants_ = nullptr;
+  std::size_t num_reactions_ = 0;
+};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ if(NOT ${MICM_GPU_TYPE} STREQUAL "None")
     PRIVATE micm
   )
   
-  target_link_libraries(micm_cuda 
+  target_link_libraries(micm_cuda
     PUBLIC CUDA::cudart CUDA::cublas
   )
   

--- a/src/process/CMakeLists.txt
+++ b/src/process/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(micm_cuda
     PRIVATE
     process_set.cu
+    process.cu
 )

--- a/src/process/process.cu
+++ b/src/process/process.cu
@@ -136,7 +136,7 @@ namespace micm
       std::size_t tid = blockIdx.x * BLOCK_SIZE + threadIdx.x;
 
       const std::size_t number_of_grid_cells = rate_constants_param.number_of_grid_cells_;
-      const std::size_t num_reactions = devstruct.num_reactions_;
+      const std::size_t number_of_reactions = devstruct.number_of_reactions_;
       const std::size_t L = rate_constants_param.vector_length_;
       const std::size_t number_of_groups = (number_of_grid_cells + L - 1) / L;
 
@@ -163,15 +163,15 @@ namespace micm
       const double* fixed_base = d_fixed_reactants + group_id * (rate_constants_param.number_of_elements_ / number_of_groups);
 
       std::size_t custom_offset = 0;
-      for (std::size_t i_rxn = 0; i_rxn < num_reactions; ++i_rxn)
+      for (std::size_t i_rxn = 0; i_rxn < number_of_reactions; ++i_rxn)
       {
         const CudaRateConstantData& rc = devstruct.rate_constants_[i_rxn];
 
         // Gather custom params for this cell (vectorized layout: col * L + local_tid)
         double custom_vals[2] = { 0.0, 0.0 };
-        if (custom_base != nullptr && rc.num_custom_params_ > 0)
+        if (custom_base != nullptr && rc.number_of_custom_parameters_ > 0)
         {
-          for (std::size_t i = 0; i < rc.num_custom_params_ && i < 2; ++i)
+          for (std::size_t i = 0; i < rc.number_of_custom_parameters_ && i < 2; ++i)
           {
             custom_vals[i] = custom_base[(custom_offset + i) * L + local_tid];
           }
@@ -182,7 +182,7 @@ namespace micm
 
         rc_base[i_rxn * L + local_tid] = rate * fixed;
 
-        custom_offset += rc.num_custom_params_;
+        custom_offset += rc.number_of_custom_parameters_;
       }
     }
 
@@ -193,9 +193,9 @@ namespace micm
     ProcessParam CopyProcessConstData(ProcessParam& hoststruct)
     {
       ProcessParam devstruct;
-      devstruct.num_reactions_ = hoststruct.num_reactions_;
+      devstruct.number_of_reactions_ = hoststruct.number_of_reactions_;
 
-      std::size_t rate_constants_bytes = sizeof(CudaRateConstantData) * hoststruct.num_reactions_;
+      std::size_t rate_constants_bytes = sizeof(CudaRateConstantData) * hoststruct.number_of_reactions_;
 
       auto cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
 

--- a/src/process/process.cu
+++ b/src/process/process.cu
@@ -1,0 +1,248 @@
+// Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+#include <micm/cuda/util/cuda_param.hpp>
+#include <micm/cuda/util/cuda_util.cuh>
+
+#define _USE_MATH_DEFINES
+#include <cmath>
+
+namespace micm
+{
+  namespace cuda
+  {
+    // ========================================================================
+    // Device functions for each rate constant type
+    // ========================================================================
+
+    /// @brief Arrhenius: k = A * exp(C/T) * (T/D)^B * (1 + E*P)
+    /// params: [A, B, C, D, E]
+    __device__ double CalculateArrhenius(double T, double P, const double* params)
+    {
+      return params[0] * exp(params[2] / T) * pow(T / params[3], params[1]) * (1.0 + params[4] * P);
+    }
+
+    /// @brief Troe falloff: k0*[M]/(1+k0*[M]/kinf) * Fc^(N/(N+log10(k0*[M]/kinf)^2))
+    /// params: [k0_A, k0_B, k0_C, kinf_A, kinf_B, kinf_C, Fc, N]
+    __device__ double CalculateTroe(double T, double air_density, const double* params)
+    {
+      double k0 = params[0] * exp(params[2] / T) * pow(T / 300.0, params[1]);
+      double kinf = params[3] * exp(params[5] / T) * pow(T / 300.0, params[4]);
+      double ratio = k0 * air_density / kinf;
+      return k0 * air_density / (1.0 + ratio) * pow(params[6], params[7] / (params[7] + pow(log10(ratio), 2)));
+    }
+
+    /// @brief Tunneling: k = A * exp(-B/T + C/T^3)
+    /// params: [A, B, C]
+    __device__ double CalculateTunneling(double T, const double* params)
+    {
+      return params[0] * exp(-params[1] / T + params[2] / (T * T * T));
+    }
+
+    /// @brief Branched rate constant
+    /// params: [X, Y, k0, z, branch(0=Alkoxy,1=Nitrate)]
+    /// k0 and z are precomputed on host during construction
+    __device__ double CalculateBranched(double T, double air_density, const double* params)
+    {
+      double pre = params[0] * exp(-params[1] / T);
+      double k0 = params[2];
+      double z = params[3];
+      int branch = static_cast<int>(params[4]);
+
+      // Calculate A(T,[M])
+      double a = k0 * air_density;
+      double b = 0.43 * pow(T / 298.0, -8.0);
+      double Atmn = a / (1.0 + a / b) * pow(0.41, 1.0 / (1.0 + pow(log10(a / b), 2)));
+
+      if (branch == 0)  // Alkoxy
+        return pre * (z / (z + Atmn));
+      else  // Nitrate
+        return pre * (Atmn / (Atmn + z));
+    }
+
+    /// @brief Ternary Chemical Activation: k0/(1+k0*[M]/kinf) * Fc^(N/(N+log10(k0*[M]/kinf)^2))
+    /// params: [k0_A, k0_B, k0_C, kinf_A, kinf_B, kinf_C, Fc, N]
+    __device__ double CalculateTernaryChemicalActivation(double T, double air_density, const double* params)
+    {
+      double k0 = params[0] * exp(params[2] / T) * pow(T / 300.0, params[1]);
+      double kinf = params[3] * exp(params[5] / T) * pow(T / 300.0, params[4]);
+      double ratio = k0 * air_density / kinf;
+      return k0 / (1.0 + ratio) * pow(params[6], params[7] / (params[7] + pow(log10(ratio), 2)));
+    }
+
+    /// @brief Reversible: k = A * exp(C/T) * k_r
+    /// params: [A, C, k_r]
+    __device__ double CalculateReversible(double T, const double* params)
+    {
+      double K_eq = params[0] * exp(params[1] / T);
+      return K_eq * params[2];
+    }
+
+    /// @brief Surface: k = 4*N*pi*r^2 / (r/D + 4/(v_mean*gamma))
+    /// params: [diffusion_coeff, mean_free_speed_factor, reaction_probability]
+    /// custom_params: [radius, number_concentration]
+    __device__ double CalculateSurface(double T, const double* params, const double* custom_params)
+    {
+      double mean_free_speed = sqrt(params[1] * T);
+      double radius = custom_params[0];
+      double number = custom_params[1];
+      return 4.0 * number * M_PI * radius * radius /
+             (radius / params[0] + 4.0 / (mean_free_speed * params[2]));
+    }
+
+    /// @brief UserDefined: k = custom_params[0] * scaling_factor
+    /// params: [scaling_factor]
+    __device__ double CalculateUserDefined(const double* params, const double* custom_params)
+    {
+      return custom_params[0] * params[0];
+    }
+
+    /// @brief Dispatch to the appropriate rate constant calculation
+    __device__ double CalculateRateConstant(
+        const CudaRateConstantData& rc,
+        double T,
+        double P,
+        double air_density,
+        const double* custom_params)
+    {
+      switch (rc.type_)
+      {
+        case CudaRateConstantType::Arrhenius: return CalculateArrhenius(T, P, rc.params_);
+        case CudaRateConstantType::Troe: return CalculateTroe(T, air_density, rc.params_);
+        case CudaRateConstantType::Tunneling: return CalculateTunneling(T, rc.params_);
+        case CudaRateConstantType::Branched: return CalculateBranched(T, air_density, rc.params_);
+        case CudaRateConstantType::TernaryChemicalActivation:
+          return CalculateTernaryChemicalActivation(T, air_density, rc.params_);
+        case CudaRateConstantType::Reversible: return CalculateReversible(T, rc.params_);
+        case CudaRateConstantType::Surface: return CalculateSurface(T, rc.params_, custom_params);
+        case CudaRateConstantType::UserDefined: return CalculateUserDefined(rc.params_, custom_params);
+        default: return 0.0;
+      }
+    }
+
+    // ========================================================================
+    // CUDA Kernel
+    // ========================================================================
+
+    /// @brief Kernel: one thread per grid cell, iterates over all reactions
+    __global__ void CalculateRateConstantsKernel(
+        const double* __restrict__ d_temperature,
+        const double* __restrict__ d_pressure,
+        const double* __restrict__ d_air_density,
+        const CudaMatrixParam custom_rate_params,
+        const double* __restrict__ d_fixed_reactants,
+        CudaMatrixParam rate_constants_param,
+        const ProcessParam devstruct)
+    {
+      std::size_t tid = blockIdx.x * BLOCK_SIZE + threadIdx.x;
+
+      const std::size_t number_of_grid_cells = rate_constants_param.number_of_grid_cells_;
+      const std::size_t num_reactions = devstruct.num_reactions_;
+      const std::size_t L = rate_constants_param.vector_length_;
+      const std::size_t number_of_groups = (number_of_grid_cells + L - 1) / L;
+
+      if (tid >= number_of_grid_cells)
+        return;
+
+      const std::size_t local_tid = tid % L;
+      const std::size_t group_id = tid / L;
+
+      double T = d_temperature[tid];
+      double P = d_pressure[tid];
+      double air_density = d_air_density[tid];
+
+      // Pointer to rate_constants output for this group
+      double* rc_base = rate_constants_param.d_data_ + group_id * (rate_constants_param.number_of_elements_ / number_of_groups);
+
+      // Pointer to custom_rate_parameters for this group
+      const double* custom_base = nullptr;
+      if (custom_rate_params.d_data_ != nullptr)
+        custom_base =
+            custom_rate_params.d_data_ + group_id * (custom_rate_params.number_of_elements_ / number_of_groups);
+
+      // Pointer to fixed_reactants for this group (same layout as rate_constants)
+      const double* fixed_base = d_fixed_reactants + group_id * (rate_constants_param.number_of_elements_ / number_of_groups);
+
+      std::size_t custom_offset = 0;
+      for (std::size_t i_rxn = 0; i_rxn < num_reactions; ++i_rxn)
+      {
+        const CudaRateConstantData& rc = devstruct.rate_constants_[i_rxn];
+
+        // Gather custom params for this cell (vectorized layout: col * L + local_tid)
+        double custom_vals[2] = { 0.0, 0.0 };
+        if (custom_base != nullptr && rc.num_custom_params_ > 0)
+        {
+          for (std::size_t i = 0; i < rc.num_custom_params_ && i < 2; ++i)
+          {
+            custom_vals[i] = custom_base[(custom_offset + i) * L + local_tid];
+          }
+        }
+
+        double rate = CalculateRateConstant(rc, T, P, air_density, custom_vals);
+        double fixed = fixed_base[i_rxn * L + local_tid];
+
+        rc_base[i_rxn * L + local_tid] = rate * fixed;
+
+        custom_offset += rc.num_custom_params_;
+      }
+    }
+
+    // ========================================================================
+    // Memory management functions
+    // ========================================================================
+
+    ProcessParam CopyProcessConstData(ProcessParam& hoststruct)
+    {
+      ProcessParam devstruct;
+      devstruct.num_reactions_ = hoststruct.num_reactions_;
+
+      std::size_t rate_constants_bytes = sizeof(CudaRateConstantData) * hoststruct.num_reactions_;
+
+      auto cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+
+      CHECK_CUDA_ERROR(cudaMallocAsync(&(devstruct.rate_constants_), rate_constants_bytes, cuda_stream_id), "cudaMalloc");
+      CHECK_CUDA_ERROR(
+          cudaMemcpyAsync(
+              devstruct.rate_constants_,
+              hoststruct.rate_constants_,
+              rate_constants_bytes,
+              cudaMemcpyHostToDevice,
+              cuda_stream_id),
+          "cudaMemcpy");
+
+      return devstruct;
+    }
+
+    void FreeProcessConstData(ProcessParam& devstruct)
+    {
+      auto cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+
+      if (devstruct.rate_constants_ != nullptr)
+        CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.rate_constants_, cuda_stream_id), "cudaFree");
+      devstruct.rate_constants_ = nullptr;
+    }
+
+    // ========================================================================
+    // Kernel driver
+    // ========================================================================
+
+    void CalculateRateConstantsKernelDriver(
+        const double* d_temperature,
+        const double* d_pressure,
+        const double* d_air_density,
+        const CudaMatrixParam& custom_rate_params,
+        const double* d_fixed_reactants,
+        CudaMatrixParam& rate_constants_param,
+        const ProcessParam& devstruct)
+    {
+      const std::size_t number_of_blocks = (rate_constants_param.number_of_grid_cells_ + BLOCK_SIZE - 1) / BLOCK_SIZE;
+
+      CalculateRateConstantsKernel<<<
+          number_of_blocks,
+          BLOCK_SIZE,
+          0,
+          micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(
+          d_temperature, d_pressure, d_air_density, custom_rate_params, d_fixed_reactants, rate_constants_param, devstruct);
+    }
+
+  }  // namespace cuda
+}  // namespace micm

--- a/src/process/process.cu
+++ b/src/process/process.cu
@@ -168,10 +168,10 @@ namespace micm
         const CudaRateConstantData& rc = devstruct.rate_constants_[i_rxn];
 
         // Gather custom params for this cell (vectorized layout: col * L + local_tid)
-        double custom_vals[2] = { 0.0, 0.0 };
+        double custom_vals[MAX_CUSTOM_PARAMETERS] = {};
         if (custom_base != nullptr && rc.number_of_custom_parameters_ > 0)
         {
-          for (std::size_t i = 0; i < rc.number_of_custom_parameters_ && i < 2; ++i)
+          for (std::size_t i = 0; i < rc.number_of_custom_parameters_ && i < MAX_CUSTOM_PARAMETERS; ++i)
           {
             custom_vals[i] = custom_base[(custom_offset + i) * L + local_tid];
           }

--- a/test/unit/cuda/process/CMakeLists.txt
+++ b/test/unit/cuda/process/CMakeLists.txt
@@ -2,3 +2,4 @@
 # Tests
 
 create_standard_test(NAME cuda_process_set SOURCES test_cuda_process_set.cpp LIBRARIES musica::micm_cuda IS_CUDA_TEST)
+create_standard_test(NAME cuda_process SOURCES test_cuda_process.cpp LIBRARIES musica::micm_cuda IS_CUDA_TEST)

--- a/test/unit/cuda/process/test_cuda_process.cpp
+++ b/test/unit/cuda/process/test_cuda_process.cpp
@@ -1,0 +1,208 @@
+// Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+#include "../../process/test_process_policy.hpp"
+
+#include <micm/cuda/util/cuda_dense_matrix.hpp>
+
+using FloatingPointType = double;
+
+using Group1CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 1>;
+using Group3CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 3>;
+using Group27CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 27>;
+using Group32CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 32>;
+using Group43CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 43>;
+using Group77CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 77>;
+using Group113CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 113>;
+using Group193CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 193>;
+using Group281CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 281>;
+using Group472CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 472>;
+using Group512CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 512>;
+using Group739CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 739>;
+using Group1130CudaDenseMatrix = micm::CudaDenseMatrix<FloatingPointType, 1130>;
+
+TEST(CudaProcess, ArrheniusRateConstants)
+{
+  testCudaProcessRateConstants<Group1CudaDenseMatrix>(5);
+  testCudaProcessRateConstants<Group3CudaDenseMatrix>(5);
+  testCudaProcessRateConstants<Group27CudaDenseMatrix>(50);
+  testCudaProcessRateConstants<Group32CudaDenseMatrix>(50);
+  testCudaProcessRateConstants<Group43CudaDenseMatrix>(50);
+  testCudaProcessRateConstants<Group77CudaDenseMatrix>(100);
+  testCudaProcessRateConstants<Group113CudaDenseMatrix>(200);
+  testCudaProcessRateConstants<Group193CudaDenseMatrix>(200);
+  testCudaProcessRateConstants<Group281CudaDenseMatrix>(400);
+  testCudaProcessRateConstants<Group472CudaDenseMatrix>(500);
+  testCudaProcessRateConstants<Group512CudaDenseMatrix>(600);
+  testCudaProcessRateConstants<Group739CudaDenseMatrix>(800);
+  testCudaProcessRateConstants<Group1130CudaDenseMatrix>(1200);
+}
+
+TEST(CudaProcess, MixedRateConstants)
+{
+  testCudaProcessMixedRateConstants<Group1CudaDenseMatrix>(5);
+  testCudaProcessMixedRateConstants<Group3CudaDenseMatrix>(5);
+  testCudaProcessMixedRateConstants<Group27CudaDenseMatrix>(50);
+  testCudaProcessMixedRateConstants<Group32CudaDenseMatrix>(50);
+  testCudaProcessMixedRateConstants<Group43CudaDenseMatrix>(50);
+  testCudaProcessMixedRateConstants<Group77CudaDenseMatrix>(100);
+  testCudaProcessMixedRateConstants<Group113CudaDenseMatrix>(200);
+  testCudaProcessMixedRateConstants<Group193CudaDenseMatrix>(200);
+  testCudaProcessMixedRateConstants<Group281CudaDenseMatrix>(400);
+  testCudaProcessMixedRateConstants<Group472CudaDenseMatrix>(500);
+  testCudaProcessMixedRateConstants<Group512CudaDenseMatrix>(600);
+  testCudaProcessMixedRateConstants<Group739CudaDenseMatrix>(800);
+  testCudaProcessMixedRateConstants<Group1130CudaDenseMatrix>(1200);
+}
+
+TEST(CudaProcess, TroeRateConstants)
+{
+  testCudaProcessTroeRateConstants<Group1CudaDenseMatrix>(5);
+  testCudaProcessTroeRateConstants<Group3CudaDenseMatrix>(5);
+  testCudaProcessTroeRateConstants<Group27CudaDenseMatrix>(50);
+  testCudaProcessTroeRateConstants<Group32CudaDenseMatrix>(50);
+  testCudaProcessTroeRateConstants<Group43CudaDenseMatrix>(50);
+  testCudaProcessTroeRateConstants<Group77CudaDenseMatrix>(100);
+  testCudaProcessTroeRateConstants<Group113CudaDenseMatrix>(200);
+  testCudaProcessTroeRateConstants<Group193CudaDenseMatrix>(200);
+  testCudaProcessTroeRateConstants<Group281CudaDenseMatrix>(400);
+  testCudaProcessTroeRateConstants<Group472CudaDenseMatrix>(500);
+  testCudaProcessTroeRateConstants<Group512CudaDenseMatrix>(600);
+  testCudaProcessTroeRateConstants<Group739CudaDenseMatrix>(800);
+  testCudaProcessTroeRateConstants<Group1130CudaDenseMatrix>(1200);
+}
+
+TEST(CudaProcess, TunnelingRateConstants)
+{
+  testCudaProcessTunnelingRateConstants<Group1CudaDenseMatrix>(5);
+  testCudaProcessTunnelingRateConstants<Group3CudaDenseMatrix>(5);
+  testCudaProcessTunnelingRateConstants<Group27CudaDenseMatrix>(50);
+  testCudaProcessTunnelingRateConstants<Group32CudaDenseMatrix>(50);
+  testCudaProcessTunnelingRateConstants<Group43CudaDenseMatrix>(50);
+  testCudaProcessTunnelingRateConstants<Group77CudaDenseMatrix>(100);
+  testCudaProcessTunnelingRateConstants<Group113CudaDenseMatrix>(200);
+  testCudaProcessTunnelingRateConstants<Group193CudaDenseMatrix>(200);
+  testCudaProcessTunnelingRateConstants<Group281CudaDenseMatrix>(400);
+  testCudaProcessTunnelingRateConstants<Group472CudaDenseMatrix>(500);
+  testCudaProcessTunnelingRateConstants<Group512CudaDenseMatrix>(600);
+  testCudaProcessTunnelingRateConstants<Group739CudaDenseMatrix>(800);
+  testCudaProcessTunnelingRateConstants<Group1130CudaDenseMatrix>(1200);
+}
+
+TEST(CudaProcess, BranchedAlkoxyRateConstants)
+{
+  testCudaProcessBranchedAlkoxyRateConstants<Group1CudaDenseMatrix>(5);
+  testCudaProcessBranchedAlkoxyRateConstants<Group3CudaDenseMatrix>(5);
+  testCudaProcessBranchedAlkoxyRateConstants<Group27CudaDenseMatrix>(50);
+  testCudaProcessBranchedAlkoxyRateConstants<Group32CudaDenseMatrix>(50);
+  testCudaProcessBranchedAlkoxyRateConstants<Group43CudaDenseMatrix>(50);
+  testCudaProcessBranchedAlkoxyRateConstants<Group77CudaDenseMatrix>(100);
+  testCudaProcessBranchedAlkoxyRateConstants<Group113CudaDenseMatrix>(200);
+  testCudaProcessBranchedAlkoxyRateConstants<Group193CudaDenseMatrix>(200);
+  testCudaProcessBranchedAlkoxyRateConstants<Group281CudaDenseMatrix>(400);
+  testCudaProcessBranchedAlkoxyRateConstants<Group472CudaDenseMatrix>(500);
+  testCudaProcessBranchedAlkoxyRateConstants<Group512CudaDenseMatrix>(600);
+  testCudaProcessBranchedAlkoxyRateConstants<Group739CudaDenseMatrix>(800);
+  testCudaProcessBranchedAlkoxyRateConstants<Group1130CudaDenseMatrix>(1200);
+}
+
+TEST(CudaProcess, BranchedNitrateRateConstants)
+{
+  testCudaProcessBranchedNitrateRateConstants<Group1CudaDenseMatrix>(5);
+  testCudaProcessBranchedNitrateRateConstants<Group3CudaDenseMatrix>(5);
+  testCudaProcessBranchedNitrateRateConstants<Group27CudaDenseMatrix>(50);
+  testCudaProcessBranchedNitrateRateConstants<Group32CudaDenseMatrix>(50);
+  testCudaProcessBranchedNitrateRateConstants<Group43CudaDenseMatrix>(50);
+  testCudaProcessBranchedNitrateRateConstants<Group77CudaDenseMatrix>(100);
+  testCudaProcessBranchedNitrateRateConstants<Group113CudaDenseMatrix>(200);
+  testCudaProcessBranchedNitrateRateConstants<Group193CudaDenseMatrix>(200);
+  testCudaProcessBranchedNitrateRateConstants<Group281CudaDenseMatrix>(400);
+  testCudaProcessBranchedNitrateRateConstants<Group472CudaDenseMatrix>(500);
+  testCudaProcessBranchedNitrateRateConstants<Group512CudaDenseMatrix>(600);
+  testCudaProcessBranchedNitrateRateConstants<Group739CudaDenseMatrix>(800);
+  testCudaProcessBranchedNitrateRateConstants<Group1130CudaDenseMatrix>(1200);
+}
+
+TEST(CudaProcess, TernaryChemicalActivationRateConstants)
+{
+  testCudaProcessTernaryChemicalActivationRateConstants<Group1CudaDenseMatrix>(5);
+  testCudaProcessTernaryChemicalActivationRateConstants<Group3CudaDenseMatrix>(5);
+  testCudaProcessTernaryChemicalActivationRateConstants<Group27CudaDenseMatrix>(50);
+  testCudaProcessTernaryChemicalActivationRateConstants<Group32CudaDenseMatrix>(50);
+  testCudaProcessTernaryChemicalActivationRateConstants<Group43CudaDenseMatrix>(50);
+  testCudaProcessTernaryChemicalActivationRateConstants<Group77CudaDenseMatrix>(100);
+  testCudaProcessTernaryChemicalActivationRateConstants<Group113CudaDenseMatrix>(200);
+  testCudaProcessTernaryChemicalActivationRateConstants<Group193CudaDenseMatrix>(200);
+  testCudaProcessTernaryChemicalActivationRateConstants<Group281CudaDenseMatrix>(400);
+  testCudaProcessTernaryChemicalActivationRateConstants<Group472CudaDenseMatrix>(500);
+  testCudaProcessTernaryChemicalActivationRateConstants<Group512CudaDenseMatrix>(600);
+  testCudaProcessTernaryChemicalActivationRateConstants<Group739CudaDenseMatrix>(800);
+  testCudaProcessTernaryChemicalActivationRateConstants<Group1130CudaDenseMatrix>(1200);
+}
+
+TEST(CudaProcess, ReversibleRateConstants)
+{
+  testCudaProcessReversibleRateConstants<Group1CudaDenseMatrix>(5);
+  testCudaProcessReversibleRateConstants<Group3CudaDenseMatrix>(5);
+  testCudaProcessReversibleRateConstants<Group27CudaDenseMatrix>(50);
+  testCudaProcessReversibleRateConstants<Group32CudaDenseMatrix>(50);
+  testCudaProcessReversibleRateConstants<Group43CudaDenseMatrix>(50);
+  testCudaProcessReversibleRateConstants<Group77CudaDenseMatrix>(100);
+  testCudaProcessReversibleRateConstants<Group113CudaDenseMatrix>(200);
+  testCudaProcessReversibleRateConstants<Group193CudaDenseMatrix>(200);
+  testCudaProcessReversibleRateConstants<Group281CudaDenseMatrix>(400);
+  testCudaProcessReversibleRateConstants<Group472CudaDenseMatrix>(500);
+  testCudaProcessReversibleRateConstants<Group512CudaDenseMatrix>(600);
+  testCudaProcessReversibleRateConstants<Group739CudaDenseMatrix>(800);
+  testCudaProcessReversibleRateConstants<Group1130CudaDenseMatrix>(1200);
+}
+
+TEST(CudaProcess, SurfaceRateConstants)
+{
+  testCudaProcessSurfaceRateConstants<Group1CudaDenseMatrix>(5);
+  testCudaProcessSurfaceRateConstants<Group3CudaDenseMatrix>(5);
+  testCudaProcessSurfaceRateConstants<Group27CudaDenseMatrix>(50);
+  testCudaProcessSurfaceRateConstants<Group32CudaDenseMatrix>(50);
+  testCudaProcessSurfaceRateConstants<Group43CudaDenseMatrix>(50);
+  testCudaProcessSurfaceRateConstants<Group77CudaDenseMatrix>(100);
+  testCudaProcessSurfaceRateConstants<Group113CudaDenseMatrix>(200);
+  testCudaProcessSurfaceRateConstants<Group193CudaDenseMatrix>(200);
+  testCudaProcessSurfaceRateConstants<Group281CudaDenseMatrix>(400);
+  testCudaProcessSurfaceRateConstants<Group472CudaDenseMatrix>(500);
+  testCudaProcessSurfaceRateConstants<Group512CudaDenseMatrix>(600);
+  testCudaProcessSurfaceRateConstants<Group739CudaDenseMatrix>(800);
+  testCudaProcessSurfaceRateConstants<Group1130CudaDenseMatrix>(1200);
+}
+
+TEST(CudaProcess, UserDefinedRateConstants)
+{
+  testCudaProcessUserDefinedRateConstants<Group1CudaDenseMatrix>(5);
+  testCudaProcessUserDefinedRateConstants<Group3CudaDenseMatrix>(5);
+  testCudaProcessUserDefinedRateConstants<Group27CudaDenseMatrix>(50);
+  testCudaProcessUserDefinedRateConstants<Group32CudaDenseMatrix>(50);
+  testCudaProcessUserDefinedRateConstants<Group43CudaDenseMatrix>(50);
+  testCudaProcessUserDefinedRateConstants<Group77CudaDenseMatrix>(100);
+  testCudaProcessUserDefinedRateConstants<Group113CudaDenseMatrix>(200);
+  testCudaProcessUserDefinedRateConstants<Group193CudaDenseMatrix>(200);
+  testCudaProcessUserDefinedRateConstants<Group281CudaDenseMatrix>(400);
+  testCudaProcessUserDefinedRateConstants<Group472CudaDenseMatrix>(500);
+  testCudaProcessUserDefinedRateConstants<Group512CudaDenseMatrix>(600);
+  testCudaProcessUserDefinedRateConstants<Group739CudaDenseMatrix>(800);
+  testCudaProcessUserDefinedRateConstants<Group1130CudaDenseMatrix>(1200);
+}
+
+TEST(CudaProcess, AllRateConstants)
+{
+  testCudaProcessAllRateConstants<Group1CudaDenseMatrix>(5);
+  testCudaProcessAllRateConstants<Group3CudaDenseMatrix>(5);
+  testCudaProcessAllRateConstants<Group27CudaDenseMatrix>(50);
+  testCudaProcessAllRateConstants<Group32CudaDenseMatrix>(50);
+  testCudaProcessAllRateConstants<Group43CudaDenseMatrix>(50);
+  testCudaProcessAllRateConstants<Group77CudaDenseMatrix>(100);
+  testCudaProcessAllRateConstants<Group113CudaDenseMatrix>(200);
+  testCudaProcessAllRateConstants<Group193CudaDenseMatrix>(200);
+  testCudaProcessAllRateConstants<Group281CudaDenseMatrix>(400);
+  testCudaProcessAllRateConstants<Group472CudaDenseMatrix>(500);
+  testCudaProcessAllRateConstants<Group512CudaDenseMatrix>(600);
+  testCudaProcessAllRateConstants<Group739CudaDenseMatrix>(800);
+  testCudaProcessAllRateConstants<Group1130CudaDenseMatrix>(1200);
+}

--- a/test/unit/cuda/util/CMakeLists.txt
+++ b/test/unit/cuda/util/CMakeLists.txt
@@ -8,7 +8,7 @@ set_target_properties(micm_cuda_test_utils PROPERTIES LINKER_LANGUAGE CXX)
 
 # add a library to use customized GTest main function for CUDA tests
 add_library(cuda_gtest_main STATIC cuda_gtest_main.cpp)
-target_link_libraries(cuda_gtest_main PUBLIC GTest::gtest micm)
+target_link_libraries(cuda_gtest_main PUBLIC GTest::gtest micm CUDA::cublas)
 
 create_standard_test(NAME cuda_dense_matrix SOURCES test_cuda_dense_matrix.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils IS_CUDA_TEST)
 create_standard_test(NAME cuda_sparse_matrix_vector_ordering_row SOURCES test_cuda_sparse_matrix_vector_ordering_row.cpp LIBRARIES musica::micm_cuda micm_cuda_test_utils IS_CUDA_TEST)

--- a/test/unit/process/test_process_policy.hpp
+++ b/test/unit/process/test_process_policy.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <micm/cuda/process/cuda_process.hpp>
+#include <micm/cuda/solver/cuda_state.hpp>
 #include <micm/process/chemical_reaction_builder.hpp>
 #include <micm/process/process.hpp>
 #include <micm/process/rate_constant/arrhenius_rate_constant.hpp>
@@ -57,7 +58,7 @@ void testCudaProcessRateConstants(const std::size_t number_of_grid_cells)
     }
   }
 
-  State<DenseMatrixPolicy> state{ StateParameters{
+  CudaState<DenseMatrixPolicy> state{ StateParameters{
                                       .number_of_rate_constants_ = processes.size(),
                                       .variable_names_ = { "foo", "bar" },
                                       .custom_rate_parameter_labels_ = param_labels,
@@ -89,6 +90,7 @@ void testCudaProcessRateConstants(const std::size_t number_of_grid_cells)
 
   // Compute on GPU
   CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  state.SyncConditionsToDevice();
   cuda_process.CalculateRateConstants(processes, state);
 
   // Copy results back to host
@@ -149,7 +151,7 @@ void testCudaProcessMixedRateConstants(const std::size_t number_of_grid_cells)
     }
   }
 
-  State<DenseMatrixPolicy> state{ StateParameters{
+  CudaState<DenseMatrixPolicy> state{ StateParameters{
                                       .number_of_rate_constants_ = processes.size(),
                                       .variable_names_ = { "foo", "bar" },
                                       .custom_rate_parameter_labels_ = param_labels,
@@ -197,6 +199,7 @@ void testCudaProcessMixedRateConstants(const std::size_t number_of_grid_cells)
 
   // Compute on GPU
   CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  state.SyncConditionsToDevice();
   cuda_process.CalculateRateConstants(processes, state);
 
   // Copy results back to host
@@ -257,7 +260,7 @@ void testCudaProcessTroeRateConstants(const std::size_t number_of_grid_cells)
     }
   }
 
-  State<DenseMatrixPolicy> state{ StateParameters{
+  CudaState<DenseMatrixPolicy> state{ StateParameters{
                                       .number_of_rate_constants_ = processes.size(),
                                       .variable_names_ = { "foo", "bar" },
                                       .custom_rate_parameter_labels_ = param_labels,
@@ -286,6 +289,7 @@ void testCudaProcessTroeRateConstants(const std::size_t number_of_grid_cells)
   Process::CalculateRateConstants(processes, cpu_state);
 
   CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  state.SyncConditionsToDevice();
   cuda_process.CalculateRateConstants(processes, state);
 
   state.rate_constants_.CopyToHost();
@@ -298,7 +302,7 @@ void testCudaProcessTroeRateConstants(const std::size_t number_of_grid_cells)
       double actual = state.rate_constants_[i_cell][i_rxn];
       if (std::abs(expected) > 1.0e-30)
       {
-        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-15)
             << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
       }
       else
@@ -343,7 +347,7 @@ void testCudaProcessTunnelingRateConstants(const std::size_t number_of_grid_cell
     }
   }
 
-  State<DenseMatrixPolicy> state{ StateParameters{
+  CudaState<DenseMatrixPolicy> state{ StateParameters{
                                       .number_of_rate_constants_ = processes.size(),
                                       .variable_names_ = { "foo", "bar" },
                                       .custom_rate_parameter_labels_ = param_labels,
@@ -372,6 +376,7 @@ void testCudaProcessTunnelingRateConstants(const std::size_t number_of_grid_cell
   Process::CalculateRateConstants(processes, cpu_state);
 
   CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  state.SyncConditionsToDevice();
   cuda_process.CalculateRateConstants(processes, state);
 
   state.rate_constants_.CopyToHost();
@@ -384,7 +389,7 @@ void testCudaProcessTunnelingRateConstants(const std::size_t number_of_grid_cell
       double actual = state.rate_constants_[i_cell][i_rxn];
       if (std::abs(expected) > 1.0e-30)
       {
-        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-15)
             << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
       }
       else
@@ -432,7 +437,7 @@ void testCudaProcessBranchedAlkoxyRateConstants(const std::size_t number_of_grid
     }
   }
 
-  State<DenseMatrixPolicy> state{ StateParameters{
+  CudaState<DenseMatrixPolicy> state{ StateParameters{
                                       .number_of_rate_constants_ = processes.size(),
                                       .variable_names_ = { "foo", "bar" },
                                       .custom_rate_parameter_labels_ = param_labels,
@@ -461,6 +466,7 @@ void testCudaProcessBranchedAlkoxyRateConstants(const std::size_t number_of_grid
   Process::CalculateRateConstants(processes, cpu_state);
 
   CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  state.SyncConditionsToDevice();
   cuda_process.CalculateRateConstants(processes, state);
 
   state.rate_constants_.CopyToHost();
@@ -473,7 +479,7 @@ void testCudaProcessBranchedAlkoxyRateConstants(const std::size_t number_of_grid
       double actual = state.rate_constants_[i_cell][i_rxn];
       if (std::abs(expected) > 1.0e-30)
       {
-        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-15)
             << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
       }
       else
@@ -521,7 +527,7 @@ void testCudaProcessBranchedNitrateRateConstants(const std::size_t number_of_gri
     }
   }
 
-  State<DenseMatrixPolicy> state{ StateParameters{
+  CudaState<DenseMatrixPolicy> state{ StateParameters{
                                       .number_of_rate_constants_ = processes.size(),
                                       .variable_names_ = { "foo", "bar" },
                                       .custom_rate_parameter_labels_ = param_labels,
@@ -550,6 +556,7 @@ void testCudaProcessBranchedNitrateRateConstants(const std::size_t number_of_gri
   Process::CalculateRateConstants(processes, cpu_state);
 
   CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  state.SyncConditionsToDevice();
   cuda_process.CalculateRateConstants(processes, state);
 
   state.rate_constants_.CopyToHost();
@@ -562,7 +569,7 @@ void testCudaProcessBranchedNitrateRateConstants(const std::size_t number_of_gri
       double actual = state.rate_constants_[i_cell][i_rxn];
       if (std::abs(expected) > 1.0e-30)
       {
-        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-15)
             << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
       }
       else
@@ -615,7 +622,7 @@ void testCudaProcessTernaryChemicalActivationRateConstants(const std::size_t num
     }
   }
 
-  State<DenseMatrixPolicy> state{ StateParameters{
+  CudaState<DenseMatrixPolicy> state{ StateParameters{
                                       .number_of_rate_constants_ = processes.size(),
                                       .variable_names_ = { "foo", "bar" },
                                       .custom_rate_parameter_labels_ = param_labels,
@@ -644,6 +651,7 @@ void testCudaProcessTernaryChemicalActivationRateConstants(const std::size_t num
   Process::CalculateRateConstants(processes, cpu_state);
 
   CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  state.SyncConditionsToDevice();
   cuda_process.CalculateRateConstants(processes, state);
 
   state.rate_constants_.CopyToHost();
@@ -656,7 +664,7 @@ void testCudaProcessTernaryChemicalActivationRateConstants(const std::size_t num
       double actual = state.rate_constants_[i_cell][i_rxn];
       if (std::abs(expected) > 1.0e-30)
       {
-        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-15)
             << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
       }
       else
@@ -701,7 +709,7 @@ void testCudaProcessReversibleRateConstants(const std::size_t number_of_grid_cel
     }
   }
 
-  State<DenseMatrixPolicy> state{ StateParameters{
+  CudaState<DenseMatrixPolicy> state{ StateParameters{
                                       .number_of_rate_constants_ = processes.size(),
                                       .variable_names_ = { "foo", "bar" },
                                       .custom_rate_parameter_labels_ = param_labels,
@@ -730,6 +738,7 @@ void testCudaProcessReversibleRateConstants(const std::size_t number_of_grid_cel
   Process::CalculateRateConstants(processes, cpu_state);
 
   CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  state.SyncConditionsToDevice();
   cuda_process.CalculateRateConstants(processes, state);
 
   state.rate_constants_.CopyToHost();
@@ -742,7 +751,7 @@ void testCudaProcessReversibleRateConstants(const std::size_t number_of_grid_cel
       double actual = state.rate_constants_[i_cell][i_rxn];
       if (std::abs(expected) > 1.0e-30)
       {
-        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-15)
             << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
       }
       else
@@ -787,7 +796,7 @@ void testCudaProcessSurfaceRateConstants(const std::size_t number_of_grid_cells)
     }
   }
 
-  State<DenseMatrixPolicy> state{ StateParameters{
+  CudaState<DenseMatrixPolicy> state{ StateParameters{
                                       .number_of_rate_constants_ = processes.size(),
                                       .variable_names_ = { "foo", "bar" },
                                       .custom_rate_parameter_labels_ = param_labels,
@@ -855,6 +864,7 @@ void testCudaProcessSurfaceRateConstants(const std::size_t number_of_grid_cells)
   Process::CalculateRateConstants(processes, cpu_state);
 
   CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  state.SyncConditionsToDevice();
   cuda_process.CalculateRateConstants(processes, state);
 
   state.rate_constants_.CopyToHost();
@@ -867,7 +877,7 @@ void testCudaProcessSurfaceRateConstants(const std::size_t number_of_grid_cells)
       double actual = state.rate_constants_[i_cell][i_rxn];
       if (std::abs(expected) > 1.0e-30)
       {
-        EXPECT_NEAR(actual / expected, 1.0, 1.0e-8)
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-15)
             << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
       }
       else
@@ -912,7 +922,7 @@ void testCudaProcessUserDefinedRateConstants(const std::size_t number_of_grid_ce
     }
   }
 
-  State<DenseMatrixPolicy> state{ StateParameters{
+  CudaState<DenseMatrixPolicy> state{ StateParameters{
                                       .number_of_rate_constants_ = processes.size(),
                                       .variable_names_ = { "foo", "bar" },
                                       .custom_rate_parameter_labels_ = param_labels,
@@ -953,6 +963,7 @@ void testCudaProcessUserDefinedRateConstants(const std::size_t number_of_grid_ce
   Process::CalculateRateConstants(processes, cpu_state);
 
   CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  state.SyncConditionsToDevice();
   cuda_process.CalculateRateConstants(processes, state);
 
   state.rate_constants_.CopyToHost();
@@ -965,7 +976,7 @@ void testCudaProcessUserDefinedRateConstants(const std::size_t number_of_grid_ce
       double actual = state.rate_constants_[i_cell][i_rxn];
       if (std::abs(expected) > 1.0e-30)
       {
-        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-15)
             << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
       }
       else
@@ -1027,7 +1038,7 @@ void testCudaProcessAllRateConstants(const std::size_t number_of_grid_cells)
     }
   }
 
-  State<DenseMatrixPolicy> state{ StateParameters{
+  CudaState<DenseMatrixPolicy> state{ StateParameters{
                                       .number_of_rate_constants_ = processes.size(),
                                       .variable_names_ = { "foo", "bar" },
                                       .custom_rate_parameter_labels_ = param_labels,
@@ -1074,6 +1085,7 @@ void testCudaProcessAllRateConstants(const std::size_t number_of_grid_cells)
   Process::CalculateRateConstants(processes, cpu_state);
 
   CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  state.SyncConditionsToDevice();
   cuda_process.CalculateRateConstants(processes, state);
 
   state.rate_constants_.CopyToHost();
@@ -1086,7 +1098,7 @@ void testCudaProcessAllRateConstants(const std::size_t number_of_grid_cells)
       double actual = state.rate_constants_[i_cell][i_rxn];
       if (std::abs(expected) > 1.0e-30)
       {
-        EXPECT_NEAR(actual / expected, 1.0, 1.0e-8)
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-15)
             << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
       }
       else

--- a/test/unit/process/test_process_policy.hpp
+++ b/test/unit/process/test_process_policy.hpp
@@ -1,0 +1,1099 @@
+// Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <micm/cuda/process/cuda_process.hpp>
+#include <micm/process/chemical_reaction_builder.hpp>
+#include <micm/process/process.hpp>
+#include <micm/process/rate_constant/arrhenius_rate_constant.hpp>
+#include <micm/process/rate_constant/branched_rate_constant.hpp>
+#include <micm/process/rate_constant/reversible_rate_constant.hpp>
+#include <micm/process/rate_constant/surface_rate_constant.hpp>
+#include <micm/process/rate_constant/ternary_chemical_activation_rate_constant.hpp>
+#include <micm/process/rate_constant/troe_rate_constant.hpp>
+#include <micm/process/rate_constant/tunneling_rate_constant.hpp>
+#include <micm/process/rate_constant/user_defined_rate_constant.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <random>
+#include <vector>
+
+using namespace micm;
+
+/// @brief Test rate constant calculation on GPU with Arrhenius rate constants
+///        and parameterized reactants, comparing against CPU reference
+template<class DenseMatrixPolicy>
+void testCudaProcessRateConstants(const std::size_t number_of_grid_cells)
+{
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 } });
+  Species bar("bar");
+  bar.parameterize_ = [](const Conditions& c) { return c.air_density_ * 0.82; };
+
+  double foo_diff_coeff = 2.3e2;
+  PhaseSpecies gas_foo(foo, foo_diff_coeff);
+  PhaseSpecies gas_bar(bar);
+  Phase gas_phase{ "gas", { gas_foo, gas_bar } };
+
+  ArrheniusRateConstant rc1({ .A_ = 12.2, .C_ = 300.0 });
+  ArrheniusRateConstant rc2({ .A_ = 3.5e-6, .B_ = 1.2, .C_ = -200.0, .D_ = 298.0, .E_ = 1.0e-5 });
+  ArrheniusRateConstant rc3({ .A_ = 1.0 });
+
+  Process r1 = ChemicalReactionBuilder().SetReactants({ foo, bar }).SetRateConstant(rc1).SetPhase(gas_phase).Build();
+  Process r2 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc2).SetPhase(gas_phase).Build();
+  Process r3 = ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc3).SetPhase(gas_phase).Build();
+  std::vector<Process> processes = { r1, r2, r3 };
+
+  std::vector<std::string> param_labels{};
+  for (const auto& process : processes)
+  {
+    if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+    {
+      for (const auto& label : reaction->rate_constant_->CustomParameters())
+      {
+        param_labels.push_back(label);
+      }
+    }
+  }
+
+  State<DenseMatrixPolicy> state{ StateParameters{
+                                      .number_of_rate_constants_ = processes.size(),
+                                      .variable_names_ = { "foo", "bar" },
+                                      .custom_rate_parameter_labels_ = param_labels,
+                                  },
+                                  number_of_grid_cells };
+
+  // CPU reference state
+  State<DenseMatrixPolicy> cpu_state{ StateParameters{
+                                          .number_of_rate_constants_ = processes.size(),
+                                          .variable_names_ = { "foo", "bar" },
+                                          .custom_rate_parameter_labels_ = param_labels,
+                                      },
+                                      number_of_grid_cells };
+
+  auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    Conditions cond;
+    cond.temperature_ = get_double() * 285.0;
+    cond.pressure_ = get_double() * 101100.0;
+    cond.air_density_ = get_double() * 10.0;
+    state.conditions_[i_cell] = cond;
+    cpu_state.conditions_[i_cell] = cond;
+  }
+
+  // Compute expected on CPU
+  Process::CalculateRateConstants(processes, cpu_state);
+
+  // Compute on GPU
+  CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  cuda_process.CalculateRateConstants(processes, state);
+
+  // Copy results back to host
+  state.rate_constants_.CopyToHost();
+
+  // Compare with relative tolerance
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    for (std::size_t i_rxn = 0; i_rxn < processes.size(); ++i_rxn)
+    {
+      double expected = cpu_state.rate_constants_[i_cell][i_rxn];
+      double actual = state.rate_constants_[i_cell][i_rxn];
+      if (std::abs(expected) > 1.0e-30)
+      {
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+            << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
+      }
+      else
+      {
+        EXPECT_NEAR(actual, expected, 1.0e-30) << "grid cell " << i_cell << "; reaction " << i_rxn;
+      }
+    }
+  }
+}
+
+/// @brief Test rate constant calculation on GPU with mixed rate constant types
+///        (Arrhenius, Surface, UserDefined) and parameterized reactants
+template<class DenseMatrixPolicy>
+void testCudaProcessMixedRateConstants(const std::size_t number_of_grid_cells)
+{
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 } });
+  Species bar("bar");
+  bar.parameterize_ = [](const Conditions& c) { return c.air_density_ * 0.82; };
+
+  double foo_diff_coeff = 2.3e2;
+  PhaseSpecies gas_foo(foo, foo_diff_coeff);
+  PhaseSpecies gas_bar(bar);
+  Phase gas_phase{ "gas", { gas_foo, gas_bar } };
+
+  ArrheniusRateConstant rc1({ .A_ = 12.2, .C_ = 300.0 });
+  SurfaceRateConstant rc2({ .label_ = "foo_surf", .phase_species_ = gas_foo });
+  UserDefinedRateConstant rc3({ .label_ = "bar_user" });
+
+  Process r1 = ChemicalReactionBuilder().SetReactants({ foo, bar }).SetRateConstant(rc1).SetPhase(gas_phase).Build();
+  Process r2 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc2).SetPhase(gas_phase).Build();
+  Process r3 = ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc3).SetPhase(gas_phase).Build();
+  std::vector<Process> processes = { r1, r2, r3 };
+
+  std::vector<std::string> param_labels{};
+  for (const auto& process : processes)
+  {
+    if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+    {
+      for (const auto& label : reaction->rate_constant_->CustomParameters())
+      {
+        param_labels.push_back(label);
+      }
+    }
+  }
+
+  State<DenseMatrixPolicy> state{ StateParameters{
+                                      .number_of_rate_constants_ = processes.size(),
+                                      .variable_names_ = { "foo", "bar" },
+                                      .custom_rate_parameter_labels_ = param_labels,
+                                  },
+                                  number_of_grid_cells };
+
+  State<DenseMatrixPolicy> cpu_state{ StateParameters{
+                                          .number_of_rate_constants_ = processes.size(),
+                                          .variable_names_ = { "foo", "bar" },
+                                          .custom_rate_parameter_labels_ = param_labels,
+                                      },
+                                      number_of_grid_cells };
+
+  auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    Conditions cond;
+    cond.temperature_ = get_double() * 285.0;
+    cond.pressure_ = get_double() * 101100.0;
+    cond.air_density_ = get_double() * 10.0;
+    state.conditions_[i_cell] = cond;
+    cpu_state.conditions_[i_cell] = cond;
+
+    double radius = get_double() * 1.0e-8;
+    double number_conc = get_double() * 1.0e5;
+    double user_rate = get_double() * 1.0e-2;
+
+    state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["foo_surf.effective radius [m]"]] = radius;
+    state.custom_rate_parameters_[i_cell]
+                                 [state.custom_rate_parameter_map_["foo_surf.particle number concentration [# m-3]"]] =
+        number_conc;
+    state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["bar_user"]] = user_rate;
+
+    cpu_state.custom_rate_parameters_[i_cell][cpu_state.custom_rate_parameter_map_["foo_surf.effective radius [m]"]] = radius;
+    cpu_state
+        .custom_rate_parameters_[i_cell]
+                                [cpu_state.custom_rate_parameter_map_["foo_surf.particle number concentration [# m-3]"]] =
+        number_conc;
+    cpu_state.custom_rate_parameters_[i_cell][cpu_state.custom_rate_parameter_map_["bar_user"]] = user_rate;
+  }
+
+  // Compute expected on CPU
+  Process::CalculateRateConstants(processes, cpu_state);
+
+  // Compute on GPU
+  CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  cuda_process.CalculateRateConstants(processes, state);
+
+  // Copy results back to host
+  state.rate_constants_.CopyToHost();
+
+  // Compare with relative tolerance for floating point differences
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    for (std::size_t i_rxn = 0; i_rxn < processes.size(); ++i_rxn)
+    {
+      double expected = cpu_state.rate_constants_[i_cell][i_rxn];
+      double actual = state.rate_constants_[i_cell][i_rxn];
+      if (std::abs(expected) > 1.0e-30)
+      {
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-8)
+            << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
+      }
+      else
+      {
+        EXPECT_NEAR(actual, expected, 1.0e-30) << "grid cell " << i_cell << "; reaction " << i_rxn;
+      }
+    }
+  }
+}
+
+/// @brief Test rate constant calculation on GPU with Troe rate constants
+template<class DenseMatrixPolicy>
+void testCudaProcessTroeRateConstants(const std::size_t number_of_grid_cells)
+{
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 } });
+  Species bar("bar");
+  bar.parameterize_ = [](const Conditions& c) { return c.air_density_ * 0.82; };
+
+  double foo_diff_coeff = 2.3e2;
+  PhaseSpecies gas_foo(foo, foo_diff_coeff);
+  PhaseSpecies gas_bar(bar);
+  Phase gas_phase{ "gas", { gas_foo, gas_bar } };
+
+  TroeRateConstant rc1({ .k0_A_ = 4.4e-32, .k0_B_ = -1.3, .kinf_A_ = 7.5e-11, .kinf_B_ = 0.2, .Fc_ = 0.6, .N_ = 1.0 });
+  TroeRateConstant rc2(
+      { .k0_A_ = 2.0e-30, .k0_B_ = -3.0, .k0_C_ = -394.0, .kinf_A_ = 2.5e-11, .kinf_C_ = -50.0, .Fc_ = 0.4, .N_ = 1.2 });
+  TroeRateConstant rc3(TroeRateConstantParameters{});
+
+  Process r1 = ChemicalReactionBuilder().SetReactants({ foo, bar }).SetRateConstant(rc1).SetPhase(gas_phase).Build();
+  Process r2 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc2).SetPhase(gas_phase).Build();
+  Process r3 = ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc3).SetPhase(gas_phase).Build();
+  std::vector<Process> processes = { r1, r2, r3 };
+
+  std::vector<std::string> param_labels{};
+  for (const auto& process : processes)
+  {
+    if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+    {
+      for (const auto& label : reaction->rate_constant_->CustomParameters())
+      {
+        param_labels.push_back(label);
+      }
+    }
+  }
+
+  State<DenseMatrixPolicy> state{ StateParameters{
+                                      .number_of_rate_constants_ = processes.size(),
+                                      .variable_names_ = { "foo", "bar" },
+                                      .custom_rate_parameter_labels_ = param_labels,
+                                  },
+                                  number_of_grid_cells };
+
+  State<DenseMatrixPolicy> cpu_state{ StateParameters{
+                                          .number_of_rate_constants_ = processes.size(),
+                                          .variable_names_ = { "foo", "bar" },
+                                          .custom_rate_parameter_labels_ = param_labels,
+                                      },
+                                      number_of_grid_cells };
+
+  auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    Conditions cond;
+    cond.temperature_ = get_double() * 285.0;
+    cond.pressure_ = get_double() * 101100.0;
+    cond.air_density_ = get_double() * 10.0;
+    state.conditions_[i_cell] = cond;
+    cpu_state.conditions_[i_cell] = cond;
+  }
+
+  Process::CalculateRateConstants(processes, cpu_state);
+
+  CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  cuda_process.CalculateRateConstants(processes, state);
+
+  state.rate_constants_.CopyToHost();
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    for (std::size_t i_rxn = 0; i_rxn < processes.size(); ++i_rxn)
+    {
+      double expected = cpu_state.rate_constants_[i_cell][i_rxn];
+      double actual = state.rate_constants_[i_cell][i_rxn];
+      if (std::abs(expected) > 1.0e-30)
+      {
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+            << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
+      }
+      else
+      {
+        EXPECT_NEAR(actual, expected, 1.0e-30) << "grid cell " << i_cell << "; reaction " << i_rxn;
+      }
+    }
+  }
+}
+
+/// @brief Test rate constant calculation on GPU with Tunneling rate constants
+template<class DenseMatrixPolicy>
+void testCudaProcessTunnelingRateConstants(const std::size_t number_of_grid_cells)
+{
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 } });
+  Species bar("bar");
+  bar.parameterize_ = [](const Conditions& c) { return c.air_density_ * 0.82; };
+
+  double foo_diff_coeff = 2.3e2;
+  PhaseSpecies gas_foo(foo, foo_diff_coeff);
+  PhaseSpecies gas_bar(bar);
+  Phase gas_phase{ "gas", { gas_foo, gas_bar } };
+
+  TunnelingRateConstant rc1({ .A_ = 2.4e-12, .B_ = 167.0, .C_ = 1.65e-18 });
+  TunnelingRateConstant rc2({ .A_ = 3.0e-13, .B_ = 500.0 });
+  TunnelingRateConstant rc3({ .A_ = 1.0 });
+
+  Process r1 = ChemicalReactionBuilder().SetReactants({ foo, bar }).SetRateConstant(rc1).SetPhase(gas_phase).Build();
+  Process r2 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc2).SetPhase(gas_phase).Build();
+  Process r3 = ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc3).SetPhase(gas_phase).Build();
+  std::vector<Process> processes = { r1, r2, r3 };
+
+  std::vector<std::string> param_labels{};
+  for (const auto& process : processes)
+  {
+    if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+    {
+      for (const auto& label : reaction->rate_constant_->CustomParameters())
+      {
+        param_labels.push_back(label);
+      }
+    }
+  }
+
+  State<DenseMatrixPolicy> state{ StateParameters{
+                                      .number_of_rate_constants_ = processes.size(),
+                                      .variable_names_ = { "foo", "bar" },
+                                      .custom_rate_parameter_labels_ = param_labels,
+                                  },
+                                  number_of_grid_cells };
+
+  State<DenseMatrixPolicy> cpu_state{ StateParameters{
+                                          .number_of_rate_constants_ = processes.size(),
+                                          .variable_names_ = { "foo", "bar" },
+                                          .custom_rate_parameter_labels_ = param_labels,
+                                      },
+                                      number_of_grid_cells };
+
+  auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    Conditions cond;
+    cond.temperature_ = get_double() * 285.0;
+    cond.pressure_ = get_double() * 101100.0;
+    cond.air_density_ = get_double() * 10.0;
+    state.conditions_[i_cell] = cond;
+    cpu_state.conditions_[i_cell] = cond;
+  }
+
+  Process::CalculateRateConstants(processes, cpu_state);
+
+  CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  cuda_process.CalculateRateConstants(processes, state);
+
+  state.rate_constants_.CopyToHost();
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    for (std::size_t i_rxn = 0; i_rxn < processes.size(); ++i_rxn)
+    {
+      double expected = cpu_state.rate_constants_[i_cell][i_rxn];
+      double actual = state.rate_constants_[i_cell][i_rxn];
+      if (std::abs(expected) > 1.0e-30)
+      {
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+            << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
+      }
+      else
+      {
+        EXPECT_NEAR(actual, expected, 1.0e-30) << "grid cell " << i_cell << "; reaction " << i_rxn;
+      }
+    }
+  }
+}
+
+/// @brief Test rate constant calculation on GPU with Branched rate constants (Alkoxy branch)
+template<class DenseMatrixPolicy>
+void testCudaProcessBranchedAlkoxyRateConstants(const std::size_t number_of_grid_cells)
+{
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 } });
+  Species bar("bar");
+  bar.parameterize_ = [](const Conditions& c) { return c.air_density_ * 0.82; };
+
+  double foo_diff_coeff = 2.3e2;
+  PhaseSpecies gas_foo(foo, foo_diff_coeff);
+  PhaseSpecies gas_bar(bar);
+  Phase gas_phase{ "gas", { gas_foo, gas_bar } };
+
+  BranchedRateConstant rc1(
+      { .branch_ = BranchedRateConstantParameters::Branch::Alkoxy, .X_ = 2.7e-12, .Y_ = 360.0, .a0_ = 2.0e-22, .n_ = 6 });
+  BranchedRateConstant rc2(
+      { .branch_ = BranchedRateConstantParameters::Branch::Alkoxy, .X_ = 1.3e-11, .Y_ = 0.0, .a0_ = 1.0e-22, .n_ = 2 });
+  BranchedRateConstant rc3(
+      { .branch_ = BranchedRateConstantParameters::Branch::Alkoxy, .X_ = 4.0e-13, .Y_ = -200.0, .a0_ = 3.5e-22, .n_ = 8 });
+
+  Process r1 = ChemicalReactionBuilder().SetReactants({ foo, bar }).SetRateConstant(rc1).SetPhase(gas_phase).Build();
+  Process r2 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc2).SetPhase(gas_phase).Build();
+  Process r3 = ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc3).SetPhase(gas_phase).Build();
+  std::vector<Process> processes = { r1, r2, r3 };
+
+  std::vector<std::string> param_labels{};
+  for (const auto& process : processes)
+  {
+    if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+    {
+      for (const auto& label : reaction->rate_constant_->CustomParameters())
+      {
+        param_labels.push_back(label);
+      }
+    }
+  }
+
+  State<DenseMatrixPolicy> state{ StateParameters{
+                                      .number_of_rate_constants_ = processes.size(),
+                                      .variable_names_ = { "foo", "bar" },
+                                      .custom_rate_parameter_labels_ = param_labels,
+                                  },
+                                  number_of_grid_cells };
+
+  State<DenseMatrixPolicy> cpu_state{ StateParameters{
+                                          .number_of_rate_constants_ = processes.size(),
+                                          .variable_names_ = { "foo", "bar" },
+                                          .custom_rate_parameter_labels_ = param_labels,
+                                      },
+                                      number_of_grid_cells };
+
+  auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    Conditions cond;
+    cond.temperature_ = get_double() * 285.0;
+    cond.pressure_ = get_double() * 101100.0;
+    cond.air_density_ = get_double() * 10.0;
+    state.conditions_[i_cell] = cond;
+    cpu_state.conditions_[i_cell] = cond;
+  }
+
+  Process::CalculateRateConstants(processes, cpu_state);
+
+  CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  cuda_process.CalculateRateConstants(processes, state);
+
+  state.rate_constants_.CopyToHost();
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    for (std::size_t i_rxn = 0; i_rxn < processes.size(); ++i_rxn)
+    {
+      double expected = cpu_state.rate_constants_[i_cell][i_rxn];
+      double actual = state.rate_constants_[i_cell][i_rxn];
+      if (std::abs(expected) > 1.0e-30)
+      {
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+            << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
+      }
+      else
+      {
+        EXPECT_NEAR(actual, expected, 1.0e-30) << "grid cell " << i_cell << "; reaction " << i_rxn;
+      }
+    }
+  }
+}
+
+/// @brief Test rate constant calculation on GPU with Branched rate constants (Nitrate branch)
+template<class DenseMatrixPolicy>
+void testCudaProcessBranchedNitrateRateConstants(const std::size_t number_of_grid_cells)
+{
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 } });
+  Species bar("bar");
+  bar.parameterize_ = [](const Conditions& c) { return c.air_density_ * 0.82; };
+
+  double foo_diff_coeff = 2.3e2;
+  PhaseSpecies gas_foo(foo, foo_diff_coeff);
+  PhaseSpecies gas_bar(bar);
+  Phase gas_phase{ "gas", { gas_foo, gas_bar } };
+
+  BranchedRateConstant rc1(
+      { .branch_ = BranchedRateConstantParameters::Branch::Nitrate, .X_ = 2.7e-12, .Y_ = 360.0, .a0_ = 2.0e-22, .n_ = 6 });
+  BranchedRateConstant rc2(
+      { .branch_ = BranchedRateConstantParameters::Branch::Nitrate, .X_ = 1.3e-11, .Y_ = 0.0, .a0_ = 1.0e-22, .n_ = 2 });
+  BranchedRateConstant rc3(
+      { .branch_ = BranchedRateConstantParameters::Branch::Nitrate, .X_ = 4.0e-13, .Y_ = -200.0, .a0_ = 3.5e-22, .n_ = 8 });
+
+  Process r1 = ChemicalReactionBuilder().SetReactants({ foo, bar }).SetRateConstant(rc1).SetPhase(gas_phase).Build();
+  Process r2 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc2).SetPhase(gas_phase).Build();
+  Process r3 = ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc3).SetPhase(gas_phase).Build();
+  std::vector<Process> processes = { r1, r2, r3 };
+
+  std::vector<std::string> param_labels{};
+  for (const auto& process : processes)
+  {
+    if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+    {
+      for (const auto& label : reaction->rate_constant_->CustomParameters())
+      {
+        param_labels.push_back(label);
+      }
+    }
+  }
+
+  State<DenseMatrixPolicy> state{ StateParameters{
+                                      .number_of_rate_constants_ = processes.size(),
+                                      .variable_names_ = { "foo", "bar" },
+                                      .custom_rate_parameter_labels_ = param_labels,
+                                  },
+                                  number_of_grid_cells };
+
+  State<DenseMatrixPolicy> cpu_state{ StateParameters{
+                                          .number_of_rate_constants_ = processes.size(),
+                                          .variable_names_ = { "foo", "bar" },
+                                          .custom_rate_parameter_labels_ = param_labels,
+                                      },
+                                      number_of_grid_cells };
+
+  auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    Conditions cond;
+    cond.temperature_ = get_double() * 285.0;
+    cond.pressure_ = get_double() * 101100.0;
+    cond.air_density_ = get_double() * 10.0;
+    state.conditions_[i_cell] = cond;
+    cpu_state.conditions_[i_cell] = cond;
+  }
+
+  Process::CalculateRateConstants(processes, cpu_state);
+
+  CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  cuda_process.CalculateRateConstants(processes, state);
+
+  state.rate_constants_.CopyToHost();
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    for (std::size_t i_rxn = 0; i_rxn < processes.size(); ++i_rxn)
+    {
+      double expected = cpu_state.rate_constants_[i_cell][i_rxn];
+      double actual = state.rate_constants_[i_cell][i_rxn];
+      if (std::abs(expected) > 1.0e-30)
+      {
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+            << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
+      }
+      else
+      {
+        EXPECT_NEAR(actual, expected, 1.0e-30) << "grid cell " << i_cell << "; reaction " << i_rxn;
+      }
+    }
+  }
+}
+
+/// @brief Test rate constant calculation on GPU with Ternary Chemical Activation rate constants
+template<class DenseMatrixPolicy>
+void testCudaProcessTernaryChemicalActivationRateConstants(const std::size_t number_of_grid_cells)
+{
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 } });
+  Species bar("bar");
+  bar.parameterize_ = [](const Conditions& c) { return c.air_density_ * 0.82; };
+
+  double foo_diff_coeff = 2.3e2;
+  PhaseSpecies gas_foo(foo, foo_diff_coeff);
+  PhaseSpecies gas_bar(bar);
+  Phase gas_phase{ "gas", { gas_foo, gas_bar } };
+
+  TernaryChemicalActivationRateConstant rc1(
+      { .k0_A_ = 9.7e-29, .k0_B_ = -5.6, .kinf_A_ = 9.3e-12, .kinf_B_ = -1.5, .Fc_ = 0.6, .N_ = 1.0 });
+  TernaryChemicalActivationRateConstant rc2(
+      { .k0_A_ = 3.0e-31,
+        .k0_B_ = -3.3,
+        .k0_C_ = -100.0,
+        .kinf_A_ = 1.5e-12,
+        .kinf_C_ = -200.0,
+        .Fc_ = 0.35,
+        .N_ = 0.8 });
+  TernaryChemicalActivationRateConstant rc3(TernaryChemicalActivationRateConstantParameters{});
+
+  Process r1 = ChemicalReactionBuilder().SetReactants({ foo, bar }).SetRateConstant(rc1).SetPhase(gas_phase).Build();
+  Process r2 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc2).SetPhase(gas_phase).Build();
+  Process r3 = ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc3).SetPhase(gas_phase).Build();
+  std::vector<Process> processes = { r1, r2, r3 };
+
+  std::vector<std::string> param_labels{};
+  for (const auto& process : processes)
+  {
+    if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+    {
+      for (const auto& label : reaction->rate_constant_->CustomParameters())
+      {
+        param_labels.push_back(label);
+      }
+    }
+  }
+
+  State<DenseMatrixPolicy> state{ StateParameters{
+                                      .number_of_rate_constants_ = processes.size(),
+                                      .variable_names_ = { "foo", "bar" },
+                                      .custom_rate_parameter_labels_ = param_labels,
+                                  },
+                                  number_of_grid_cells };
+
+  State<DenseMatrixPolicy> cpu_state{ StateParameters{
+                                          .number_of_rate_constants_ = processes.size(),
+                                          .variable_names_ = { "foo", "bar" },
+                                          .custom_rate_parameter_labels_ = param_labels,
+                                      },
+                                      number_of_grid_cells };
+
+  auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    Conditions cond;
+    cond.temperature_ = get_double() * 285.0;
+    cond.pressure_ = get_double() * 101100.0;
+    cond.air_density_ = get_double() * 10.0;
+    state.conditions_[i_cell] = cond;
+    cpu_state.conditions_[i_cell] = cond;
+  }
+
+  Process::CalculateRateConstants(processes, cpu_state);
+
+  CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  cuda_process.CalculateRateConstants(processes, state);
+
+  state.rate_constants_.CopyToHost();
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    for (std::size_t i_rxn = 0; i_rxn < processes.size(); ++i_rxn)
+    {
+      double expected = cpu_state.rate_constants_[i_cell][i_rxn];
+      double actual = state.rate_constants_[i_cell][i_rxn];
+      if (std::abs(expected) > 1.0e-30)
+      {
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+            << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
+      }
+      else
+      {
+        EXPECT_NEAR(actual, expected, 1.0e-30) << "grid cell " << i_cell << "; reaction " << i_rxn;
+      }
+    }
+  }
+}
+
+/// @brief Test rate constant calculation on GPU with Reversible rate constants
+template<class DenseMatrixPolicy>
+void testCudaProcessReversibleRateConstants(const std::size_t number_of_grid_cells)
+{
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 } });
+  Species bar("bar");
+  bar.parameterize_ = [](const Conditions& c) { return c.air_density_ * 0.82; };
+
+  double foo_diff_coeff = 2.3e2;
+  PhaseSpecies gas_foo(foo, foo_diff_coeff);
+  PhaseSpecies gas_bar(bar);
+  Phase gas_phase{ "gas", { gas_foo, gas_bar } };
+
+  ReversibleRateConstant rc1({ .A_ = 3.3e-10, .C_ = -1500.0, .k_r_ = 1.0e-3 });
+  ReversibleRateConstant rc2({ .A_ = 1.0e-12, .k_r_ = 5.0e-6 });
+  ReversibleRateConstant rc3({ .A_ = 2.5e-8, .C_ = -800.0 });
+
+  Process r1 = ChemicalReactionBuilder().SetReactants({ foo, bar }).SetRateConstant(rc1).SetPhase(gas_phase).Build();
+  Process r2 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc2).SetPhase(gas_phase).Build();
+  Process r3 = ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc3).SetPhase(gas_phase).Build();
+  std::vector<Process> processes = { r1, r2, r3 };
+
+  std::vector<std::string> param_labels{};
+  for (const auto& process : processes)
+  {
+    if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+    {
+      for (const auto& label : reaction->rate_constant_->CustomParameters())
+      {
+        param_labels.push_back(label);
+      }
+    }
+  }
+
+  State<DenseMatrixPolicy> state{ StateParameters{
+                                      .number_of_rate_constants_ = processes.size(),
+                                      .variable_names_ = { "foo", "bar" },
+                                      .custom_rate_parameter_labels_ = param_labels,
+                                  },
+                                  number_of_grid_cells };
+
+  State<DenseMatrixPolicy> cpu_state{ StateParameters{
+                                          .number_of_rate_constants_ = processes.size(),
+                                          .variable_names_ = { "foo", "bar" },
+                                          .custom_rate_parameter_labels_ = param_labels,
+                                      },
+                                      number_of_grid_cells };
+
+  auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    Conditions cond;
+    cond.temperature_ = get_double() * 285.0;
+    cond.pressure_ = get_double() * 101100.0;
+    cond.air_density_ = get_double() * 10.0;
+    state.conditions_[i_cell] = cond;
+    cpu_state.conditions_[i_cell] = cond;
+  }
+
+  Process::CalculateRateConstants(processes, cpu_state);
+
+  CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  cuda_process.CalculateRateConstants(processes, state);
+
+  state.rate_constants_.CopyToHost();
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    for (std::size_t i_rxn = 0; i_rxn < processes.size(); ++i_rxn)
+    {
+      double expected = cpu_state.rate_constants_[i_cell][i_rxn];
+      double actual = state.rate_constants_[i_cell][i_rxn];
+      if (std::abs(expected) > 1.0e-30)
+      {
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+            << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
+      }
+      else
+      {
+        EXPECT_NEAR(actual, expected, 1.0e-30) << "grid cell " << i_cell << "; reaction " << i_rxn;
+      }
+    }
+  }
+}
+
+/// @brief Test rate constant calculation on GPU with Surface rate constants
+template<class DenseMatrixPolicy>
+void testCudaProcessSurfaceRateConstants(const std::size_t number_of_grid_cells)
+{
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 } });
+  Species bar("bar");
+  bar.parameterize_ = [](const Conditions& c) { return c.air_density_ * 0.82; };
+
+  double foo_diff_coeff = 2.3e2;
+  PhaseSpecies gas_foo(foo, foo_diff_coeff);
+  PhaseSpecies gas_bar(bar);
+  Phase gas_phase{ "gas", { gas_foo, gas_bar } };
+
+  SurfaceRateConstant rc1({ .label_ = "surf_rxn1", .phase_species_ = gas_foo, .reaction_probability_ = 0.8 });
+  SurfaceRateConstant rc2({ .label_ = "surf_rxn2", .phase_species_ = gas_foo, .reaction_probability_ = 0.1 });
+  SurfaceRateConstant rc3({ .label_ = "surf_rxn3", .phase_species_ = gas_foo });
+
+  Process r1 = ChemicalReactionBuilder().SetReactants({ foo, bar }).SetRateConstant(rc1).SetPhase(gas_phase).Build();
+  Process r2 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc2).SetPhase(gas_phase).Build();
+  Process r3 = ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc3).SetPhase(gas_phase).Build();
+  std::vector<Process> processes = { r1, r2, r3 };
+
+  std::vector<std::string> param_labels{};
+  for (const auto& process : processes)
+  {
+    if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+    {
+      for (const auto& label : reaction->rate_constant_->CustomParameters())
+      {
+        param_labels.push_back(label);
+      }
+    }
+  }
+
+  State<DenseMatrixPolicy> state{ StateParameters{
+                                      .number_of_rate_constants_ = processes.size(),
+                                      .variable_names_ = { "foo", "bar" },
+                                      .custom_rate_parameter_labels_ = param_labels,
+                                  },
+                                  number_of_grid_cells };
+
+  State<DenseMatrixPolicy> cpu_state{ StateParameters{
+                                          .number_of_rate_constants_ = processes.size(),
+                                          .variable_names_ = { "foo", "bar" },
+                                          .custom_rate_parameter_labels_ = param_labels,
+                                      },
+                                      number_of_grid_cells };
+
+  auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    Conditions cond;
+    cond.temperature_ = get_double() * 285.0;
+    cond.pressure_ = get_double() * 101100.0;
+    cond.air_density_ = get_double() * 10.0;
+    state.conditions_[i_cell] = cond;
+    cpu_state.conditions_[i_cell] = cond;
+
+    double radius1 = get_double() * 1.0e-8;
+    double number_conc1 = get_double() * 1.0e5;
+    double radius2 = get_double() * 1.0e-8;
+    double number_conc2 = get_double() * 1.0e5;
+    double radius3 = get_double() * 1.0e-8;
+    double number_conc3 = get_double() * 1.0e5;
+
+    state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["surf_rxn1.effective radius [m]"]] = radius1;
+    state.custom_rate_parameters_[i_cell]
+                                 [state.custom_rate_parameter_map_["surf_rxn1.particle number concentration [# m-3]"]] =
+        number_conc1;
+    state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["surf_rxn2.effective radius [m]"]] = radius2;
+    state.custom_rate_parameters_[i_cell]
+                                 [state.custom_rate_parameter_map_["surf_rxn2.particle number concentration [# m-3]"]] =
+        number_conc2;
+    state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["surf_rxn3.effective radius [m]"]] = radius3;
+    state.custom_rate_parameters_[i_cell]
+                                 [state.custom_rate_parameter_map_["surf_rxn3.particle number concentration [# m-3]"]] =
+        number_conc3;
+
+    cpu_state.custom_rate_parameters_[i_cell][cpu_state.custom_rate_parameter_map_["surf_rxn1.effective radius [m]"]] =
+        radius1;
+    cpu_state
+        .custom_rate_parameters_[i_cell]
+                                [cpu_state.custom_rate_parameter_map_["surf_rxn1.particle number concentration [# m-3]"]] =
+        number_conc1;
+    cpu_state.custom_rate_parameters_[i_cell][cpu_state.custom_rate_parameter_map_["surf_rxn2.effective radius [m]"]] =
+        radius2;
+    cpu_state
+        .custom_rate_parameters_[i_cell]
+                                [cpu_state.custom_rate_parameter_map_["surf_rxn2.particle number concentration [# m-3]"]] =
+        number_conc2;
+    cpu_state.custom_rate_parameters_[i_cell][cpu_state.custom_rate_parameter_map_["surf_rxn3.effective radius [m]"]] =
+        radius3;
+    cpu_state
+        .custom_rate_parameters_[i_cell]
+                                [cpu_state.custom_rate_parameter_map_["surf_rxn3.particle number concentration [# m-3]"]] =
+        number_conc3;
+  }
+
+  Process::CalculateRateConstants(processes, cpu_state);
+
+  CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  cuda_process.CalculateRateConstants(processes, state);
+
+  state.rate_constants_.CopyToHost();
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    for (std::size_t i_rxn = 0; i_rxn < processes.size(); ++i_rxn)
+    {
+      double expected = cpu_state.rate_constants_[i_cell][i_rxn];
+      double actual = state.rate_constants_[i_cell][i_rxn];
+      if (std::abs(expected) > 1.0e-30)
+      {
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-8)
+            << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
+      }
+      else
+      {
+        EXPECT_NEAR(actual, expected, 1.0e-30) << "grid cell " << i_cell << "; reaction " << i_rxn;
+      }
+    }
+  }
+}
+
+/// @brief Test rate constant calculation on GPU with UserDefined rate constants
+template<class DenseMatrixPolicy>
+void testCudaProcessUserDefinedRateConstants(const std::size_t number_of_grid_cells)
+{
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 } });
+  Species bar("bar");
+  bar.parameterize_ = [](const Conditions& c) { return c.air_density_ * 0.82; };
+
+  double foo_diff_coeff = 2.3e2;
+  PhaseSpecies gas_foo(foo, foo_diff_coeff);
+  PhaseSpecies gas_bar(bar);
+  Phase gas_phase{ "gas", { gas_foo, gas_bar } };
+
+  UserDefinedRateConstant rc1({ .label_ = "user_rate1" });
+  UserDefinedRateConstant rc2({ .label_ = "user_rate2", .scaling_factor_ = 2.5 });
+  UserDefinedRateConstant rc3({ .label_ = "user_rate3", .scaling_factor_ = 0.1 });
+
+  Process r1 = ChemicalReactionBuilder().SetReactants({ foo, bar }).SetRateConstant(rc1).SetPhase(gas_phase).Build();
+  Process r2 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc2).SetPhase(gas_phase).Build();
+  Process r3 = ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc3).SetPhase(gas_phase).Build();
+  std::vector<Process> processes = { r1, r2, r3 };
+
+  std::vector<std::string> param_labels{};
+  for (const auto& process : processes)
+  {
+    if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+    {
+      for (const auto& label : reaction->rate_constant_->CustomParameters())
+      {
+        param_labels.push_back(label);
+      }
+    }
+  }
+
+  State<DenseMatrixPolicy> state{ StateParameters{
+                                      .number_of_rate_constants_ = processes.size(),
+                                      .variable_names_ = { "foo", "bar" },
+                                      .custom_rate_parameter_labels_ = param_labels,
+                                  },
+                                  number_of_grid_cells };
+
+  State<DenseMatrixPolicy> cpu_state{ StateParameters{
+                                          .number_of_rate_constants_ = processes.size(),
+                                          .variable_names_ = { "foo", "bar" },
+                                          .custom_rate_parameter_labels_ = param_labels,
+                                      },
+                                      number_of_grid_cells };
+
+  auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    Conditions cond;
+    cond.temperature_ = get_double() * 285.0;
+    cond.pressure_ = get_double() * 101100.0;
+    cond.air_density_ = get_double() * 10.0;
+    state.conditions_[i_cell] = cond;
+    cpu_state.conditions_[i_cell] = cond;
+
+    double user_rate1 = get_double() * 1.0e-2;
+    double user_rate2 = get_double() * 1.0e-2;
+    double user_rate3 = get_double() * 1.0e-2;
+
+    state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["user_rate1"]] = user_rate1;
+    state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["user_rate2"]] = user_rate2;
+    state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["user_rate3"]] = user_rate3;
+
+    cpu_state.custom_rate_parameters_[i_cell][cpu_state.custom_rate_parameter_map_["user_rate1"]] = user_rate1;
+    cpu_state.custom_rate_parameters_[i_cell][cpu_state.custom_rate_parameter_map_["user_rate2"]] = user_rate2;
+    cpu_state.custom_rate_parameters_[i_cell][cpu_state.custom_rate_parameter_map_["user_rate3"]] = user_rate3;
+  }
+
+  Process::CalculateRateConstants(processes, cpu_state);
+
+  CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  cuda_process.CalculateRateConstants(processes, state);
+
+  state.rate_constants_.CopyToHost();
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    for (std::size_t i_rxn = 0; i_rxn < processes.size(); ++i_rxn)
+    {
+      double expected = cpu_state.rate_constants_[i_cell][i_rxn];
+      double actual = state.rate_constants_[i_cell][i_rxn];
+      if (std::abs(expected) > 1.0e-30)
+      {
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-10)
+            << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
+      }
+      else
+      {
+        EXPECT_NEAR(actual, expected, 1.0e-30) << "grid cell " << i_cell << "; reaction " << i_rxn;
+      }
+    }
+  }
+}
+
+/// @brief Test rate constant calculation on GPU with all rate constant types combined
+template<class DenseMatrixPolicy>
+void testCudaProcessAllRateConstants(const std::size_t number_of_grid_cells)
+{
+  Species foo("foo", { { "molecular weight [kg mol-1]", 0.025 } });
+  Species bar("bar");
+  bar.parameterize_ = [](const Conditions& c) { return c.air_density_ * 0.82; };
+
+  double foo_diff_coeff = 2.3e2;
+  PhaseSpecies gas_foo(foo, foo_diff_coeff);
+  PhaseSpecies gas_bar(bar);
+  Phase gas_phase{ "gas", { gas_foo, gas_bar } };
+
+  ArrheniusRateConstant rc_arrhenius({ .A_ = 12.2, .C_ = 300.0 });
+  TroeRateConstant rc_troe({ .k0_A_ = 4.4e-32, .k0_B_ = -1.3, .kinf_A_ = 7.5e-11, .Fc_ = 0.6 });
+  TunnelingRateConstant rc_tunneling({ .A_ = 2.4e-12, .B_ = 167.0, .C_ = 1.65e-18 });
+  BranchedRateConstant rc_branched_alkoxy(
+      { .branch_ = BranchedRateConstantParameters::Branch::Alkoxy, .X_ = 2.7e-12, .Y_ = 360.0, .a0_ = 2.0e-22, .n_ = 6 });
+  BranchedRateConstant rc_branched_nitrate(
+      { .branch_ = BranchedRateConstantParameters::Branch::Nitrate, .X_ = 1.3e-11, .Y_ = 0.0, .a0_ = 1.0e-22, .n_ = 2 });
+  TernaryChemicalActivationRateConstant rc_ternary(
+      { .k0_A_ = 9.7e-29, .k0_B_ = -5.6, .kinf_A_ = 9.3e-12, .kinf_B_ = -1.5, .Fc_ = 0.6 });
+  ReversibleRateConstant rc_reversible({ .A_ = 3.3e-10, .C_ = -1500.0, .k_r_ = 1.0e-3 });
+  SurfaceRateConstant rc_surface({ .label_ = "all_surf", .phase_species_ = gas_foo, .reaction_probability_ = 0.5 });
+  UserDefinedRateConstant rc_user({ .label_ = "all_user", .scaling_factor_ = 1.5 });
+
+  Process r1 = ChemicalReactionBuilder().SetReactants({ foo, bar }).SetRateConstant(rc_arrhenius).SetPhase(gas_phase).Build();
+  Process r2 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc_troe).SetPhase(gas_phase).Build();
+  Process r3 = ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc_tunneling).SetPhase(gas_phase).Build();
+  Process r4 =
+      ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc_branched_alkoxy).SetPhase(gas_phase).Build();
+  Process r5 =
+      ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc_branched_nitrate).SetPhase(gas_phase).Build();
+  Process r6 = ChemicalReactionBuilder().SetReactants({ foo, bar }).SetRateConstant(rc_ternary).SetPhase(gas_phase).Build();
+  Process r7 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc_reversible).SetPhase(gas_phase).Build();
+  Process r8 = ChemicalReactionBuilder().SetReactants({ bar }).SetRateConstant(rc_surface).SetPhase(gas_phase).Build();
+  Process r9 = ChemicalReactionBuilder().SetReactants({ foo }).SetRateConstant(rc_user).SetPhase(gas_phase).Build();
+  std::vector<Process> processes = { r1, r2, r3, r4, r5, r6, r7, r8, r9 };
+
+  std::vector<std::string> param_labels{};
+  for (const auto& process : processes)
+  {
+    if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+    {
+      for (const auto& label : reaction->rate_constant_->CustomParameters())
+      {
+        param_labels.push_back(label);
+      }
+    }
+  }
+
+  State<DenseMatrixPolicy> state{ StateParameters{
+                                      .number_of_rate_constants_ = processes.size(),
+                                      .variable_names_ = { "foo", "bar" },
+                                      .custom_rate_parameter_labels_ = param_labels,
+                                  },
+                                  number_of_grid_cells };
+
+  State<DenseMatrixPolicy> cpu_state{ StateParameters{
+                                          .number_of_rate_constants_ = processes.size(),
+                                          .variable_names_ = { "foo", "bar" },
+                                          .custom_rate_parameter_labels_ = param_labels,
+                                      },
+                                      number_of_grid_cells };
+
+  auto get_double = std::bind(std::lognormal_distribution(0.0, 0.01), std::default_random_engine());
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    Conditions cond;
+    cond.temperature_ = get_double() * 285.0;
+    cond.pressure_ = get_double() * 101100.0;
+    cond.air_density_ = get_double() * 10.0;
+    state.conditions_[i_cell] = cond;
+    cpu_state.conditions_[i_cell] = cond;
+
+    double radius = get_double() * 1.0e-8;
+    double number_conc = get_double() * 1.0e5;
+    double user_rate = get_double() * 1.0e-2;
+
+    state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["all_surf.effective radius [m]"]] = radius;
+    state.custom_rate_parameters_[i_cell]
+                                 [state.custom_rate_parameter_map_["all_surf.particle number concentration [# m-3]"]] =
+        number_conc;
+    state.custom_rate_parameters_[i_cell][state.custom_rate_parameter_map_["all_user"]] = user_rate;
+
+    cpu_state.custom_rate_parameters_[i_cell][cpu_state.custom_rate_parameter_map_["all_surf.effective radius [m]"]] =
+        radius;
+    cpu_state
+        .custom_rate_parameters_[i_cell]
+                                [cpu_state.custom_rate_parameter_map_["all_surf.particle number concentration [# m-3]"]] =
+        number_conc;
+    cpu_state.custom_rate_parameters_[i_cell][cpu_state.custom_rate_parameter_map_["all_user"]] = user_rate;
+  }
+
+  Process::CalculateRateConstants(processes, cpu_state);
+
+  CudaProcess<DenseMatrixPolicy> cuda_process(processes);
+  cuda_process.CalculateRateConstants(processes, state);
+
+  state.rate_constants_.CopyToHost();
+
+  for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
+  {
+    for (std::size_t i_rxn = 0; i_rxn < processes.size(); ++i_rxn)
+    {
+      double expected = cpu_state.rate_constants_[i_cell][i_rxn];
+      double actual = state.rate_constants_[i_cell][i_rxn];
+      if (std::abs(expected) > 1.0e-30)
+      {
+        EXPECT_NEAR(actual / expected, 1.0, 1.0e-8)
+            << "grid cell " << i_cell << "; reaction " << i_rxn << "; expected " << expected << "; actual " << actual;
+      }
+      else
+      {
+        EXPECT_NEAR(actual, expected, 1.0e-30) << "grid cell " << i_cell << "; reaction " << i_rxn;
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
This PR ports the calculation of chemistry reaction rates to GPU using CUDA. Now the whole chemistry package (chemistry reaction rate + chemistry solver) should be GPU-ready.

This is 100% done by Claude.