### PR TITLE
Address readability braces around statements clang tidy failure

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,7 +49,11 @@
 #   msc51 is a Windows-specific RNG check.
 
 Checks: >
+  # disable all checks
   -*,
+  # explicitly enabled checks
+  readability-braces-around-statements,
+  # explicitly disabled checks
   -readability-identifier-length,
   -readability-convert-member-functions-to-static,
   -readability-magic-numbers,
@@ -101,3 +105,5 @@ CheckOptions:
     value:           1
   - key:             readability-implicit-bool-conversion.AllowPointerConditions
     value:           1
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           0

--- a/include/micm/constraint/constraint_set.hpp
+++ b/include/micm/constraint/constraint_set.hpp
@@ -340,8 +340,9 @@ namespace micm
         constraint_param_functions_.push_back(
             constraints_[info.index_].template ConstraintParameterFunction<DenseMatrixPolicy>(info));
 
-        constraint_forcing_functions_.push_back(constraints_[info.index_].template ResidualFunction<DenseMatrixPolicy>(
-            info, state_variable_indices, state_parameter_indices));
+        constraint_forcing_functions_.push_back(
+            constraints_[info.index_].template ResidualFunction<DenseMatrixPolicy>(
+                info, state_variable_indices, state_parameter_indices));
 
         constraint_jacobian_functions_.push_back(
             constraints_[info.index_].template JacobianFunction<DenseMatrixPolicy, SparseMatrixPolicy>(

--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
@@ -19,7 +19,7 @@ namespace micm
     LinearSolverInPlaceParam devstruct_;
 
     /// This is the default constructor, taking no arguments;
-    CudaLinearSolverInPlace(){};
+    CudaLinearSolverInPlace() { };
 
     CudaLinearSolverInPlace(const CudaLinearSolverInPlace&) = delete;
     CudaLinearSolverInPlace& operator=(const CudaLinearSolverInPlace&) = delete;
@@ -46,7 +46,7 @@ namespace micm
         : CudaLinearSolverInPlace<SparseMatrixPolicy, LuDecompositionPolicy>(
               matrix,
               initial_value,
-              [&](const SparseMatrixPolicy& m) -> LuDecompositionPolicy { return LuDecompositionPolicy(m); }){};
+              [&](const SparseMatrixPolicy& m) -> LuDecompositionPolicy { return LuDecompositionPolicy(m); }) { };
 
     CudaLinearSolverInPlace(
         const SparseMatrixPolicy& matrix,

--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
@@ -18,7 +18,7 @@ namespace micm
     LuDecomposeMozartInPlaceParam devstruct_;
 
     /// This is the default constructor, taking no arguments;
-    CudaLuDecompositionMozartInPlace(){};
+    CudaLuDecompositionMozartInPlace() { };
 
     CudaLuDecompositionMozartInPlace(const CudaLuDecompositionMozartInPlace&) = delete;
     CudaLuDecompositionMozartInPlace& operator=(const CudaLuDecompositionMozartInPlace&) = delete;

--- a/include/micm/cuda/solver/cuda_rosenbrock.hpp
+++ b/include/micm/cuda/solver/cuda_rosenbrock.hpp
@@ -33,7 +33,7 @@ namespace micm
               RatesPolicy,
               LinearSolverPolicy,
               ConstraintSetPolicy,
-              CudaRosenbrockSolver<RatesPolicy, LinearSolverPolicy, ConstraintSetPolicy>>(std::move(other)){};
+              CudaRosenbrockSolver<RatesPolicy, LinearSolverPolicy, ConstraintSetPolicy>>(std::move(other)) { };
 
     CudaRosenbrockSolver& operator=(CudaRosenbrockSolver&& other)
     {
@@ -42,7 +42,7 @@ namespace micm
     };
 
     /// @brief Default constructor
-    CudaRosenbrockSolver(){};
+    CudaRosenbrockSolver() { };
 
     /// @brief Builds a CUDA Rosenbrock solver for the given system and solver parameters
     /// @param linear_solver Linear solver
@@ -56,11 +56,11 @@ namespace micm
               CudaRosenbrockSolver<RatesPolicy, LinearSolverPolicy, ConstraintSetPolicy>>(
               std::move(linear_solver),
               std::move(rates),
-              std::move(constraints)){};
+              std::move(constraints)) { };
 
     /// This is the destructor that will free the device memory of
     ///   the constant data from the class "CudaRosenbrockSolver"
-    ~CudaRosenbrockSolver(){};
+    ~CudaRosenbrockSolver() { };
 
     /// @brief Computes [alpha * I - jacobian] on the GPU
     /// @tparam SparseMatrixPolicy

--- a/include/micm/external_model.hpp
+++ b/include/micm/external_model.hpp
@@ -450,7 +450,7 @@ namespace micm
         get_initialize_constraint_parameters_function_ = [](const std::unordered_map<std::string, std::size_t>&,
                                                             const std::unordered_map<std::string, std::size_t>&)
             -> std::function<void(const DenseMatrixPolicy&, DenseMatrixPolicy&)>
-        { return [](const DenseMatrixPolicy&, DenseMatrixPolicy&) {}; };
+        { return [](const DenseMatrixPolicy&, DenseMatrixPolicy&) { }; };
       }
     }
   };

--- a/include/micm/process/chemical_reaction_builder.hpp
+++ b/include/micm/process/chemical_reaction_builder.hpp
@@ -65,11 +65,12 @@ namespace micm
     /// @throws MicmException if the rate constant has not been set
     Process Build()
     {
-      if (!rate_constant_.has_value())
+      if (!rate_constant_.has_value()) {
         throw MicmException(
             MICM_ERROR_CATEGORY_PROCESS,
             MICM_PROCESS_ERROR_CODE_RATE_CONSTANT_IS_NOT_SET,
             "Rate constant has not been set.");
+}
 
       ChemicalReaction reaction(std::move(reactants_), std::move(products_), std::move(rate_constant_.value()), phase_);
       return Process(std::move(reaction));

--- a/include/micm/process/chemical_reaction_builder.hpp
+++ b/include/micm/process/chemical_reaction_builder.hpp
@@ -65,12 +65,13 @@ namespace micm
     /// @throws MicmException if the rate constant has not been set
     Process Build()
     {
-      if (!rate_constant_.has_value()) {
+      if (!rate_constant_.has_value())
+      {
         throw MicmException(
             MICM_ERROR_CATEGORY_PROCESS,
             MICM_PROCESS_ERROR_CODE_RATE_CONSTANT_IS_NOT_SET,
             "Rate constant has not been set.");
-}
+      }
 
       ChemicalReaction reaction(std::move(reactants_), std::move(products_), std::move(rate_constant_.value()), phase_);
       return Process(std::move(reaction));

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -423,9 +423,10 @@ namespace micm
           std::size_t idx_state_variables = offset_state + react_id[i_react] * L;
           auto rate_it = rate.begin();
           auto v_state_variables_it = v_state_variables.begin() + idx_state_variables;
-          for (std::size_t i_cell = 0; i_cell < L; ++i_cell) {
+          for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+          {
             *(rate_it++) *= *(v_state_variables_it++);
-}
+          }
         }
         for (std::size_t i_react = 0; i_react < number_of_reactants; ++i_react)
         {
@@ -434,9 +435,10 @@ namespace micm
           {
             auto v_forcing_it = v_forcing.begin() + offset_forcing + row_id * L;
             auto rate_it = rate.begin();
-            for (std::size_t i_cell = 0; i_cell < L; ++i_cell) {
+            for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+            {
               *(v_forcing_it++) -= *(rate_it++);
-}
+            }
           }
         }
         const std::size_t number_of_products = number_of_products_[i_rxn];
@@ -448,9 +450,10 @@ namespace micm
             auto v_forcing_it = v_forcing.begin() + offset_forcing + row_id * L;
             auto rate_it = rate.begin();
             auto yield_value = yield[i_prod];
-            for (std::size_t i_cell = 0; i_cell < L; ++i_cell) {
+            for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+            {
               *(v_forcing_it++) += yield_value * *(rate_it++);
-}
+            }
           }
         }
         react_id += number_of_reactants_[i_rxn];

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -423,8 +423,9 @@ namespace micm
           std::size_t idx_state_variables = offset_state + react_id[i_react] * L;
           auto rate_it = rate.begin();
           auto v_state_variables_it = v_state_variables.begin() + idx_state_variables;
-          for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+          for (std::size_t i_cell = 0; i_cell < L; ++i_cell) {
             *(rate_it++) *= *(v_state_variables_it++);
+}
         }
         for (std::size_t i_react = 0; i_react < number_of_reactants; ++i_react)
         {
@@ -433,8 +434,9 @@ namespace micm
           {
             auto v_forcing_it = v_forcing.begin() + offset_forcing + row_id * L;
             auto rate_it = rate.begin();
-            for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+            for (std::size_t i_cell = 0; i_cell < L; ++i_cell) {
               *(v_forcing_it++) -= *(rate_it++);
+}
           }
         }
         const std::size_t number_of_products = number_of_products_[i_rxn];
@@ -446,8 +448,9 @@ namespace micm
             auto v_forcing_it = v_forcing.begin() + offset_forcing + row_id * L;
             auto rate_it = rate.begin();
             auto yield_value = yield[i_prod];
-            for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+            for (std::size_t i_cell = 0; i_cell < L; ++i_cell) {
               *(v_forcing_it++) += yield_value * *(rate_it++);
+}
           }
         }
         react_id += number_of_reactants_[i_rxn];

--- a/include/micm/process/rate_constant/rate_constant_functions.hpp
+++ b/include/micm/process/rate_constant/rate_constant_functions.hpp
@@ -108,9 +108,10 @@ namespace micm
   {
     double poly = 0.0;
     double t_pow = 1.0;
-    for (std::size_t j = 0; j < p.n_coefficients_; ++j, t_pow *= temperature) {
+    for (std::size_t j = 0; j < p.n_coefficients_; ++j, t_pow *= temperature)
+    {
       poly += p.coefficients_[j] * t_pow;
-}
+    }
     return poly * p.A_ * std::exp(p.C_ / temperature) * std::pow(temperature / p.D_, p.B_) * (1.0 + p.E_ * pressure);
   }
 

--- a/include/micm/process/rate_constant/rate_constant_functions.hpp
+++ b/include/micm/process/rate_constant/rate_constant_functions.hpp
@@ -108,8 +108,9 @@ namespace micm
   {
     double poly = 0.0;
     double t_pow = 1.0;
-    for (std::size_t j = 0; j < p.n_coefficients_; ++j, t_pow *= temperature)
+    for (std::size_t j = 0; j < p.n_coefficients_; ++j, t_pow *= temperature) {
       poly += p.coefficients_[j] * t_pow;
+}
     return poly * p.A_ * std::exp(p.C_ / temperature) * std::pow(temperature / p.D_, p.B_) * (1.0 + p.E_ * pressure);
   }
 

--- a/include/micm/process/reaction_rate_store.hpp
+++ b/include/micm/process/reaction_rate_store.hpp
@@ -145,14 +145,15 @@ namespace micm
 
           if (!param_funcs.empty())
           {
-            store.parameterized_multipliers_.push_back({ [pf = std::move(param_funcs)](const Conditions& cond)
-                                                         {
-                                                           double val = 1.0;
-                                                           for (const auto& f : pf)
-                                                             val *= f(cond);
-                                                           return val;
-                                                         },
-                                                         rc_index });
+            store.parameterized_multipliers_.push_back(
+                { [pf = std::move(param_funcs)](const Conditions& cond)
+                  {
+                    double val = 1.0;
+                    for (const auto& f : pf)
+                      val *= f(cond);
+                    return val;
+                  },
+                  rc_index });
           }
         }
 
@@ -237,9 +238,10 @@ namespace micm
     template<class StatePolicy>
     static void EvaluateCpuRateConstants(const ReactionRateConstantStore& store, StatePolicy& state)
     {
-      if (store.lambda_entries_.empty()) {
+      if (store.lambda_entries_.empty())
+      {
         return;
-}
+      }
 
       using DenseMatrixPolicy = typename StatePolicy::DenseMatrixPolicyType;
 

--- a/include/micm/process/reaction_rate_store.hpp
+++ b/include/micm/process/reaction_rate_store.hpp
@@ -237,8 +237,9 @@ namespace micm
     template<class StatePolicy>
     static void EvaluateCpuRateConstants(const ReactionRateConstantStore& store, StatePolicy& state)
     {
-      if (store.lambda_entries_.empty())
+      if (store.lambda_entries_.empty()) {
         return;
+}
 
       using DenseMatrixPolicy = typename StatePolicy::DenseMatrixPolicyType;
 

--- a/include/micm/solver/backward_euler.inl
+++ b/include/micm/solver/backward_euler.inl
@@ -102,9 +102,10 @@ namespace micm
         Yn1.ForEach([&](double& yn1, const double& f) { yn1 = std::max(0.0, yn1 + f); }, forcing);
 
         // if this is the first iteration, we don't need to check for convergence
-        if (iterations++ == 0) {
+        if (iterations++ == 0)
+        {
           continue;
-}
+        }
 
         // check for convergence
         converged = IsConverged(parameters, forcing, Yn1, state.absolute_tolerance_, state.relative_tolerance_);

--- a/include/micm/solver/backward_euler.inl
+++ b/include/micm/solver/backward_euler.inl
@@ -102,8 +102,9 @@ namespace micm
         Yn1.ForEach([&](double& yn1, const double& f) { yn1 = std::max(0.0, yn1 + f); }, forcing);
 
         // if this is the first iteration, we don't need to check for convergence
-        if (iterations++ == 0)
+        if (iterations++ == 0) {
           continue;
+}
 
         // check for convergence
         converged = IsConverged(parameters, forcing, Yn1, state.absolute_tolerance_, state.relative_tolerance_);

--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -76,7 +76,7 @@ namespace micm
 
    public:
     /// @brief default constructor
-    LinearSolver(){};
+    LinearSolver() { };
 
     LinearSolver(const LinearSolver&) = delete;
     LinearSolver& operator=(const LinearSolver&) = delete;

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -40,10 +40,13 @@ namespace micm
           std::swap(pattern[i][row], pattern[i][max_row]);
         std::swap(perm[row], perm[max_row]);
       }
-      for (std::size_t col = row + 1; col < order; ++col)
-        if (pattern[row][col])
-          for (std::size_t i = row + 1; i < order; ++i)
+      for (std::size_t col = row + 1; col < order; ++col) {
+        if (pattern[row][col]) {
+          for (std::size_t i = row + 1; i < order; ++i) {
             pattern[i][col] = pattern[i][row] || pattern[i][col];
+}
+}
+}
     }
     return perm;
   }
@@ -80,8 +83,9 @@ namespace micm
       std::size_t nLij = 0;
       for (std::size_t j = 0; j < i; ++j)
       {
-        if (lower_matrix.IsZero(i, j))
+        if (lower_matrix.IsZero(i, j)) {
           continue;
+}
         Lij_yj_.push_back(std::make_pair(lower_matrix.VectorIndex(0, i, j), j));
         ++nLij;
       }
@@ -93,8 +97,9 @@ namespace micm
       std::size_t nUij = 0;
       for (std::size_t j = i + 1; j < upper_matrix.NumColumns(); ++j)
       {
-        if (upper_matrix.IsZero(i, j))
+        if (upper_matrix.IsZero(i, j)) {
           continue;
+}
         Uij_xj_.push_back(std::make_pair(upper_matrix.VectorIndex(0, i, j), j));
         ++nUij;
       }

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -40,13 +40,16 @@ namespace micm
           std::swap(pattern[i][row], pattern[i][max_row]);
         std::swap(perm[row], perm[max_row]);
       }
-      for (std::size_t col = row + 1; col < order; ++col) {
-        if (pattern[row][col]) {
-          for (std::size_t i = row + 1; i < order; ++i) {
+      for (std::size_t col = row + 1; col < order; ++col)
+      {
+        if (pattern[row][col])
+        {
+          for (std::size_t i = row + 1; i < order; ++i)
+          {
             pattern[i][col] = pattern[i][row] || pattern[i][col];
-}
-}
-}
+          }
+        }
+      }
     }
     return perm;
   }
@@ -83,9 +86,10 @@ namespace micm
       std::size_t nLij = 0;
       for (std::size_t j = 0; j < i; ++j)
       {
-        if (lower_matrix.IsZero(i, j)) {
+        if (lower_matrix.IsZero(i, j))
+        {
           continue;
-}
+        }
         Lij_yj_.push_back(std::make_pair(lower_matrix.VectorIndex(0, i, j), j));
         ++nLij;
       }
@@ -97,9 +101,10 @@ namespace micm
       std::size_t nUij = 0;
       for (std::size_t j = i + 1; j < upper_matrix.NumColumns(); ++j)
       {
-        if (upper_matrix.IsZero(i, j)) {
+        if (upper_matrix.IsZero(i, j))
+        {
           continue;
-}
+        }
         Uij_xj_.push_back(std::make_pair(upper_matrix.VectorIndex(0, i, j), j));
         ++nUij;
       }

--- a/include/micm/solver/linear_solver_in_place.hpp
+++ b/include/micm/solver/linear_solver_in_place.hpp
@@ -45,7 +45,7 @@ namespace micm
 
    public:
     /// @brief default constructor
-    LinearSolverInPlace(){};
+    LinearSolverInPlace() { };
 
     LinearSolverInPlace(const LinearSolverInPlace&) = delete;
     LinearSolverInPlace& operator=(const LinearSolverInPlace&) = delete;

--- a/include/micm/solver/linear_solver_in_place.inl
+++ b/include/micm/solver/linear_solver_in_place.inl
@@ -31,8 +31,9 @@ namespace micm
       std::size_t nLij = 0;
       for (std::size_t j = 0; j < i; ++j)
       {
-        if (lu.IsZero(i, j))
+        if (lu.IsZero(i, j)) {
           continue;
+}
         Lij_yj_.push_back(std::make_pair(lu.VectorIndex(0, i, j), j));
         ++nLij;
       }
@@ -43,8 +44,9 @@ namespace micm
       std::size_t nUij = 0;
       for (std::size_t j = i + 1; j < lu.NumColumns(); ++j)
       {
-        if (lu.IsZero(i, j))
+        if (lu.IsZero(i, j)) {
           continue;
+}
         Uij_xj_.push_back(std::make_pair(lu.VectorIndex(0, i, j), j));
         ++nUij;
       }

--- a/include/micm/solver/linear_solver_in_place.inl
+++ b/include/micm/solver/linear_solver_in_place.inl
@@ -31,9 +31,10 @@ namespace micm
       std::size_t nLij = 0;
       for (std::size_t j = 0; j < i; ++j)
       {
-        if (lu.IsZero(i, j)) {
+        if (lu.IsZero(i, j))
+        {
           continue;
-}
+        }
         Lij_yj_.push_back(std::make_pair(lu.VectorIndex(0, i, j), j));
         ++nLij;
       }
@@ -44,9 +45,10 @@ namespace micm
       std::size_t nUij = 0;
       for (std::size_t j = i + 1; j < lu.NumColumns(); ++j)
       {
-        if (lu.IsZero(i, j)) {
+        if (lu.IsZero(i, j))
+        {
           continue;
-}
+        }
         Uij_xj_.push_back(std::make_pair(lu.VectorIndex(0, i, j), j));
         ++nUij;
       }

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -40,17 +40,19 @@ namespace micm
         std::size_t nkj = 0;
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (LU.first.IsZero(i, j) || LU.second.IsZero(j, k)) {
+          if (LU.first.IsZero(i, j) || LU.second.IsZero(j, k))
+          {
             continue;
-}
+          }
           ++nkj;
           lij_ujk_.push_back(std::make_pair(LU.first.VectorIndex(0, i, j), LU.second.VectorIndex(0, j, k)));
         }
         if (matrix.IsZero(i, k))
         {
-          if (nkj == 0 && k != i) {
+          if (nkj == 0 && k != i)
+          {
             continue;
-}
+          }
           do_aik_.push_back(false);
         }
         else
@@ -68,17 +70,19 @@ namespace micm
         std::size_t nkj = 0;
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (LU.first.IsZero(k, j) || LU.second.IsZero(j, i)) {
+          if (LU.first.IsZero(k, j) || LU.second.IsZero(j, i))
+          {
             continue;
-}
+          }
           ++nkj;
           lkj_uji_.push_back(std::make_pair(LU.first.VectorIndex(0, k, j), LU.second.VectorIndex(0, j, i)));
         }
         if (matrix.IsZero(k, i))
         {
-          if (nkj == 0) {
+          if (nkj == 0)
+          {
             continue;
-}
+          }
           do_aki_.push_back(false);
         }
         else

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -40,15 +40,17 @@ namespace micm
         std::size_t nkj = 0;
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (LU.first.IsZero(i, j) || LU.second.IsZero(j, k))
+          if (LU.first.IsZero(i, j) || LU.second.IsZero(j, k)) {
             continue;
+}
           ++nkj;
           lij_ujk_.push_back(std::make_pair(LU.first.VectorIndex(0, i, j), LU.second.VectorIndex(0, j, k)));
         }
         if (matrix.IsZero(i, k))
         {
-          if (nkj == 0 && k != i)
+          if (nkj == 0 && k != i) {
             continue;
+}
           do_aik_.push_back(false);
         }
         else
@@ -66,15 +68,17 @@ namespace micm
         std::size_t nkj = 0;
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (LU.first.IsZero(k, j) || LU.second.IsZero(j, i))
+          if (LU.first.IsZero(k, j) || LU.second.IsZero(j, i)) {
             continue;
+}
           ++nkj;
           lkj_uji_.push_back(std::make_pair(LU.first.VectorIndex(0, k, j), LU.second.VectorIndex(0, j, i)));
         }
         if (matrix.IsZero(k, i))
         {
-          if (nkj == 0)
+          if (nkj == 0) {
             continue;
+}
           do_aki_.push_back(false);
         }
         else

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -39,15 +39,17 @@ namespace micm
       std::tuple<std::size_t, std::size_t, std::size_t> nik_nki_aii(0, 0, ALU.VectorIndex(0, i, i));
       for (std::size_t k = i; k < n; ++k)
       {
-        if (ALU.IsZero(i, k)) {
+        if (ALU.IsZero(i, k))
+        {
           continue;
-}
+        }
         std::pair<std::size_t, std::size_t> aik_njk(ALU.VectorIndex(0, i, k), 0);
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (ALU.IsZero(i, j) || ALU.IsZero(j, k)) {
+          if (ALU.IsZero(i, j) || ALU.IsZero(j, k))
+          {
             continue;
-}
+          }
           aij_ajk_.push_back(std::make_pair(ALU.VectorIndex(0, i, j), ALU.VectorIndex(0, j, k)));
           ++(aik_njk.second);
         }
@@ -56,15 +58,17 @@ namespace micm
       }
       for (std::size_t k = i + 1; k < n; ++k)
       {
-        if (ALU.IsZero(k, i)) {
+        if (ALU.IsZero(k, i))
+        {
           continue;
-}
+        }
         std::pair<std::size_t, std::size_t> aki_nji(ALU.VectorIndex(0, k, i), 0);
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (ALU.IsZero(k, j) || ALU.IsZero(j, i)) {
+          if (ALU.IsZero(k, j) || ALU.IsZero(j, i))
+          {
             continue;
-}
+          }
           akj_aji_.push_back(std::make_pair(ALU.VectorIndex(0, k, j), ALU.VectorIndex(0, j, i)));
           ++(aki_nji.second);
         }

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -39,13 +39,15 @@ namespace micm
       std::tuple<std::size_t, std::size_t, std::size_t> nik_nki_aii(0, 0, ALU.VectorIndex(0, i, i));
       for (std::size_t k = i; k < n; ++k)
       {
-        if (ALU.IsZero(i, k))
+        if (ALU.IsZero(i, k)) {
           continue;
+}
         std::pair<std::size_t, std::size_t> aik_njk(ALU.VectorIndex(0, i, k), 0);
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (ALU.IsZero(i, j) || ALU.IsZero(j, k))
+          if (ALU.IsZero(i, j) || ALU.IsZero(j, k)) {
             continue;
+}
           aij_ajk_.push_back(std::make_pair(ALU.VectorIndex(0, i, j), ALU.VectorIndex(0, j, k)));
           ++(aik_njk.second);
         }
