### PR TITLE
Explicitly Specify Algebraic Species in EquilibriumConstraint 

### DIFF
--- a/include/micm/constraint/types/equilibrium_constraint.hpp
+++ b/include/micm/constraint/types/equilibrium_constraint.hpp
@@ -36,6 +36,9 @@ namespace micm
     /// @brief Name of the constraint, used when generating state parameter name
     std::string name_;
 
+    /// @brief Algebraic species
+    Species algebraic_species_;
+
     /// @brief Names of species this constraint depends on
     std::vector<std::string> species_dependencies_;
 
@@ -71,18 +74,21 @@ namespace micm
     ///        Stores index mappings for efficient Jacobian computation.
     ///        Stores a temperature-dependent equilibrium constant function.
     /// @param name Constraint identifier
+    /// @param algebraic_species Species whose row is replaced by this algebraic constraint
     /// @param reactants Vector of StoichSpecies (species, stoichiometry) for reactants
     /// @param products Vector of StoichSpecies (species, stoichiometry) for products
     /// @param vant_hoff_param Parameters for Van't Hoff equation
     EquilibriumConstraint(
-        std::string&& name,
-        std::vector<StoichSpecies>&& reactants,
-        std::vector<StoichSpecies>&& products,
-        VantHoffParam&& vant_hoff_param)
+        const std::string& name,
+        const Species& algebraic_species,
+        std::vector<StoichSpecies> reactants,
+        std::vector<StoichSpecies> products,
+        VantHoffParam vant_hoff_param)
         : name_(name),
-          reactants_(reactants),
-          products_(products),
-          vant_hoff_param_(vant_hoff_param)
+          algebraic_species_(algebraic_species),
+          reactants_(std::move(reactants)),
+          products_(std::move(products)),
+          vant_hoff_param_(std::move(vant_hoff_param))
     {
       if (reactants_.empty())
       {
@@ -121,7 +127,6 @@ namespace micm
       if (vant_hoff_param_.K_HLC_ref <= 0)
       {
         throw MicmException(
-
             MICM_ERROR_CATEGORY_CONSTRAINT,
             MICM_CONSTRAINT_ERROR_CODE_INVALID_EQUILIBRIUM_CONSTANT,
             "Henry’s Law constant (K_HLC_ref) must be positive");
@@ -149,13 +154,10 @@ namespace micm
     }
 
     /// @brief Returns the species whose row should be replaced by this algebraic constraint
-    /// @return Species name of the primary algebraic variable
-    ///
-    /// For equilibrium constraints, we use the first product species as the algebraic row target.
-    /// This supports common forms such as K_eq * [B] - [C] = 0 where C is algebraic.
+    /// @return Species name of the explicitly set algebraic variable
     const std::string& AlgebraicSpecies() const
     {
-      return products_[0].species_.name_;
+      return algebraic_species_.name_;
     }
 
     /// @brief Create function object to update temperature-dependent K_eq parameter

--- a/include/micm/constraint/types/linear_constraint.hpp
+++ b/include/micm/constraint/types/linear_constraint.hpp
@@ -47,7 +47,7 @@ namespace micm
     ///        Validates that terms are non-empty
     ///        Builds species_dependencies_ from terms
     /// @param name Constraint identifier
-    /// @param algebraic_species Algebraic species
+    /// @param algebraic_species Species whose row is replaced by this algebraic constraint
     /// @param terms Vector of StoichSpecies (species, coefficient) in the linear sum
     /// @param constant The value that sum(coeff[i] * [species[i]]) should equal
     LinearConstraint(const std::string& name, const Species& algebraic_species, const std::vector<StoichSpecies>& terms, double constant)

--- a/test/integration/test_dae_algebraic_error_insensitivity.cpp
+++ b/test/integration/test_dae_algebraic_error_insensitivity.cpp
@@ -73,11 +73,13 @@ namespace
     std::vector<Constraint> constraints;
     constraints.push_back(EquilibriumConstraint(
         "eq1",
+        A_aq,
         std::vector<StoichSpecies>{ { A_gas, 1.0 } },
         std::vector<StoichSpecies>{ { A_aq, 1.0 } },
         VantHoffParam{ .K_HLC_ref = K1, .delta_H = 0.0 }));
     constraints.push_back(EquilibriumConstraint(
         "eq2",
+        B_aq,
         std::vector<StoichSpecies>{ { A_aq, 1.0 } },
         std::vector<StoichSpecies>{ { B_aq, 1.0 } },
         VantHoffParam{ .K_HLC_ref = K2, .delta_H = 0.0 }));

--- a/test/integration/test_dae_constraint_overshoot.cpp
+++ b/test/integration/test_dae_constraint_overshoot.cpp
@@ -149,9 +149,10 @@ TEST(DAEConstraintOvershoot, EquilibriumPlusConservation)
 
   std::vector<Constraint> constraints;
 
-  // Equilibrium: K_eq * A_gas = A_aq  (A_aq is algebraic — first product)
+  // Equilibrium: K_eq * A_gas = A_aq  (A_aq is the explicitly set algebraic species)
   constraints.push_back(EquilibriumConstraint(
       "gas_aq_eq",
+      A_aq,
       std::vector<StoichSpecies>{ { A_gas, 1.0 } },
       std::vector<StoichSpecies>{ { A_aq, 1.0 } },
       VantHoffParam{ .K_HLC_ref = K_eq, .delta_H = 0.0 }));

--- a/test/integration/test_equilibrium_constraint.cpp
+++ b/test/integration/test_equilibrium_constraint.cpp
@@ -45,6 +45,7 @@ TEST(EquilibriumIntegration, SetConstraintsAPIWorks)
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "B_C_eq",
+      C,
       std::vector<StoichSpecies>{ { B, 1.0 } },
       std::vector<StoichSpecies>{ { C, 1.0 } },
       VantHoffParam{ .K_HLC_ref = K_eq, .delta_H = -2400.0 }));
