### PR TITLE
Explicitly Specify Algebraic Species in LinearConstraint

### DIFF
--- a/include/micm/constraint/types/linear_constraint.hpp
+++ b/include/micm/constraint/types/linear_constraint.hpp
@@ -66,8 +66,7 @@ namespace micm
     }
 
     /// @brief Returns the species whose row should be replaced by this algebraic constraint
-    ///        For linear constraints, the last species is used in the terms list as the algebraic row target.
-    /// @return Species name of the primary algebraic variable
+    /// @return Species name of the explicitly set algebraic variable
     const std::string& AlgebraicSpecies() const
     {
       return algebraic_species_.name_;

--- a/include/micm/constraint/types/linear_constraint.hpp
+++ b/include/micm/constraint/types/linear_constraint.hpp
@@ -47,6 +47,7 @@ namespace micm
     ///        Validates that terms are non-empty
     ///        Builds species_dependencies_ from terms
     /// @param name Constraint identifier
+    /// @param algebraic_species Algebraic species
     /// @param terms Vector of StoichSpecies (species, coefficient) in the linear sum
     /// @param constant The value that sum(coeff[i] * [species[i]]) should equal
     LinearConstraint(const std::string& name, const Species& algebraic_species, const std::vector<StoichSpecies>& terms, double constant)

--- a/include/micm/constraint/types/linear_constraint.hpp
+++ b/include/micm/constraint/types/linear_constraint.hpp
@@ -24,6 +24,9 @@ namespace micm
     /// @brief Name of the constraint
     std::string name_;
 
+    /// @brief Algebraic species
+    Species algebraic_species_;
+
     /// @brief Names of species this constraint depends on
     std::vector<std::string> species_dependencies_;
 
@@ -46,8 +49,9 @@ namespace micm
     /// @param name Constraint identifier
     /// @param terms Vector of StoichSpecies (species, coefficient) in the linear sum
     /// @param constant The value that sum(coeff[i] * [species[i]]) should equal
-    LinearConstraint(const std::string& name, const std::vector<StoichSpecies>& terms, double constant)
+    LinearConstraint(const std::string& name, const Species& algebraic_species, const std::vector<StoichSpecies>& terms, double constant)
         : name_(name),
+          algebraic_species_(algebraic_species),
           terms_(terms),
           constant_(constant)
     {
@@ -66,7 +70,7 @@ namespace micm
     /// @return Species name of the primary algebraic variable
     const std::string& AlgebraicSpecies() const
     {
-      return terms_.back().species_.name_;
+      return algebraic_species_.name_;
     }
 
     template<typename DenseMatrixPolicy>

--- a/test/integration/test_dae_algebraic_error_insensitivity.cpp
+++ b/test/integration/test_dae_algebraic_error_insensitivity.cpp
@@ -82,7 +82,7 @@ namespace
         std::vector<StoichSpecies>{ { B_aq, 1.0 } },
         VantHoffParam{ .K_HLC_ref = K2, .delta_H = 0.0 }));
     // A_gas is LAST so it becomes the algebraic balance variable
-    constraints.push_back(LinearConstraint("mass", { { A_aq, 1.0 }, { B_aq, 1.0 }, { P, 1.0 }, { A_gas, 1.0 } }, C_total));
+    constraints.push_back(LinearConstraint("mass", A_gas, { { A_aq, 1.0 }, { B_aq, 1.0 }, { P, 1.0 }, { A_gas, 1.0 } }, C_total));
 
     auto options = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))

--- a/test/integration/test_dae_algebraic_error_insensitivity.cpp
+++ b/test/integration/test_dae_algebraic_error_insensitivity.cpp
@@ -14,7 +14,7 @@
 //   A_gas <-> A_aq   (equilibrium, K1)    -- A_aq is algebraic
 //   A_aq  <-> B_aq   (equilibrium, K2)    -- B_aq is algebraic
 //   B_aq  -> P       (kinetics, rate k)   -- P is the only differential variable
-//   Conservation: A_aq + B_aq + P + A_gas = C_total   -- A_gas is algebraic (last term)
+//   Conservation: A_aq + B_aq + P + A_gas = C_total   -- A_gas is the algebraic balance variable
 //
 // Analytical solution:
 //   A_gas(t) = (C - P(t)) / (1 + K1 + K1*K2)
@@ -81,7 +81,7 @@ namespace
         std::vector<StoichSpecies>{ { A_aq, 1.0 } },
         std::vector<StoichSpecies>{ { B_aq, 1.0 } },
         VantHoffParam{ .K_HLC_ref = K2, .delta_H = 0.0 }));
