### PR TITLE
Reclassify unused species as an Error

### DIFF
--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -57,7 +57,7 @@ namespace micm
       for (auto& species : unused_species)
         err_msg += " '" + species + "'";
       err_msg += ".";
-      throw MicmException(MicmSeverity::Warning, MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_UNUSED_SPECIES, err_msg);
+      throw MicmException(MicmSeverity::Error, MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_UNUSED_SPECIES, err_msg);
     }
   }
 

--- a/include/micm/util/micm_exception.hpp
+++ b/include/micm/util/micm_exception.hpp
@@ -11,7 +11,6 @@ namespace micm
 {
   enum class MicmSeverity
   {
-    Warning,
     Error,
     Critical
   };

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -47,6 +47,22 @@ TEST(SolverBuilder, ThrowsMissingSystem)
       micm::MicmException);
 }
 
+TEST(SolverBuilder, ThrowsUnusedSpecies)
+{
+  auto d = micm::Species("D");
+  micm::Phase phase_with_unused{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c, d } };
+  micm::System system_with_unused = micm::System(micm::SystemParameters{ .gas_phase_ = phase_with_unused });
+
+  EXPECT_THROW(
+      micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
+          micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
+          .SetSystem(system_with_unused)
+          .SetReactions(reactions)
+          .SetIgnoreUnusedSpecies(false)
+          .Build(),
+      micm::MicmException);
+}
+
 TEST(SolverBuilder, CanBuildBackwardEuler)
 {
   auto backward_euler = micm::CpuSolverBuilder<micm::BackwardEulerSolverParameters>(micm::BackwardEulerSolverParameters{})

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -53,15 +53,22 @@ TEST(SolverBuilder, ThrowsUnusedSpecies)
   micm::Phase phase_with_unused{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c, d } };
   micm::System system_with_unused = micm::System(micm::SystemParameters{ .gas_phase_ = phase_with_unused });
 
-  EXPECT_THROW(
-      micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
-          micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-          .SetSystem(system_with_unused)
-          .SetReactions(reactions)
-          .SetIgnoreUnusedSpecies(false)
-          .Build(),
-      micm::MicmException);
+  try
+  {
+    micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
+        micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
+        .SetSystem(system_with_unused)
+        .SetReactions(reactions)
+        .SetIgnoreUnusedSpecies(false)
+        .Build();
+    FAIL() << "Expected micm::MicmException to be thrown";
+  }
+  catch (const micm::MicmException& e)
+  {
+    EXPECT_EQ(e.severity_, micm::MicmSeverity::Error);
+  }
 }
+
 
 TEST(SolverBuilder, CanBuildBackwardEuler)
 {


### PR DESCRIPTION


There's currently just one case in MICM that gets classified as a warning. 
This PR reclassifies it as a error for the following reason: 

- `ignore_unused_species_` defaults to `true` so unused species don't have any effect unless you explicitly set it. If a user explicitly pass `false` to `SetIgnoreUnusedSpecies`,  throwing an error makes sense.  

One idea mentioned in the issue is to include warnings in the return value, so the caller explicitly receives and handles them.
The implementation could look something like this, where solver and warnings are bundled together in a struct.

```C++
struct BuildResult 
{
  Solver solver;
  std::vector<MicmWarning> warnings;
};

auto result = builder.Build();
// handle warnings 
for (auto& w : result.warnings) { ... }
auto solver = std::move(result.solver);
```

`Build()` currently returns a type deduced by auto, so wrapping it in a `BuildResult` struct would require the struct to be also templated on the solver type.


As for using `std::expected`, it really only works for a single warning. We shouldn't assume the solver builder would only produce one warning. This also requires C++23.

```C++
std::expected<Solver, MicmWarning> Build();

auto result = builder.Build();
// handle warnings 
if (!result) {...}
```

Note:  This PR removes the case that produces a warning, but doesn't add any handling. If we want to support warnings properly, we'd probably need something like a warning logger to collect them.

Warnings are usually treated as logs, but we don't have a logging system.  We could revisit this later, or just decide not to support warnings at all.

- Closes #965