@@ -130,11 +131,13 @@ TEST(EquilibriumIntegration, SetConstraintsAPIMultipleConstraints)
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "B_C_eq",
+      C,
       std::vector<StoichSpecies>{ { B, 1.0 } },
       std::vector<StoichSpecies>{ { C, 1.0 } },
       VantHoffParam{ .K_HLC_ref = K_eq1, .delta_H = delta_H1 }));
   constraints.push_back(EquilibriumConstraint(
       "E_F_eq",
+      F,
       std::vector<StoichSpecies>{ { E, 1.0 } },
       std::vector<StoichSpecies>{ { F, 1.0 } },
       VantHoffParam{ .K_HLC_ref = K_eq2, .delta_H = delta_H2 }));
@@ -208,6 +211,7 @@ TEST(EquilibriumIntegration, DAESolveWithConstraint)
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "B_C_eq",
+      C,
       std::vector<StoichSpecies>{ { B, 1.0 } },
       std::vector<StoichSpecies>{ { C, 1.0 } },
       VantHoffParam{ .K_HLC_ref = K_eq, .delta_H = delta_H }));
@@ -305,6 +309,7 @@ TEST(EquilibriumIntegration, DAESolveWithConstraintAndReorderState)
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "B_C_eq",
+      C,
       std::vector<StoichSpecies>{ { B, 1.0 } },
       std::vector<StoichSpecies>{ { C, 1.0 } },
       VantHoffParam{ .K_HLC_ref = K_eq, .delta_H = -2400.0 }));
@@ -380,11 +385,13 @@ TEST(EquilibriumIntegration, DAESolveWithTwoCoupledConstraints)
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "B_C_eq",
+      C,
       std::vector<StoichSpecies>{ { B, 1.0 } },
       std::vector<StoichSpecies>{ { C, 1.0 } },
       VantHoffParam{ .K_HLC_ref = K_eq1, .delta_H = -2400.0 }));
   constraints.push_back(EquilibriumConstraint(
       "B_D_eq",
+      D,
       std::vector<StoichSpecies>{ { B, 1.0 } },
       std::vector<StoichSpecies>{ { D, 1.0 } },
       VantHoffParam{ .K_HLC_ref = K_eq2, .delta_H = -2400.0 }));
