### PR TITLE
Remove single-type std::variant

### DIFF
--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -3,10 +3,6 @@
 #pragma once
 
 #include <micm/process/chemical_reaction.hpp>
-#include <micm/system/phase.hpp>
-#include <micm/system/species.hpp>
-#include <micm/system/stoich_species.hpp>
-#include <micm/util/error.hpp>
 
 #include <utility>
 
@@ -18,8 +14,13 @@ namespace micm
    public:
     ChemicalReaction process_;
 
-    Process(ChemicalReaction process)
-        : process_(std::move(process))
+    Process(const ChemicalReaction& process) 
+        : process_(process)
+    {
+    }
+
+    Process(ChemicalReaction&& process)
+         : process_(std::move(process))
     {
     }
   };

--- a/include/micm/process/process.hpp
+++ b/include/micm/process/process.hpp
@@ -9,8 +9,6 @@
 #include <micm/util/error.hpp>
 
 #include <utility>
-#include <variant>
-#include <vector>
 
 namespace micm
 {
@@ -18,14 +16,10 @@ namespace micm
   class Process
   {
    public:
-    using ProcessVariant = std::variant<ChemicalReaction>;
+    ChemicalReaction process_;
 
-    ProcessVariant process_;
-
-    template<typename T>
-      requires std::same_as<std::decay_t<T>, ChemicalReaction>
-    Process(T&& process)
-        : process_(std::forward<T>(process))
+    Process(ChemicalReaction process)
+        : process_(std::move(process))
     {
     }
   };

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -149,36 +149,34 @@ namespace micm
     // store the corresponding index
     for (const auto& process : processes)
     {
-      if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+      const auto& reaction = process.process_;
+      std::size_t number_of_reactants = 0;
+      std::size_t number_of_products = 0;
+      for (const auto& reactant : reaction.reactants_)
       {
-        std::size_t number_of_reactants = 0;
-        std::size_t number_of_products = 0;
-        for (const auto& reactant : reaction->reactants_)
-        {
-          if (reactant.IsParameterized())
-            continue;  // Skip reactants that are parameterizations
-          if (variable_map.count(reactant.name_) < 1)
-            throw MicmException(
-                MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_REACTANT_DOES_NOT_EXIST, reactant.name_);
-          reactant_ids_.push_back(variable_map.at(reactant.name_));
-          ++number_of_reactants;
-        }
-        // Store product indices and yields
-        for (const auto& product : reaction->products_)
-        {
-          if (product.species_.IsParameterized())
-            continue;  // Skip products that are parameterizations
-          if (variable_map.count(product.species_.name_) < 1)
-            throw MicmException(
-                MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_PRODUCT_DOES_NOT_EXIST, product.species_.name_);
-          product_ids_.push_back(variable_map.at(product.species_.name_));
-          yields_.push_back(product.coefficient_);
-          ++number_of_products;
-        }
-        // Record how many reactants and products were processed for each process
-        number_of_reactants_.push_back(number_of_reactants);
-        number_of_products_.push_back(number_of_products);
+        if (reactant.IsParameterized())
+          continue;  // Skip reactants that are parameterizations
+        if (variable_map.count(reactant.name_) < 1)
+          throw MicmException(
+              MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_REACTANT_DOES_NOT_EXIST, reactant.name_);
+        reactant_ids_.push_back(variable_map.at(reactant.name_));
+        ++number_of_reactants;
       }
+      // Store product indices and yields
+      for (const auto& product : reaction.products_)
+      {
+        if (product.species_.IsParameterized())
+          continue;  // Skip products that are parameterizations
+        if (variable_map.count(product.species_.name_) < 1)
+          throw MicmException(
+              MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_PRODUCT_DOES_NOT_EXIST, product.species_.name_);
+        product_ids_.push_back(variable_map.at(product.species_.name_));
+        yields_.push_back(product.coefficient_);
+        ++number_of_products;
+      }
+      // Record how many reactants and products were processed for each process
+      number_of_reactants_.push_back(number_of_reactants);
+      number_of_products_.push_back(number_of_products);
     }
 
     // Set up process information for Jacobian calculations
@@ -194,8 +192,8 @@ namespace micm
       for (std::size_t i_process = 0; i_process < processes.size(); ++i_process)
       {
         const auto& process = processes[i_process];
-        if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
-          for (const auto& ind_reactant : reaction->reactants_)
+        const auto& reaction = process.process_;
+        for (const auto& ind_reactant : reaction.reactants_)
           {
             if (ind_reactant.name_ != independent_variable.first)
               continue;
@@ -207,7 +205,7 @@ namespace micm
 
             // Collect other (dependent) reactants and products
             bool found = false;
-            for (const auto& reactant : reaction->reactants_)
+            for (const auto& reactant : reaction.reactants_)
             {
               if (reactant.IsParameterized())
                 continue;  // Skip reactants that are parameterizations
@@ -222,7 +220,7 @@ namespace micm
               jacobian_reactant_ids_.push_back(variable_map.at(reactant.name_));
               ++info.number_of_dependent_reactants_;
             }
-            for (const auto& product : reaction->products_)
+            for (const auto& product : reaction.products_)
             {
               if (product.species_.IsParameterized())
                 continue;  // Skip products that are parameterizations
@@ -629,16 +627,14 @@ namespace micm
     std::set<std::string> used_species;
     for (const auto& process : processes)
     {
-      if (auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+      const auto& reaction = process.process_;
+      for (const auto& reactant : reaction.reactants_)
       {
-        for (const auto& reactant : reaction->reactants_)
-        {
-          used_species.insert(reactant.name_);
-        }
-        for (const auto& product : reaction->products_)
-        {
-          used_species.insert(product.species_.name_);
-        }
+        used_species.insert(reactant.name_);
+      }
+      for (const auto& product : reaction.products_)
+      {
+        used_species.insert(product.species_.name_);
       }
     }
 

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -4,12 +4,11 @@
 
 #include <micm/external_model.hpp>
 #include <micm/process/process.hpp>
-#include <micm/solver/state.hpp>
 #include <micm/util/error.hpp>
+#include <micm/util/matrix.hpp>
 #include <micm/util/sparse_matrix.hpp>
 
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <unordered_map>
 #include <vector>
@@ -191,8 +190,7 @@ namespace micm
     {
       for (std::size_t i_process = 0; i_process < processes.size(); ++i_process)
       {
-        const auto& process = processes[i_process];
-        const auto& reaction = process.process_;
+        const auto& reaction = processes[i_process].process_;
         for (const auto& ind_reactant : reaction.reactants_)
           {
             if (ind_reactant.name_ != independent_variable.first)

--- a/include/micm/process/reaction_rate_store.hpp
+++ b/include/micm/process/reaction_rate_store.hpp
@@ -135,13 +135,11 @@ namespace micm
 
       for (auto& process : processes)
       {
-        ChemicalReaction* reaction = std::get_if<ChemicalReaction>(&process.process_);
-        if (!reaction)
-          continue;
+        auto& reaction = process.process_;
 
         {  // parameterized-reactant multiplier
           std::vector<std::function<double(const Conditions&)>> param_funcs;
-          for (const auto& reactant : reaction->reactants_)
+          for (const auto& reactant : reaction.reactants_)
             if (reactant.IsParameterized())
               param_funcs.push_back(reactant.parameterize_);
 
@@ -160,7 +158,7 @@ namespace micm
 
         std::size_t n_custom = 0;
 
-        RateConstantVariant& rc = reaction->rate_constant_;
+        RateConstantVariant& rc = reaction.rate_constant_;
 
         if (auto* p = std::get_if<ArrheniusRateConstantParameters>(&rc))
         {

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -227,13 +227,11 @@ namespace micm
     {
       for (const auto& process : processes_)
       {
-        if (const auto* reaction = std::get_if<ChemicalReaction>(&process.process_))
+        const auto& reaction = process.process_;
+        if (const auto* params = std::get_if<LambdaRateConstantParameters>(&reaction.rate_constant_))
         {
-          if (const auto* params = std::get_if<LambdaRateConstantParameters>(&reaction->rate_constant_))
-          {
-            if (params->label_ == name)
-              return *params;
-          }
+          if (params->label_ == name)
+            return *params;
         }
       }
       throw MicmException(

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -137,15 +137,13 @@ namespace micm
     // Include custom parameter labels from chemical reactions
     for (const auto& reaction : reactions_)
     {
-      if (auto* process = std::get_if<ChemicalReaction>(&reaction.process_))
+      const auto& process = reaction.process_;
+      if (auto* ud = std::get_if<UserDefinedRateConstantParameters>(&process.rate_constant_))
+        add_param(ud->label_, "reaction");
+      else if (auto* surf = std::get_if<SurfaceRateConstantParameters>(&process.rate_constant_))
       {
-        if (auto* ud = std::get_if<UserDefinedRateConstantParameters>(&process->rate_constant_))
-          add_param(ud->label_, "reaction");
-        else if (auto* surf = std::get_if<SurfaceRateConstantParameters>(&process->rate_constant_))
-        {
-          add_param(surf->label_ + ".effective radius [m]", "reaction");
-          add_param(surf->label_ + ".particle number concentration [# m-3]", "reaction");
-        }
+        add_param(surf->label_ + ".effective radius [m]", "reaction");
+        add_param(surf->label_ + ".particle number concentration [# m-3]", "reaction");
       }
     }
 
@@ -261,9 +259,6 @@ namespace micm
         {
           auto type_order = [](const Process& p) -> int
           {
-            const ChemicalReaction* rxn = std::get_if<ChemicalReaction>(&p.process_);
-            if (!rxn)
-              return 10;  // PhaseTransferProcess → end
             return std::visit(
                 [](const auto& v) -> int
                 {
@@ -289,7 +284,7 @@ namespace micm
                   else
                     return 9;  // LambdaRateConstantParameters
                 },
-                rxn->rate_constant_);
+                p.process_.rate_constant_);
           };
           return type_order(a) < type_order(b);
         });

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -34,9 +34,6 @@ static void SortLikeBuilder(std::vector<Process>& procs)
       {
         auto order = [](const Process& p) -> int
         {
-          const ChemicalReaction* rxn = std::get_if<ChemicalReaction>(&p.process_);
-          if (!rxn)
-            return 10;
           return std::visit(
               [](const auto& v) -> int
               {
@@ -62,7 +59,7 @@ static void SortLikeBuilder(std::vector<Process>& procs)
                 else
                   return 9;
               },
-              rxn->rate_constant_);
+              p.process_.rate_constant_);
         };
         return order(a) < order(b);
       });
@@ -71,13 +68,10 @@ static void SortLikeBuilder(std::vector<Process>& procs)
 /// @brief Return the custom parameter labels that BuildFrom assigns for a process.
 static std::vector<std::string> CustomParamLabels(const Process& proc)
 {
-  if (const auto* rxn = std::get_if<ChemicalReaction>(&proc.process_))
-  {
-    if (const auto* p = std::get_if<UserDefinedRateConstantParameters>(&rxn->rate_constant_))
-      return { p->label_ };
-    if (const auto* p = std::get_if<SurfaceRateConstantParameters>(&rxn->rate_constant_))
-      return { p->label_ + ".effective radius [m]", p->label_ + ".particle number concentration [# m-3]" };
-  }
+  if (const auto* p = std::get_if<UserDefinedRateConstantParameters>(&proc.process_.rate_constant_))
+    return { p->label_ };
+  if (const auto* p = std::get_if<SurfaceRateConstantParameters>(&proc.process_.rate_constant_))
+    return { p->label_ + ".effective radius [m]", p->label_ + ".particle number concentration [# m-3]" };
   return {};
 }
 
@@ -212,23 +206,10 @@ TEST(Process, BuildsChemicalReaction)
                                   .SetPhase(gas_phase)
                                   .Build();
 
-  // Check that the first process is a ChemicalReaction
-  std::visit(
-      [](auto&& value)
-      {
-        using T = std::decay_t<decltype(value)>;
-        if constexpr (std::is_same_v<T, ChemicalReaction>)
-        {
-          EXPECT_EQ(value.reactants_.size(), 2);
-          EXPECT_EQ(value.products_[0].species_.name_, "NO2");
-          EXPECT_EQ(value.phase_.name_, "gas");
-        }
-        else
-        {
-          FAIL() << "Expected ChemicalReaction, got different type";
-        }
-      },
-      chemical_reaction.process_);
+  const auto& value = chemical_reaction.process_;
+  EXPECT_EQ(value.reactants_.size(), 2);
+  EXPECT_EQ(value.products_[0].species_.name_, "NO2");
+  EXPECT_EQ(value.phase_.name_, "gas");
 }
 
 TEST(Process, ChemicalReactionCopyAssignmentSucceeds)
@@ -248,29 +229,16 @@ TEST(Process, ChemicalReactionCopyAssignmentSucceeds)
   // Assign original to copy
   Process copy_reaction = reaction;
 
-  std::visit(
-      [](auto&& copy, auto&& original)
-      {
-        using T = std::decay_t<decltype(copy)>;
-        using U = std::decay_t<decltype(original)>;
-        if constexpr (std::is_same_v<T, ChemicalReaction> && std::is_same_v<U, ChemicalReaction>)
-        {
-          EXPECT_EQ(copy.reactants_[0].name_, original.reactants_[0].name_);
-          EXPECT_EQ(copy.products_.size(), original.products_.size());
-          EXPECT_EQ(copy.phase_.name_, original.phase_.name_);
-          // With value semantics, rate_constant_ is copied by value — verify parameters match
-          const auto* copy_arr = std::get_if<ArrheniusRateConstantParameters>(&copy.rate_constant_);
-          const auto* orig_arr = std::get_if<ArrheniusRateConstantParameters>(&original.rate_constant_);
-          EXPECT_NE(copy_arr, nullptr);
-          EXPECT_NE(orig_arr, nullptr);
-          if (copy_arr && orig_arr)
-            EXPECT_EQ(copy_arr->A_, orig_arr->A_);
-        }
-        else
-        {
-          FAIL() << "Expected both variants to hold ChemicalReaction";
-        }
-      },
-      copy_reaction.process_,
-      reaction.process_);
+  const auto& copy = copy_reaction.process_;
+  const auto& original = reaction.process_;
+  EXPECT_EQ(copy.reactants_[0].name_, original.reactants_[0].name_);
+  EXPECT_EQ(copy.products_.size(), original.products_.size());
+  EXPECT_EQ(copy.phase_.name_, original.phase_.name_);
+  // With value semantics, rate_constant_ is copied by value — verify parameters match
+  const auto* copy_arr = std::get_if<ArrheniusRateConstantParameters>(&copy.rate_constant_);
+  const auto* orig_arr = std::get_if<ArrheniusRateConstantParameters>(&original.rate_constant_);
+  EXPECT_NE(copy_arr, nullptr);
+  EXPECT_NE(orig_arr, nullptr);
+  if (copy_arr && orig_arr)
+    EXPECT_EQ(copy_arr->A_, orig_arr->A_);
 }

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -206,10 +206,10 @@ TEST(Process, BuildsChemicalReaction)
                                   .SetPhase(gas_phase)
                                   .Build();
 
-  const auto& value = chemical_reaction.process_;
-  EXPECT_EQ(value.reactants_.size(), 2);
-  EXPECT_EQ(value.products_[0].species_.name_, "NO2");
-  EXPECT_EQ(value.phase_.name_, "gas");
+  const auto& reaction = chemical_reaction.process_;
+  EXPECT_EQ(reaction.reactants_.size(), 2);
+  EXPECT_EQ(reaction.products_[0].species_.name_, "NO2");
+  EXPECT_EQ(reaction.phase_.name_, "gas");
 }
 
 TEST(Process, ChemicalReactionCopyAssignmentSucceeds)

--- a/test/unit/process/test_reaction_rate_store.cpp
+++ b/test/unit/process/test_reaction_rate_store.cpp
@@ -49,9 +49,6 @@ namespace
   {
     auto type_order = [](const Process& p) -> int
     {
-      const auto* rxn = std::get_if<ChemicalReaction>(&p.process_);
-      if (!rxn)
-        return 10;
       return std::visit(
           [](const auto& v) -> int
           {
@@ -77,7 +74,7 @@ namespace
             else
               return 9;
           },
-          rxn->rate_constant_);
+          p.process_.rate_constant_);
     };
     std::stable_sort(
         procs.begin(), procs.end(), [&](const Process& a, const Process& b) { return type_order(a) < type_order(b); });
@@ -448,10 +445,7 @@ TEST(ReactionRateConstantStore, TotalRateConstantsMatchesProcessCount)
   auto store = ReactionRateConstantStore::BuildFrom(procs);
 
   // Total = lambda_offset() + lambda_entries_.size() = number of chemical reactions
-  std::size_t n_rxn = 0;
-  for (const auto& p : procs)
-    if (std::holds_alternative<ChemicalReaction>(p.process_))
-      ++n_rxn;
+  std::size_t n_rxn = procs.size();
 
   EXPECT_EQ(store.lambda_offset() + store.lambda_entries_.size(), n_rxn);
 }


### PR DESCRIPTION
This PR:
- Removes `using ProcessVariant = std::variant<ChemicalReaction> ` typedef
- Changes `ProcessVariant process_ ` -> `ChemicalReaction process_`
- Replaces template an `require` constraint constructor with plain constructor. 
- Closes #990 