-    // A_gas is LAST so it becomes the algebraic balance variable
+    // A_gas is explicitly set as the algebraic balance variable
     constraints.push_back(LinearConstraint("mass", A_gas, { { A_aq, 1.0 }, { B_aq, 1.0 }, { P, 1.0 }, { A_gas, 1.0 } }, C_total));
 
     auto options = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();

--- a/test/integration/test_dae_constraint_overshoot.cpp
+++ b/test/integration/test_dae_constraint_overshoot.cpp
@@ -58,7 +58,7 @@ TEST(DAEConstraintOvershoot, AlgebraicVariableStaysNonNegative)
   double C_total = 1.0e-6;
 
   std::vector<Constraint> constraints;
-  constraints.push_back(LinearConstraint("mass_conservation", { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, C_total));
+  constraints.push_back(LinearConstraint("mass_conservation", C, { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, C_total));
 
   auto options = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
@@ -158,7 +158,7 @@ TEST(DAEConstraintOvershoot, EquilibriumPlusConservation)
 
   // Conservation: A_gas + A_aq + P = C_total  (A_gas is algebraic balance — last term)
   // Note: A_gas appears last so it becomes the algebraic variable for this constraint.
-  constraints.push_back(LinearConstraint("mass_conservation", { { A_aq, 1.0 }, { P, 1.0 }, { A_gas, 1.0 } }, C_total));
+  constraints.push_back(LinearConstraint("mass_conservation", A_gas, { { A_aq, 1.0 }, { P, 1.0 }, { A_gas, 1.0 } }, C_total));
 
   auto options = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
@@ -253,7 +253,7 @@ TEST(DAEConstraintOvershoot, AllRosenbrockOrdersConstrained)
 
     constexpr double C_total = 1.0e-6;
     std::vector<Constraint> constraints;
-    constraints.push_back(LinearConstraint("mass_conservation", { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, C_total));
+    constraints.push_back(LinearConstraint("mass_conservation", C, { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, C_total));
 
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(options)
                       .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))

--- a/test/integration/test_dae_constraint_overshoot.cpp
+++ b/test/integration/test_dae_constraint_overshoot.cpp
@@ -52,7 +52,7 @@ TEST(DAEConstraintOvershoot, AlgebraicVariableStaysNonNegative)
                     .Build();
 
   // Conservation constraint: A + B + C = C_total
-  // C is the algebraic variable (last in the terms list).
+  // C is the explicitly set algebraic variable.
   // In the continuous system, C >= 0 always because A,B cannot exceed C_total
   // together. But the discrete solver can overshoot.
   double C_total = 1.0e-6;
@@ -156,8 +156,7 @@ TEST(DAEConstraintOvershoot, EquilibriumPlusConservation)
       std::vector<StoichSpecies>{ { A_aq, 1.0 } },
       VantHoffParam{ .K_HLC_ref = K_eq, .delta_H = 0.0 }));
 
-  // Conservation: A_gas + A_aq + P = C_total  (A_gas is algebraic balance — last term)
-  // Note: A_gas appears last so it becomes the algebraic variable for this constraint.
+  // Conservation: A_gas + A_aq + P = C_total  (A_gas is the algebraic balance variable)
   constraints.push_back(LinearConstraint("mass_conservation", A_gas, { { A_aq, 1.0 }, { P, 1.0 }, { A_gas, 1.0 } }, C_total));
 
   auto options = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();

--- a/test/integration/test_linear_constraint.cpp
+++ b/test/integration/test_linear_constraint.cpp
@@ -67,7 +67,7 @@ TEST(DAESolveWithConstraint, TerminatorAndRobertson)
 
   std::vector<micm::Constraint> constraints;
   constraints.push_back(
-      micm::LinearConstraint("mass_conservation", { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, sum_initial_conc));
+      micm::LinearConstraint("mass_conservation", C, { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, sum_initial_conc));
 
   // ---------------------------------------------------------------------------
   // Solver

--- a/test/unit/constraint/type/test_linear.cpp
+++ b/test/unit/constraint/type/test_linear.cpp
@@ -26,9 +26,13 @@ TEST(LinearConstraint, Construction)
   // Test: A + B = 1.0 (total concentration conservation)
   // Constraint: G = [A] + [B] - 1.0 = 0
 
+  auto A = Species("A");
+  auto B = Species("B");
+
   LinearConstraint constraint(
       "A_B_conservation",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
       1.0);
 
   EXPECT_EQ(constraint.name_, "A_B_conservation");
@@ -42,10 +46,14 @@ TEST(LinearConstraint, Construction)
 TEST(LinearConstraint, AlgebraicSpecies)
 {
   // Test that AlgebraicSpecies returns the last species in terms list
+  auto A = Species("A");
+  auto B = Species("B");
+  auto C = Species("C");
+
   LinearConstraint constraint(
       "A_B_C_conservation",
-      std::vector<StoichSpecies>{
-          StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0), StoichSpecies(Species("C"), 1.0) },
+      C,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0), StoichSpecies(C, 1.0) },
       10.0);
 
   EXPECT_EQ(constraint.AlgebraicSpecies(), "C");