@@ -471,6 +478,7 @@ TEST(EquilibriumIntegration, DAESolveWithNonUnitStoichiometry)
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "A2_B_eq",
+      B,
       std::vector<StoichSpecies>{ { A, 2.0 } },
       std::vector<StoichSpecies>{ { B, 1.0 } },
       VantHoffParam{ .K_HLC_ref = K_eq, .delta_H = -2400.0 }));

--- a/test/integration/test_external_model_constraints.cpp
+++ b/test/integration/test_external_model_constraints.cpp
@@ -435,6 +435,7 @@ TEST(ExternalModelConstraints, CombinedBuiltInAndExternalConstraints)
   std::vector<micm::Constraint> constraints;
   constraints.push_back(micm::EquilibriumConstraint(
       "B_C_eq",
+      C,
       std::vector<micm::StoichSpecies>{ { B, 1.0 } },
       std::vector<micm::StoichSpecies>{ { C, 1.0 } },
       micm::VantHoffParam{ K_eq, 0.0 }));
@@ -837,6 +838,7 @@ TEST(ExternalModelConstraints, BuiltInVsExternalModelConstraintStepByStep)
   std::vector<micm::Constraint> constraints;
   constraints.push_back(micm::EquilibriumConstraint(
       "B_C_eq",
+      C,
       std::vector<micm::StoichSpecies>{ { B, 1.0 } },
       std::vector<micm::StoichSpecies>{ { C, 1.0 } },
       micm::VantHoffParam{ K_EQ, 0.0 }));