@@ -54,13 +56,15 @@ namespace micm
       }
       for (std::size_t k = i + 1; k < n; ++k)
       {
-        if (ALU.IsZero(k, i))
+        if (ALU.IsZero(k, i)) {
           continue;
+}
         std::pair<std::size_t, std::size_t> aki_nji(ALU.VectorIndex(0, k, i), 0);
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (ALU.IsZero(k, j) || ALU.IsZero(j, i))
+          if (ALU.IsZero(k, j) || ALU.IsZero(j, i)) {
             continue;
+}
           akj_aji_.push_back(std::make_pair(ALU.VectorIndex(0, k, j), ALU.VectorIndex(0, j, i)));
           ++(aki_nji.second);
         }

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -68,23 +68,26 @@ namespace micm
       // middle j loop to set L[j][i]
       for (std::size_t j = i + 1; j < n; ++j)
       {
-        if (LU.first.IsZero(j, i))
+        if (LU.first.IsZero(j, i)) {
           continue;
+}
         lji_.push_back(LU.first.VectorIndex(0, j, i));
         ++(std::get<1>(uii_nj_nk));
       }
       // middle k loop to set U[j][k] and L[j][k]
       for (std::size_t k = i + 1; k < n; ++k)
       {
-        if (LU.second.IsZero(i, k))
+        if (LU.second.IsZero(i, k)) {
           continue;
+}
         std::tuple<std::size_t, std::size_t, std::size_t> nujk_nljk_uik(0, 0, 0);
         std::get<2>(nujk_nljk_uik) = LU.second.VectorIndex(0, i, k);
         // inner j loop to set U[j][k]
         for (std::size_t j = i + 1; j <= k; ++j)
         {
-          if (LU.first.IsZero(j, i))
+          if (LU.first.IsZero(j, i)) {
             continue;
+}
           std::pair<std::size_t, std::size_t> ujk_lji(0, 0);
           ujk_lji.first = LU.second.VectorIndex(0, j, k);
           ujk_lji.second = LU.first.VectorIndex(0, j, i);
@@ -94,8 +97,9 @@ namespace micm
         // inner j loop to set L[j][k]
         for (std::size_t j = k + 1; j < n; ++j)
         {
-          if (LU.first.IsZero(j, i))
+          if (LU.first.IsZero(j, i)) {
             continue;
+}
           std::pair<std::size_t, std::size_t> ljk_lji(0, 0);
           ljk_lji.first = LU.first.VectorIndex(0, j, k);
           ljk_lji.second = LU.first.VectorIndex(0, j, i);
@@ -137,8 +141,9 @@ namespace micm
       }
       for (std::size_t k = i + 1; k < n; ++k)
       {
-        if (!(std::find(U_ids.begin(), U_ids.end(), std::make_pair(i, k)) != U_ids.end()))
+        if (!(std::find(U_ids.begin(), U_ids.end(), std::make_pair(i, k)) != U_ids.end())) {
           continue;
+}
         for (std::size_t j = i + 1; j <= k; ++j)
           if (std::find(L_ids.begin(), L_ids.end(), std::make_pair(j, i)) != L_ids.end())
             U_ids.insert(std::make_pair(j, k));
@@ -283,8 +288,9 @@ namespace micm
           Uii_inverse[i_cell] = 1.0 / U_vector[std::get<0>(*uii_nj_nk) + i_cell];
         for (std::size_t ij = 0; ij < std::get<1>(*uii_nj_nk); ++ij)
         {
-          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
             L_vector[*lji + i_cell] = L_vector[*lji + i_cell] * Uii_inverse[i_cell];
+}
           ++lji;
         }
         for (std::size_t ik = 0; ik < std::get<2>(*uii_nj_nk); ++ik)
@@ -292,14 +298,16 @@ namespace micm
           const std::size_t uik = std::get<2>(*nujk_nljk_uik);
           for (std::size_t ij = 0; ij < std::get<0>(*nujk_nljk_uik); ++ij)
           {
-            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
               U_vector[ujk_lji->first + i_cell] -= L_vector[ujk_lji->second + i_cell] * U_vector[uik + i_cell];
+}
             ++ujk_lji;
           }
           for (std::size_t ij = 0; ij < std::get<1>(*nujk_nljk_uik); ++ij)
           {
-            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
               L_vector[ljk_lji->first + i_cell] -= L_vector[ljk_lji->second + i_cell] * U_vector[uik + i_cell];
+}
             ++ljk_lji;
           }
           ++nujk_nljk_uik;

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -68,26 +68,29 @@ namespace micm
       // middle j loop to set L[j][i]
       for (std::size_t j = i + 1; j < n; ++j)
       {
-        if (LU.first.IsZero(j, i)) {
+        if (LU.first.IsZero(j, i))
+        {
           continue;
-}
+        }
         lji_.push_back(LU.first.VectorIndex(0, j, i));
         ++(std::get<1>(uii_nj_nk));
       }
       // middle k loop to set U[j][k] and L[j][k]
       for (std::size_t k = i + 1; k < n; ++k)
       {
-        if (LU.second.IsZero(i, k)) {
+        if (LU.second.IsZero(i, k))
+        {
           continue;
-}
+        }
         std::tuple<std::size_t, std::size_t, std::size_t> nujk_nljk_uik(0, 0, 0);
         std::get<2>(nujk_nljk_uik) = LU.second.VectorIndex(0, i, k);
         // inner j loop to set U[j][k]
         for (std::size_t j = i + 1; j <= k; ++j)
         {
-          if (LU.first.IsZero(j, i)) {
+          if (LU.first.IsZero(j, i))
+          {
             continue;
-}
+          }
           std::pair<std::size_t, std::size_t> ujk_lji(0, 0);
           ujk_lji.first = LU.second.VectorIndex(0, j, k);
           ujk_lji.second = LU.first.VectorIndex(0, j, i);
@@ -97,9 +100,10 @@ namespace micm
         // inner j loop to set L[j][k]
         for (std::size_t j = k + 1; j < n; ++j)
         {
-          if (LU.first.IsZero(j, i)) {
+          if (LU.first.IsZero(j, i))
+          {
             continue;
-}
+          }
           std::pair<std::size_t, std::size_t> ljk_lji(0, 0);
           ljk_lji.first = LU.first.VectorIndex(0, j, k);
           ljk_lji.second = LU.first.VectorIndex(0, j, i);
@@ -141,9 +145,10 @@ namespace micm
       }
       for (std::size_t k = i + 1; k < n; ++k)
       {
-        if (!(std::find(U_ids.begin(), U_ids.end(), std::make_pair(i, k)) != U_ids.end())) {
+        if (!(std::find(U_ids.begin(), U_ids.end(), std::make_pair(i, k)) != U_ids.end()))
+        {
           continue;
-}
+        }
         for (std::size_t j = i + 1; j <= k; ++j)
           if (std::find(L_ids.begin(), L_ids.end(), std::make_pair(j, i)) != L_ids.end())
             U_ids.insert(std::make_pair(j, k));
@@ -288,9 +293,10 @@ namespace micm
           Uii_inverse[i_cell] = 1.0 / U_vector[std::get<0>(*uii_nj_nk) + i_cell];
         for (std::size_t ij = 0; ij < std::get<1>(*uii_nj_nk); ++ij)
         {
-          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
+          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+          {
             L_vector[*lji + i_cell] = L_vector[*lji + i_cell] * Uii_inverse[i_cell];
-}
+          }
           ++lji;
         }
         for (std::size_t ik = 0; ik < std::get<2>(*uii_nj_nk); ++ik)
@@ -298,16 +304,18 @@ namespace micm
           const std::size_t uik = std::get<2>(*nujk_nljk_uik);
           for (std::size_t ij = 0; ij < std::get<0>(*nujk_nljk_uik); ++ij)
           {
-            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            {
               U_vector[ujk_lji->first + i_cell] -= L_vector[ujk_lji->second + i_cell] * U_vector[uik + i_cell];
-}
+            }
             ++ujk_lji;
           }
           for (std::size_t ij = 0; ij < std::get<1>(*nujk_nljk_uik); ++ij)
           {
-            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            {
               L_vector[ljk_lji->first + i_cell] -= L_vector[ljk_lji->second + i_cell] * U_vector[uik + i_cell];
-}
+            }
             ++ljk_lji;
           }
           ++nujk_nljk_uik;

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -39,20 +39,23 @@ namespace micm
       std::tuple<std::size_t, std::size_t, std::size_t> aii_nji_nki(ALU.VectorIndex(0, i, i), 0, 0);
       for (std::size_t j = i + 1; j < n; ++j)
       {
-        if (ALU.IsZero(j, i))
+        if (ALU.IsZero(j, i)) {
           continue;
+}
         aji_.push_back(ALU.VectorIndex(0, j, i));
         ++(std::get<1>(aii_nji_nki));
       }
       for (std::size_t k = i + 1; k < n; ++k)
       {
-        if (ALU.IsZero(i, k))
+        if (ALU.IsZero(i, k)) {
           continue;
+}
         std::pair<std::size_t, std::size_t> aik_njk(ALU.VectorIndex(0, i, k), 0);
         for (std::size_t j = i + 1; j < n; ++j)
         {
-          if (ALU.IsZero(j, i))
+          if (ALU.IsZero(j, i)) {
             continue;
+}
           std::pair<std::size_t, std::size_t> ajk_aji(ALU.VectorIndex(0, j, k), ALU.VectorIndex(0, j, i));
           ajk_aji_.push_back(ajk_aji);
           ++(std::get<1>(aik_njk));

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -39,23 +39,26 @@ namespace micm
       std::tuple<std::size_t, std::size_t, std::size_t> aii_nji_nki(ALU.VectorIndex(0, i, i), 0, 0);
       for (std::size_t j = i + 1; j < n; ++j)
       {
-        if (ALU.IsZero(j, i)) {
+        if (ALU.IsZero(j, i))
+        {
           continue;
-}
+        }
         aji_.push_back(ALU.VectorIndex(0, j, i));
         ++(std::get<1>(aii_nji_nki));
       }
       for (std::size_t k = i + 1; k < n; ++k)
       {
-        if (ALU.IsZero(i, k)) {
+        if (ALU.IsZero(i, k))
+        {
           continue;
-}
+        }
         std::pair<std::size_t, std::size_t> aik_njk(ALU.VectorIndex(0, i, k), 0);
         for (std::size_t j = i + 1; j < n; ++j)
         {
-          if (ALU.IsZero(j, i)) {
+          if (ALU.IsZero(j, i))
+          {
             continue;
-}
+          }
           std::pair<std::size_t, std::size_t> ajk_aji(ALU.VectorIndex(0, j, k), ALU.VectorIndex(0, j, i));
           ajk_aji_.push_back(ajk_aji);
           ++(std::get<1>(aik_njk));

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -90,8 +90,9 @@ namespace micm
       initial_forcing.Fill(0);
       rates_.AddForcingTerms(state, Y, initial_forcing);
 
-      if (has_constraints)
+      if (has_constraints) {
         constraints_.AddForcingTerms(Y, state.custom_rate_parameters_, initial_forcing);
+}
 
       result.stats_.function_calls_ += 1;
 
@@ -99,8 +100,9 @@ namespace micm
       state.jacobian_.Fill(0);
       rates_.SubtractJacobianTerms(state, Y, state.jacobian_);
 
-      if (has_constraints)
+      if (has_constraints) {
         constraints_.SubtractJacobianTerms(Y, state.custom_rate_parameters_, state.jacobian_);
+}
 
       result.stats_.jacobian_updates_ += 1;
 
@@ -180,12 +182,14 @@ namespace micm
         }
 
         Ynew.Copy(Y);
-        for (uint64_t stage = 0; stage < parameters.stages_; ++stage)
+        for (uint64_t stage = 0; stage < parameters.stages_; ++stage) {
           Ynew.Axpy(parameters.m_[stage], K[stage]);
+}
 
         Yerror.Fill(0);
-        for (uint64_t stage = 0; stage < parameters.stages_; ++stage)
+        for (uint64_t stage = 0; stage < parameters.stages_; ++stage) {
           Yerror.Axpy(parameters.e_[stage], K[stage]);
+}
 
         // For DAE systems, replace the near-zero algebraic error estimates with step changes.
         // The embedded error formula produces Yerror ≈ 0 for algebraic rows (M_ii = 0 zeroes
@@ -264,8 +268,9 @@ namespace micm
             state.jacobian_.Fill(0);
             rates_.SubtractJacobianTerms(state, Y, state.jacobian_);
             // Subtract constraint Jacobian terms (for DAE systems)
-            if (has_constraints)
+            if (has_constraints) {
               constraints_.SubtractJacobianTerms(Y, state.custom_rate_parameters_, state.jacobian_);
+}
             result.stats_.jacobian_updates_ += 1;
           }
         }
@@ -318,8 +323,9 @@ namespace micm
       for (const auto& i_elem : state.jacobian_diagonal_elements_)
       {
         const double diagonal_scale = state.upper_left_identity_diagonal_[i_diag++];
-        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
           jacobian_vector[i_elem + i_cell] += alpha * diagonal_scale;
+}
       }
     }
   }
@@ -451,12 +457,13 @@ namespace micm
                   [&](const double& val)
                   {
                     double abs_val = std::abs(val);
-                    if (std::isnan(abs_val))
+                    if (std::isnan(abs_val)) {
                       nan_detected = true;
-                    else if (std::isinf(abs_val))
+                    } else if (std::isinf(abs_val)) {
                       inf_detected = true;
-                    else
-                      max_residual = std::max(max_residual, abs_val);
+                    } else {
+                      m
+}ax_residual = std::max(max_residual, abs_val);
                   },
                   delta_view.GetConstColumnView(i_var));
             }
@@ -474,12 +481,13 @@ namespace micm
               y_view.ForEachRow(
                   [&](double& y_val, const double& d_val)
                   {
-                    if (std::isnan(d_val))
+                    if (std::isnan(d_val)) {
                       nan_detected = true;
-                    else if (std::isinf(d_val))
+                    } else if (std::isinf(d_val)) {
                       inf_detected = true;
-                    else
+                    } else {
                       y_val += d_val;
+}
                   },
                   y_view.GetColumnView(i_var),
                   delta_view.GetConstColumnView(i_var));
@@ -501,15 +509,18 @@ namespace micm
       inf_detected = false;
       check_convergence(delta);
 
-      if (nan_detected)
+      if (nan_detected) {
         return SolverState::NaNDetected;
-      if (inf_detected)
+}
+      if (inf_detected) {
         return SolverState::InfDetected;
+}
 
       stats.constraint_init_iterations_ = iter + 1;
 
-      if (max_residual < parameters.constraint_init_tolerance_)
+      if (max_residual < parameters.constraint_init_tolerance_) {
         return SolverState::Converged;
+}
 
       // 3. Compute constraint Jacobian: -dG/dy
       state.jacobian_.Fill(0);
@@ -548,10 +559,12 @@ namespace micm
       inf_detected = false;
       apply_update(Y, delta);
 
-      if (nan_detected)
+      if (nan_detected) {
         return SolverState::NaNDetected;
-      if (inf_detected)
+}
+      if (inf_detected) {
         return SolverState::InfDetected;
+}
     }
 
     // Did not converge within max iterations

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -90,9 +90,10 @@ namespace micm
       initial_forcing.Fill(0);
       rates_.AddForcingTerms(state, Y, initial_forcing);
 
-      if (has_constraints) {
+      if (has_constraints)
+      {
         constraints_.AddForcingTerms(Y, state.custom_rate_parameters_, initial_forcing);
-}
+      }
 
       result.stats_.function_calls_ += 1;
 
@@ -100,9 +101,10 @@ namespace micm
       state.jacobian_.Fill(0);
       rates_.SubtractJacobianTerms(state, Y, state.jacobian_);
 
-      if (has_constraints) {
+      if (has_constraints)
+      {
         constraints_.SubtractJacobianTerms(Y, state.custom_rate_parameters_, state.jacobian_);
-}
+      }
 
       result.stats_.jacobian_updates_ += 1;
 
@@ -182,14 +184,16 @@ namespace micm
         }
 
         Ynew.Copy(Y);
-        for (uint64_t stage = 0; stage < parameters.stages_; ++stage) {
+        for (uint64_t stage = 0; stage < parameters.stages_; ++stage)
+        {
           Ynew.Axpy(parameters.m_[stage], K[stage]);
-}
+        }
 
         Yerror.Fill(0);
-        for (uint64_t stage = 0; stage < parameters.stages_; ++stage) {
+        for (uint64_t stage = 0; stage < parameters.stages_; ++stage)
+        {
           Yerror.Axpy(parameters.e_[stage], K[stage]);
-}
+        }
 
         // For DAE systems, replace the near-zero algebraic error estimates with step changes.
         // The embedded error formula produces Yerror ≈ 0 for algebraic rows (M_ii = 0 zeroes
@@ -268,9 +272,10 @@ namespace micm
             state.jacobian_.Fill(0);
             rates_.SubtractJacobianTerms(state, Y, state.jacobian_);
             // Subtract constraint Jacobian terms (for DAE systems)
-            if (has_constraints) {
+            if (has_constraints)
+            {
               constraints_.SubtractJacobianTerms(Y, state.custom_rate_parameters_, state.jacobian_);
-}
+            }
             result.stats_.jacobian_updates_ += 1;
           }
         }
@@ -323,9 +328,10 @@ namespace micm
       for (const auto& i_elem : state.jacobian_diagonal_elements_)
       {
         const double diagonal_scale = state.upper_left_identity_diagonal_[i_diag++];
-        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
+        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+        {
           jacobian_vector[i_elem + i_cell] += alpha * diagonal_scale;
-}
+        }
       }
     }
   }
@@ -457,13 +463,19 @@ namespace micm
                   [&](const double& val)
                   {
                     double abs_val = std::abs(val);
-                    if (std::isnan(abs_val)) {
+                    if (std::isnan(abs_val))
+                    {
                       nan_detected = true;
-                    } else if (std::isinf(abs_val)) {
+                    }
+                    else if (std::isinf(abs_val))
+                    {
                       inf_detected = true;
-                    } else {
+                    }
+                    else
+                    {
                       m
-}ax_residual = std::max(max_residual, abs_val);
+                    }
+                    ax_residual = std::max(max_residual, abs_val);
                   },
                   delta_view.GetConstColumnView(i_var));
             }
@@ -481,13 +493,18 @@ namespace micm
               y_view.ForEachRow(
                   [&](double& y_val, const double& d_val)
                   {
-                    if (std::isnan(d_val)) {
+                    if (std::isnan(d_val))
+                    {
                       nan_detected = true;
-                    } else if (std::isinf(d_val)) {
+                    }
+                    else if (std::isinf(d_val))
+                    {
                       inf_detected = true;
-                    } else {
+                    }
+                    else
+                    {
                       y_val += d_val;
-}
+                    }
                   },
                   y_view.GetColumnView(i_var),
                   delta_view.GetConstColumnView(i_var));
@@ -509,18 +526,21 @@ namespace micm
       inf_detected = false;
       check_convergence(delta);
 
-      if (nan_detected) {
+      if (nan_detected)
+      {
         return SolverState::NaNDetected;
-}
-      if (inf_detected) {
+      }
+      if (inf_detected)
+      {
         return SolverState::InfDetected;
-}
+      }
 
       stats.constraint_init_iterations_ = iter + 1;
 
-      if (max_residual < parameters.constraint_init_tolerance_) {
+      if (max_residual < parameters.constraint_init_tolerance_)
+      {
         return SolverState::Converged;
-}
+      }
 
       // 3. Compute constraint Jacobian: -dG/dy
       state.jacobian_.Fill(0);
@@ -559,12 +579,14 @@ namespace micm
       inf_detected = false;
       apply_update(Y, delta);
 
-      if (nan_detected) {
+      if (nan_detected)
+      {
         return SolverState::NaNDetected;
-}
-      if (inf_detected) {
+      }
+      if (inf_detected)
+      {
         return SolverState::InfDetected;
-}
+      }
     }
 
     // Did not converge within max iterations

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -473,9 +473,8 @@ namespace micm
                     }
                     else
                     {
-                      m
+                      max_residual = std::max(max_residual, abs_val);
                     }
-                    ax_residual = std::max(max_residual, abs_val);
                   },
                   delta_view.GetConstColumnView(i_var));
             }

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -66,9 +66,10 @@ namespace micm
           update_state_parameters_functions_(update_state_parameters_functions),
           store_(ReactionRateConstantStore::BuildFrom(processes_))
     {
-      if constexpr (requires { solver_.rates_.BuildCudaStore(store_); }) {
+      if constexpr (requires { solver_.rates_.BuildCudaStore(store_); })
+      {
         solver_.rates_.BuildCudaStore(store_);
-}
+      }
     }
 
     Solver(
@@ -90,9 +91,10 @@ namespace micm
           store_(ReactionRateConstantStore::BuildFrom(processes_)),
           initialize_constraint_parameters_functions_(initialize_constraint_parameters_functions)
     {
-      if constexpr (requires { solver_.rates_.BuildCudaStore(store_); }) {
+      if constexpr (requires { solver_.rates_.BuildCudaStore(store_); })
+      {
         solver_.rates_.BuildCudaStore(store_);
-}
+      }
     }
 
     Solver(Solver&& other)
@@ -211,9 +213,11 @@ namespace micm
 
       // Dispatch to GPU path if the RatesPolicy (e.g. CudaProcessSet) exposes
       // GpuCalculateRateConstants; otherwise use the CPU path.
-      if constexpr (requires { solver_.rates_.GpuCalculateRateConstants(store_, state); }) {
+      if constexpr (requires { solver_.rates_.GpuCalculateRateConstants(store_, state); })
+      {
         solver_.rates_.GpuCalculateRateConstants(store_, state);
-      } else
+      }
+      else
       {
         ReactionRateConstantStore::EvaluateCpuRateConstants(store_, state);
         ReactionRateConstantStore::CpuCalculateRateConstants(store_, state);

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -66,8 +66,9 @@ namespace micm
           update_state_parameters_functions_(update_state_parameters_functions),
           store_(ReactionRateConstantStore::BuildFrom(processes_))
     {
-      if constexpr (requires { solver_.rates_.BuildCudaStore(store_); })
+      if constexpr (requires { solver_.rates_.BuildCudaStore(store_); }) {
         solver_.rates_.BuildCudaStore(store_);
+}
     }
 
     Solver(
@@ -89,8 +90,9 @@ namespace micm
           store_(ReactionRateConstantStore::BuildFrom(processes_)),
           initialize_constraint_parameters_functions_(initialize_constraint_parameters_functions)
     {
-      if constexpr (requires { solver_.rates_.BuildCudaStore(store_); })
+      if constexpr (requires { solver_.rates_.BuildCudaStore(store_); }) {
         solver_.rates_.BuildCudaStore(store_);
+}
     }
 
     Solver(Solver&& other)
@@ -209,9 +211,9 @@ namespace micm
 
       // Dispatch to GPU path if the RatesPolicy (e.g. CudaProcessSet) exposes
       // GpuCalculateRateConstants; otherwise use the CPU path.
-      if constexpr (requires { solver_.rates_.GpuCalculateRateConstants(store_, state); })
+      if constexpr (requires { solver_.rates_.GpuCalculateRateConstants(store_, state); }) {
         solver_.rates_.GpuCalculateRateConstants(store_, state);
-      else
+      } else
       {
         ReactionRateConstantStore::EvaluateCpuRateConstants(store_, state);
         ReactionRateConstantStore::CpuCalculateRateConstants(store_, state);

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -318,9 +318,10 @@ namespace micm
       constraint_set.SetUniqueParameterNames();
       for (const auto& label : constraint_set.GetParameterNames())
       {
-        if (params_map.count(label) > 0)
+        if (params_map.count(label) > 0) {
           throw MicmException(
               MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_DUPLICATE_PARAMETER, "Duplicate parameter name: " + label);
+}
         params_map.emplace(label, params_map.size());
       }
 
@@ -332,10 +333,11 @@ namespace micm
       // Filter kinetic sparsity entries from algebraic rows (they will be entirely replaced by constraints)
       for (auto it = nonzero_elements.begin(); it != nonzero_elements.end();)
       {
-        if (algebraic_variable_ids.count(it->first) > 0)
+        if (algebraic_variable_ids.count(it->first) > 0) {
           it = nonzero_elements.erase(it);
-        else
+        } else {
           ++it;
+}
       }
 
       // Merge constraint Jacobian elements with ODE Jacobian elements
@@ -353,18 +355,20 @@ namespace micm
       // Add external constraint parameter names to the params map
       for (const auto& label : constraint_set.ExternalConstraintParameterNames())
       {
-        if (params_map.count(label) > 0)
+        if (params_map.count(label) > 0) {
           throw MicmException(
               MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_DUPLICATE_PARAMETER, "Duplicate parameter name: " + label);
+}
         params_map.emplace(label, params_map.size());
       }
 
       // Add initialize constraint parameter names to the params map
       for (const auto& label : constraint_set.ExternalInitializeConstraintParameterNames())
       {
-        if (params_map.count(label) > 0)
+        if (params_map.count(label) > 0) {
           throw MicmException(
               MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_DUPLICATE_PARAMETER, "Duplicate parameter name: " + label);
+}
         params_map.emplace(label, params_map.size());
       }
 
@@ -377,10 +381,11 @@ namespace micm
           // Filter kinetic sparsity entries from this new algebraic row
           for (auto it = nonzero_elements.begin(); it != nonzero_elements.end();)
           {
-            if (it->first == id)
+            if (it->first == id) {
               it = nonzero_elements.erase(it);
-            else
+            } else {
               ++it;
+}
           }
           mass_matrix_diagonal[id] = 0.0;
         }

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -318,10 +318,11 @@ namespace micm
       constraint_set.SetUniqueParameterNames();
       for (const auto& label : constraint_set.GetParameterNames())
       {
-        if (params_map.count(label) > 0) {
+        if (params_map.count(label) > 0)
+        {
           throw MicmException(
               MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_DUPLICATE_PARAMETER, "Duplicate parameter name: " + label);
-}
+        }
         params_map.emplace(label, params_map.size());
       }
 
@@ -333,11 +334,14 @@ namespace micm
       // Filter kinetic sparsity entries from algebraic rows (they will be entirely replaced by constraints)
       for (auto it = nonzero_elements.begin(); it != nonzero_elements.end();)
       {
-        if (algebraic_variable_ids.count(it->first) > 0) {
+        if (algebraic_variable_ids.count(it->first) > 0)
+        {
           it = nonzero_elements.erase(it);
-        } else {
+        }
+        else
+        {
           ++it;
-}
+        }
       }
 
       // Merge constraint Jacobian elements with ODE Jacobian elements
@@ -355,20 +359,22 @@ namespace micm
       // Add external constraint parameter names to the params map
       for (const auto& label : constraint_set.ExternalConstraintParameterNames())
       {
-        if (params_map.count(label) > 0) {
+        if (params_map.count(label) > 0)
+        {
           throw MicmException(
               MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_DUPLICATE_PARAMETER, "Duplicate parameter name: " + label);
-}
+        }
         params_map.emplace(label, params_map.size());
       }
 
       // Add initialize constraint parameter names to the params map
       for (const auto& label : constraint_set.ExternalInitializeConstraintParameterNames())
       {
-        if (params_map.count(label) > 0) {
+        if (params_map.count(label) > 0)
+        {
           throw MicmException(
               MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_DUPLICATE_PARAMETER, "Duplicate parameter name: " + label);
-}
+        }
         params_map.emplace(label, params_map.size());
       }
 
@@ -381,11 +387,14 @@ namespace micm
           // Filter kinetic sparsity entries from this new algebraic row
           for (auto it = nonzero_elements.begin(); it != nonzero_elements.end();)
           {
-            if (it->first == id) {
+            if (it->first == id)
+            {
               it = nonzero_elements.erase(it);
-            } else {
+            }
+            else
+            {
               ++it;
-}
+            }
           }
           mass_matrix_diagonal[id] = 0.0;
         }

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -13,11 +13,12 @@ namespace micm
   inline State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
   operator double() const
   {
-    if (state_.variables_.NumRows() != 1)
+    if (state_.variables_.NumRows() != 1) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot convert multi-gridcell State variable to single double value");
+}
     return state_.variables_[0][index_];
   }
 
@@ -32,11 +33,12 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator=(double value)
   {
-    if (state_.variables_.NumRows() != 1)
+    if (state_.variables_.NumRows() != 1) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot assign single value to multi-gridcell State variable");
+}
     state_.variables_[0][index_] = value;
     return *this;
   }