@@ -56,10 +64,14 @@ TEST(LinearConstraint, WeightedTerms)
   // Test: 2*A + 3*B - C = 5.0
   // Constraint: G = 2*[A] + 3*[B] - [C] - 5.0 = 0
 
+  auto A = Species("A");
+  auto B = Species("B");
+  auto C = Species("C");
+
   LinearConstraint constraint(
       "weighted_sum",
-      std::vector<StoichSpecies>{
-          StoichSpecies(Species("A"), 2.0), StoichSpecies(Species("B"), 3.0), StoichSpecies(Species("C"), -1.0) },
+      C,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 2.0), StoichSpecies(B, 3.0), StoichSpecies(C, -1.0) },
       5.0);
 
   EXPECT_EQ(constraint.name_, "weighted_sum");
@@ -76,8 +88,14 @@ TEST(LinearConstraint, ZeroConstant)
   // Test: A - B = 0 (species balance)
   // Constraint: G = [A] - [B] = 0
 
+  auto A = Species("A");
+  auto B = Species("B");
+
   LinearConstraint constraint(
-      "A_equals_B", std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), -1.0) }, 0.0);
+      "A_equals_B",
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, -1.0) },
+      0.0);
 
   EXPECT_EQ(constraint.name_, "A_equals_B");
   EXPECT_EQ(constraint.constant_, 0.0);
@@ -89,9 +107,13 @@ TEST(LinearConstraint, FractionalCoefficients)
   // Test: 0.5*A + 1.5*B = 2.0
   // Constraint: G = 0.5*[A] + 1.5*[B] - 2.0 = 0
 
+  auto A = Species("A");
+  auto B = Species("B");
+
   LinearConstraint constraint(
       "fractional_conservation",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 0.5), StoichSpecies(Species("B"), 1.5) },
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 0.5), StoichSpecies(B, 1.5) },
       2.0);
 
   EXPECT_EQ(constraint.name_, "fractional_conservation");
@@ -109,10 +131,14 @@ TEST(LinearConstraint, ResidualComputationThroughConstraintSet)
 
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+
   std::vector<Constraint> constraints;
   constraints.push_back(LinearConstraint(
       "A_B_conservation",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
       1.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
@@ -172,10 +198,14 @@ TEST(LinearConstraint, JacobianComputationThroughConstraintSet)
 
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+
   std::vector<Constraint> constraints;
   constraints.push_back(LinearConstraint(
       "A_B_conservation",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
       1.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
@@ -222,11 +252,15 @@ TEST(LinearConstraint, WeightedSumResidualAndJacobian)
 
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+  auto C = Species("C");
+
   std::vector<Constraint> constraints;
   constraints.push_back(LinearConstraint(
       "weighted_sum",
-      std::vector<StoichSpecies>{
-          StoichSpecies(Species("A"), 2.0), StoichSpecies(Species("B"), 3.0), StoichSpecies(Species("C"), -1.0) },
+      C,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 2.0), StoichSpecies(B, 3.0), StoichSpecies(C, -1.0) },
       5.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "C", 2 } };
@@ -288,11 +322,15 @@ TEST(LinearConstraint, ThreeSpeciesConservationResidual)
 
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+  auto C = Species("C");
+
   std::vector<Constraint> constraints;
   constraints.push_back(LinearConstraint(
       "ABC_total",
-      std::vector<StoichSpecies>{
-          StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0), StoichSpecies(Species("C"), 1.0) },
+      C,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0), StoichSpecies(C, 1.0) },
       10.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "C", 2 } };
@@ -349,9 +387,15 @@ TEST(LinearConstraint, ZeroConstantResidual)
 
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+
   std::vector<Constraint> constraints;
   constraints.push_back(LinearConstraint(
-      "A_equals_B", std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), -1.0) }, 0.0));
+      "A_equals_B",
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, -1.0) },
+      0.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
 