--- a/test/unit/constraint/test_constraint_set_policy.hpp
+++ b/test/unit/constraint/test_constraint_set_policy.hpp
@@ -22,11 +22,15 @@ using namespace micm;
 template<class DenseMatrixPolicy, class SparseMatrixPolicy, class ConstraintSetPolicy>
 void testConstruction()
 {
+  auto A = Species("A");
+  auto B = Species("B");
+  auto AB = Species("AB");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "A_B_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("AB"), 1.0) },
+      AB,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(AB, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "AB", 2 } };
@@ -39,11 +43,14 @@ void testConstruction()
 template<class DenseMatrixPolicy, class SparseMatrixPolicy, class ConstraintSetPolicy>
 void testReplaceStateRowsMapsToAlgebraicSpecies()
 {
+  auto B = Species("B");
+  auto C = Species("C");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "B_C_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("C"), 1.0) },
+      C,
+      std::vector<StoichSpecies>{ StoichSpecies(B, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(C, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "C", 2 } };
@@ -63,11 +70,15 @@ void testReplaceStateRowsMapsToAlgebraicSpecies()
 template<class DenseMatrixPolicy, class SparseMatrixPolicy, class ConstraintSetPolicy>
 void testNonZeroJacobianElements()
 {
+  auto A = Species("A");
+  auto B = Species("B");
+  auto AB = Species("AB");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "A_B_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("AB"), 1.0) },
+      AB,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(AB, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "AB", 2 } };
@@ -88,16 +99,23 @@ template<class DenseMatrixPolicy, class SparseMatrixPolicy, class ConstraintSetP
 void testMultipleConstraints()
 {
   // Create constraint set with two equilibrium constraints
+  auto A = Species("A");
+  auto B = Species("B");
+  auto AB = Species("AB");
+  auto C = Species("C");
+  auto D = Species("D");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "A_B_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("AB"), 1.0) },
+      AB,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(AB, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
   constraints.push_back(EquilibriumConstraint(
       "C_D_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("C"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("D"), 1.0) },
+      D,
+      std::vector<StoichSpecies>{ StoichSpecies(C, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(D, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = {
@@ -125,11 +143,15 @@ void testMultipleConstraints()
 template<class DenseMatrixPolicy, class SparseMatrixPolicy, class ConstraintSetPolicy>
 void testAddForcingTerms()
 {
+  auto A = Species("A");
+  auto B = Species("B");
+  auto AB = Species("AB");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "A_B_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("AB"), 1.0) },
+      AB,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(AB, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "AB", 2 } };
@@ -174,11 +196,15 @@ void testAddForcingTerms()
 template<class DenseMatrixPolicy, class SparseMatrixPolicy, class ConstraintSetPolicy>
 void testSubtractJacobianTerms()
 {
+  auto A = Species("A");
+  auto B = Species("B");
+  auto AB = Species("AB");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "A_B_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("AB"), 1.0) },
+      AB,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(AB, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "AB", 2 } };
@@ -259,11 +285,15 @@ template<class DenseMatrixPolicy, class SparseMatrixPolicy, class ConstraintSetP
 void testUnknownSpeciesThrows()
 {
   // Creating a constraint with unknown species should throw
+  auto X = Species("X");
+  auto Y = Species("Y");
+  auto XY = Species("XY");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "invalid",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("X"), 1.0), StoichSpecies(Species("Y"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("XY"), 1.0) },
+      XY,
+      std::vector<StoichSpecies>{ StoichSpecies(X, 1.0), StoichSpecies(Y, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(XY, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
@@ -279,11 +309,14 @@ void testThreeDStateOneConstraint()
   const std::size_t num_species = 3;
 
   // Create constraint: X <-> Y with K_eq = 3.3e-2
+  auto X = Species("X");
+  auto Y = Species("Y");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "X_Y_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("X"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("Y"), 1.0) },
+      Y,
+      std::vector<StoichSpecies>{ StoichSpecies(X, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(Y, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "X", 0 }, { "Y", 1 }, { "Z", 2 } };
@@ -373,17 +406,23 @@ void testFourDStateTwoConstraints()
   std::vector<Constraint> constraints;
 
   // Constraint 1: A <-> B with K_eq1 = 3.3e-2, algebraic species = B (row 1)
+  auto A = Species("A");
+  auto B = Species("B");
+  auto C = Species("C");
+  auto D = Species("D");
   constraints.push_back(EquilibriumConstraint(
       "A_B_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 1.0) },
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(B, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   // Constraint 2: C + D <-> A with K_eq2 = 3.3e-2, algebraic species = A (row 0)
   constraints.push_back(EquilibriumConstraint(
       "CD_A_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("C"), 1.0), StoichSpecies(Species("D"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0) },
+      A,
+      std::vector<StoichSpecies>{ StoichSpecies(C, 1.0), StoichSpecies(D, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "C", 2 }, { "D", 3 } };
@@ -509,16 +548,21 @@ void testCoupledConstraintsSharedSpecies()
   std::vector<Constraint> constraints;
 
   // Both constraints depend on species A
+  auto A = Species("A");
+  auto B = Species("B");
+  auto C = Species("C");
   constraints.push_back(EquilibriumConstraint(
       "A_B_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 1.0) },
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(B, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   constraints.push_back(EquilibriumConstraint(
       "A_C_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("C"), 1.0) },
+      C,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(C, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "C", 2 } };
@@ -591,11 +635,15 @@ void testVectorizedMatricesRespectGridCellIndexing()
 {
   const std::size_t num_species = 3;
 
+  auto A = Species("A");
+  auto B = Species("B");
+  auto AB = Species("AB");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "A_B_eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("AB"), 1.0) },
+      AB,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(AB, 1.0) },
       VantHoffParam{ .K_HLC_ref = 3.3e-2, .delta_H = -24000.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "AB", 2 } };

--- a/test/unit/constraint/type/test_equilibrium.cpp
+++ b/test/unit/constraint/type/test_equilibrium.cpp
@@ -28,10 +28,14 @@ TEST(EquilibriumConstraint, Construction)
   // Constraint: G = K_eq * [A] * [B] - [AB] = 0
 
   double K_eq = 1000.0;
+  auto A = Species("A");
+  auto B = Species("B");
+  auto AB = Species("AB");
   EquilibriumConstraint constraint(
       "A_B_equilibrium",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("AB"), 1.0) },
+      AB,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(AB, 1.0) },
       VantHoffParam{ .K_HLC_ref = K_eq, .delta_H = -2400.0 });
 
   EXPECT_EQ(constraint.name_, "A_B_equilibrium");
@@ -45,13 +49,17 @@ TEST(EquilibriumConstraint, Construction)
 
 TEST(EquilibriumConstraint, AlgebraicSpecies)
 {
-  // Test that AlgebraicSpecies returns the first product species
+  // Test that AlgebraicSpecies returns the explicitly set algebraic species
 
   double K_eq = 1000.0;
+  auto A = Species("A");
+  auto B = Species("B");
+  auto AB = Species("AB");
   EquilibriumConstraint constraint(
       "A_B_equilibrium",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("AB"), 1.0) },
+      AB,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(AB, 1.0) },
       VantHoffParam{ .K_HLC_ref = K_eq, .delta_H = -2400.0 });
 
   EXPECT_EQ(constraint.AlgebraicSpecies(), "AB");
@@ -64,10 +72,13 @@ TEST(EquilibriumConstraint, SingleReactantSingleProduct)
   // Constraint: G = K_eq * [A] - [B] = 0
 
   double K_eq = 10.0;
+  auto A = Species("A");
+  auto B = Species("B");
   EquilibriumConstraint constraint(
       "A_B_simple",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 1.0) },
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(B, 1.0) },
       VantHoffParam{ .K_HLC_ref = K_eq, .delta_H = -2400.0 });
 
   EXPECT_EQ(constraint.name_, "A_B_simple");
@@ -84,10 +95,14 @@ TEST(EquilibriumConstraint, MultipleReactantsAndProducts)
   // Constraint: G = K_eq * [A]^2 - [B] * [C] = 0
 
   double K_eq = 100.0;
+  auto A = Species("A");
+  auto B = Species("B");
+  auto C = Species("C");
   EquilibriumConstraint constraint(
       "dissociation",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 2.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 1.0), StoichSpecies(Species("C"), 1.0) },
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 2.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(B, 1.0), StoichSpecies(C, 1.0) },
       VantHoffParam{ .K_HLC_ref = K_eq, .delta_H = -2400.0 });
 
   EXPECT_EQ(constraint.name_, "dissociation");
@@ -104,40 +119,48 @@ TEST(EquilibriumConstraint, MultipleReactantsAndProducts)
 TEST(EquilibriumConstraint, InvalidEquilibriumConstant)
 {
   // Test that negative or zero K_eq throws
+  auto A = Species("A");
+  auto B = Species("B");
   EXPECT_THROW(
       EquilibriumConstraint(
           "invalid",
-          std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0) },
-          std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 1.0) },
+          B,
+          std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
+          std::vector<StoichSpecies>{ StoichSpecies(B, 1.0) },
           VantHoffParam{ .K_HLC_ref = -1.0, .delta_H = -2400.0 }),
       micm::MicmException);
 
   EXPECT_THROW(
       EquilibriumConstraint(
           "invalid",
-          std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0) },
-          std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 1.0) },
+          B,
+          std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
+          std::vector<StoichSpecies>{ StoichSpecies(B, 1.0) },
           VantHoffParam{ .K_HLC_ref = 0.0, .delta_H = -2400.0 }),
       micm::MicmException);
 }
 
 TEST(EquilibriumConstraint, EmptyReactantsThrows)
 {
+  auto B = Species("B");
   EXPECT_THROW(
       EquilibriumConstraint(
           "invalid",
+          B,
           std::vector<StoichSpecies>{},  // empty reactants
-          std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 1.0) },
+          std::vector<StoichSpecies>{ StoichSpecies(B, 1.0) },
           VantHoffParam{ .K_HLC_ref = 1.0, .delta_H = -2400.0 }),
       micm::MicmException);
 }
 
 TEST(EquilibriumConstraint, EmptyProductsThrows)
 {
+  auto A = Species("A");
   EXPECT_THROW(
       EquilibriumConstraint(
           "invalid",
-          std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0) },
+          Species("B"),
+          std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
           std::vector<StoichSpecies>{},  // empty products
           VantHoffParam{ .K_HLC_ref = 1.0, .delta_H = -2400.0 }),
       micm::MicmException);