@@ -52,11 +54,12 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator=(const std::vector<double>& values)
   {
-    if (values.size() != state_.number_of_grid_cells_)
+    if (values.size() != state_.number_of_grid_cells_) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Number of values does not match number of grid cells in State");
+}
     for (std::size_t i = 0; i < state_.number_of_grid_cells_; ++i)
     {
       state_.variables_[i][index_] = values[i];
@@ -75,11 +78,12 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator=(const VariableProxy& other)
   {
-    if (state_.number_of_grid_cells_ != other.state_.number_of_grid_cells_)
+    if (state_.number_of_grid_cells_ != other.state_.number_of_grid_cells_) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Number of grid cells does not match between State variables");
+}
     for (std::size_t i = 0; i < state_.number_of_grid_cells_; ++i)
     {
       state_.variables_[i][index_] = other.state_.variables_[i][other.index_];
@@ -98,11 +102,12 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator+=(double value)
   {
-    if (state_.number_of_grid_cells_ != 1)
+    if (state_.number_of_grid_cells_ != 1) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot add single value to multi-gridcell State variable");
+}
     state_.variables_[0][index_] += value;
     return *this;
   }
@@ -118,11 +123,12 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator-=(double value)
   {
-    if (state_.number_of_grid_cells_ != 1)
+    if (state_.number_of_grid_cells_ != 1) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot subtract single value from multi-gridcell State variable");
+}
     state_.variables_[0][index_] -= value;
     return *this;
   }
@@ -138,11 +144,12 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator*=(double value)
   {
-    if (state_.number_of_grid_cells_ != 1)
+    if (state_.number_of_grid_cells_ != 1) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot multiply single value with multi-gridcell State variable");
+}
     state_.variables_[0][index_] *= value;
     return *this;
   }
@@ -158,11 +165,12 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator/=(double value)
   {
-    if (state_.number_of_grid_cells_ != 1)
+    if (state_.number_of_grid_cells_ != 1) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot divide multi-gridcell State variable by single value");
+}
     state_.variables_[0][index_] /= value;
     return *this;
   }
@@ -204,11 +212,12 @@ namespace micm
   inline State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::
       ConstVariableProxy::operator double() const
   {
-    if (state_.variables_.NumRows() != 1)
+    if (state_.variables_.NumRows() != 1) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot convert multi-gridcell State variable to single double value");
+}
     return state_.variables_[0][index_];
   }
 
@@ -235,12 +244,14 @@ namespace micm
   inline bool State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::
       VariableProxy::operator==(const std::vector<double>& other) const
   {
-    if (other.size() != state_.number_of_grid_cells_)
+    if (other.size() != state_.number_of_grid_cells_) {
       return false;
+}
     for (std::size_t i = 0; i < state_.number_of_grid_cells_; ++i)
     {
-      if (state_.variables_[i][index_] != other[i])
+      if (state_.variables_[i][index_] != other[i]) {
         return false;
+}
     }
     return true;
   }
@@ -254,12 +265,14 @@ namespace micm
   inline bool State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::
       ConstVariableProxy::operator==(const std::vector<double>& other) const
   {
-    if (other.size() != state_.number_of_grid_cells_)
+    if (other.size() != state_.number_of_grid_cells_) {
       return false;
+}
     for (std::size_t i = 0; i < state_.number_of_grid_cells_; ++i)
     {
-      if (state_.variables_[i][index_] != other[i])
+      if (state_.variables_[i][index_] != other[i]) {
         return false;
+}
     }
     return true;
   }
@@ -408,8 +421,9 @@ namespace micm
           const std::string& name)
   {
     auto var = variable_map_.find(name);
-    if (var == variable_map_.end())
+    if (var == variable_map_.end()) {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_SPECIES, name);
+}
     return VariableProxy(*this, var->second);
   }
 
@@ -425,8 +439,9 @@ namespace micm
           const std::string& name) const
   {
     auto var = variable_map_.find(name);
-    if (var == variable_map_.end())
+    if (var == variable_map_.end()) {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_SPECIES, name);
+}
     return ConstVariableProxy(*this, var->second);
   }
 
@@ -485,13 +500,15 @@ namespace micm
       double concentration)
   {
     auto var = variable_map_.find(species.name_);
-    if (var == variable_map_.end())
+    if (var == variable_map_.end()) {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_SPECIES, species.name_);
-    if (variables_.NumRows() != 1)
+}
+    if (variables_.NumRows() != 1) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Concentration vector size does not match the number of grid cells");
+}
     variables_[0][variable_map_[species.name_]] = concentration;
   }
 
@@ -507,16 +524,19 @@ namespace micm
       const std::vector<double>& concentration)
   {
     auto var = variable_map_.find(species.name_);
-    if (var == variable_map_.end())
+    if (var == variable_map_.end()) {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_SPECIES, species.name_);
-    if (variables_.NumRows() != concentration.size())
+}
+    if (variables_.NumRows() != concentration.size()) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Concentration vector size does not match the number of grid cells");
+}
     std::size_t i_species = variable_map_[species.name_];
-    for (std::size_t i = 0; i < variables_.NumRows(); ++i)
+    for (std::size_t i = 0; i < variables_.NumRows(); ++i) {
       variables_[i][i_species] = concentration[i];
+}
   }
 
   template<
@@ -531,13 +551,15 @@ namespace micm
       double concentration)
   {
     auto var = variable_map_.find(element);
-    if (var == variable_map_.end())
+    if (var == variable_map_.end()) {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_SPECIES, element);
-    if (variables_.NumRows() != 1)
+}
+    if (variables_.NumRows() != 1) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Concentration vector size does not match the number of grid cells");
+}
     variables_[0][variable_map_[element]] = concentration;
   }
 
@@ -553,16 +575,19 @@ namespace micm
       const std::vector<double>& concentration)
   {
     auto var = variable_map_.find(element);
-    if (var == variable_map_.end())
+    if (var == variable_map_.end()) {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_SPECIES, element);
-    if (variables_.NumRows() != concentration.size())
+}
+    if (variables_.NumRows() != concentration.size()) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Concentration vector size does not match the number of grid cells");
+}
     std::size_t i_species = variable_map_[element];
-    for (std::size_t i = 0; i < variables_.NumRows(); ++i)
+    for (std::size_t i = 0; i < variables_.NumRows(); ++i) {
       variables_[i][i_species] = concentration[i];
+}
   }
 
   template<
@@ -574,17 +599,19 @@ namespace micm
   inline void State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::
       UnsafelySetCustomRateParameters(const std::vector<std::vector<double>>& parameters)
   {
-    if (parameters.size() != variables_.NumRows())
+    if (parameters.size() != variables_.NumRows()) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CUSTOM_RATE_PARAM_COUNT_MULTIGRID,
           "Custom rate parameter vector size does not match the number of grid cells");
+}
 
-    if (parameters[0].size() != custom_rate_parameters_.NumColumns())
+    if (parameters[0].size() != custom_rate_parameters_.NumColumns()) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CUSTOM_RATE_PARAM_COUNT,
           "Custom rate parameter count does not match the number of rate constants");
+}
 
     for (size_t i = 0; i < number_of_grid_cells_; ++i)
     {
@@ -618,13 +645,15 @@ namespace micm
       double value)
   {
     auto param = custom_rate_parameter_map_.find(label);
-    if (param == custom_rate_parameter_map_.end())
+    if (param == custom_rate_parameter_map_.end()) {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_RATE_CONSTANT_PARAMETER, label);
-    if (custom_rate_parameters_.NumRows() != 1)
+}
+    if (custom_rate_parameters_.NumRows() != 1) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CUSTOM_RATE_PARAM_COUNT_MULTIGRID,
           "Custom rate parameter vector size does not match the number of grid cells");
+}
     custom_rate_parameters_[0][param->second] = value;
   }
 
@@ -640,15 +669,18 @@ namespace micm
       const std::vector<double>& values)
   {
     auto param = custom_rate_parameter_map_.find(label);
-    if (param == custom_rate_parameter_map_.end())
+    if (param == custom_rate_parameter_map_.end()) {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_RATE_CONSTANT_PARAMETER, label);
-    if (custom_rate_parameters_.NumRows() != values.size())
+}
+    if (custom_rate_parameters_.NumRows() != values.size()) {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CUSTOM_RATE_PARAM_COUNT_MULTIGRID,
           "Custom rate parameter vector size does not match the number of grid cells");
-    for (std::size_t i = 0; i < custom_rate_parameters_.NumRows(); ++i)
+}
+    for (std::size_t i = 0; i < custom_rate_parameters_.NumRows(); ++i) {
       custom_rate_parameters_[i][param->second] = values[i];
+}
   }
 
   template<

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -13,12 +13,13 @@ namespace micm
   inline State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
   operator double() const
   {
-    if (state_.variables_.NumRows() != 1) {
+    if (state_.variables_.NumRows() != 1)
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot convert multi-gridcell State variable to single double value");
-}
+    }
     return state_.variables_[0][index_];
   }
 
@@ -33,12 +34,13 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator=(double value)
   {
-    if (state_.variables_.NumRows() != 1) {
+    if (state_.variables_.NumRows() != 1)
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot assign single value to multi-gridcell State variable");
-}
+    }
     state_.variables_[0][index_] = value;
     return *this;
   }
@@ -54,12 +56,13 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator=(const std::vector<double>& values)
   {
-    if (values.size() != state_.number_of_grid_cells_) {
+    if (values.size() != state_.number_of_grid_cells_)
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Number of values does not match number of grid cells in State");
-}
+    }
     for (std::size_t i = 0; i < state_.number_of_grid_cells_; ++i)
     {
       state_.variables_[i][index_] = values[i];
@@ -78,12 +81,13 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator=(const VariableProxy& other)
   {
-    if (state_.number_of_grid_cells_ != other.state_.number_of_grid_cells_) {
+    if (state_.number_of_grid_cells_ != other.state_.number_of_grid_cells_)
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Number of grid cells does not match between State variables");
-}
+    }
     for (std::size_t i = 0; i < state_.number_of_grid_cells_; ++i)
     {
       state_.variables_[i][index_] = other.state_.variables_[i][other.index_];
@@ -102,12 +106,13 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator+=(double value)
   {
-    if (state_.number_of_grid_cells_ != 1) {
+    if (state_.number_of_grid_cells_ != 1)
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot add single value to multi-gridcell State variable");
-}
+    }
     state_.variables_[0][index_] += value;
     return *this;
   }
@@ -123,12 +128,13 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator-=(double value)
   {
-    if (state_.number_of_grid_cells_ != 1) {
+    if (state_.number_of_grid_cells_ != 1)
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot subtract single value from multi-gridcell State variable");
-}
+    }
     state_.variables_[0][index_] -= value;
     return *this;
   }
@@ -144,12 +150,13 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator*=(double value)
   {
-    if (state_.number_of_grid_cells_ != 1) {
+    if (state_.number_of_grid_cells_ != 1)
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot multiply single value with multi-gridcell State variable");
-}
+    }
     state_.variables_[0][index_] *= value;
     return *this;
   }
@@ -165,12 +172,13 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator/=(double value)
   {
-    if (state_.number_of_grid_cells_ != 1) {
+    if (state_.number_of_grid_cells_ != 1)
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot divide multi-gridcell State variable by single value");
-}
+    }
     state_.variables_[0][index_] /= value;
     return *this;
   }
@@ -210,14 +218,16 @@ namespace micm
       class LMatrixPolicy,
       class UMatrixPolicy>
   inline State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::
-      ConstVariableProxy::operator double() const
+      ConstVariableProxy::
+      operator double() const
   {
-    if (state_.variables_.NumRows() != 1) {
+    if (state_.variables_.NumRows() != 1)
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Cannot convert multi-gridcell State variable to single double value");
-}
+    }
     return state_.variables_[0][index_];
   }
 
@@ -244,14 +254,16 @@ namespace micm
   inline bool State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::
       VariableProxy::operator==(const std::vector<double>& other) const
   {
-    if (other.size() != state_.number_of_grid_cells_) {
+    if (other.size() != state_.number_of_grid_cells_)
+    {
       return false;
-}
+    }
     for (std::size_t i = 0; i < state_.number_of_grid_cells_; ++i)
     {
-      if (state_.variables_[i][index_] != other[i]) {
+      if (state_.variables_[i][index_] != other[i])
+      {
         return false;
-}
+      }
     }
     return true;
   }
@@ -265,14 +277,16 @@ namespace micm
   inline bool State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::
       ConstVariableProxy::operator==(const std::vector<double>& other) const
   {
-    if (other.size() != state_.number_of_grid_cells_) {
+    if (other.size() != state_.number_of_grid_cells_)
+    {
       return false;
-}
+    }
     for (std::size_t i = 0; i < state_.number_of_grid_cells_; ++i)
     {
-      if (state_.variables_[i][index_] != other[i]) {
+      if (state_.variables_[i][index_] != other[i])
+      {
         return false;
-}
+      }
     }
     return true;
   }
@@ -421,9 +435,10 @@ namespace micm
           const std::string& name)
   {
     auto var = variable_map_.find(name);
-    if (var == variable_map_.end()) {
+    if (var == variable_map_.end())
+    {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_SPECIES, name);
-}
+    }
     return VariableProxy(*this, var->second);
   }
 
@@ -439,9 +454,10 @@ namespace micm
           const std::string& name) const
   {
     auto var = variable_map_.find(name);
-    if (var == variable_map_.end()) {
+    if (var == variable_map_.end())
+    {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_SPECIES, name);
-}
+    }
     return ConstVariableProxy(*this, var->second);
   }
 
@@ -500,15 +516,17 @@ namespace micm
       double concentration)
   {
     auto var = variable_map_.find(species.name_);
-    if (var == variable_map_.end()) {
+    if (var == variable_map_.end())
+    {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_SPECIES, species.name_);
-}
-    if (variables_.NumRows() != 1) {
+    }
+    if (variables_.NumRows() != 1)
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Concentration vector size does not match the number of grid cells");
-}
+    }
     variables_[0][variable_map_[species.name_]] = concentration;
   }
 
@@ -524,19 +542,22 @@ namespace micm
       const std::vector<double>& concentration)
   {
     auto var = variable_map_.find(species.name_);
-    if (var == variable_map_.end()) {
+    if (var == variable_map_.end())
+    {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_SPECIES, species.name_);
-}
-    if (variables_.NumRows() != concentration.size()) {
+    }
+    if (variables_.NumRows() != concentration.size())
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Concentration vector size does not match the number of grid cells");
-}
+    }
     std::size_t i_species = variable_map_[species.name_];
-    for (std::size_t i = 0; i < variables_.NumRows(); ++i) {
+    for (std::size_t i = 0; i < variables_.NumRows(); ++i)
+    {
       variables_[i][i_species] = concentration[i];
-}
+    }
   }
 
   template<
@@ -551,15 +572,17 @@ namespace micm
       double concentration)
   {
     auto var = variable_map_.find(element);
-    if (var == variable_map_.end()) {
+    if (var == variable_map_.end())
+    {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_SPECIES, element);
-}
-    if (variables_.NumRows() != 1) {
+    }
+    if (variables_.NumRows() != 1)
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Concentration vector size does not match the number of grid cells");
-}
+    }
     variables_[0][variable_map_[element]] = concentration;
   }
 
@@ -575,19 +598,22 @@ namespace micm
       const std::vector<double>& concentration)
   {
     auto var = variable_map_.find(element);
-    if (var == variable_map_.end()) {
+    if (var == variable_map_.end())
+    {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_SPECIES, element);
-}
-    if (variables_.NumRows() != concentration.size()) {
+    }
+    if (variables_.NumRows() != concentration.size())
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CONCENTRATION_COUNT_MULTIGRID,
           "Concentration vector size does not match the number of grid cells");
-}
+    }
     std::size_t i_species = variable_map_[element];
-    for (std::size_t i = 0; i < variables_.NumRows(); ++i) {
+    for (std::size_t i = 0; i < variables_.NumRows(); ++i)
+    {
       variables_[i][i_species] = concentration[i];
-}
+    }
   }
 
   template<
@@ -599,19 +625,21 @@ namespace micm
   inline void State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::
       UnsafelySetCustomRateParameters(const std::vector<std::vector<double>>& parameters)
   {
-    if (parameters.size() != variables_.NumRows()) {
+    if (parameters.size() != variables_.NumRows())
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CUSTOM_RATE_PARAM_COUNT_MULTIGRID,
           "Custom rate parameter vector size does not match the number of grid cells");
-}
+    }
 
-    if (parameters[0].size() != custom_rate_parameters_.NumColumns()) {
+    if (parameters[0].size() != custom_rate_parameters_.NumColumns())
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CUSTOM_RATE_PARAM_COUNT,
           "Custom rate parameter count does not match the number of rate constants");
-}
+    }
 
     for (size_t i = 0; i < number_of_grid_cells_; ++i)
     {
@@ -645,15 +673,17 @@ namespace micm
       double value)
   {
     auto param = custom_rate_parameter_map_.find(label);
-    if (param == custom_rate_parameter_map_.end()) {
+    if (param == custom_rate_parameter_map_.end())
+    {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_RATE_CONSTANT_PARAMETER, label);
-}
-    if (custom_rate_parameters_.NumRows() != 1) {
+    }
+    if (custom_rate_parameters_.NumRows() != 1)
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CUSTOM_RATE_PARAM_COUNT_MULTIGRID,
           "Custom rate parameter vector size does not match the number of grid cells");
-}
+    }
     custom_rate_parameters_[0][param->second] = value;
   }
 
@@ -669,18 +699,21 @@ namespace micm
       const std::vector<double>& values)
   {
     auto param = custom_rate_parameter_map_.find(label);
-    if (param == custom_rate_parameter_map_.end()) {
+    if (param == custom_rate_parameter_map_.end())
+    {
       throw MicmException(MICM_ERROR_CATEGORY_STATE, MICM_STATE_ERROR_CODE_UNKNOWN_RATE_CONSTANT_PARAMETER, label);
-}
-    if (custom_rate_parameters_.NumRows() != values.size()) {
+    }
+    if (custom_rate_parameters_.NumRows() != values.size())
+    {
       throw MicmException(
           MICM_ERROR_CATEGORY_STATE,
           MICM_STATE_ERROR_CODE_INVALID_CUSTOM_RATE_PARAM_COUNT_MULTIGRID,
           "Custom rate parameter vector size does not match the number of grid cells");
-}
-    for (std::size_t i = 0; i < custom_rate_parameters_.NumRows(); ++i) {
+    }
+    for (std::size_t i = 0; i < custom_rate_parameters_.NumRows(); ++i)
+    {
       custom_rate_parameters_[i][param->second] = values[i];
-}
+    }
   }
 
   template<

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -94,14 +94,14 @@ namespace micm
         properties_double_(other.properties_double_),
         properties_int_(other.properties_int_),
         properties_bool_(other.properties_bool_),
-        parameterize_(other.parameterize_){};
+        parameterize_(other.parameterize_) { };
 
   inline Species::Species(const std::string& name)
-      : name_(name){};
+      : name_(name) { };
 
   inline Species::Species(const std::string& name, const std::map<std::string, double>& properties)
       : name_(name),
-        properties_double_(properties){};
+        properties_double_(properties) { };
 
   inline bool Species::IsParameterized() const
   {

--- a/include/micm/util/jacobian_verification.hpp
+++ b/include/micm/util/jacobian_verification.hpp
@@ -129,9 +129,10 @@ namespace micm
       {
         for (std::size_t col = 0; col < num_species; ++col)
         {
-          if (analytical_jacobian.IsZero(row, col)) {
+          if (analytical_jacobian.IsZero(row, col))
+          {
             continue;
-}
+          }
 
           // Analytical stores -(df/dx); negate to get +df/dx
           double analytical_val = -analytical_jacobian[block][row][col];
@@ -187,9 +188,10 @@ namespace micm
       {
         for (std::size_t col = 0; col < num_species; ++col)
         {
-          if (!analytical_jacobian.IsZero(row, col)) {
+          if (!analytical_jacobian.IsZero(row, col))
+          {
             continue;
-}
+          }
 
           double fd_val = std::abs(fd_jacobian[block][row * num_species + col]);
           if (fd_val > threshold)

--- a/include/micm/util/jacobian_verification.hpp
+++ b/include/micm/util/jacobian_verification.hpp
@@ -129,8 +129,9 @@ namespace micm
       {
         for (std::size_t col = 0; col < num_species; ++col)
         {
-          if (analytical_jacobian.IsZero(row, col))
+          if (analytical_jacobian.IsZero(row, col)) {
             continue;
+}
 
           // Analytical stores -(df/dx); negate to get +df/dx
           double analytical_val = -analytical_jacobian[block][row][col];
@@ -186,8 +187,9 @@ namespace micm
       {
         for (std::size_t col = 0; col < num_species; ++col)
         {
-          if (!analytical_jacobian.IsZero(row, col))
+          if (!analytical_jacobian.IsZero(row, col)) {
             continue;
+}
 
           double fd_val = std::abs(fd_jacobian[block][row * num_species + col]);
           if (fd_val > threshold)

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -307,11 +307,12 @@ namespace micm
 
     std::size_t VectorIndex(std::size_t row, std::size_t column) const
     {
-      if (number_of_blocks_ != 1)
+      if (number_of_blocks_ != 1) {
         throw MicmException(
             MICM_ERROR_CATEGORY_MATRIX,
             MICM_MATRIX_ERROR_CODE_MISSING_BLOCK_INDEX,
             "Matrix has multiple blocks; use the (block, row, col) overload of VectorIndex instead");
+}
       return VectorIndex(0, row, column);
     }
 
@@ -367,10 +368,11 @@ namespace micm
         {
           for (std::size_t k = 0; k < matrix.block_size_ - 1; ++k)
           {
-            if (matrix.IsZero(j, k))
+            if (matrix.IsZero(j, k)) {
               os << "0,";
-            else
+            } else {
               os << matrix[i][j][k] << ',';
+}
           }
           if (matrix.IsZero(j, matrix.block_size_ - 1))
             os << "0" << std::endl;
@@ -724,8 +726,9 @@ namespace micm
 
     SparseMatrixBuilder& WithElement(std::size_t x, std::size_t y)
     {
-      if (x >= block_size_ || y >= block_size_)
+      if (x >= block_size_ || y >= block_size_) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       non_zero_elements_.insert(std::make_pair(x, y));
       return *this;
     }

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -307,12 +307,13 @@ namespace micm
 
     std::size_t VectorIndex(std::size_t row, std::size_t column) const
     {
-      if (number_of_blocks_ != 1) {
+      if (number_of_blocks_ != 1)
+      {
         throw MicmException(
             MICM_ERROR_CATEGORY_MATRIX,
             MICM_MATRIX_ERROR_CODE_MISSING_BLOCK_INDEX,
             "Matrix has multiple blocks; use the (block, row, col) overload of VectorIndex instead");
-}
+      }
       return VectorIndex(0, row, column);
     }
 
@@ -368,11 +369,14 @@ namespace micm
         {
           for (std::size_t k = 0; k < matrix.block_size_ - 1; ++k)
           {
-            if (matrix.IsZero(j, k)) {
+            if (matrix.IsZero(j, k))
+            {
               os << "0,";
-            } else {
+            }
+            else
+            {
               os << matrix[i][j][k] << ',';
-}
+            }
           }
           if (matrix.IsZero(j, matrix.block_size_ - 1))
             os << "0" << std::endl;
@@ -726,9 +730,10 @@ namespace micm
 
     SparseMatrixBuilder& WithElement(std::size_t x, std::size_t y)
     {
-      if (x >= block_size_ || y >= block_size_) {
+      if (x >= block_size_ || y >= block_size_)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       non_zero_elements_.insert(std::make_pair(x, y));
       return *this;
     }

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
@@ -69,13 +69,15 @@ namespace micm
     /// @return Index of the element in the compressed data vector
     std::size_t VectorIndex(std::size_t number_of_blocks, std::size_t block, std::size_t row, std::size_t column) const
     {
-      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1 || block >= number_of_blocks)
+      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1 || block >= number_of_blocks) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       auto begin = std::next(column_ids_.begin(), column_start_[column]);
       auto end = std::next(column_ids_.begin(), column_start_[column + 1]);
       auto elem = std::find(begin, end, row);
-      if (elem == end)
+      if (elem == end) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
+}
       return std::size_t{ (elem - column_ids_.begin()) + block * column_ids_.size() };
     }
 
@@ -97,13 +99,15 @@ namespace micm
     /// @return The index of the nth non-zero element within a block (0-based)
     std::size_t VectorIndexFromRowColumn(std::size_t row, std::size_t col) const
     {
-      if (col >= column_start_.size() - 1 || row >= column_start_.size() - 1)
+      if (col >= column_start_.size() - 1 || row >= column_start_.size() - 1) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       auto begin = std::next(column_ids_.begin(), column_start_[col]);
       auto end = std::next(column_ids_.begin(), column_start_[col + 1]);
       auto elem = std::find(begin, end, row);
-      if (elem == end)
+      if (elem == end) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
+}
       return std::distance(column_ids_.begin(), elem);
     }
 
@@ -436,8 +440,9 @@ namespace micm
     /// @return true if the element is always zero, false otherwise
     bool IsZero(std::size_t row, std::size_t column) const
     {
-      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1)
+      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       auto begin = std::next(column_ids_.begin(), column_start_[column]);
       auto end = std::next(column_ids_.begin(), column_start_[column + 1]);
       auto elem = std::find(begin, end, row);

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
@@ -69,15 +69,17 @@ namespace micm
     /// @return Index of the element in the compressed data vector
     std::size_t VectorIndex(std::size_t number_of_blocks, std::size_t block, std::size_t row, std::size_t column) const
     {
-      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1 || block >= number_of_blocks) {
+      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1 || block >= number_of_blocks)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       auto begin = std::next(column_ids_.begin(), column_start_[column]);
       auto end = std::next(column_ids_.begin(), column_start_[column + 1]);
       auto elem = std::find(begin, end, row);
-      if (elem == end) {
+      if (elem == end)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
-}
+      }
       return std::size_t{ (elem - column_ids_.begin()) + block * column_ids_.size() };
     }
 
@@ -99,15 +101,17 @@ namespace micm
     /// @return The index of the nth non-zero element within a block (0-based)
     std::size_t VectorIndexFromRowColumn(std::size_t row, std::size_t col) const
     {
-      if (col >= column_start_.size() - 1 || row >= column_start_.size() - 1) {
+      if (col >= column_start_.size() - 1 || row >= column_start_.size() - 1)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       auto begin = std::next(column_ids_.begin(), column_start_[col]);
       auto end = std::next(column_ids_.begin(), column_start_[col + 1]);
       auto elem = std::find(begin, end, row);
-      if (elem == end) {
+      if (elem == end)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
-}
+      }
       return std::distance(column_ids_.begin(), elem);
     }
 
@@ -440,9 +444,10 @@ namespace micm
     /// @return true if the element is always zero, false otherwise
     bool IsZero(std::size_t row, std::size_t column) const
     {
-      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1) {
+      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       auto begin = std::next(column_ids_.begin(), column_start_[column]);
       auto end = std::next(column_ids_.begin(), column_start_[column + 1]);
       auto elem = std::find(begin, end, row);

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
@@ -69,15 +69,17 @@ namespace micm
     /// @return Index of the element in the compressed data vector
     std::size_t VectorIndex(std::size_t number_of_blocks, std::size_t block, std::size_t row, std::size_t column) const
     {
-      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1 || block >= number_of_blocks) {
+      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1 || block >= number_of_blocks)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       auto begin = std::next(row_ids_.begin(), row_start_[row]);
       auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
       auto elem = std::find(begin, end, column);
-      if (elem == end) {
+      if (elem == end)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
-}
+      }
       return std::size_t{ (elem - row_ids_.begin()) + block * row_ids_.size() };
     }
 
@@ -98,15 +100,17 @@ namespace micm
     /// @return The index of the nth non-zero element within a block (0-based)
     std::size_t VectorIndexFromRowColumn(std::size_t row, std::size_t col) const
     {
-      if (row >= row_start_.size() - 1 || col >= row_start_.size() - 1) {
+      if (row >= row_start_.size() - 1 || col >= row_start_.size() - 1)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       auto begin = std::next(row_ids_.begin(), row_start_[row]);
       auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
       auto elem = std::find(begin, end, col);
-      if (elem == end) {
+      if (elem == end)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
-}
+      }
       return std::distance(row_ids_.begin(), elem);
     }
 
@@ -433,9 +437,10 @@ namespace micm
     /// @return true if the element is always zero, false otherwise
     bool IsZero(std::size_t row, std::size_t column) const
     {
-      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1) {
+      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       auto begin = std::next(row_ids_.begin(), row_start_[row]);
       auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
       auto elem = std::find(begin, end, column);

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
@@ -69,13 +69,15 @@ namespace micm
     /// @return Index of the element in the compressed data vector
     std::size_t VectorIndex(std::size_t number_of_blocks, std::size_t block, std::size_t row, std::size_t column) const
     {
-      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1 || block >= number_of_blocks)
+      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1 || block >= number_of_blocks) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       auto begin = std::next(row_ids_.begin(), row_start_[row]);
       auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
       auto elem = std::find(begin, end, column);
-      if (elem == end)
+      if (elem == end) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
+}
       return std::size_t{ (elem - row_ids_.begin()) + block * row_ids_.size() };
     }
 
@@ -96,13 +98,15 @@ namespace micm
     /// @return The index of the nth non-zero element within a block (0-based)
     std::size_t VectorIndexFromRowColumn(std::size_t row, std::size_t col) const
     {
-      if (row >= row_start_.size() - 1 || col >= row_start_.size() - 1)
+      if (row >= row_start_.size() - 1 || col >= row_start_.size() - 1) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       auto begin = std::next(row_ids_.begin(), row_start_[row]);
       auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
       auto elem = std::find(begin, end, col);
-      if (elem == end)
+      if (elem == end) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
+}
       return std::distance(row_ids_.begin(), elem);
     }
 
@@ -429,8 +433,9 @@ namespace micm
     /// @return true if the element is always zero, false otherwise
     bool IsZero(std::size_t row, std::size_t column) const
     {
-      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1)
+      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       auto begin = std::next(row_ids_.begin(), row_start_[row]);
       auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
       auto elem = std::find(begin, end, column);

--- a/include/micm/util/sparse_matrix_vector_ordering.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering.hpp
@@ -22,8 +22,9 @@ namespace micm
   {
     if constexpr (requires {
                     { matrix.CopyToDevice() } -> std::same_as<void>;
-                  })
+                  }) {
       matrix.CopyToDevice();
+}
   }
 
   template<class MatrixPolicy>