@@ -405,10 +449,14 @@ TEST(LinearConstraint, FractionalCoefficientsResidualAndJacobian)
 
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+
   std::vector<Constraint> constraints;
   constraints.push_back(LinearConstraint(
       "fractional_conservation",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 0.5), StoichSpecies(Species("B"), 1.5) },
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 0.5), StoichSpecies(B, 1.5) },
       2.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
@@ -460,9 +508,15 @@ TEST(LinearConstraint, JacobianIndependentOfConcentrations)
 
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+
   std::vector<Constraint> constraints;
   constraints.push_back(LinearConstraint(
-      "A_B_sum", std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 2.0), StoichSpecies(Species("B"), 3.0) }, 1.0));
+      "A_B_sum",
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 2.0), StoichSpecies(B, 3.0) },
+      1.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
 
@@ -525,10 +579,14 @@ TEST(LinearConstraint, FiniteDifferenceJacobianSimpleConservation)
   // G = [A] + [B] - 1.0, dG/dA = 1, dG/dB = 1
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+
   std::vector<Constraint> constraints;
   constraints.push_back(LinearConstraint(
       "conservation",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
       1.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
@@ -582,11 +640,15 @@ TEST(LinearConstraint, FiniteDifferenceJacobianWeightedSum)
   // G = 2[A] + 3[B] - [C] - 5, dG/dA = 2, dG/dB = 3, dG/dC = -1
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+  auto C = Species("C");
+
   std::vector<Constraint> constraints;
   constraints.push_back(LinearConstraint(
       "weighted",
-      std::vector<StoichSpecies>{
-          StoichSpecies(Species("A"), 2.0), StoichSpecies(Species("B"), 3.0), StoichSpecies(Species("C"), -1.0) },
+      C,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 2.0), StoichSpecies(B, 3.0), StoichSpecies(C, -1.0) },
       5.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "C", 2 } };

--- a/test/unit/constraint/type/test_linear.cpp
+++ b/test/unit/constraint/type/test_linear.cpp
@@ -45,7 +45,7 @@ TEST(LinearConstraint, Construction)
 
 TEST(LinearConstraint, AlgebraicSpecies)
 {
-  // Test that AlgebraicSpecies returns the last species in terms list
+  // Test that AlgebraicSpecies returns the explicitly set algebraic species
   auto A = Species("A");
   auto B = Species("B");
   auto C = Species("C");
@@ -175,7 +175,7 @@ TEST(LinearConstraint, ResidualComputationThroughConstraintSet)
   DenseMatrix state_parameters(1, 0);  // No parameters for linear constraints
   set.AddForcingTerms(state, state_parameters, forcing);
 
-  // The forcing term for B (row 1, last term) should be the constraint residual
+  // The forcing term for B (row 1, algebraic species) should be the constraint residual
   EXPECT_NEAR(forcing[0][1], 0.0, 1e-10);
 
   // Test when constraint is not satisfied: [A] = 0.5, [B] = 0.6
@@ -297,7 +297,7 @@ TEST(LinearConstraint, WeightedSumResidualAndJacobian)
   DenseMatrix state_parameters(1, 0);  // No parameters for linear constraints
   set.AddForcingTerms(state, state_parameters, forcing);
 
-  // The forcing term for C (row 2, last term) should be the constraint residual
+  // The forcing term for C (row 2, algebraic species) should be the constraint residual
   EXPECT_NEAR(forcing[0][2], 0.0, 1e-10);
 
   // Test Jacobian - reset jacobian values to zero first
@@ -575,7 +575,7 @@ TEST(LinearConstraint, JacobianIndependentOfConcentrations)
 
 TEST(LinearConstraint, FiniteDifferenceJacobianSimpleConservation)
 {
-  // A + B = 1.0, algebraic species = B (last term)
+  // A + B = 1.0, algebraic species = B
   // G = [A] + [B] - 1.0, dG/dA = 1, dG/dB = 1
   using DenseMatrix = Matrix<double>;
 
@@ -636,7 +636,7 @@ TEST(LinearConstraint, FiniteDifferenceJacobianSimpleConservation)
 
 TEST(LinearConstraint, FiniteDifferenceJacobianWeightedSum)
 {
-  // 2*A + 3*B - C = 5.0, algebraic species = C (last term)
+  // 2*A + 3*B - C = 5.0, algebraic species = C
   // G = 2[A] + 3[B] - [C] - 5, dG/dA = 2, dG/dB = 3, dG/dC = -1
   using DenseMatrix = Matrix<double>;
 


### PR DESCRIPTION
The current MICM `LinearConstraint` implicitly assumes that the last species is the algebraic one. 
This PR specifies which species should be treated as algebraic. 
- Closes #986