@@ -145,12 +168,16 @@ TEST(EquilibriumConstraint, EmptyProductsThrows)
 
 TEST(EquilibriumConstraint, InvalidStoichiometryThrows)
 {
+  auto A = Species("A");
+  auto B = Species("B");
+
   // Zero stoichiometry for reactant
   EXPECT_THROW(
       EquilibriumConstraint(
           "invalid",
-          std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 0.0) },
-          std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 1.0) },
+          B,
+          std::vector<StoichSpecies>{ StoichSpecies(A, 0.0) },
+          std::vector<StoichSpecies>{ StoichSpecies(B, 1.0) },
           VantHoffParam{ .K_HLC_ref = 1.0, .delta_H = -2400.0 }),
       micm::MicmException);
 
@@ -158,8 +185,9 @@ TEST(EquilibriumConstraint, InvalidStoichiometryThrows)
   EXPECT_THROW(
       EquilibriumConstraint(
           "invalid",
-          std::vector<StoichSpecies>{ StoichSpecies(Species("A"), -1.0) },
-          std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 1.0) },
+          B,
+          std::vector<StoichSpecies>{ StoichSpecies(A, -1.0) },
+          std::vector<StoichSpecies>{ StoichSpecies(B, 1.0) },
           VantHoffParam{ .K_HLC_ref = 1.0, .delta_H = -2400.0 }),
       micm::MicmException);
 