@@ -31,8 +32,9 @@ namespace micm
   {
     if constexpr (requires {
                     { matrix.CopyToHost() } -> std::same_as<void>;
-                  })
+                  }) {
       matrix.CopyToHost();
+}
   }
 
 }  // namespace micm

--- a/include/micm/util/sparse_matrix_vector_ordering.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering.hpp
@@ -22,9 +22,10 @@ namespace micm
   {
     if constexpr (requires {
                     { matrix.CopyToDevice() } -> std::same_as<void>;
-                  }) {
+                  })
+    {
       matrix.CopyToDevice();
-}
+    }
   }
 
   template<class MatrixPolicy>
@@ -32,9 +33,10 @@ namespace micm
   {
     if constexpr (requires {
                     { matrix.CopyToHost() } -> std::same_as<void>;
-                  }) {
+                  })
+    {
       matrix.CopyToHost();
-}
+    }
   }
 
 }  // namespace micm

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
@@ -75,13 +75,15 @@ namespace micm
     /// @return Index of the element in the compressed data vector
     std::size_t VectorIndex(std::size_t number_of_blocks, std::size_t block, std::size_t row, std::size_t column) const
     {
-      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1 || block >= number_of_blocks)
+      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1 || block >= number_of_blocks) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       auto begin = std::next(column_ids_.begin(), column_start_[column]);
       auto end = std::next(column_ids_.begin(), column_start_[column + 1]);
       auto elem = std::find(begin, end, row);
-      if (elem == end)
+      if (elem == end) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
+}
       return std::size_t{ (elem - column_ids_.begin()) * L + block % L + (block / L) * L * column_ids_.size() };
     }
 
@@ -108,13 +110,15 @@ namespace micm
     /// @return The index of the nth non-zero element within a block (0-based)
     std::size_t VectorIndexFromRowColumn(std::size_t row, std::size_t col) const
     {
-      if (col >= column_start_.size() - 1 || row >= column_start_.size() - 1)
+      if (col >= column_start_.size() - 1 || row >= column_start_.size() - 1) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       auto begin = std::next(column_ids_.begin(), column_start_[col]);
       auto end = std::next(column_ids_.begin(), column_start_[col + 1]);
       auto elem = std::find(begin, end, row);
-      if (elem == end)
+      if (elem == end) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
+}
       return std::distance(column_ids_.begin(), elem);
     }
 
@@ -543,10 +547,11 @@ namespace micm
     /// @return True if the element is zero, false otherwise
     bool IsZero(const std::size_t row, const std::size_t column) const
     {
-      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1)
+      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1) {
         throw MicmException(
 
             MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       auto begin = std::next(column_ids_.begin(), column_start_[column]);
       auto end = std::next(column_ids_.begin(), column_start_[column + 1]);
       auto elem = std::find(begin, end, row);

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
@@ -75,15 +75,17 @@ namespace micm
     /// @return Index of the element in the compressed data vector
     std::size_t VectorIndex(std::size_t number_of_blocks, std::size_t block, std::size_t row, std::size_t column) const
     {
-      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1 || block >= number_of_blocks) {
+      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1 || block >= number_of_blocks)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       auto begin = std::next(column_ids_.begin(), column_start_[column]);
       auto end = std::next(column_ids_.begin(), column_start_[column + 1]);
       auto elem = std::find(begin, end, row);
-      if (elem == end) {
+      if (elem == end)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
-}
+      }
       return std::size_t{ (elem - column_ids_.begin()) * L + block % L + (block / L) * L * column_ids_.size() };
     }
 
@@ -110,15 +112,17 @@ namespace micm
     /// @return The index of the nth non-zero element within a block (0-based)
     std::size_t VectorIndexFromRowColumn(std::size_t row, std::size_t col) const
     {
-      if (col >= column_start_.size() - 1 || row >= column_start_.size() - 1) {
+      if (col >= column_start_.size() - 1 || row >= column_start_.size() - 1)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       auto begin = std::next(column_ids_.begin(), column_start_[col]);
       auto end = std::next(column_ids_.begin(), column_start_[col + 1]);
       auto elem = std::find(begin, end, row);
-      if (elem == end) {
+      if (elem == end)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
-}
+      }
       return std::distance(column_ids_.begin(), elem);
     }
 
@@ -547,11 +551,12 @@ namespace micm
     /// @return True if the element is zero, false otherwise
     bool IsZero(const std::size_t row, const std::size_t column) const
     {
-      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1) {
+      if (column >= column_start_.size() - 1 || row >= column_start_.size() - 1)
+      {
         throw MicmException(
 
             MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       auto begin = std::next(column_ids_.begin(), column_start_[column]);
       auto end = std::next(column_ids_.begin(), column_start_[column + 1]);
       auto elem = std::find(begin, end, row);

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
@@ -76,13 +76,15 @@ namespace micm
     /// @return Index of the element in the compressed data vector
     std::size_t VectorIndex(std::size_t number_of_blocks, std::size_t block, std::size_t row, std::size_t column) const
     {
-      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1 || block >= number_of_blocks)
+      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1 || block >= number_of_blocks) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       auto begin = std::next(row_ids_.begin(), row_start_[row]);
       auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
       auto elem = std::find(begin, end, column);
-      if (elem == end)
+      if (elem == end) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
+}
       return std::size_t{ (elem - row_ids_.begin()) * L + block % L + (block / L) * L * row_ids_.size() };
     }
 
@@ -114,13 +116,15 @@ namespace micm
     /// @return The index of the nth non-zero element within a block (0-based)
     std::size_t VectorIndexFromRowColumn(std::size_t row, std::size_t col) const
     {
-      if (row >= row_start_.size() - 1 || col >= row_start_.size() - 1)
+      if (row >= row_start_.size() - 1 || col >= row_start_.size() - 1) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       auto begin = std::next(row_ids_.begin(), row_start_[row]);
       auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
       auto elem = std::find(begin, end, col);
-      if (elem == end)
+      if (elem == end) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
+}
       return std::distance(row_ids_.begin(), elem);
     }
 
@@ -541,8 +545,9 @@ namespace micm
     /// @return true if the element is always zero, false otherwise
     bool IsZero(std::size_t row, std::size_t column) const
     {
-      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1)
+      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1) {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
+}
       auto begin = std::next(row_ids_.begin(), row_start_[row]);
       auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
       return std::find(begin, end, column) == end;

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
@@ -76,15 +76,17 @@ namespace micm
     /// @return Index of the element in the compressed data vector
     std::size_t VectorIndex(std::size_t number_of_blocks, std::size_t block, std::size_t row, std::size_t column) const
     {
-      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1 || block >= number_of_blocks) {
+      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1 || block >= number_of_blocks)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       auto begin = std::next(row_ids_.begin(), row_start_[row]);
       auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
       auto elem = std::find(begin, end, column);
-      if (elem == end) {
+      if (elem == end)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
-}
+      }
       return std::size_t{ (elem - row_ids_.begin()) * L + block % L + (block / L) * L * row_ids_.size() };
     }
 
@@ -116,15 +118,17 @@ namespace micm
     /// @return The index of the nth non-zero element within a block (0-based)
     std::size_t VectorIndexFromRowColumn(std::size_t row, std::size_t col) const
     {
-      if (row >= row_start_.size() - 1 || col >= row_start_.size() - 1) {
+      if (row >= row_start_.size() - 1 || col >= row_start_.size() - 1)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       auto begin = std::next(row_ids_.begin(), row_start_[row]);
       auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
       auto elem = std::find(begin, end, col);
-      if (elem == end) {
+      if (elem == end)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ZERO_ELEMENT_ACCESS, "Zero element access");
-}
+      }
       return std::distance(row_ids_.begin(), elem);
     }
 
@@ -545,9 +549,10 @@ namespace micm
     /// @return true if the element is always zero, false otherwise
     bool IsZero(std::size_t row, std::size_t column) const
     {
-      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1) {
+      if (row >= row_start_.size() - 1 || column >= row_start_.size() - 1)
+      {
         throw MicmException(MICM_ERROR_CATEGORY_MATRIX, MICM_MATRIX_ERROR_CODE_ELEMENT_OUT_OF_RANGE, "Element out of range");
-}
+      }
       auto begin = std::next(row_ids_.begin(), row_start_[row]);
       auto end = std::next(row_ids_.begin(), row_start_[row + 1]);
       return std::find(begin, end, column) == end;

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -367,9 +367,9 @@ void test_analytical_troe(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-10,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A -> B, k1
@@ -394,14 +394,15 @@ void test_analytical_troe(
   micm::Process r2 = micm::ChemicalReactionBuilder()
                          .SetReactants({ b })
                          .SetProducts({ micm::StoichSpecies(c, 1) })
-                         .SetRateConstant(micm::TroeRateConstantParameters{ .k0_A_ = 1.2e-3,
-                                                                            .k0_B_ = 1.6,
-                                                                            .k0_C_ = 3,
-                                                                            .kinf_A_ = 136,
-                                                                            .kinf_B_ = 5,
-                                                                            .kinf_C_ = 24,
-                                                                            .Fc_ = 0.9,
-                                                                            .N_ = 0.8 })
+                         .SetRateConstant(
+                             micm::TroeRateConstantParameters{ .k0_A_ = 1.2e-3,
+                                                               .k0_B_ = 1.6,
+                                                               .k0_C_ = 3,
+                                                               .kinf_A_ = 136,
+                                                               .kinf_B_ = 5,
+                                                               .kinf_C_ = 24,
+                                                               .Fc_ = 0.9,
+                                                               .N_ = 0.8 })
                          .SetPhase(gas_phase)
                          .Build();
 
@@ -437,9 +438,9 @@ void test_analytical_stiff_troe(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-5,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A1 -> B, k1
@@ -474,14 +475,15 @@ void test_analytical_stiff_troe(
   micm::Process r3 = micm::ChemicalReactionBuilder()
                          .SetReactants({ b })
                          .SetProducts({ micm::StoichSpecies(c, 1) })
-                         .SetRateConstant(micm::TroeRateConstantParameters{ .k0_A_ = 1.2e-3,
-                                                                            .k0_B_ = 1.6,
-                                                                            .k0_C_ = 3,
-                                                                            .kinf_A_ = 136,
-                                                                            .kinf_B_ = 5,
-                                                                            .kinf_C_ = 24,
-                                                                            .Fc_ = 0.9,
-                                                                            .N_ = 0.8 })
+                         .SetRateConstant(
+                             micm::TroeRateConstantParameters{ .k0_A_ = 1.2e-3,
+                                                               .k0_B_ = 1.6,
+                                                               .k0_C_ = 3,
+                                                               .kinf_A_ = 136,
+                                                               .kinf_B_ = 5,
+                                                               .kinf_C_ = 24,
+                                                               .Fc_ = 0.9,
+                                                               .N_ = 0.8 })
                          .SetPhase(gas_phase)
                          .Build();
 
@@ -531,9 +533,9 @@ void test_analytical_photolysis(
     BuilderPolicy builder,
     double absolute_tolerances = 2e-6,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A -> B, k1
@@ -593,9 +595,9 @@ void test_analytical_stiff_photolysis(
     BuilderPolicy builder,
     double absolute_tolerances = 2e-5,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A1 -> B, k1
@@ -681,9 +683,9 @@ void test_analytical_ternary_chemical_activation(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-08,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A -> B, k1
@@ -710,14 +712,15 @@ void test_analytical_ternary_chemical_activation(
   micm::Process r2 = micm::ChemicalReactionBuilder()
                          .SetReactants({ b })
                          .SetProducts({ micm::StoichSpecies(c, 1) })
-                         .SetRateConstant(micm::TernaryChemicalActivationRateConstantParameters{ .k0_A_ = 1.2e-3,
-                                                                                                 .k0_B_ = 1.6,
-                                                                                                 .k0_C_ = 3,
-                                                                                                 .kinf_A_ = 136,
-                                                                                                 .kinf_B_ = 5,
-                                                                                                 .kinf_C_ = 24,
-                                                                                                 .Fc_ = 0.9,
-                                                                                                 .N_ = 0.8 })
+                         .SetRateConstant(
+                             micm::TernaryChemicalActivationRateConstantParameters{ .k0_A_ = 1.2e-3,
+                                                                                    .k0_B_ = 1.6,
+                                                                                    .k0_C_ = 3,
+                                                                                    .kinf_A_ = 136,
+                                                                                    .kinf_B_ = 5,
+                                                                                    .kinf_C_ = 24,
+                                                                                    .Fc_ = 0.9,
+                                                                                    .N_ = 0.8 })
                          .SetPhase(gas_phase)
                          .Build();
 
@@ -753,9 +756,9 @@ void test_analytical_stiff_ternary_chemical_activation(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-6,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A1 -> B, k1
@@ -792,14 +795,15 @@ void test_analytical_stiff_ternary_chemical_activation(
   micm::Process r3 = micm::ChemicalReactionBuilder()
                          .SetReactants({ b })
                          .SetProducts({ micm::StoichSpecies(c, 1) })
-                         .SetRateConstant(micm::TernaryChemicalActivationRateConstantParameters{ .k0_A_ = 1.2e-3,
-                                                                                                 .k0_B_ = 1.6,
-                                                                                                 .k0_C_ = 3,
-                                                                                                 .kinf_A_ = 136,
-                                                                                                 .kinf_B_ = 5,
-                                                                                                 .kinf_C_ = 24,
-                                                                                                 .Fc_ = 0.9,
-                                                                                                 .N_ = 0.8 })
+                         .SetRateConstant(
+                             micm::TernaryChemicalActivationRateConstantParameters{ .k0_A_ = 1.2e-3,
+                                                                                    .k0_B_ = 1.6,
+                                                                                    .k0_C_ = 3,
+                                                                                    .kinf_A_ = 136,
+                                                                                    .kinf_B_ = 5,
+                                                                                    .kinf_C_ = 24,
+                                                                                    .Fc_ = 0.9,
+                                                                                    .N_ = 0.8 })
                          .SetPhase(gas_phase)
                          .Build();
 
@@ -849,9 +853,9 @@ void test_analytical_tunneling(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-8,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A -> B, k1
@@ -909,9 +913,9 @@ void test_analytical_stiff_tunneling(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-6,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A1 -> B, k1
@@ -992,9 +996,9 @@ void test_analytical_arrhenius(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-9,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A -> B, k1
@@ -1051,9 +1055,9 @@ void test_analytical_stiff_arrhenius(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-6,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A1 -> B, k1
@@ -1135,9 +1139,9 @@ void test_analytical_branched(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-13,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A -> B, k1
@@ -1152,29 +1156,31 @@ void test_analytical_branched(
 
   micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c } };
 
-  micm::Process r1 = micm::ChemicalReactionBuilder()
-                         .SetReactants({ a })
-                         .SetProducts({ micm::StoichSpecies(b, 1) })
-                         .SetRateConstant(micm::BranchedRateConstantParameters{
-                             .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
-                             .X_ = 1e-4,
-                             .Y_ = 204.3,
-                             .a0_ = 1.0e-3,
-                             .n_ = 2 })
-                         .SetPhase(gas_phase)
-                         .Build();
+  micm::Process r1 =
+      micm::ChemicalReactionBuilder()
+          .SetReactants({ a })
+          .SetProducts({ micm::StoichSpecies(b, 1) })
+          .SetRateConstant(
+              micm::BranchedRateConstantParameters{ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
+                                                    .X_ = 1e-4,
+                                                    .Y_ = 204.3,
+                                                    .a0_ = 1.0e-3,
+                                                    .n_ = 2 })
+          .SetPhase(gas_phase)
+          .Build();
 
-  micm::Process r2 = micm::ChemicalReactionBuilder()
-                         .SetReactants({ b })
-                         .SetProducts({ micm::StoichSpecies(c, 1) })
-                         .SetRateConstant(micm::BranchedRateConstantParameters{
-                             .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate,
-                             .X_ = 1e-4,
-                             .Y_ = 204.3,
-                             .a0_ = 1.0e-3,
-                             .n_ = 2 })
-                         .SetPhase(gas_phase)
-                         .Build();
+  micm::Process r2 =
+      micm::ChemicalReactionBuilder()
+          .SetReactants({ b })
+          .SetProducts({ micm::StoichSpecies(c, 1) })
+          .SetRateConstant(
+              micm::BranchedRateConstantParameters{ .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate,
+                                                    .X_ = 1e-4,
+                                                    .Y_ = 204.3,
+                                                    .a0_ = 1.0e-3,
+                                                    .n_ = 2 })
+          .SetPhase(gas_phase)
+          .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2 };
   builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
@@ -1222,9 +1228,9 @@ void test_analytical_stiff_branched(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-6,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A1 -> B, k1
@@ -1242,41 +1248,44 @@ void test_analytical_stiff_branched(
 
   micm::Phase gas_phase{ "gas", std::vector<micm::PhaseSpecies>{ a1, a2, b, c } };
 
-  micm::Process r1 = micm::ChemicalReactionBuilder()
-                         .SetReactants({ a1 })
-                         .SetProducts({ micm::StoichSpecies(b, 1) })
-                         .SetRateConstant(micm::BranchedRateConstantParameters{
-                             .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
-                             .X_ = 1e-4,
-                             .Y_ = 204.3,
-                             .a0_ = 1.0e-3,
-                             .n_ = 2 })
-                         .SetPhase(gas_phase)
-                         .Build();
+  micm::Process r1 =
+      micm::ChemicalReactionBuilder()
+          .SetReactants({ a1 })
+          .SetProducts({ micm::StoichSpecies(b, 1) })
+          .SetRateConstant(
+              micm::BranchedRateConstantParameters{ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
+                                                    .X_ = 1e-4,
+                                                    .Y_ = 204.3,
+                                                    .a0_ = 1.0e-3,
+                                                    .n_ = 2 })
+          .SetPhase(gas_phase)
+          .Build();
 
-  micm::Process r2 = micm::ChemicalReactionBuilder()
-                         .SetReactants({ a2 })
-                         .SetProducts({ micm::StoichSpecies(b, 1) })
-                         .SetRateConstant(micm::BranchedRateConstantParameters{
-                             .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
-                             .X_ = 1e-4,
-                             .Y_ = 204.3,
-                             .a0_ = 1.0e-3,
-                             .n_ = 2 })
-                         .SetPhase(gas_phase)
-                         .Build();
+  micm::Process r2 =
+      micm::ChemicalReactionBuilder()
+          .SetReactants({ a2 })
+          .SetProducts({ micm::StoichSpecies(b, 1) })
+          .SetRateConstant(
+              micm::BranchedRateConstantParameters{ .branch_ = micm::BranchedRateConstantParameters::Branch::Alkoxy,
+                                                    .X_ = 1e-4,
+                                                    .Y_ = 204.3,
+                                                    .a0_ = 1.0e-3,
+                                                    .n_ = 2 })
+          .SetPhase(gas_phase)
+          .Build();
 
-  micm::Process r3 = micm::ChemicalReactionBuilder()
-                         .SetReactants({ b })
-                         .SetProducts({ micm::StoichSpecies(c, 1) })
-                         .SetRateConstant(micm::BranchedRateConstantParameters{
-                             .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate,
-                             .X_ = 1e-4,
-                             .Y_ = 204.3,
-                             .a0_ = 1.0e-3,
-                             .n_ = 2 })
-                         .SetPhase(gas_phase)
-                         .Build();
+  micm::Process r3 =
+      micm::ChemicalReactionBuilder()
+          .SetReactants({ b })
+          .SetProducts({ micm::StoichSpecies(c, 1) })
+          .SetRateConstant(
+              micm::BranchedRateConstantParameters{ .branch_ = micm::BranchedRateConstantParameters::Branch::Nitrate,
+                                                    .X_ = 1e-4,
+                                                    .Y_ = 204.3,
+                                                    .a0_ = 1.0e-3,
+                                                    .n_ = 2 })
+          .SetPhase(gas_phase)
+          .Build();
 
   micm::Process r4 = micm::ChemicalReactionBuilder()
                          .SetReactants({ a1 })
@@ -1338,9 +1347,9 @@ void test_analytical_robertson(
     BuilderPolicy builder,
     double relative_tolerance = 1e-8,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A -> B, k1 = 0.04
@@ -1492,9 +1501,9 @@ void test_analytical_oregonator(
     BuilderPolicy builder,
     double relative_tolerance = 1e-4,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * This problem is described in
@@ -1700,9 +1709,9 @@ void test_analytical_hires(
     BuilderPolicy builder,
     double absolute_tolerance = 1e-8,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * This problem is described in
@@ -1910,9 +1919,9 @@ void test_analytical_e5(
     BuilderPolicy builder,
     double relative_tolerance = 1e-8,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * A1 -> A2 + A3,  k1 = 7.89e-10

--- a/test/integration/analytical_surface_rxn_policy.hpp
+++ b/test/integration/analytical_surface_rxn_policy.hpp
@@ -7,9 +7,9 @@ void test_analytical_surface_rxn(
     BuilderPolicy& builder,
     double tolerance = 1e-8,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   // parameters, from CAMP/test/unit_rxn_data/test_rxn_surface.F90
   const double mode_GMD = 1.0e-6;            // mode geometric mean diameter [m]

--- a/test/integration/stub_aerosol_1.hpp
+++ b/test/integration/stub_aerosol_1.hpp
@@ -176,23 +176,27 @@ class StubAerosolModel
     auto fo2_mode2_index_it = state_variable_indices.find("STUB1.MODE2.CORGE.FO2");
     if (fo2_gas_index_it != state_variable_indices.end() && fo2_mode2_index_it != state_variable_indices.end())
     {
-      jacobian_info.push_back({ fo2_gas_index_it->second,
-                                fo2_gas_index_it->second,
-                                -rate_constants_.fo2_gas_to_mode2_corge });  // reactant partial derivative
-      jacobian_info.push_back({ fo2_mode2_index_it->second,
-                                fo2_gas_index_it->second,
-                                rate_constants_.fo2_gas_to_mode2_corge });  // product partial derivative
+      jacobian_info.push_back(
+          { fo2_gas_index_it->second,
+            fo2_gas_index_it->second,
+            -rate_constants_.fo2_gas_to_mode2_corge });  // reactant partial derivative
+      jacobian_info.push_back(
+          { fo2_mode2_index_it->second,
+            fo2_gas_index_it->second,
+            rate_constants_.fo2_gas_to_mode2_corge });  // product partial derivative
     }
     auto baz_mode1_index_it = state_variable_indices.find("STUB1.MODE1.QUUX.BAZ");
     auto baz_mode2_index_it = state_variable_indices.find("STUB1.MODE2.QUUX.BAZ");
     if (baz_mode1_index_it != state_variable_indices.end() && baz_mode2_index_it != state_variable_indices.end())
     {
-      jacobian_info.push_back({ baz_mode1_index_it->second,
-                                baz_mode1_index_it->second,
-                                -rate_constants_.baz_mode1_to_mode2_quux });  // reactant partial derivative
-      jacobian_info.push_back({ baz_mode2_index_it->second,
-                                baz_mode1_index_it->second,
-                                rate_constants_.baz_mode1_to_mode2_quux });  // product partial derivative
+      jacobian_info.push_back(
+          { baz_mode1_index_it->second,
+            baz_mode1_index_it->second,
+            -rate_constants_.baz_mode1_to_mode2_quux });  // reactant partial derivative
+      jacobian_info.push_back(
+          { baz_mode2_index_it->second,
+            baz_mode1_index_it->second,
+            rate_constants_.baz_mode1_to_mode2_quux });  // product partial derivative
     }
 
     // copy-capture the jacobian_info vector in the lambda function that will calculate the Jacobian terms

--- a/test/integration/stub_aerosol_2.hpp
+++ b/test/integration/stub_aerosol_2.hpp
@@ -128,7 +128,7 @@ class AnotherStubAerosolModel
     if (baz_to_qux_param_it == state_parameter_indices.end())
     {
       // If the parameter is missing, return a no-op updater to avoid undefined behavior.
-      return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) {};
+      return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) { };
     }
     std::size_t baz_to_qux_param_index = baz_to_qux_param_it->second;
     return [baz_to_qux_param_index](const std::vector<micm::Conditions>& conditions, DenseMatrixPolicy& state_parameters)
@@ -209,14 +209,16 @@ class AnotherStubAerosolModel
     if (fo2_mode2_index_it != state_variable_indices.end() && baz_mode2_index_it != state_variable_indices.end() &&
         fo2_to_baz_param_it != state_parameter_indices.end())
     {
-      jacobian_info.push_back({ fo2_mode2_index_it->second,
-                                fo2_mode2_index_it->second,
-                                fo2_to_baz_param_it->second,
-                                -1.0 });  // reactant partial derivative
-      jacobian_info.push_back({ baz_mode2_index_it->second,
-                                fo2_mode2_index_it->second,
-                                fo2_to_baz_param_it->second,
-                                1.0 });  // product partial derivative
+      jacobian_info.push_back(
+          { fo2_mode2_index_it->second,
+            fo2_mode2_index_it->second,
+            fo2_to_baz_param_it->second,
+            -1.0 });  // reactant partial derivative
+      jacobian_info.push_back(
+          { baz_mode2_index_it->second,
+            fo2_mode2_index_it->second,
+            fo2_to_baz_param_it->second,
+            1.0 });  // product partial derivative
     }
     auto baz_mode3_index_it = state_variable_indices.find("STUB2.MODE3.QUUX.BAZ");
     auto qux_mode3_index_it = state_variable_indices.find("STUB2.MODE3.QUUX.QUX");
@@ -224,14 +226,16 @@ class AnotherStubAerosolModel
     if (baz_mode3_index_it != state_variable_indices.end() && qux_mode3_index_it != state_variable_indices.end() &&
         baz_to_qux_param_it != state_parameter_indices.end())
     {
-      jacobian_info.push_back({ baz_mode3_index_it->second,
-                                baz_mode3_index_it->second,
-                                baz_to_qux_param_it->second,
-                                -1.0 });  // reactant partial derivative
-      jacobian_info.push_back({ qux_mode3_index_it->second,
-                                baz_mode3_index_it->second,
-                                baz_to_qux_param_it->second,
-                                1.0 });  // product partial derivative
+      jacobian_info.push_back(
+          { baz_mode3_index_it->second,
+            baz_mode3_index_it->second,
+            baz_to_qux_param_it->second,
+            -1.0 });  // reactant partial derivative
+      jacobian_info.push_back(
+          { qux_mode3_index_it->second,
+            baz_mode3_index_it->second,
+            baz_to_qux_param_it->second,
+            1.0 });  // product partial derivative
     }
 
     // copy-capture the jacobian_info vector in the lambda function that will calculate the Jacobian terms

--- a/test/integration/stub_aerosol_with_constraints.hpp
+++ b/test/integration/stub_aerosol_with_constraints.hpp
@@ -79,7 +79,7 @@ class StubAerosolWithConstraints
   std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> UpdateStateParametersFunction(
       const std::unordered_map<std::string, std::size_t>& state_parameter_indices) const
   {
-    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) {};
+    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) { };
   }
 
   template<typename DenseMatrixPolicy>
@@ -156,7 +156,7 @@ class StubAerosolWithConstraints
   std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> ConstraintUpdateStateParametersFunction(
       const std::unordered_map<std::string, std::size_t>&) const
   {
-    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) {};
+    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) { };
   }
 
   /// Constraint residual: G(y) = [A_GAS] + [A_AQ] - total = 0
@@ -265,7 +265,7 @@ class StubAerosolWithSolvent
   std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> UpdateStateParametersFunction(
       const std::unordered_map<std::string, std::size_t>& state_parameter_indices) const
   {
-    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) {};
+    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) { };
   }
 
   template<typename DenseMatrixPolicy>
@@ -344,7 +344,7 @@ class StubAerosolWithSolvent
   std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> ConstraintUpdateStateParametersFunction(
       const std::unordered_map<std::string, std::size_t>&) const
   {
-    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) {};
+    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) { };
   }
 
   template<typename DenseMatrixPolicy>

--- a/test/integration/test_dae_algebraic_error_insensitivity.cpp
+++ b/test/integration/test_dae_algebraic_error_insensitivity.cpp
@@ -135,8 +135,9 @@ namespace
     {
       auto result = solver.Solve(dt - advanced, state);
       EXPECT_EQ(result.state_, SolverState::Converged);
-      if (result.state_ != SolverState::Converged)
+      if (result.state_ != SolverState::Converged) {
         break;
+}
       advanced += result.stats_.final_time_;
       total_accepted += result.stats_.accepted_;
       total_rejected += result.stats_.rejected_;

--- a/test/integration/test_dae_algebraic_error_insensitivity.cpp
+++ b/test/integration/test_dae_algebraic_error_insensitivity.cpp
@@ -135,9 +135,10 @@ namespace
     {
       auto result = solver.Solve(dt - advanced, state);
       EXPECT_EQ(result.state_, SolverState::Converged);
-      if (result.state_ != SolverState::Converged) {
+      if (result.state_ != SolverState::Converged)
+      {
         break;
-}
+      }
       advanced += result.stats_.final_time_;
       total_accepted += result.stats_.accepted_;
       total_rejected += result.stats_.rejected_;

--- a/test/integration/test_external_model_constraints.cpp
+++ b/test/integration/test_external_model_constraints.cpp
@@ -57,7 +57,7 @@ class EquilibriumConstraintModel
   std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> ConstraintUpdateStateParametersFunction(
       const std::unordered_map<std::string, std::size_t>&) const
   {
-    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) {};
+    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) { };
   }
 
   /// Residual: G = K_eq * [reactant] - [product]
@@ -164,7 +164,7 @@ class ConservativeEquilibriumConstraintModel
   std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> ConstraintUpdateStateParametersFunction(
       const std::unordered_map<std::string, std::size_t>&) const
   {
-    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) {};
+    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) { };
   }
 
   template<typename DenseMatrixPolicy>
@@ -268,7 +268,7 @@ class MassConservationModel
   std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> ConstraintUpdateStateParametersFunction(
       const std::unordered_map<std::string, std::size_t>&) const
   {
-    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) {};
+    return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) { };
   }
 
   template<typename DenseMatrixPolicy>
@@ -433,12 +433,13 @@ TEST(ExternalModelConstraints, CombinedBuiltInAndExternalConstraints)
   // Built-in constraint: B <-> C equilibrium
   double K_eq = 5.0;
   std::vector<micm::Constraint> constraints;
-  constraints.push_back(micm::EquilibriumConstraint(
-      "B_C_eq",
-      C,
-      std::vector<micm::StoichSpecies>{ { B, 1.0 } },
-      std::vector<micm::StoichSpecies>{ { C, 1.0 } },
-      micm::VantHoffParam{ K_eq, 0.0 }));
+  constraints.push_back(
+      micm::EquilibriumConstraint(
+          "B_C_eq",
+          C,
+          std::vector<micm::StoichSpecies>{ { B, 1.0 } },
+          std::vector<micm::StoichSpecies>{ { C, 1.0 } },
+          micm::VantHoffParam{ K_eq, 0.0 }));
 
   // Process: A_GAS -> B
   double k_rxn = 0.05;
@@ -836,12 +837,13 @@ TEST(ExternalModelConstraints, BuiltInVsExternalModelConstraintStepByStep)
 
   // Built-in constraint solver
   std::vector<micm::Constraint> constraints;
-  constraints.push_back(micm::EquilibriumConstraint(
-      "B_C_eq",
-      C,
-      std::vector<micm::StoichSpecies>{ { B, 1.0 } },
-      std::vector<micm::StoichSpecies>{ { C, 1.0 } },
-      micm::VantHoffParam{ K_EQ, 0.0 }));
+  constraints.push_back(
+      micm::EquilibriumConstraint(
+          "B_C_eq",
+          C,
+          std::vector<micm::StoichSpecies>{ { B, 1.0 } },
+          std::vector<micm::StoichSpecies>{ { C, 1.0 } },
+          micm::VantHoffParam{ K_EQ, 0.0 }));
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto builtin_solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)

--- a/test/regression/RosenbrockChapman/regression_test_solve_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_solve_policy.hpp
@@ -25,12 +25,13 @@ void testSolve(SolverPolicy& solver, double relative_tolerance = 1.0e-8)
   state.conditions_[2].pressure_ = 101398.0;   // [Pa]
   std::vector<std::vector<double>> variables(3, std::vector<double>(fixed_state.variables_.NumColumns(), 0.0));
   double abs_tol = 0.0;
-  for (int i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < fixed_state.variables_.NumColumns(); ++j)
     {
       variables[i][j] = get_double();
       abs_tol = std::max(abs_tol, variables[i][j]);
     }
+}
   state.variables_ = variables;
   abs_tol *= 1.0e-12;
 
@@ -51,11 +52,12 @@ void testSolve(SolverPolicy& solver, double relative_tolerance = 1.0e-8)
   }
 
   // compare results
-  for (int i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < fixed_results[i].result_.size(); ++j)
     {
       double a = state.variables_[i][state.variable_map_[fixed_solver.species_names()[j]]];
       double b = fixed_results[i].result_[j];
       EXPECT_NEAR(a, b, (std::abs(a) + std::abs(b)) * relative_tolerance + abs_tol);
     }
+}
 }

--- a/test/regression/RosenbrockChapman/regression_test_solve_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_solve_policy.hpp
@@ -25,13 +25,14 @@ void testSolve(SolverPolicy& solver, double relative_tolerance = 1.0e-8)
   state.conditions_[2].pressure_ = 101398.0;   // [Pa]
   std::vector<std::vector<double>> variables(3, std::vector<double>(fixed_state.variables_.NumColumns(), 0.0));
   double abs_tol = 0.0;
-  for (int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 3; ++i)
+  {
     for (int j = 0; j < fixed_state.variables_.NumColumns(); ++j)
     {
       variables[i][j] = get_double();
       abs_tol = std::max(abs_tol, variables[i][j]);
     }
-}
+  }
   state.variables_ = variables;
   abs_tol *= 1.0e-12;
 
@@ -52,12 +53,13 @@ void testSolve(SolverPolicy& solver, double relative_tolerance = 1.0e-8)
   }
 
   // compare results
-  for (int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 3; ++i)
+  {
     for (int j = 0; j < fixed_results[i].result_.size(); ++j)
     {
       double a = state.variables_[i][state.variable_map_[fixed_solver.species_names()[j]]];
       double b = fixed_results[i].result_[j];
       EXPECT_NEAR(a, b, (std::abs(a) + std::abs(b)) * relative_tolerance + abs_tol);
     }
-}
+  }
 }

--- a/test/regression/regression_policy.hpp
+++ b/test/regression/regression_policy.hpp
@@ -106,9 +106,9 @@ void test_flow_tube(
     BuilderPolicy builder,
     std::string expected_results_path,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * SOA1 ->                                , k1 = 0.01

--- a/test/unit/constraint/test_constraint_set_policy.hpp
+++ b/test/unit/constraint/test_constraint_set_policy.hpp
@@ -163,9 +163,10 @@ void testAddForcingTerms()
   // Build sparse Jacobian for SetConstraintFunctions
   auto non_zero_elements = set.NonZeroJacobianElements();
   auto builder = SparseMatrixPolicy::Create(num_species).SetNumberOfBlocks(2).InitialValue(0.0);
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   SparseMatrixPolicy jacobian{ builder };
@@ -220,9 +221,10 @@ void testSubtractJacobianTerms()
   // Build a 3x3 sparse Jacobian (constraint replaces AB's row)
   auto builder = SparseMatrixPolicy::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);  // Diagonals
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -340,9 +342,10 @@ void testThreeDStateOneConstraint()
                      .SetNumberOfBlocks(2)  // Test with 2 grid cells
                      .InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -454,9 +457,10 @@ void testFourDStateTwoConstraints()
                      .SetNumberOfBlocks(3)  // Test with 3 grid cells
                      .InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -591,9 +595,10 @@ void testCoupledConstraintsSharedSpecies()
   // Build Jacobian (3x3)
   auto builder = SparseMatrixPolicy::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -658,9 +663,10 @@ void testVectorizedMatricesRespectGridCellIndexing()
 
   // Constraint replaces AB's row (index 2), Jacobian is 3x3
   auto builder = SparseMatrixPolicy::Create(num_species).SetNumberOfBlocks(3).InitialValue(0.0);
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 

--- a/test/unit/constraint/test_constraint_set_policy.hpp
+++ b/test/unit/constraint/test_constraint_set_policy.hpp
@@ -163,8 +163,9 @@ void testAddForcingTerms()
   // Build sparse Jacobian for SetConstraintFunctions
   auto non_zero_elements = set.NonZeroJacobianElements();
   auto builder = SparseMatrixPolicy::Create(num_species).SetNumberOfBlocks(2).InitialValue(0.0);
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   SparseMatrixPolicy jacobian{ builder };
@@ -219,8 +220,9 @@ void testSubtractJacobianTerms()
   // Build a 3x3 sparse Jacobian (constraint replaces AB's row)
   auto builder = SparseMatrixPolicy::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);  // Diagonals
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -338,8 +340,9 @@ void testThreeDStateOneConstraint()
                      .SetNumberOfBlocks(2)  // Test with 2 grid cells
                      .InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -451,8 +454,9 @@ void testFourDStateTwoConstraints()
                      .SetNumberOfBlocks(3)  // Test with 3 grid cells
                      .InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -587,8 +591,9 @@ void testCoupledConstraintsSharedSpecies()
   // Build Jacobian (3x3)
   auto builder = SparseMatrixPolicy::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -653,8 +658,9 @@ void testVectorizedMatricesRespectGridCellIndexing()
 
   // Constraint replaces AB's row (index 2), Jacobian is 3x3
   auto builder = SparseMatrixPolicy::Create(num_species).SetNumberOfBlocks(3).InitialValue(0.0);
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 

--- a/test/unit/constraint/type/test_equilibrium.cpp
+++ b/test/unit/constraint/type/test_equilibrium.cpp
@@ -243,9 +243,10 @@ TEST(EquilibriumConstraint, ResidualComputationThroughConstraintSet)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -317,9 +318,10 @@ TEST(EquilibriumConstraint, JacobianComputationThroughConstraintSet)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);  // Diagonals
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -380,9 +382,10 @@ TEST(EquilibriumConstraint, ComplexStoichiometryResidual)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -434,9 +437,10 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianSimple)
 
   auto non_zero_elements = set.NonZeroJacobianElements();
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(2).InitialValue(0.0);
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   StandardSparseMatrix jacobian{ builder };
@@ -500,9 +504,10 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianComplexStoichiometry)
 
   auto non_zero_elements = set.NonZeroJacobianElements();
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   StandardSparseMatrix jacobian{ builder };

--- a/test/unit/constraint/type/test_equilibrium.cpp
+++ b/test/unit/constraint/type/test_equilibrium.cpp
@@ -243,8 +243,9 @@ TEST(EquilibriumConstraint, ResidualComputationThroughConstraintSet)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -316,8 +317,9 @@ TEST(EquilibriumConstraint, JacobianComputationThroughConstraintSet)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);  // Diagonals
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -378,8 +380,9 @@ TEST(EquilibriumConstraint, ComplexStoichiometryResidual)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -431,8 +434,9 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianSimple)
 
   auto non_zero_elements = set.NonZeroJacobianElements();
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(2).InitialValue(0.0);
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   StandardSparseMatrix jacobian{ builder };
@@ -496,8 +500,9 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianComplexStoichiometry)
 
   auto non_zero_elements = set.NonZeroJacobianElements();
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   StandardSparseMatrix jacobian{ builder };

--- a/test/unit/constraint/type/test_linear.cpp
+++ b/test/unit/constraint/type/test_linear.cpp
@@ -140,8 +140,9 @@ TEST(LinearConstraint, ResidualComputationThroughConstraintSet)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -204,8 +205,9 @@ TEST(LinearConstraint, JacobianComputationThroughConstraintSet)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);  // Diagonals
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -259,8 +261,9 @@ TEST(LinearConstraint, WeightedSumResidualAndJacobian)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -329,8 +332,9 @@ TEST(LinearConstraint, ThreeSpeciesConservationResidual)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -390,8 +394,9 @@ TEST(LinearConstraint, ZeroConstantResidual)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -449,8 +454,9 @@ TEST(LinearConstraint, FractionalCoefficientsResidualAndJacobian)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -504,8 +510,9 @@ TEST(LinearConstraint, JacobianIndependentOfConcentrations)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -569,8 +576,9 @@ TEST(LinearConstraint, FiniteDifferenceJacobianSimpleConservation)
 
   auto non_zero_elements = set.NonZeroJacobianElements();
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(2).InitialValue(0.0);
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   StandardSparseMatrix jacobian{ builder };
@@ -631,8 +639,9 @@ TEST(LinearConstraint, FiniteDifferenceJacobianWeightedSum)
 
   auto non_zero_elements = set.NonZeroJacobianElements();
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
-  for (std::size_t i = 0; i < num_species; ++i)
+  for (std::size_t i = 0; i < num_species; ++i) {
     builder = builder.WithElement(i, i);
+}
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   StandardSparseMatrix jacobian{ builder };

--- a/test/unit/constraint/type/test_linear.cpp
+++ b/test/unit/constraint/type/test_linear.cpp
@@ -140,9 +140,10 @@ TEST(LinearConstraint, ResidualComputationThroughConstraintSet)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -205,9 +206,10 @@ TEST(LinearConstraint, JacobianComputationThroughConstraintSet)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);  // Diagonals
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -261,9 +263,10 @@ TEST(LinearConstraint, WeightedSumResidualAndJacobian)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -332,9 +335,10 @@ TEST(LinearConstraint, ThreeSpeciesConservationResidual)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -394,9 +398,10 @@ TEST(LinearConstraint, ZeroConstantResidual)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -454,9 +459,10 @@ TEST(LinearConstraint, FractionalCoefficientsResidualAndJacobian)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -510,9 +516,10 @@ TEST(LinearConstraint, JacobianIndependentOfConcentrations)
 
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
 
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
@@ -576,9 +583,10 @@ TEST(LinearConstraint, FiniteDifferenceJacobianSimpleConservation)
 
   auto non_zero_elements = set.NonZeroJacobianElements();
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(2).InitialValue(0.0);
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   StandardSparseMatrix jacobian{ builder };
@@ -639,9 +647,10 @@ TEST(LinearConstraint, FiniteDifferenceJacobianWeightedSum)
 
   auto non_zero_elements = set.NonZeroJacobianElements();
   auto builder = StandardSparseMatrix::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