@@ -167,8 +195,9 @@ TEST(EquilibriumConstraint, InvalidStoichiometryThrows)
   EXPECT_THROW(
       EquilibriumConstraint(
           "invalid",
-          std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0) },
-          std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 0.0) },
+          B,
+          std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
+          std::vector<StoichSpecies>{ StoichSpecies(B, 0.0) },
           VantHoffParam{ .K_HLC_ref = 1.0, .delta_H = -2400.0 }),
       micm::MicmException);
 
@@ -176,8 +205,9 @@ TEST(EquilibriumConstraint, InvalidStoichiometryThrows)
   EXPECT_THROW(
       EquilibriumConstraint(
           "invalid",
-          std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0) },
-          std::vector<StoichSpecies>{ StoichSpecies(Species("B"), -2.0) },
+          B,
+          std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
+          std::vector<StoichSpecies>{ StoichSpecies(B, -2.0) },
           VantHoffParam{ .K_HLC_ref = 1.0, .delta_H = -2400.0 }),
       micm::MicmException);
 }
@@ -191,11 +221,15 @@ TEST(EquilibriumConstraint, ResidualComputationThroughConstraintSet)
 
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+  auto AB = Species("AB");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "A_B_equilibrium",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("AB"), 1.0) },
+      AB,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(AB, 1.0) },
       VantHoffParam{ .K_HLC_ref = 1000.0, .delta_H = -2400.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "AB", 2 } };
@@ -260,11 +294,15 @@ TEST(EquilibriumConstraint, JacobianComputationThroughConstraintSet)
 
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+  auto AB = Species("AB");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "A_B_equilibrium",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("AB"), 1.0) },
+      AB,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(AB, 1.0) },
       VantHoffParam{ .K_HLC_ref = 1000.0, .delta_H = -2400.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "AB", 2 } };