-  for (std::size_t i = 0; i < num_species; ++i) {
+  for (std::size_t i = 0; i < num_species; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
   for (auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   StandardSparseMatrix jacobian{ builder };

--- a/test/unit/cuda/util/cuda_gtest_main.cpp
+++ b/test/unit/cuda/util/cuda_gtest_main.cpp
@@ -2,7 +2,7 @@
 
 #include <gtest/gtest.h>
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -68,10 +68,12 @@ static void SortLikeBuilder(std::vector<Process>& procs)
 /// @brief Return the custom parameter labels that BuildFrom assigns for a process.
 static std::vector<std::string> CustomParamLabels(const Process& proc)
 {
-  if (const auto* p = std::get_if<UserDefinedRateConstantParameters>(&proc.process_.rate_constant_))
+  if (const auto* p = std::get_if<UserDefinedRateConstantParameters>(&proc.process_.rate_constant_)) {
     return { p->label_ };
-  if (const auto* p = std::get_if<SurfaceRateConstantParameters>(&proc.process_.rate_constant_))
+}
+  if (const auto* p = std::get_if<SurfaceRateConstantParameters>(&proc.process_.rate_constant_)) {
     return { p->label_ + ".effective radius [m]", p->label_ + ".particle number concentration [# m-3]" };
+}
   return {};
 }
 
@@ -239,6 +241,7 @@ TEST(Process, ChemicalReactionCopyAssignmentSucceeds)
   const auto* orig_arr = std::get_if<ArrheniusRateConstantParameters>(&original.rate_constant_);
   EXPECT_NE(copy_arr, nullptr);
   EXPECT_NE(orig_arr, nullptr);
-  if (copy_arr && orig_arr)
+  if (copy_arr && orig_arr) {
     EXPECT_EQ(copy_arr->A_, orig_arr->A_);
+}
 }

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -68,12 +68,14 @@ static void SortLikeBuilder(std::vector<Process>& procs)
 /// @brief Return the custom parameter labels that BuildFrom assigns for a process.
 static std::vector<std::string> CustomParamLabels(const Process& proc)
 {
-  if (const auto* p = std::get_if<UserDefinedRateConstantParameters>(&proc.process_.rate_constant_)) {
+  if (const auto* p = std::get_if<UserDefinedRateConstantParameters>(&proc.process_.rate_constant_))
+  {
     return { p->label_ };
-}
-  if (const auto* p = std::get_if<SurfaceRateConstantParameters>(&proc.process_.rate_constant_)) {
+  }
+  if (const auto* p = std::get_if<SurfaceRateConstantParameters>(&proc.process_.rate_constant_))
+  {
     return { p->label_ + ".effective radius [m]", p->label_ + ".particle number concentration [# m-3]" };
-}
+  }
   return {};
 }
 
@@ -241,7 +243,8 @@ TEST(Process, ChemicalReactionCopyAssignmentSucceeds)
   const auto* orig_arr = std::get_if<ArrheniusRateConstantParameters>(&original.rate_constant_);
   EXPECT_NE(copy_arr, nullptr);
   EXPECT_NE(orig_arr, nullptr);
-  if (copy_arr && orig_arr) {
+  if (copy_arr && orig_arr)
+  {
     EXPECT_EQ(copy_arr->A_, orig_arr->A_);
-}
+  }
 }

--- a/test/unit/process/test_process_set_policy.hpp
+++ b/test/unit/process/test_process_set_policy.hpp
@@ -137,9 +137,10 @@ void testProcessSet()
   compare_pair(*(++elem), index_pair(4, 2));
 
   auto builder = SparseMatrixPolicy::Create(5).SetNumberOfBlocks(2).InitialValue(100.0);
-  for (auto& elem : non_zero_elements) {
+  for (auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
-}
+  }
   SparseMatrixPolicy jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
 
@@ -330,9 +331,10 @@ void testAlgebraicMasking()
     // Build Jacobian structure
     auto non_zero_elements = process_set.NonZeroJacobianElements();
     auto builder = SparseMatrixPolicy::Create(4).SetNumberOfBlocks(2).InitialValue(500.0);
-    for (auto& elem : non_zero_elements) {
+    for (auto& elem : non_zero_elements)
+    {
       builder = builder.WithElement(elem.first, elem.second);
-}
+    }
     SparseMatrixPolicy jacobian{ builder };
     process_set.SetJacobianFlatIds(jacobian);
 
@@ -432,9 +434,10 @@ void testProcessSetFiniteDifferenceJacobian()
   // Build analytical Jacobian
   auto non_zero_elements = process_set.NonZeroJacobianElements();
   auto builder = SparseMatrixPolicy::Create(num_species).SetNumberOfBlocks(2).InitialValue(0.0);
-  for (auto& elem : non_zero_elements) {
+  for (auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
-}
+  }
   SparseMatrixPolicy analytical_jacobian{ builder };
   process_set.SetJacobianFlatIds(analytical_jacobian);
 

--- a/test/unit/process/test_process_set_policy.hpp
+++ b/test/unit/process/test_process_set_policy.hpp
@@ -137,8 +137,9 @@ void testProcessSet()
   compare_pair(*(++elem), index_pair(4, 2));
 
   auto builder = SparseMatrixPolicy::Create(5).SetNumberOfBlocks(2).InitialValue(100.0);
-  for (auto& elem : non_zero_elements)
+  for (auto& elem : non_zero_elements) {
     builder = builder.WithElement(elem.first, elem.second);
+}
   SparseMatrixPolicy jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
 
@@ -329,8 +330,9 @@ void testAlgebraicMasking()
     // Build Jacobian structure
     auto non_zero_elements = process_set.NonZeroJacobianElements();
     auto builder = SparseMatrixPolicy::Create(4).SetNumberOfBlocks(2).InitialValue(500.0);
-    for (auto& elem : non_zero_elements)
+    for (auto& elem : non_zero_elements) {
       builder = builder.WithElement(elem.first, elem.second);
+}
     SparseMatrixPolicy jacobian{ builder };
     process_set.SetJacobianFlatIds(jacobian);
 
@@ -430,8 +432,9 @@ void testProcessSetFiniteDifferenceJacobian()
   // Build analytical Jacobian
   auto non_zero_elements = process_set.NonZeroJacobianElements();
   auto builder = SparseMatrixPolicy::Create(num_species).SetNumberOfBlocks(2).InitialValue(0.0);
-  for (auto& elem : non_zero_elements)
+  for (auto& elem : non_zero_elements) {
     builder = builder.WithElement(elem.first, elem.second);
+}
   SparseMatrixPolicy analytical_jacobian{ builder };
   process_set.SetJacobianFlatIds(analytical_jacobian);
 

--- a/test/unit/process/test_reaction_rate_store.cpp
+++ b/test/unit/process/test_reaction_rate_store.cpp
@@ -93,42 +93,48 @@ TEST(ReactionRateConstantStore, OffsetsAreContiguousCumulativeSizes)
   Phase gas{ "gas", { PhaseSpecies(a), PhaseSpecies(b), gas_c } };
 
   std::vector<Process> procs;
-  procs.push_back(ChemicalReactionBuilder()
-                      .SetReactants({ a })
-                      .SetProducts({ StoichSpecies(b, 1) })
-                      .SetRateConstant(ArrheniusRateConstantParameters{})
-                      .SetPhase(gas)
-                      .Build());
-  procs.push_back(ChemicalReactionBuilder()
-                      .SetReactants({ a })
-                      .SetProducts({ StoichSpecies(b, 1) })
-                      .SetRateConstant(ArrheniusRateConstantParameters{})
-                      .SetPhase(gas)
-                      .Build());
-  procs.push_back(ChemicalReactionBuilder()
-                      .SetReactants({ a })
-                      .SetProducts({ StoichSpecies(b, 1) })
-                      .SetRateConstant(TroeRateConstantParameters{ .k0_A_ = 1.0, .kinf_A_ = 1.0 })
-                      .SetPhase(gas)
-                      .Build());
-  procs.push_back(ChemicalReactionBuilder()
-                      .SetReactants({ a })
-                      .SetProducts({ StoichSpecies(b, 1) })
-                      .SetRateConstant(TunnelingRateConstantParameters{})
-                      .SetPhase(gas)
-                      .Build());
-  procs.push_back(ChemicalReactionBuilder()
-                      .SetReactants({ a })
-                      .SetProducts({ StoichSpecies(b, 1) })
-                      .SetRateConstant(UserDefinedRateConstantParameters{ .label_ = "ud1" })
-                      .SetPhase(gas)
-                      .Build());
-  procs.push_back(ChemicalReactionBuilder()
-                      .SetReactants({ c })
-                      .SetProducts({ StoichSpecies(b, 1) })
-                      .SetRateConstant(SurfaceRateConstantParameters{ .label_ = "surf1", .phase_species_ = gas_c })
-                      .SetPhase(gas)
-                      .Build());
+  procs.push_back(
+      ChemicalReactionBuilder()
+          .SetReactants({ a })
+          .SetProducts({ StoichSpecies(b, 1) })
+          .SetRateConstant(ArrheniusRateConstantParameters{})
+          .SetPhase(gas)
+          .Build());
+  procs.push_back(
+      ChemicalReactionBuilder()
+          .SetReactants({ a })
+          .SetProducts({ StoichSpecies(b, 1) })
+          .SetRateConstant(ArrheniusRateConstantParameters{})
+          .SetPhase(gas)
+          .Build());
+  procs.push_back(
+      ChemicalReactionBuilder()
+          .SetReactants({ a })
+          .SetProducts({ StoichSpecies(b, 1) })
+          .SetRateConstant(TroeRateConstantParameters{ .k0_A_ = 1.0, .kinf_A_ = 1.0 })
+          .SetPhase(gas)
+          .Build());
+  procs.push_back(
+      ChemicalReactionBuilder()
+          .SetReactants({ a })
+          .SetProducts({ StoichSpecies(b, 1) })
+          .SetRateConstant(TunnelingRateConstantParameters{})
+          .SetPhase(gas)
+          .Build());
+  procs.push_back(
+      ChemicalReactionBuilder()
+          .SetReactants({ a })
+          .SetProducts({ StoichSpecies(b, 1) })
+          .SetRateConstant(UserDefinedRateConstantParameters{ .label_ = "ud1" })
+          .SetPhase(gas)
+          .Build());
+  procs.push_back(
+      ChemicalReactionBuilder()
+          .SetReactants({ c })
+          .SetProducts({ StoichSpecies(b, 1) })
+          .SetRateConstant(SurfaceRateConstantParameters{ .label_ = "surf1", .phase_species_ = gas_c })
+          .SetPhase(gas)
+          .Build());
 
   SortByTypeOrder(procs);
   auto store = ReactionRateConstantStore::BuildFrom(procs);
@@ -410,36 +416,41 @@ TEST(ReactionRateConstantStore, TotalRateConstantsMatchesProcessCount)
   SurfaceRateConstantParameters surf{ .label_ = "surf", .phase_species_ = gas_c };
 
   std::vector<Process> procs;
-  procs.push_back(ChemicalReactionBuilder()
-                      .SetReactants({ a })
-                      .SetProducts({ StoichSpecies(b, 1) })
-                      .SetRateConstant(ArrheniusRateConstantParameters{})
-                      .SetPhase(gas)
-                      .Build());
-  procs.push_back(ChemicalReactionBuilder()
-                      .SetReactants({ a })
-                      .SetProducts({ StoichSpecies(b, 1) })
-                      .SetRateConstant(TroeRateConstantParameters{ .k0_A_ = 1.0, .kinf_A_ = 1.0 })
-                      .SetPhase(gas)
-                      .Build());
-  procs.push_back(ChemicalReactionBuilder()
-                      .SetReactants({ a })
-                      .SetProducts({ StoichSpecies(b, 1) })
-                      .SetRateConstant(UserDefinedRateConstantParameters{ .label_ = "ud" })
-                      .SetPhase(gas)
-                      .Build());
-  procs.push_back(ChemicalReactionBuilder()
-                      .SetReactants({ c })
-                      .SetProducts({ StoichSpecies(b, 1) })
-                      .SetRateConstant(surf)
-                      .SetPhase(gas)
-                      .Build());
-  procs.push_back(ChemicalReactionBuilder()
-                      .SetReactants({ a })
-                      .SetProducts({ StoichSpecies(b, 1) })
-                      .SetRateConstant(lam)
-                      .SetPhase(gas)
-                      .Build());
+  procs.push_back(
+      ChemicalReactionBuilder()
+          .SetReactants({ a })
+          .SetProducts({ StoichSpecies(b, 1) })
+          .SetRateConstant(ArrheniusRateConstantParameters{})
+          .SetPhase(gas)
+          .Build());
+  procs.push_back(
+      ChemicalReactionBuilder()
+          .SetReactants({ a })
+          .SetProducts({ StoichSpecies(b, 1) })
+          .SetRateConstant(TroeRateConstantParameters{ .k0_A_ = 1.0, .kinf_A_ = 1.0 })
+          .SetPhase(gas)
+          .Build());
+  procs.push_back(
+      ChemicalReactionBuilder()
+          .SetReactants({ a })
+          .SetProducts({ StoichSpecies(b, 1) })
+          .SetRateConstant(UserDefinedRateConstantParameters{ .label_ = "ud" })
+          .SetPhase(gas)
+          .Build());
+  procs.push_back(
+      ChemicalReactionBuilder()
+          .SetReactants({ c })
+          .SetProducts({ StoichSpecies(b, 1) })
+          .SetRateConstant(surf)
+          .SetPhase(gas)
+          .Build());
+  procs.push_back(
+      ChemicalReactionBuilder()
+          .SetReactants({ a })
+          .SetProducts({ StoichSpecies(b, 1) })
+          .SetRateConstant(lam)
+          .SetPhase(gas)
+          .Build());
 
   SortByTypeOrder(procs);
   auto store = ReactionRateConstantStore::BuildFrom(procs);

--- a/test/unit/solver/test_linear_solver_in_place_policy.hpp
+++ b/test/unit/solver/test_linear_solver_in_place_policy.hpp
@@ -22,11 +22,13 @@ void check_results(
     for (std::size_t i = 0; i < A.NumRows(); ++i)
     {
       result = 0.0;
-      for (std::size_t j = 0; j < A.NumColumns(); ++j) {
-        if (!A.IsZero(i, j)) {
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
+      {
+        if (!A.IsZero(i, j))
+        {
           result += A[i_block][i][j] * x[i_block][j];
-}
-}
+        }
+      }
       f(b[i_block][i], result);
     }
   }
@@ -62,17 +64,18 @@ void testDenseMatrix()
 {
   using FloatingPointType = typename MatrixPolicy::value_type;
 
-  SparseMatrixPolicy A = SparseMatrixPolicy(SparseMatrixPolicy::Create(3)
-                                                .InitialValue(0)
-                                                .WithElement(0, 0)
-                                                .WithElement(0, 1)
-                                                .WithElement(0, 2)
-                                                .WithElement(1, 0)
-                                                .WithElement(1, 1)
-                                                .WithElement(1, 2)
-                                                .WithElement(2, 0)
-                                                .WithElement(2, 1)
-                                                .WithElement(2, 2));
+  SparseMatrixPolicy A = SparseMatrixPolicy(
+      SparseMatrixPolicy::Create(3)
+          .InitialValue(0)
+          .WithElement(0, 0)
+          .WithElement(0, 1)
+          .WithElement(0, 2)
+          .WithElement(1, 0)
+          .WithElement(1, 1)
+          .WithElement(1, 2)
+          .WithElement(2, 0)
+          .WithElement(2, 1)
+          .WithElement(2, 2));
   MatrixPolicy b(1, 3, 0.0);
   MatrixPolicy x(1, 3, 0.0);
 
@@ -99,13 +102,16 @@ void testDenseMatrix()
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
   auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   alu.Fill(0);
-  for (std::size_t i = 0; i < A.NumRows(); ++i) {
-    for (std::size_t j = 0; j < A.NumColumns(); ++j) {
-      if (!A.IsZero(i, j)) {
+  for (std::size_t i = 0; i < A.NumRows(); ++i)
+  {
+    for (std::size_t j = 0; j < A.NumColumns(); ++j)
+    {
+      if (!A.IsZero(i, j))
+      {
         alu[0][i][j] = A[0][i][j];
-}
-}
-}
+      }
+    }
+  }
 
   // Only copy the data to the device when it is a CudaMatrix
   CheckCopyToDevice<SparseMatrixPolicy>(alu);
@@ -129,33 +135,42 @@ void testRandomMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 10; ++i) {
-    for (std::size_t j = 0; j < 10; ++j) {
-      if (i == j || gen_bool()) {
+  for (std::size_t i = 0; i < 10; ++i)
+  {
+    for (std::size_t j = 0; j < 10; ++j)
+    {
+      if (i == j || gen_bool())
+      {
         builder = builder.WithElement(i, j);
-}
-}
-}
+      }
+    }
+  }
 
   SparseMatrixPolicy A(builder);
   MatrixPolicy b(number_of_blocks, 10, 0.0);
   MatrixPolicy x(number_of_blocks, 10, 0.0);
 
-  for (std::size_t i = 0; i < 10; ++i) {
-    for (std::size_t j = 0; j < 10; ++j) {
-      if (!A.IsZero(i, j)) {
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < 10; ++i)
+  {
+    for (std::size_t j = 0; j < 10; ++j)
+    {
+      if (!A.IsZero(i, j))
+      {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+        {
           A[i_block][i][j] = get_double();
-}
-}
-}
-}
+        }
+      }
+    }
+  }
 
-  for (std::size_t i = 0; i < 10; ++i) {
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < 10; ++i)
+  {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    {
       b[i_block][i] = get_double();
-}
-}
+    }
+  }
 
   x = b;
 
@@ -165,15 +180,19 @@ void testRandomMatrix(std::size_t number_of_blocks)
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
   auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   alu.Fill(0);
-  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
-    for (std::size_t i = 0; i < A.NumRows(); ++i) {
-      for (std::size_t j = 0; j < A.NumColumns(); ++j) {
-        if (!A.IsZero(i, j)) {
+  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  {
+    for (std::size_t i = 0; i < A.NumRows(); ++i)
+    {
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
+      {
+        if (!A.IsZero(i, j))
+        {
           alu[i_block][i][j] = A[i_block][i][j];
-}
-}
-}
-}
+        }
+      }
+    }
+  }
 
   // Only copy the data to the device when it is a CudaMatrix
   CheckCopyToDevice<SparseMatrixPolicy>(alu);
@@ -218,21 +237,27 @@ void testExtremeInitialValue(std::size_t number_of_blocks, double initial_value)
   MatrixPolicy b(number_of_blocks, size, 0.0);
   MatrixPolicy x(number_of_blocks, size, 0.0);
 
-  for (std::size_t i = 0; i < size; ++i) {
-    for (std::size_t j = 0; j < size; ++j) {
-      if (!A.IsZero(i, j)) {
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t j = 0; j < size; ++j)
+    {
+      if (!A.IsZero(i, j))
+      {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+        {
           A[i_block][i][j] = get_double();
-}
-}
-}
-}
+        }
+      }
+    }
+  }
 
-  for (std::size_t i = 0; i < size; ++i) {
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    {
       b[i_block][i] = get_double();
-}
-}
+    }
+  }
 
   x = b;
 
@@ -241,17 +266,23 @@ void testExtremeInitialValue(std::size_t number_of_blocks, double initial_value)
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, initial_value);
   auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, initial_value, false);
-  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
-    for (std::size_t i = 0; i < A.NumRows(); ++i) {
-      for (std::size_t j = 0; j < A.NumColumns(); ++j) {
-        if (!A.IsZero(i, j)) {
+  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  {
+    for (std::size_t i = 0; i < A.NumRows(); ++i)
+    {
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
+      {
+        if (!A.IsZero(i, j))
+        {
           alu[i_block][i][j] = A[i_block][i][j];
-        } else if (!alu.IsZero(i, j)) {
+        }
+        else if (!alu.IsZero(i, j))
+        {
           alu[i_block][i][j] = 0;
-}
-}
-}
-}
+        }
+      }
+    }
+  }
 
   // Only copy the data to the device when it is a CudaMatrix
   CheckCopyToDevice<SparseMatrixPolicy>(alu);
@@ -278,25 +309,30 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(6).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 6; ++i) {
+  for (std::size_t i = 0; i < 6; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
 
   SparseMatrixPolicy A(builder);
   MatrixPolicy b(number_of_blocks, 6, 0.0);
   MatrixPolicy x(number_of_blocks, 6, 0.0);
 
-  for (std::size_t i = 0; i < 6; ++i) {
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < 6; ++i)
+  {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    {
       A[i_block][i][i] = get_double();
-}
-}
+    }
+  }
 
-  for (std::size_t i = 0; i < 6; ++i) {
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < 6; ++i)
+  {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    {
       b[i_block][i] = get_double();
-}
-}
+    }
+  }
 
   x = b;
 
@@ -306,15 +342,19 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
   auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   alu.Fill(0);
-  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
-    for (std::size_t i = 0; i < A.NumRows(); ++i) {
-      for (std::size_t j = 0; j < A.NumColumns(); ++j) {
-        if (!A.IsZero(i, j)) {
+  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  {
+    for (std::size_t i = 0; i < A.NumRows(); ++i)
+    {
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
+      {
+        if (!A.IsZero(i, j))
+        {
           alu[i_block][i][j] = A[i_block][i][j];
-}
-}
-}
-}
+        }
+      }
+    }
+  }
 
   // Only copy the data to the device when it is a CudaMatrix
   CheckCopyToDevice<SparseMatrixPolicy>(alu);
@@ -336,32 +376,40 @@ void testMarkowitzReordering()
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   MatrixPolicy orig(order, order, 0);
 
-  for (std::size_t i = 0; i < order; ++i) {
-    for (std::size_t j = 0; j < order; ++j) {
+  for (std::size_t i = 0; i < order; ++i)
+  {
+    for (std::size_t j = 0; j < order; ++j)
+    {
       orig[i][j] = (i == j || gen_bool()) ? 1 : 0;
-}
-}
+    }
+  }
 
   auto reorder_map = micm::DiagonalMarkowitzReorder<MatrixPolicy>(orig);
 
   auto builder = SparseMatrixPolicy::Create(50);
-  for (std::size_t i = 0; i < order; ++i) {
-    for (std::size_t j = 0; j < order; ++j) {
-      if (orig[i][j] != 0) {
+  for (std::size_t i = 0; i < order; ++i)
+  {
+    for (std::size_t j = 0; j < order; ++j)
+    {
+      if (orig[i][j] != 0)
+      {
         builder = builder.WithElement(i, j);
-}
-}
-}
+      }
+    }
+  }
   SparseMatrixPolicy orig_jac{ builder };
 
   builder = SparseMatrixPolicy::Create(50);
-  for (std::size_t i = 0; i < order; ++i) {
-    for (std::size_t j = 0; j < order; ++j) {
-      if (orig[reorder_map[i]][reorder_map[j]] != 0) {
+  for (std::size_t i = 0; i < order; ++i)
+  {
+    for (std::size_t j = 0; j < order; ++j)
+    {
+      if (orig[reorder_map[i]][reorder_map[j]] != 0)
+      {
         builder = builder.WithElement(i, j);
-}
-}
-}
+      }
+    }
+  }
   SparseMatrixPolicy reordered_jac{ builder };
 
   auto orig_LU_calc = micm::LuDecompositionInPlace::Create<SparseMatrixPolicy>(orig_jac);

--- a/test/unit/solver/test_linear_solver_in_place_policy.hpp
+++ b/test/unit/solver/test_linear_solver_in_place_policy.hpp
@@ -22,9 +22,11 @@ void check_results(
     for (std::size_t i = 0; i < A.NumRows(); ++i)
     {
       result = 0.0;
-      for (std::size_t j = 0; j < A.NumColumns(); ++j)
-        if (!A.IsZero(i, j))
+      for (std::size_t j = 0; j < A.NumColumns(); ++j) {
+        if (!A.IsZero(i, j)) {
           result += A[i_block][i][j] * x[i_block][j];
+}
+}
       f(b[i_block][i], result);
     }
   }
@@ -97,10 +99,13 @@ void testDenseMatrix()
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
   auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   alu.Fill(0);
-  for (std::size_t i = 0; i < A.NumRows(); ++i)
-    for (std::size_t j = 0; j < A.NumColumns(); ++j)
-      if (!A.IsZero(i, j))
+  for (std::size_t i = 0; i < A.NumRows(); ++i) {
+    for (std::size_t j = 0; j < A.NumColumns(); ++j) {
+      if (!A.IsZero(i, j)) {
         alu[0][i][j] = A[0][i][j];
+}
+}
+}
 
   // Only copy the data to the device when it is a CudaMatrix
   CheckCopyToDevice<SparseMatrixPolicy>(alu);
@@ -124,24 +129,33 @@ void testRandomMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 10; ++i)
-    for (std::size_t j = 0; j < 10; ++j)
-      if (i == j || gen_bool())
+  for (std::size_t i = 0; i < 10; ++i) {
+    for (std::size_t j = 0; j < 10; ++j) {
+      if (i == j || gen_bool()) {
         builder = builder.WithElement(i, j);
+}
+}
+}
 
   SparseMatrixPolicy A(builder);
   MatrixPolicy b(number_of_blocks, 10, 0.0);
   MatrixPolicy x(number_of_blocks, 10, 0.0);
 
-  for (std::size_t i = 0; i < 10; ++i)
-    for (std::size_t j = 0; j < 10; ++j)
-      if (!A.IsZero(i, j))
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < 10; ++i) {
+    for (std::size_t j = 0; j < 10; ++j) {
+      if (!A.IsZero(i, j)) {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
           A[i_block][i][j] = get_double();
+}
+}
+}
+}
 
-  for (std::size_t i = 0; i < 10; ++i)
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < 10; ++i) {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
       b[i_block][i] = get_double();
+}
+}
 
   x = b;
 
@@ -151,11 +165,15 @@ void testRandomMatrix(std::size_t number_of_blocks)
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
   auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   alu.Fill(0);
-  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
-    for (std::size_t i = 0; i < A.NumRows(); ++i)
-      for (std::size_t j = 0; j < A.NumColumns(); ++j)
-        if (!A.IsZero(i, j))
+  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+    for (std::size_t i = 0; i < A.NumRows(); ++i) {
+      for (std::size_t j = 0; j < A.NumColumns(); ++j) {
+        if (!A.IsZero(i, j)) {
           alu[i_block][i][j] = A[i_block][i][j];
+}
+}
+}
+}
 
   // Only copy the data to the device when it is a CudaMatrix
   CheckCopyToDevice<SparseMatrixPolicy>(alu);
@@ -200,15 +218,21 @@ void testExtremeInitialValue(std::size_t number_of_blocks, double initial_value)
   MatrixPolicy b(number_of_blocks, size, 0.0);
   MatrixPolicy x(number_of_blocks, size, 0.0);
 
-  for (std::size_t i = 0; i < size; ++i)
-    for (std::size_t j = 0; j < size; ++j)
-      if (!A.IsZero(i, j))
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < size; ++i) {
+    for (std::size_t j = 0; j < size; ++j) {
+      if (!A.IsZero(i, j)) {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
           A[i_block][i][j] = get_double();
+}
+}
+}
+}
 
-  for (std::size_t i = 0; i < size; ++i)
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < size; ++i) {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
       b[i_block][i] = get_double();
+}
+}
 
   x = b;
 
@@ -217,13 +241,17 @@ void testExtremeInitialValue(std::size_t number_of_blocks, double initial_value)
 
   LinearSolverPolicy solver = LinearSolverPolicy(A, initial_value);
   auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, initial_value, false);
-  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
-    for (std::size_t i = 0; i < A.NumRows(); ++i)
-      for (std::size_t j = 0; j < A.NumColumns(); ++j)
-        if (!A.IsZero(i, j))
+  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+    for (std::size_t i = 0; i < A.NumRows(); ++i) {
+      for (std::size_t j = 0; j < A.NumColumns(); ++j) {
+        if (!A.IsZero(i, j)) {
           alu[i_block][i][j] = A[i_block][i][j];
-        else if (!alu.IsZero(i, j))
+        } else if (!alu.IsZero(i, j)) {
           alu[i_block][i][j] = 0;
+}
+}
+}
+}
 
   // Only copy the data to the device when it is a CudaMatrix
   CheckCopyToDevice<SparseMatrixPolicy>(alu);
@@ -250,20 +278,25 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(6).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 6; ++i)
+  for (std::size_t i = 0; i < 6; ++i) {
     builder = builder.WithElement(i, i);
+}
 
   SparseMatrixPolicy A(builder);
   MatrixPolicy b(number_of_blocks, 6, 0.0);
   MatrixPolicy x(number_of_blocks, 6, 0.0);
 
-  for (std::size_t i = 0; i < 6; ++i)
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < 6; ++i) {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
       A[i_block][i][i] = get_double();
+}
+}
 
-  for (std::size_t i = 0; i < 6; ++i)
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < 6; ++i) {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
       b[i_block][i] = get_double();
+}
+}
 
   x = b;
 
@@ -273,11 +306,15 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   LinearSolverPolicy solver = LinearSolverPolicy(A, 0);
   auto alu = micm::LuDecompositionInPlace::GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   alu.Fill(0);
-  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
-    for (std::size_t i = 0; i < A.NumRows(); ++i)
-      for (std::size_t j = 0; j < A.NumColumns(); ++j)
-        if (!A.IsZero(i, j))
+  for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+    for (std::size_t i = 0; i < A.NumRows(); ++i) {
+      for (std::size_t j = 0; j < A.NumColumns(); ++j) {
+        if (!A.IsZero(i, j)) {
           alu[i_block][i][j] = A[i_block][i][j];
+}
+}
+}
+}
 
   // Only copy the data to the device when it is a CudaMatrix
   CheckCopyToDevice<SparseMatrixPolicy>(alu);
@@ -299,24 +336,32 @@ void testMarkowitzReordering()
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   MatrixPolicy orig(order, order, 0);
 
-  for (std::size_t i = 0; i < order; ++i)
-    for (std::size_t j = 0; j < order; ++j)
+  for (std::size_t i = 0; i < order; ++i) {
+    for (std::size_t j = 0; j < order; ++j) {
       orig[i][j] = (i == j || gen_bool()) ? 1 : 0;
+}
+}
 
   auto reorder_map = micm::DiagonalMarkowitzReorder<MatrixPolicy>(orig);
 
   auto builder = SparseMatrixPolicy::Create(50);
-  for (std::size_t i = 0; i < order; ++i)
-    for (std::size_t j = 0; j < order; ++j)
-      if (orig[i][j] != 0)
+  for (std::size_t i = 0; i < order; ++i) {
+    for (std::size_t j = 0; j < order; ++j) {
+      if (orig[i][j] != 0) {
         builder = builder.WithElement(i, j);
+}
+}
+}
   SparseMatrixPolicy orig_jac{ builder };
 
   builder = SparseMatrixPolicy::Create(50);
-  for (std::size_t i = 0; i < order; ++i)
-    for (std::size_t j = 0; j < order; ++j)
-      if (orig[reorder_map[i]][reorder_map[j]] != 0)
+  for (std::size_t i = 0; i < order; ++i) {
+    for (std::size_t j = 0; j < order; ++j) {
+      if (orig[reorder_map[i]][reorder_map[j]] != 0) {
         builder = builder.WithElement(i, j);
+}
+}
+}
   SparseMatrixPolicy reordered_jac{ builder };
 
   auto orig_LU_calc = micm::LuDecompositionInPlace::Create<SparseMatrixPolicy>(orig_jac);

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -13,8 +13,9 @@ void CopyToDeviceDense(MatrixPolicy& matrix)
 {
   if constexpr (requires {
                   { matrix.CopyToDevice() } -> std::same_as<void>;
-                })
+                }) {
     matrix.CopyToDevice();
+}
 }
 
 template<class SparseMatrixPolicy>
@@ -22,8 +23,9 @@ void CopyToDeviceSparse(SparseMatrixPolicy& matrix)
 {
   if constexpr (requires {
                   { matrix.CopyToDevice() } -> std::same_as<void>;
-                })
+                }) {
     matrix.CopyToDevice();
+}
 }
 
 template<class MatrixPolicy>
@@ -31,8 +33,9 @@ void CopyToHostDense(MatrixPolicy& matrix)
 {
   if constexpr (requires {
                   { matrix.CopyToHost() } -> std::same_as<void>;
-                })
+                }) {
     matrix.CopyToHost();
+}
 }
 
 template<typename T, class MatrixPolicy, class SparseMatrixPolicy>
@@ -50,9 +53,11 @@ void check_results(
     for (std::size_t i = 0; i < A.NumRows(); ++i)
     {
       result = 0.0;
-      for (std::size_t j = 0; j < A.NumColumns(); ++j)
-        if (!A.IsZero(i, j))
+      for (std::size_t j = 0; j < A.NumColumns(); ++j) {
+        if (!A.IsZero(i, j)) {
           result += A[i_block][i][j] * x[i_block][j];
+}
+}
       f(b[i_block][i], result);
     }
   }
@@ -151,24 +156,33 @@ void testRandomMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 10; ++i)
-    for (std::size_t j = 0; j < 10; ++j)
-      if (i == j || gen_bool())
+  for (std::size_t i = 0; i < 10; ++i) {
+    for (std::size_t j = 0; j < 10; ++j) {
+      if (i == j || gen_bool()) {
         builder = builder.WithElement(i, j);
+}
+}
+}
 
   SparseMatrixPolicy A(builder);
   MatrixPolicy b(number_of_blocks, 10, 0.0);
   MatrixPolicy x(number_of_blocks, 10, 0.0);
 
-  for (std::size_t i = 0; i < 10; ++i)
-    for (std::size_t j = 0; j < 10; ++j)
-      if (!A.IsZero(i, j))
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < 10; ++i) {
+    for (std::size_t j = 0; j < 10; ++j) {
+      if (!A.IsZero(i, j)) {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
           A[i_block][i][j] = get_double();
+}
+}
+}
+}
 
-  for (std::size_t i = 0; i < 10; ++i)
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < 10; ++i) {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
       b[i_block][i] = get_double();
+}
+}
 
   x = b;
 
@@ -225,15 +239,21 @@ void testExtremeInitialValue(std::size_t number_of_blocks, double initial_value)
   MatrixPolicy b(number_of_blocks, size, 0.0);
   MatrixPolicy x(number_of_blocks, size, 0.0);
 
-  for (std::size_t i = 0; i < size; ++i)
-    for (std::size_t j = 0; j < size; ++j)
-      if (!A.IsZero(i, j))
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < size; ++i) {
+    for (std::size_t j = 0; j < size; ++j) {
+      if (!A.IsZero(i, j)) {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
           A[i_block][i][j] = get_double();
+}
+}
+}
+}
 
-  for (std::size_t i = 0; i < size; ++i)
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < size; ++i) {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
       b[i_block][i] = get_double();
+}
+}
 
   x = b;
 
@@ -274,20 +294,25 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(6).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 6; ++i)
+  for (std::size_t i = 0; i < 6; ++i) {
     builder = builder.WithElement(i, i);
+}
 
   SparseMatrixPolicy A(builder);
   MatrixPolicy b(number_of_blocks, 6, 0.0);
   MatrixPolicy x(number_of_blocks, 6, 0.0);
 
-  for (std::size_t i = 0; i < 6; ++i)
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < 6; ++i) {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
       A[i_block][i][i] = get_double();
+}
+}
 
-  for (std::size_t i = 0; i < 6; ++i)
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < 6; ++i) {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
       b[i_block][i] = get_double();
+}
+}
 
   x = b;
 
@@ -321,24 +346,32 @@ void testMarkowitzReordering()
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   MatrixPolicy orig(order, order, 0);
 
-  for (std::size_t i = 0; i < order; ++i)
-    for (std::size_t j = 0; j < order; ++j)
+  for (std::size_t i = 0; i < order; ++i) {
+    for (std::size_t j = 0; j < order; ++j) {
       orig[i][j] = (i == j || gen_bool()) ? 1 : 0;
+}
+}
 
   auto reorder_map = micm::DiagonalMarkowitzReorder<MatrixPolicy>(orig);
 
   auto builder = SparseMatrixPolicy::Create(50);
-  for (std::size_t i = 0; i < order; ++i)
-    for (std::size_t j = 0; j < order; ++j)
-      if (orig[i][j] != 0)
+  for (std::size_t i = 0; i < order; ++i) {
+    for (std::size_t j = 0; j < order; ++j) {
+      if (orig[i][j] != 0) {
         builder = builder.WithElement(i, j);
+}
+}
+}
   SparseMatrixPolicy orig_jac{ builder };
 
   builder = SparseMatrixPolicy::Create(50);
-  for (std::size_t i = 0; i < order; ++i)
-    for (std::size_t j = 0; j < order; ++j)
-      if (orig[reorder_map[i]][reorder_map[j]] != 0)
+  for (std::size_t i = 0; i < order; ++i) {
+    for (std::size_t j = 0; j < order; ++j) {
+      if (orig[reorder_map[i]][reorder_map[j]] != 0) {
         builder = builder.WithElement(i, j);
+}
+}
+}
   SparseMatrixPolicy reordered_jac{ builder };
 
   auto orig_LU_calc = micm::LuDecomposition::Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(orig_jac);

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -13,9 +13,10 @@ void CopyToDeviceDense(MatrixPolicy& matrix)
 {
   if constexpr (requires {
                   { matrix.CopyToDevice() } -> std::same_as<void>;
-                }) {
+                })
+  {
     matrix.CopyToDevice();
-}
+  }
 }
 
 template<class SparseMatrixPolicy>
@@ -23,9 +24,10 @@ void CopyToDeviceSparse(SparseMatrixPolicy& matrix)
 {
   if constexpr (requires {
                   { matrix.CopyToDevice() } -> std::same_as<void>;
-                }) {
+                })
+  {
     matrix.CopyToDevice();
-}
+  }
 }
 
 template<class MatrixPolicy>
@@ -33,9 +35,10 @@ void CopyToHostDense(MatrixPolicy& matrix)
 {
   if constexpr (requires {
                   { matrix.CopyToHost() } -> std::same_as<void>;
-                }) {
+                })
+  {
     matrix.CopyToHost();
-}
+  }
 }
 
 template<typename T, class MatrixPolicy, class SparseMatrixPolicy>
@@ -53,11 +56,13 @@ void check_results(
     for (std::size_t i = 0; i < A.NumRows(); ++i)
     {
       result = 0.0;
-      for (std::size_t j = 0; j < A.NumColumns(); ++j) {
-        if (!A.IsZero(i, j)) {
+      for (std::size_t j = 0; j < A.NumColumns(); ++j)
+      {
+        if (!A.IsZero(i, j))
+        {
           result += A[i_block][i][j] * x[i_block][j];
-}
-}
+        }
+      }
       f(b[i_block][i], result);
     }
   }
@@ -93,17 +98,18 @@ void testDenseMatrix()
 {
   using FloatingPointType = typename MatrixPolicy::value_type;
 
-  SparseMatrixPolicy A = SparseMatrixPolicy(SparseMatrixPolicy::Create(3)
-                                                .InitialValue(0)
-                                                .WithElement(0, 0)
-                                                .WithElement(0, 1)
-                                                .WithElement(0, 2)
-                                                .WithElement(1, 0)
-                                                .WithElement(1, 1)
-                                                .WithElement(1, 2)
-                                                .WithElement(2, 0)
-                                                .WithElement(2, 1)
-                                                .WithElement(2, 2));
+  SparseMatrixPolicy A = SparseMatrixPolicy(
+      SparseMatrixPolicy::Create(3)
+          .InitialValue(0)
+          .WithElement(0, 0)
+          .WithElement(0, 1)
+          .WithElement(0, 2)
+          .WithElement(1, 0)
+          .WithElement(1, 1)
+          .WithElement(1, 2)
+          .WithElement(2, 0)
+          .WithElement(2, 1)
+          .WithElement(2, 2));
   MatrixPolicy b(1, 3, 0.0);
   MatrixPolicy x(1, 3, 0.0);
 
@@ -156,33 +162,42 @@ void testRandomMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 10; ++i) {
-    for (std::size_t j = 0; j < 10; ++j) {
-      if (i == j || gen_bool()) {
+  for (std::size_t i = 0; i < 10; ++i)
+  {
+    for (std::size_t j = 0; j < 10; ++j)
+    {
+      if (i == j || gen_bool())
+      {
         builder = builder.WithElement(i, j);
-}
-}
-}
+      }
+    }
+  }
 
   SparseMatrixPolicy A(builder);
   MatrixPolicy b(number_of_blocks, 10, 0.0);
   MatrixPolicy x(number_of_blocks, 10, 0.0);
 
-  for (std::size_t i = 0; i < 10; ++i) {
-    for (std::size_t j = 0; j < 10; ++j) {
-      if (!A.IsZero(i, j)) {
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < 10; ++i)
+  {
+    for (std::size_t j = 0; j < 10; ++j)
+    {
+      if (!A.IsZero(i, j))
+      {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+        {
           A[i_block][i][j] = get_double();
-}
-}
-}
-}
+        }
+      }
+    }
+  }
 
-  for (std::size_t i = 0; i < 10; ++i) {
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < 10; ++i)
+  {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    {
       b[i_block][i] = get_double();
-}
-}
+    }
+  }
 
   x = b;
 
@@ -239,21 +254,27 @@ void testExtremeInitialValue(std::size_t number_of_blocks, double initial_value)
   MatrixPolicy b(number_of_blocks, size, 0.0);
   MatrixPolicy x(number_of_blocks, size, 0.0);
 
-  for (std::size_t i = 0; i < size; ++i) {
-    for (std::size_t j = 0; j < size; ++j) {
-      if (!A.IsZero(i, j)) {
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t j = 0; j < size; ++j)
+    {
+      if (!A.IsZero(i, j))
+      {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+        {
           A[i_block][i][j] = get_double();
-}
-}
-}
-}
+        }
+      }
+    }
+  }
 
-  for (std::size_t i = 0; i < size; ++i) {
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    {
       b[i_block][i] = get_double();
-}
-}
+    }
+  }
 
   x = b;
 
@@ -294,25 +315,30 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(6).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 6; ++i) {
+  for (std::size_t i = 0; i < 6; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
 
   SparseMatrixPolicy A(builder);
   MatrixPolicy b(number_of_blocks, 6, 0.0);
   MatrixPolicy x(number_of_blocks, 6, 0.0);
 
-  for (std::size_t i = 0; i < 6; ++i) {
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < 6; ++i)
+  {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    {
       A[i_block][i][i] = get_double();
-}
-}
+    }
+  }
 
-  for (std::size_t i = 0; i < 6; ++i) {
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < 6; ++i)
+  {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    {
       b[i_block][i] = get_double();
-}
-}
+    }
+  }
 
   x = b;
 
@@ -346,32 +372,40 @@ void testMarkowitzReordering()
   auto gen_bool = std::bind(std::uniform_int_distribution<>(0, 1), std::default_random_engine());
   MatrixPolicy orig(order, order, 0);
 
-  for (std::size_t i = 0; i < order; ++i) {
-    for (std::size_t j = 0; j < order; ++j) {
+  for (std::size_t i = 0; i < order; ++i)
+  {
+    for (std::size_t j = 0; j < order; ++j)
+    {
       orig[i][j] = (i == j || gen_bool()) ? 1 : 0;
-}
-}
+    }
+  }
 
   auto reorder_map = micm::DiagonalMarkowitzReorder<MatrixPolicy>(orig);
 
   auto builder = SparseMatrixPolicy::Create(50);
-  for (std::size_t i = 0; i < order; ++i) {
-    for (std::size_t j = 0; j < order; ++j) {
-      if (orig[i][j] != 0) {
+  for (std::size_t i = 0; i < order; ++i)
+  {
+    for (std::size_t j = 0; j < order; ++j)
+    {
+      if (orig[i][j] != 0)
+      {
         builder = builder.WithElement(i, j);
-}
-}
-}
+      }
+    }
+  }
   SparseMatrixPolicy orig_jac{ builder };
 
   builder = SparseMatrixPolicy::Create(50);
-  for (std::size_t i = 0; i < order; ++i) {
-    for (std::size_t j = 0; j < order; ++j) {
-      if (orig[reorder_map[i]][reorder_map[j]] != 0) {
+  for (std::size_t i = 0; i < order; ++i)
+  {
+    for (std::size_t j = 0; j < order; ++j)
+    {
+      if (orig[reorder_map[i]][reorder_map[j]] != 0)
+      {
         builder = builder.WithElement(i, j);
-}
-}
-}
+      }
+    }
+  }
   SparseMatrixPolicy reordered_jac{ builder };
 
   auto orig_LU_calc = micm::LuDecomposition::Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(orig_jac);

--- a/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
@@ -95,10 +95,13 @@ void testDenseMatrix()
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
   auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   ALU.Fill(0);
-  for (std::size_t i = 0; i < 3; ++i)
-    for (std::size_t j = 0; j < 3; ++j)
-      if (!A.IsZero(i, j))
+  for (std::size_t i = 0; i < 3; ++i) {
+    for (std::size_t j = 0; j < 3; ++j) {
+      if (!A.IsZero(i, j)) {
         ALU[0][i][j] = A[0][i][j];
+}
+}
+}
   lud.template Decompose<SparseMatrixPolicy>(ALU);
   check_results<double, SparseMatrixPolicy>(
       A, ALU, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });
@@ -112,10 +115,13 @@ void testRandomMatrix(std::size_t number_of_blocks)
   auto size = 10;
 
   auto builder = SparseMatrixPolicy::Create(size).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < size; ++i)
-    for (std::size_t j = 0; j < size; ++j)
-      if (i == j || gen_bool())
+  for (std::size_t i = 0; i < size; ++i) {
+    for (std::size_t j = 0; j < size; ++j) {
+      if (i == j || gen_bool()) {
         builder = builder.WithElement(i, j);
+}
+}
+}
 
   SparseMatrixPolicy A(builder);
 
@@ -123,22 +129,29 @@ void testRandomMatrix(std::size_t number_of_blocks)
   // for very large numbers of grid cells
   // To keep the accuracy on the check results function small, we only generat 1 blocks worth of
   // random values and then copy that into every other block
-  for (std::size_t i = 0; i < size; ++i)
-    for (std::size_t j = 0; j < size; ++j)
+  for (std::size_t i = 0; i < size; ++i) {
+    for (std::size_t j = 0; j < size; ++j) {
       if (!A.IsZero(i, j))
       {
         A[0][i][j] = get_double();
-        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block)
+        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block) {
           A[i_block][i][j] = A[0][i][j];
+}
       }
+}
+}
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
   auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
-  for (std::size_t i = 0; i < size; ++i)
-    for (std::size_t j = 0; j < size; ++j)
-      if (!A.IsZero(i, j))
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < size; ++i) {
+    for (std::size_t j = 0; j < size; ++j) {
+      if (!A.IsZero(i, j)) {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
           ALU[i_block][i][j] = A[i_block][i][j];
+}
+}
+}
+}
 
   CheckCopyToDevice<SparseMatrixPolicy>(ALU);
 
@@ -158,10 +171,13 @@ void testExtremeValueInitialization(std::size_t number_of_blocks, double initial
   auto size = 5;
 
   auto builder = SparseMatrixPolicy::Create(size).SetNumberOfBlocks(number_of_blocks).InitialValue(initial_value);
-  for (std::size_t i = 0; i < size; ++i)
-    for (std::size_t j = 0; j < size; ++j)
-      if (i == j || gen_bool())
+  for (std::size_t i = 0; i < size; ++i) {
+    for (std::size_t j = 0; j < size; ++j) {
+      if (i == j || gen_bool()) {
         builder = builder.WithElement(i, j);
+}
+}
+}
 
   SparseMatrixPolicy A(builder);
 
@@ -169,30 +185,38 @@ void testExtremeValueInitialization(std::size_t number_of_blocks, double initial
   // for very large numbers of grid cells
   // To keep the accuracy on the check results function small, we only generat 1 blocks worth of
   // random values and then copy that into every other block
-  for (std::size_t i = 0; i < size; ++i)
-    for (std::size_t j = 0; j < size; ++j)
+  for (std::size_t i = 0; i < size; ++i) {
+    for (std::size_t j = 0; j < size; ++j) {
       if (!A.IsZero(i, j))
       {
         A[0][i][j] = get_double();
-        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block)
+        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block) {
           A[i_block][i][j] = A[0][i][j];
+}
       }
+}
+}
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
   auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, initial_value, false);
-  for (std::size_t i = 0; i < size; ++i)
-    for (std::size_t j = 0; j < size; ++j)
+  for (std::size_t i = 0; i < size; ++i) {
+    for (std::size_t j = 0; j < size; ++j) {
       if (!A.IsZero(i, j))
       {
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
           ALU[i_block][i][j] = A[i_block][i][j];
+}
       }
       else
       {
-        if (!ALU.IsZero(i, j))
-          for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+        if (!ALU.IsZero(i, j)) {
+          for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
             ALU[i_block][i][j] = 0;
+}
+}
       }
+}
+}
 
   CheckCopyToDevice<SparseMatrixPolicy>(ALU);
 
@@ -210,21 +234,26 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(6).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 6; ++i)
+  for (std::size_t i = 0; i < 6; ++i) {
     builder = builder.WithElement(i, i);
+}
 
   SparseMatrixPolicy A(builder);
 
-  for (std::size_t i = 0; i < 6; ++i)
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < 6; ++i) {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
       A[i_block][i][i] = get_double();
+}
+}
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
   auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   ALU.Fill(0);
-  for (std::size_t i = 0; i < 6; ++i)
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < 6; ++i) {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
       ALU[i_block][i][i] = A[i_block][i][i];
+}
+}
   lud.template Decompose<SparseMatrixPolicy>(ALU);
   check_results<double, SparseMatrixPolicy>(
       A, ALU, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });

--- a/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
@@ -70,17 +70,18 @@ void print_matrix(const auto& matrix, std::size_t width)
 template<class SparseMatrixPolicy, class LuDecompositionPolicy>
 void testDenseMatrix()
 {
-  SparseMatrixPolicy A = SparseMatrixPolicy(SparseMatrixPolicy::Create(3)
-                                                .InitialValue(0)
-                                                .WithElement(0, 0)
-                                                .WithElement(0, 1)
-                                                .WithElement(0, 2)
-                                                .WithElement(1, 0)
-                                                .WithElement(1, 1)
-                                                .WithElement(1, 2)
-                                                .WithElement(2, 0)
-                                                .WithElement(2, 1)
-                                                .WithElement(2, 2));
+  SparseMatrixPolicy A = SparseMatrixPolicy(
+      SparseMatrixPolicy::Create(3)
+          .InitialValue(0)
+          .WithElement(0, 0)
+          .WithElement(0, 1)
+          .WithElement(0, 2)
+          .WithElement(1, 0)
+          .WithElement(1, 1)
+          .WithElement(1, 2)
+          .WithElement(2, 0)
+          .WithElement(2, 1)
+          .WithElement(2, 2));
 
   A[0][0][0] = 2;
   A[0][0][1] = -1;
@@ -95,13 +96,16 @@ void testDenseMatrix()
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
   auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   ALU.Fill(0);
-  for (std::size_t i = 0; i < 3; ++i) {
-    for (std::size_t j = 0; j < 3; ++j) {
-      if (!A.IsZero(i, j)) {
+  for (std::size_t i = 0; i < 3; ++i)
+  {
+    for (std::size_t j = 0; j < 3; ++j)
+    {
+      if (!A.IsZero(i, j))
+      {
         ALU[0][i][j] = A[0][i][j];
-}
-}
-}
+      }
+    }
+  }
   lud.template Decompose<SparseMatrixPolicy>(ALU);
   check_results<double, SparseMatrixPolicy>(
       A, ALU, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });
@@ -115,13 +119,16 @@ void testRandomMatrix(std::size_t number_of_blocks)
   auto size = 10;
 
   auto builder = SparseMatrixPolicy::Create(size).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < size; ++i) {
-    for (std::size_t j = 0; j < size; ++j) {
-      if (i == j || gen_bool()) {
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t j = 0; j < size; ++j)
+    {
+      if (i == j || gen_bool())
+      {
         builder = builder.WithElement(i, j);
-}
-}
-}
+      }
+    }
+  }
 
   SparseMatrixPolicy A(builder);
 
@@ -129,29 +136,36 @@ void testRandomMatrix(std::size_t number_of_blocks)
   // for very large numbers of grid cells
   // To keep the accuracy on the check results function small, we only generat 1 blocks worth of
   // random values and then copy that into every other block
-  for (std::size_t i = 0; i < size; ++i) {
-    for (std::size_t j = 0; j < size; ++j) {
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t j = 0; j < size; ++j)
+    {
       if (!A.IsZero(i, j))
       {
         A[0][i][j] = get_double();
-        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block) {
+        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block)
+        {
           A[i_block][i][j] = A[0][i][j];
-}
+        }
       }
-}
-}
+    }
+  }
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
   auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
-  for (std::size_t i = 0; i < size; ++i) {
-    for (std::size_t j = 0; j < size; ++j) {
-      if (!A.IsZero(i, j)) {
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t j = 0; j < size; ++j)
+    {
+      if (!A.IsZero(i, j))
+      {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+        {
           ALU[i_block][i][j] = A[i_block][i][j];
-}
-}
-}
-}
+        }
+      }
+    }
+  }
 
   CheckCopyToDevice<SparseMatrixPolicy>(ALU);
 
@@ -171,13 +185,16 @@ void testExtremeValueInitialization(std::size_t number_of_blocks, double initial
   auto size = 5;
 
   auto builder = SparseMatrixPolicy::Create(size).SetNumberOfBlocks(number_of_blocks).InitialValue(initial_value);
-  for (std::size_t i = 0; i < size; ++i) {
-    for (std::size_t j = 0; j < size; ++j) {
-      if (i == j || gen_bool()) {
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t j = 0; j < size; ++j)
+    {
+      if (i == j || gen_bool())
+      {
         builder = builder.WithElement(i, j);
-}
-}
-}
+      }
+    }
+  }
 
   SparseMatrixPolicy A(builder);
 
@@ -185,38 +202,46 @@ void testExtremeValueInitialization(std::size_t number_of_blocks, double initial
   // for very large numbers of grid cells
   // To keep the accuracy on the check results function small, we only generat 1 blocks worth of
   // random values and then copy that into every other block
-  for (std::size_t i = 0; i < size; ++i) {
-    for (std::size_t j = 0; j < size; ++j) {
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t j = 0; j < size; ++j)
+    {
       if (!A.IsZero(i, j))
       {
         A[0][i][j] = get_double();
-        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block) {
+        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block)
+        {
           A[i_block][i][j] = A[0][i][j];
-}
+        }
       }
-}
-}
+    }
+  }
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
   auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, initial_value, false);
-  for (std::size_t i = 0; i < size; ++i) {
-    for (std::size_t j = 0; j < size; ++j) {
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t j = 0; j < size; ++j)
+    {
       if (!A.IsZero(i, j))
       {
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+        {
           ALU[i_block][i][j] = A[i_block][i][j];
-}
+        }
       }
       else
       {
-        if (!ALU.IsZero(i, j)) {
-          for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+        if (!ALU.IsZero(i, j))
+        {
+          for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+          {
             ALU[i_block][i][j] = 0;
-}
-}
+          }
+        }
       }
-}
-}
+    }
+  }
 
   CheckCopyToDevice<SparseMatrixPolicy>(ALU);
 
@@ -234,26 +259,31 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(6).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 6; ++i) {
+  for (std::size_t i = 0; i < 6; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
 
   SparseMatrixPolicy A(builder);
 
-  for (std::size_t i = 0; i < 6; ++i) {
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < 6; ++i)
+  {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    {
       A[i_block][i][i] = get_double();
-}
-}
+    }
+  }
 
   LuDecompositionPolicy lud = LuDecompositionPolicy::template Create<SparseMatrixPolicy>(A);
   auto ALU = LuDecompositionPolicy::template GetLUMatrix<SparseMatrixPolicy>(A, 0, false);
   ALU.Fill(0);
-  for (std::size_t i = 0; i < 6; ++i) {
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < 6; ++i)
+  {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    {
       ALU[i_block][i][i] = A[i_block][i][i];
-}
-}
+    }
+  }
   lud.template Decompose<SparseMatrixPolicy>(ALU);
   check_results<double, SparseMatrixPolicy>(
       A, ALU, [&](const double a, const double b) -> void { EXPECT_NEAR(a, b, 1.0e-10); });

--- a/test/unit/solver/test_lu_decomposition_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_policy.hpp
@@ -112,18 +112,25 @@ void testRandomMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 10; ++i)
-    for (std::size_t j = 0; j < 10; ++j)
-      if (i == j || gen_bool())
+  for (std::size_t i = 0; i < 10; ++i) {
+    for (std::size_t j = 0; j < 10; ++j) {
+      if (i == j || gen_bool()) {
         builder = builder.WithElement(i, j);
+}
+}
+}
 
   SparseMatrixPolicy A(builder);
 
-  for (std::size_t i = 0; i < 10; ++i)
-    for (std::size_t j = 0; j < 10; ++j)
-      if (!A.IsZero(i, j))
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < 10; ++i) {
+    for (std::size_t j = 0; j < 10; ++j) {
+      if (!A.IsZero(i, j)) {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
           A[i_block][i][j] = get_double();
+}
+}
+}
+}
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
@@ -142,10 +149,13 @@ void testExtremeValueInitialization(std::size_t number_of_blocks, double initial
   auto size = 10;
 
   auto builder = SparseMatrixPolicy::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(initial_value);
-  for (std::size_t i = 0; i < size; ++i)
-    for (std::size_t j = 0; j < size; ++j)
-      if (i == j || gen_bool())
+  for (std::size_t i = 0; i < size; ++i) {
+    for (std::size_t j = 0; j < size; ++j) {
+      if (i == j || gen_bool()) {
         builder = builder.WithElement(i, j);
+}
+}
+}
 
   SparseMatrixPolicy A(builder);
 
@@ -153,14 +163,17 @@ void testExtremeValueInitialization(std::size_t number_of_blocks, double initial
   // for very large numbers of grid cells
   // To keep the accuracy on the check results function small, we only generat 1 blocks worth of
   // random values and then copy that into every other block
-  for (std::size_t i = 0; i < size; ++i)
-    for (std::size_t j = 0; j < size; ++j)
+  for (std::size_t i = 0; i < size; ++i) {
+    for (std::size_t j = 0; j < size; ++j) {
       if (!A.IsZero(i, j))
       {
         A[0][i][j] = get_double();
-        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block)
+        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block) {
           A[i_block][i][j] = A[0][i][j];
+}
       }
+}
+}
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
@@ -187,14 +200,17 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(6).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 6; ++i)
+  for (std::size_t i = 0; i < 6; ++i) {
     builder = builder.WithElement(i, i);
+}
 
   SparseMatrixPolicy A(builder);
 
-  for (std::size_t i = 0; i < 6; ++i)
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+  for (std::size_t i = 0; i < 6; ++i) {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
       A[i_block][i][i] = get_double();
+}
+}
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);

--- a/test/unit/solver/test_lu_decomposition_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_policy.hpp
@@ -74,17 +74,18 @@ void print_matrix(const auto& matrix, std::size_t width)
 template<class SparseMatrixPolicy, class LuDecompositionPolicy>
 void testDenseMatrix()
 {
-  SparseMatrixPolicy A = SparseMatrixPolicy(SparseMatrixPolicy::Create(3)
-                                                .InitialValue(0)
-                                                .WithElement(0, 0)
-                                                .WithElement(0, 1)
-                                                .WithElement(0, 2)
-                                                .WithElement(1, 0)
-                                                .WithElement(1, 1)
-                                                .WithElement(1, 2)
-                                                .WithElement(2, 0)
-                                                .WithElement(2, 1)
-                                                .WithElement(2, 2));
+  SparseMatrixPolicy A = SparseMatrixPolicy(
+      SparseMatrixPolicy::Create(3)
+          .InitialValue(0)
+          .WithElement(0, 0)
+          .WithElement(0, 1)
+          .WithElement(0, 2)
+          .WithElement(1, 0)
+          .WithElement(1, 1)
+          .WithElement(1, 2)
+          .WithElement(2, 0)
+          .WithElement(2, 1)
+          .WithElement(2, 2));
 
   A[0][0][0] = 2;
   A[0][0][1] = -1;
@@ -112,25 +113,32 @@ void testRandomMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 2.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 10; ++i) {
-    for (std::size_t j = 0; j < 10; ++j) {
-      if (i == j || gen_bool()) {
+  for (std::size_t i = 0; i < 10; ++i)
+  {
+    for (std::size_t j = 0; j < 10; ++j)
+    {
+      if (i == j || gen_bool())
+      {
         builder = builder.WithElement(i, j);
-}
-}
-}
+      }
+    }
+  }
 
   SparseMatrixPolicy A(builder);
 