@@ -318,11 +356,15 @@ TEST(EquilibriumConstraint, ComplexStoichiometryResidual)
 
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+  auto C = Species("C");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "dissociation",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 2.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 1.0), StoichSpecies(Species("C"), 1.0) },
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 2.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(B, 1.0), StoichSpecies(C, 1.0) },
       VantHoffParam{ .K_HLC_ref = 100.0, .delta_H = -2400.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "C", 2 } };
@@ -360,7 +402,7 @@ TEST(EquilibriumConstraint, ComplexStoichiometryResidual)
   DenseMatrix state_parameters(1, 1, 100.0);  // K_eq = 100.0
   set.AddForcingTerms(state, state_parameters, forcing);
 
-  // The forcing term for B (row 1, first product) should be the constraint residual
+  // The forcing term for B (row 1, algebraic species) should be the constraint residual
   EXPECT_NEAR(forcing[0][1], 0.0, 1e-10);
 }
 
@@ -371,11 +413,15 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianSimple)
   // dG/dA = K_eq * [B], dG/dB = K_eq * [A], dG/dAB = -1
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+  auto AB = Species("AB");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "eq",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 1.0), StoichSpecies(Species("B"), 1.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("AB"), 1.0) },
+      AB,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(AB, 1.0) },
       VantHoffParam{ .K_HLC_ref = 1000.0, .delta_H = 0.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "AB", 2 } };
@@ -432,11 +478,15 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianComplexStoichiometry)
   // dG/dA = K_eq * 2 * [A], dG/dB = -[C], dG/dC = -[B]
   using DenseMatrix = Matrix<double>;
 
+  auto A = Species("A");
+  auto B = Species("B");
+  auto C = Species("C");
   std::vector<Constraint> constraints;
   constraints.push_back(EquilibriumConstraint(
       "dissociation",
-      std::vector<StoichSpecies>{ StoichSpecies(Species("A"), 2.0) },
-      std::vector<StoichSpecies>{ StoichSpecies(Species("B"), 1.0), StoichSpecies(Species("C"), 1.0) },
+      B,
+      std::vector<StoichSpecies>{ StoichSpecies(A, 2.0) },
+      std::vector<StoichSpecies>{ StoichSpecies(B, 1.0), StoichSpecies(C, 1.0) },
       VantHoffParam{ .K_HLC_ref = 100.0, .delta_H = 0.0 }));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 }, { "C", 2 } };

--- a/test/unit/solver/test_constraint_initialization.cpp
+++ b/test/unit/solver/test_constraint_initialization.cpp
@@ -41,6 +41,7 @@ struct SimpleConstrainedSystem
     std::vector<Constraint> constraints;
     constraints.push_back(EquilibriumConstraint(
         "B_C_eq",
+        C,
         std::vector<StoichSpecies>{ { B, 1.0 } },
         std::vector<StoichSpecies>{ { C, 1.0 } },
         VantHoffParam{ .K_HLC_ref = K_eq, .delta_H = delta_H }));

--- a/test/unit/solver/test_rosenbrock.cpp
+++ b/test/unit/solver/test_rosenbrock.cpp
@@ -76,6 +76,7 @@ void testNormalizedErrorIncludesAllVariables(SolverBuilderPolicy builder, std::s
   std::vector<micm::Constraint> constraints;
   constraints.push_back(micm::EquilibriumConstraint(
       "B_C_eq",
+      C,
       std::vector<micm::StoichSpecies>{ micm::StoichSpecies(B, 1.0) },
       std::vector<micm::StoichSpecies>{ micm::StoichSpecies(C, 1.0) },
       micm::VantHoffParam{ .K_HLC_ref = 10.0, .delta_H = -2400.0 }));


### PR DESCRIPTION
The current `micm::EquilibriumConstraint` implicitly assumes that the last species is the algebraic one. 
This is problematic and the algebraic species should be explicitly specified by user.
- Closes #987 