-  for (std::size_t i = 0; i < 10; ++i) {
-    for (std::size_t j = 0; j < 10; ++j) {
-      if (!A.IsZero(i, j)) {
-        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < 10; ++i)
+  {
+    for (std::size_t j = 0; j < 10; ++j)
+    {
+      if (!A.IsZero(i, j))
+      {
+        for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+        {
           A[i_block][i][j] = get_double();
-}
-}
-}
-}
+        }
+      }
+    }
+  }
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
@@ -149,13 +157,16 @@ void testExtremeValueInitialization(std::size_t number_of_blocks, double initial
   auto size = 10;
 
   auto builder = SparseMatrixPolicy::Create(10).SetNumberOfBlocks(number_of_blocks).InitialValue(initial_value);
-  for (std::size_t i = 0; i < size; ++i) {
-    for (std::size_t j = 0; j < size; ++j) {
-      if (i == j || gen_bool()) {
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t j = 0; j < size; ++j)
+    {
+      if (i == j || gen_bool())
+      {
         builder = builder.WithElement(i, j);
-}
-}
-}
+      }
+    }
+  }
 
   SparseMatrixPolicy A(builder);
 
@@ -163,17 +174,20 @@ void testExtremeValueInitialization(std::size_t number_of_blocks, double initial
   // for very large numbers of grid cells
   // To keep the accuracy on the check results function small, we only generat 1 blocks worth of
   // random values and then copy that into every other block
-  for (std::size_t i = 0; i < size; ++i) {
-    for (std::size_t j = 0; j < size; ++j) {
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    for (std::size_t j = 0; j < size; ++j)
+    {
       if (!A.IsZero(i, j))
       {
         A[0][i][j] = get_double();
-        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block) {
+        for (std::size_t i_block = 1; i_block < number_of_blocks; ++i_block)
+        {
           A[i_block][i][j] = A[0][i][j];
-}
+        }
       }
-}
-}
+    }
+  }
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);
@@ -200,17 +214,20 @@ void testDiagonalMatrix(std::size_t number_of_blocks)
   auto get_double = std::bind(std::lognormal_distribution(-2.0, 4.0), std::default_random_engine());
 
   auto builder = SparseMatrixPolicy::Create(6).SetNumberOfBlocks(number_of_blocks).InitialValue(0);
-  for (std::size_t i = 0; i < 6; ++i) {
+  for (std::size_t i = 0; i < 6; ++i)
+  {
     builder = builder.WithElement(i, i);
-}
+  }
 
   SparseMatrixPolicy A(builder);
 
-  for (std::size_t i = 0; i < 6; ++i) {
-    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block) {
+  for (std::size_t i = 0; i < 6; ++i)
+  {
+    for (std::size_t i_block = 0; i_block < number_of_blocks; ++i_block)
+    {
       A[i_block][i][i] = get_double();
-}
-}
+    }
+  }
 
   LuDecompositionPolicy lud =
       LuDecompositionPolicy::template Create<SparseMatrixPolicy, SparseMatrixPolicy, SparseMatrixPolicy>(A);

--- a/test/unit/solver/test_rosenbrock.cpp
+++ b/test/unit/solver/test_rosenbrock.cpp
@@ -74,12 +74,13 @@ void testNormalizedErrorIncludesAllVariables(SolverBuilderPolicy builder, std::s
                                .Build();
 
   std::vector<micm::Constraint> constraints;
-  constraints.push_back(micm::EquilibriumConstraint(
-      "B_C_eq",
-      C,
-      std::vector<micm::StoichSpecies>{ micm::StoichSpecies(B, 1.0) },
-      std::vector<micm::StoichSpecies>{ micm::StoichSpecies(C, 1.0) },
-      micm::VantHoffParam{ .K_HLC_ref = 10.0, .delta_H = -2400.0 }));
+  constraints.push_back(
+      micm::EquilibriumConstraint(
+          "B_C_eq",
+          C,
+          std::vector<micm::StoichSpecies>{ micm::StoichSpecies(B, 1.0) },
+          std::vector<micm::StoichSpecies>{ micm::StoichSpecies(C, 1.0) },
+          micm::VantHoffParam{ .K_HLC_ref = 10.0, .delta_H = -2400.0 }));
 
   auto solver = builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
                     .SetReactions({ reaction })

--- a/test/unit/solver/test_state.cpp
+++ b/test/unit/solver/test_state.cpp
@@ -266,9 +266,10 @@ TEST(State, SetSingleConcentration)
                        3 };
     std::vector<double> concentrations{ 12.0, 42.0, 35.2 };
     state.SetConcentration(micm::Species{ "bar" }, concentrations);
-    for (std::size_t i = 0; i < concentrations.size(); ++i) {
+    for (std::size_t i = 0; i < concentrations.size(); ++i)
+    {
       EXPECT_EQ(state.variables_[i][state.variable_map_["bar"]], concentrations[i]);
-}
+    }
   }
   {
     micm::State state{ micm::StateParameters{
@@ -314,9 +315,10 @@ TEST(State, SetConcentrationByElementVector)
 
   state.SetConcentration("foo", concentrations);
 
-  for (std::size_t i = 0; i < concentrations.size(); ++i) {
+  for (std::size_t i = 0; i < concentrations.size(); ++i)
+  {
     EXPECT_EQ(state.variables_[i][state.variable_map_["foo"]], concentrations[i]);
-}
+  }
 }
 
 TEST(State, SettingConcentrationsWithInvalidArguementsThrowsException)

--- a/test/unit/solver/test_state.cpp
+++ b/test/unit/solver/test_state.cpp
@@ -266,8 +266,9 @@ TEST(State, SetSingleConcentration)
                        3 };
     std::vector<double> concentrations{ 12.0, 42.0, 35.2 };
     state.SetConcentration(micm::Species{ "bar" }, concentrations);
-    for (std::size_t i = 0; i < concentrations.size(); ++i)
+    for (std::size_t i = 0; i < concentrations.size(); ++i) {
       EXPECT_EQ(state.variables_[i][state.variable_map_["bar"]], concentrations[i]);
+}
   }
   {
     micm::State state{ micm::StateParameters{
@@ -313,8 +314,9 @@ TEST(State, SetConcentrationByElementVector)
 
   state.SetConcentration("foo", concentrations);
 
-  for (std::size_t i = 0; i < concentrations.size(); ++i)
+  for (std::size_t i = 0; i < concentrations.size(); ++i) {
     EXPECT_EQ(state.variables_[i][state.variable_map_["foo"]], concentrations[i]);
+}
 }
 
 TEST(State, SettingConcentrationsWithInvalidArguementsThrowsException)

--- a/test/unit/util/test_matrix_policy.hpp
+++ b/test/unit/util/test_matrix_policy.hpp
@@ -117,9 +117,11 @@ MatrixPolicy<int> testStrides()
 {
   MatrixPolicy<int> matrix(3, 4, 0);
 
-  for (std::size_t i = 0; i < matrix.NumRows(); ++i)
-    for (std::size_t j = 0; j < matrix.NumColumns(); ++j)
+  for (std::size_t i = 0; i < matrix.NumRows(); ++i) {
+    for (std::size_t j = 0; j < matrix.NumColumns(); ++j) {
       matrix.AsVector()[i * matrix.RowStride() + j * matrix.ColumnStride()] = i * 100 + j;
+}
+}
 
   EXPECT_EQ(matrix[0][0], 0);
   EXPECT_EQ(matrix[0][1], 1);
@@ -244,7 +246,7 @@ MatrixPolicy<double> testAxpy()
   double sum = 0.0;
   double result = 0.0;
 
-  for (int i = 0; i < num_rows; ++i)
+  for (int i = 0; i < num_rows; ++i) {
     for (int j = 0; j < num_columns; ++j)
     {
       auto y = i * 10.3 + j * 100.5;
@@ -253,12 +255,15 @@ MatrixPolicy<double> testAxpy()
       other[i][j] = x;
       sum += y + alpha * x;
     }
+}
 
   matrix.Axpy(alpha, other);
 
-  for (int i = 0; i < num_rows; ++i)
-    for (int j = 0; j < num_columns; ++j)
+  for (int i = 0; i < num_rows; ++i) {
+    for (int j = 0; j < num_columns; ++j) {
       result += matrix[i][j];
+}
+}
   EXPECT_NEAR(sum, result, 1.0e-5);
 
   return matrix;
@@ -274,7 +279,7 @@ MatrixPolicy<double> testForEach()
   double sum2 = 0.0;
   double result = 0.0;
 
-  for (int i = 0; i < 4; ++i)
+  for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 3; ++j)
     {
       matrix[i][j] = i * 10.3 + j * 100.5;
@@ -283,6 +288,7 @@ MatrixPolicy<double> testForEach()
       other2[i][j] = i * 19.5 + j * 32.2;
       sum2 += i * 10.3 + j * 100.5 + i * 1.7 + j * 10.2 - i * 19.5 - j * 32.2;
     }
+}
 
   matrix.ForEach([&](double& a, const double& b) { result += a + b; }, other);
   EXPECT_NEAR(sum, result, 1.0e-5);
@@ -382,9 +388,11 @@ MatrixPolicy<double> testArrayFunction()
   MatrixPolicy<double> matrix{ 5, 3, -1.0 };
 
   // Set initial values that differ by rows
-  for (int i = 0; i < static_cast<int>(matrix.NumRows()); ++i)
-    for (int j = 0; j < static_cast<int>(matrix.NumColumns()); ++j)
+  for (int i = 0; i < static_cast<int>(matrix.NumRows()); ++i) {
+    for (int j = 0; j < static_cast<int>(matrix.NumColumns()); ++j) {
       matrix[i][j] = static_cast<double>(i - 2 + 10 * j);
+}
+}
 
   // Initial Matrix values:
   // Row 0: -2, 8, 18
@@ -462,8 +470,9 @@ std::tuple<MatrixPolicy<double>, MatrixPolicy<double>> testMultiMatrixArrayFunct
     }
   }
   // Set column 2 of matrixB separately
-  for (int i = 0; i < static_cast<int>(matrixB.NumRows()); ++i)
+  for (int i = 0; i < static_cast<int>(matrixB.NumRows()); ++i) {
     matrixB[i][2] = static_cast<double>(i * 4);
+}
 
   // Initial MatrixA values:
   // Row 0: 0, 10
@@ -513,9 +522,11 @@ MatrixPolicy<double> testVectorInMatrixFunction()
   MatrixPolicy<double> matrix{ 5, 3, -1.0 };
 
   // Set initial values that differ by rows
-  for (int i = 0; i < static_cast<int>(matrix.NumRows()); ++i)
-    for (int j = 0; j < static_cast<int>(matrix.NumColumns()); ++j)
+  for (int i = 0; i < static_cast<int>(matrix.NumRows()); ++i) {
+    for (int j = 0; j < static_cast<int>(matrix.NumColumns()); ++j) {
       matrix[i][j] = static_cast<double>(i - 2 + 10 * j);
+}
+}
 
   // Initial Matrix values:
   // Row 0: -2, 8, 18
@@ -898,8 +909,9 @@ MatrixPolicy<double> testColumnViewReuse()
 {
   MatrixPolicy<double> matrix{ 3, 4, 0.0 };
 
-  for (std::size_t i = 0; i < matrix.NumRows(); ++i)
+  for (std::size_t i = 0; i < matrix.NumRows(); ++i) {
     matrix[i][0] = static_cast<double>(i + 1);
+}
 
   auto func = MatrixPolicy<double>::Function(
       [](auto&& m)
@@ -963,9 +975,11 @@ MatrixPolicy<double> testFunctionReusability()
       matrix1);
 
   // Apply to first matrix
-  for (std::size_t i = 0; i < matrix1.NumRows(); ++i)
-    for (std::size_t j = 0; j < matrix1.NumColumns(); ++j)
+  for (std::size_t i = 0; i < matrix1.NumRows(); ++i) {
+    for (std::size_t j = 0; j < matrix1.NumColumns(); ++j) {
       matrix1[i][j] = static_cast<double>(i + j);
+}
+}
 
   func(matrix1);
   EXPECT_EQ(matrix1[0][2], 2.0 * (0 + 1 + 2));  // 6
@@ -979,8 +993,9 @@ MatrixPolicy<double> testFunctionReusability()
 
   // Apply to third matrix with different values
   MatrixPolicy<double> matrix3{ 2, 3, 0.0 };
-  for (std::size_t i = 0; i < matrix3.NumRows(); ++i)
+  for (std::size_t i = 0; i < matrix3.NumRows(); ++i) {
     matrix3[i][0] = static_cast<double>(i * 10);
+}
 
   func(matrix3);
   EXPECT_EQ(matrix3[0][2], 2.0 * (0 + 0 + 0));   // 0
@@ -995,9 +1010,11 @@ void testConstMatrixFunction()
   MatrixPolicy<double> matrix{ 3, 4, 0.0 };
 
   // Set initial values
-  for (std::size_t i = 0; i < matrix.NumRows(); ++i)
-    for (std::size_t j = 0; j < matrix.NumColumns(); ++j)
+  for (std::size_t i = 0; i < matrix.NumRows(); ++i) {
+    for (std::size_t j = 0; j < matrix.NumColumns(); ++j) {
       matrix[i][j] = static_cast<double>(i * 10 + j);
+}
+}
 
   // Create a const reference
   const MatrixPolicy<double>& const_matrix = matrix;

--- a/test/unit/util/test_matrix_policy.hpp
+++ b/test/unit/util/test_matrix_policy.hpp
@@ -117,11 +117,13 @@ MatrixPolicy<int> testStrides()
 {
   MatrixPolicy<int> matrix(3, 4, 0);
 
-  for (std::size_t i = 0; i < matrix.NumRows(); ++i) {
-    for (std::size_t j = 0; j < matrix.NumColumns(); ++j) {
+  for (std::size_t i = 0; i < matrix.NumRows(); ++i)
+  {
+    for (std::size_t j = 0; j < matrix.NumColumns(); ++j)
+    {
       matrix.AsVector()[i * matrix.RowStride() + j * matrix.ColumnStride()] = i * 100 + j;
-}
-}
+    }
+  }
 
   EXPECT_EQ(matrix[0][0], 0);
   EXPECT_EQ(matrix[0][1], 1);
@@ -246,7 +248,8 @@ MatrixPolicy<double> testAxpy()
   double sum = 0.0;
   double result = 0.0;
 
-  for (int i = 0; i < num_rows; ++i) {
+  for (int i = 0; i < num_rows; ++i)
+  {
     for (int j = 0; j < num_columns; ++j)
     {
       auto y = i * 10.3 + j * 100.5;
@@ -255,15 +258,17 @@ MatrixPolicy<double> testAxpy()
       other[i][j] = x;
       sum += y + alpha * x;
     }
-}
+  }
 
   matrix.Axpy(alpha, other);
 
-  for (int i = 0; i < num_rows; ++i) {
-    for (int j = 0; j < num_columns; ++j) {
+  for (int i = 0; i < num_rows; ++i)
+  {
+    for (int j = 0; j < num_columns; ++j)
+    {
       result += matrix[i][j];
-}
-}
+    }
+  }
   EXPECT_NEAR(sum, result, 1.0e-5);
 
   return matrix;
@@ -279,7 +284,8 @@ MatrixPolicy<double> testForEach()
   double sum2 = 0.0;
   double result = 0.0;
 
-  for (int i = 0; i < 4; ++i) {
+  for (int i = 0; i < 4; ++i)
+  {
     for (int j = 0; j < 3; ++j)
     {
       matrix[i][j] = i * 10.3 + j * 100.5;
@@ -288,7 +294,7 @@ MatrixPolicy<double> testForEach()
       other2[i][j] = i * 19.5 + j * 32.2;
       sum2 += i * 10.3 + j * 100.5 + i * 1.7 + j * 10.2 - i * 19.5 - j * 32.2;
     }
-}
+  }
 
   matrix.ForEach([&](double& a, const double& b) { result += a + b; }, other);
   EXPECT_NEAR(sum, result, 1.0e-5);
@@ -388,11 +394,13 @@ MatrixPolicy<double> testArrayFunction()
   MatrixPolicy<double> matrix{ 5, 3, -1.0 };
 
   // Set initial values that differ by rows
-  for (int i = 0; i < static_cast<int>(matrix.NumRows()); ++i) {
-    for (int j = 0; j < static_cast<int>(matrix.NumColumns()); ++j) {
+  for (int i = 0; i < static_cast<int>(matrix.NumRows()); ++i)
+  {
+    for (int j = 0; j < static_cast<int>(matrix.NumColumns()); ++j)
+    {
       matrix[i][j] = static_cast<double>(i - 2 + 10 * j);
-}
-}
+    }
+  }
 
   // Initial Matrix values:
   // Row 0: -2, 8, 18
@@ -470,9 +478,10 @@ std::tuple<MatrixPolicy<double>, MatrixPolicy<double>> testMultiMatrixArrayFunct
     }
   }
   // Set column 2 of matrixB separately
-  for (int i = 0; i < static_cast<int>(matrixB.NumRows()); ++i) {
+  for (int i = 0; i < static_cast<int>(matrixB.NumRows()); ++i)
+  {
     matrixB[i][2] = static_cast<double>(i * 4);
-}
+  }
 
   // Initial MatrixA values:
   // Row 0: 0, 10
@@ -522,11 +531,13 @@ MatrixPolicy<double> testVectorInMatrixFunction()
   MatrixPolicy<double> matrix{ 5, 3, -1.0 };
 
   // Set initial values that differ by rows
-  for (int i = 0; i < static_cast<int>(matrix.NumRows()); ++i) {
-    for (int j = 0; j < static_cast<int>(matrix.NumColumns()); ++j) {
+  for (int i = 0; i < static_cast<int>(matrix.NumRows()); ++i)
+  {
+    for (int j = 0; j < static_cast<int>(matrix.NumColumns()); ++j)
+    {
       matrix[i][j] = static_cast<double>(i - 2 + 10 * j);
-}
-}
+    }
+  }
 
   // Initial Matrix values:
   // Row 0: -2, 8, 18
@@ -909,9 +920,10 @@ MatrixPolicy<double> testColumnViewReuse()
 {
   MatrixPolicy<double> matrix{ 3, 4, 0.0 };
 
-  for (std::size_t i = 0; i < matrix.NumRows(); ++i) {
+  for (std::size_t i = 0; i < matrix.NumRows(); ++i)
+  {
     matrix[i][0] = static_cast<double>(i + 1);
-}
+  }
 
   auto func = MatrixPolicy<double>::Function(
       [](auto&& m)
@@ -975,11 +987,13 @@ MatrixPolicy<double> testFunctionReusability()
       matrix1);
 
   // Apply to first matrix
-  for (std::size_t i = 0; i < matrix1.NumRows(); ++i) {
-    for (std::size_t j = 0; j < matrix1.NumColumns(); ++j) {
+  for (std::size_t i = 0; i < matrix1.NumRows(); ++i)
+  {
+    for (std::size_t j = 0; j < matrix1.NumColumns(); ++j)
+    {
       matrix1[i][j] = static_cast<double>(i + j);
-}
-}
+    }
+  }
 
   func(matrix1);
   EXPECT_EQ(matrix1[0][2], 2.0 * (0 + 1 + 2));  // 6
@@ -993,9 +1007,10 @@ MatrixPolicy<double> testFunctionReusability()
 
   // Apply to third matrix with different values
   MatrixPolicy<double> matrix3{ 2, 3, 0.0 };
-  for (std::size_t i = 0; i < matrix3.NumRows(); ++i) {
+  for (std::size_t i = 0; i < matrix3.NumRows(); ++i)
+  {
     matrix3[i][0] = static_cast<double>(i * 10);
-}
+  }
 
   func(matrix3);
   EXPECT_EQ(matrix3[0][2], 2.0 * (0 + 0 + 0));   // 0
@@ -1010,11 +1025,13 @@ void testConstMatrixFunction()
   MatrixPolicy<double> matrix{ 3, 4, 0.0 };
 
   // Set initial values
-  for (std::size_t i = 0; i < matrix.NumRows(); ++i) {
-    for (std::size_t j = 0; j < matrix.NumColumns(); ++j) {
+  for (std::size_t i = 0; i < matrix.NumRows(); ++i)
+  {
+    for (std::size_t j = 0; j < matrix.NumColumns(); ++j)
+    {
       matrix[i][j] = static_cast<double>(i * 10 + j);
-}
-}
+    }
+  }
 
   // Create a const reference
   const MatrixPolicy<double>& const_matrix = matrix;

--- a/test/unit/util/test_sparse_matrix_policy.hpp
+++ b/test/unit/util/test_sparse_matrix_policy.hpp
@@ -954,7 +954,8 @@ void testMismatchedBlocksAtInvocation()
 
   // Create function
   auto func = MatrixPolicy<double, OrderingPolicy>::Function(
-      [](auto&& mA, auto&& mB) {
+      [](auto&& mA, auto&& mB)
+      {
         mA.ForEachBlock([&](const double& a, double& b) { b = a * 2.0; }, mB.GetConstBlockView(0, 1), mA.GetBlockView(1, 2));
       },
       matrix3,
@@ -1147,9 +1148,10 @@ MatrixPolicy<double, OrderingPolicy> testBlockViewReuse()
 
   MatrixPolicy<double, OrderingPolicy> matrix{ builder };
 
-  for (std::size_t block = 0; block < 3; ++block) {
+  for (std::size_t block = 0; block < 3; ++block)
+  {
     matrix[block][0][1] = static_cast<double>(block + 1);
-}
+  }
 
   auto func = MatrixPolicy<double, OrderingPolicy>::Function(
       [](auto&& m)
@@ -1243,9 +1245,10 @@ MatrixPolicy<double, OrderingPolicy> testFunctionReusability()
   // Apply to third matrix with different values
   MatrixPolicy<double, OrderingPolicy> matrix3{ builder };
   matrix3 = 0.0;
-  for (std::size_t block = 0; block < 2; ++block) {
+  for (std::size_t block = 0; block < 2; ++block)
+  {
     matrix3[block][0][0] = static_cast<double>(block * 10);
-}
+  }
 
   func(matrix3);
   EXPECT_EQ(matrix3[0][2][2], 2.0 * (0 + 0 + 0));   // 0
@@ -1462,7 +1465,7 @@ void testIncompatibleOrdering()
 
     // This should throw during validation (before lambda execution)
     EXPECT_THROW(
-        (SparseMatrixPolicy<double, OrderingPolicy>::Function([](auto&&, auto&&) {}, sparseMatrix, denseMatrix)),
+        (SparseMatrixPolicy<double, OrderingPolicy>::Function([](auto&&, auto&&) { }, sparseMatrix, denseMatrix)),
         micm::MicmException);
   }
 }
@@ -1554,7 +1557,7 @@ void testIncompatibleVectorOrdering()
 
     // This should throw during validation (before lambda execution)
     EXPECT_THROW(
-        (SparseMatrixPolicy<double, OrderingPolicy>::Function([](auto&&, auto&&) {}, sparseMatrix, vectorMatrix)),
+        (SparseMatrixPolicy<double, OrderingPolicy>::Function([](auto&&, auto&&) { }, sparseMatrix, vectorMatrix)),
         micm::MicmException);
   }
 }
@@ -1582,7 +1585,7 @@ void testIncompatibleSparseOrdering()
     // This should throw during validation (before lambda execution)
     // Use a simple lambda that doesn't access mismatched data to avoid template instantiation issues
     EXPECT_THROW(
-        (SparseMatrixPolicy<double, OrderingPolicy1>::Function([](auto&&, auto&&) {}, sparseMatrix1, sparseMatrix2)),
+        (SparseMatrixPolicy<double, OrderingPolicy1>::Function([](auto&&, auto&&) { }, sparseMatrix1, sparseMatrix2)),
         micm::MicmException);
   }
 }
@@ -2018,7 +2021,7 @@ void testFunctionInvocationWithWrongSizedVectorSparse()
   std::vector<double> vec1 = { 1.0, 2.0, 3.0 };
   std::vector<double> vec2 = { 1.0, 2.0 };  // Wrong size
 
-  auto func = SparseMatrixPolicy<double, OrderingPolicy>::Function([](auto&&, auto&&) {}, matrix, vec1);
+  auto func = SparseMatrixPolicy<double, OrderingPolicy>::Function([](auto&&, auto&&) { }, matrix, vec1);
 
   EXPECT_THROW(
       try { func(matrix, vec2); } catch (micm::MicmException& e) {

--- a/test/unit/util/test_sparse_matrix_policy.hpp
+++ b/test/unit/util/test_sparse_matrix_policy.hpp
@@ -1147,8 +1147,9 @@ MatrixPolicy<double, OrderingPolicy> testBlockViewReuse()
 
   MatrixPolicy<double, OrderingPolicy> matrix{ builder };
 
-  for (std::size_t block = 0; block < 3; ++block)
+  for (std::size_t block = 0; block < 3; ++block) {
     matrix[block][0][1] = static_cast<double>(block + 1);
+}
 
   auto func = MatrixPolicy<double, OrderingPolicy>::Function(
       [](auto&& m)
@@ -1242,8 +1243,9 @@ MatrixPolicy<double, OrderingPolicy> testFunctionReusability()
   // Apply to third matrix with different values
   MatrixPolicy<double, OrderingPolicy> matrix3{ builder };
   matrix3 = 0.0;
-  for (std::size_t block = 0; block < 2; ++block)
+  for (std::size_t block = 0; block < 2; ++block) {
     matrix3[block][0][0] = static_cast<double>(block * 10);
+}
 
   func(matrix3);
   EXPECT_EQ(matrix3[0][2][2], 2.0 * (0 + 0 + 0));   // 0


### PR DESCRIPTION
Closes #999
partially addressing #997

I ran clang format after having clang tidy add the braces. The braces were at the beginning of the line and not indented. The formatting seems a little different, probably because of the difference between clang format versions, but the follow on PR will normalize everything