### PR TITLE
Refactor Solver Builder API to avoid passing ExternalModel object twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ int main(const int argc, const char *argv[])
 
   Phase gas_phase{ "gas", std::vector<PhaseSpecies>{ foo, bar, baz } };
 
-  System chemical_system{ SystemParameters{ .gas_phase_ = gas_phase } };
+  System chemical_system{ gas_phase };
 
   Process r1 = ChemicalReactionBuilder()
                    .SetReactants({ foo })

--- a/docs/source/user_guide/user_defined_rate_constant_tutorial.rst
+++ b/docs/source/user_guide/user_defined_rate_constant_tutorial.rst
@@ -87,7 +87,7 @@ Then setup the reaction which will use this rate constant:
       +                 .SetPhase(gas_phase)
       +                 .Build();
 
-      auto chemical_system = System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+      auto chemical_system = System(gas_phase);
       - auto reactions = std::vector<micm::Process>{ r1, r2, r3, r4, r5, r6, r7 };
       + auto reactions = std::vector<micm::Process>{ r1, r2, r3, r4, r5, r6, r7, r8, r9, r10 };
 

--- a/include/micm/constraint/constraint_set.hpp
+++ b/include/micm/constraint/constraint_set.hpp
@@ -58,7 +58,7 @@ namespace micm
         constraint_jacobian_functions_;
 
     /// @brief External model constraint wrappers
-    std::vector<ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>> external_constraint_models_;
+    std::vector<ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>> external_constraints_;
 
     /// @brief Runtime count of algebraic variables contributed by external models
     std::size_t external_constraint_count_ = 0;
@@ -369,7 +369,7 @@ namespace micm
     /// @param models Vector of type-erased external model constraint wrappers
     void SetExternalConstraintModels(std::vector<ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>>&& models)
     {
-      external_constraint_models_ = std::move(models);
+      external_constraints_ = std::move(models);
     }
 
     /// @brief Resolve external model constraints at runtime
@@ -382,7 +382,7 @@ namespace micm
     void ResolveExternalConstraints(const std::unordered_map<std::string, std::size_t>& variable_map)
     {
       external_constraint_count_ = 0;
-      for (const auto& model : external_constraint_models_)
+      for (const auto& model : external_constraints_)
       {
         auto alg_names = model.algebraic_variable_names_func_();
         for (const auto& name : alg_names)
@@ -414,7 +414,7 @@ namespace micm
         const std::unordered_map<std::string, std::size_t>& variable_map) const
     {
       std::set<std::pair<std::size_t, std::size_t>> ids;
-      for (const auto& model : external_constraint_models_)
+      for (const auto& model : external_constraints_)
       {
         auto alg_names = model.algebraic_variable_names_func_();
         if (alg_names.empty())
@@ -438,7 +438,7 @@ namespace micm
     {
       std::set<std::string> seen;
       std::vector<std::string> names;
-      for (const auto& model : external_constraint_models_)
+      for (const auto& model : external_constraints_)
       {
         auto alg_names = model.algebraic_variable_names_func_();
         if (alg_names.empty())
@@ -469,7 +469,7 @@ namespace micm
     {
       std::set<std::string> seen;
       std::vector<std::string> names;
-      for (const auto& model : external_constraint_models_)
+      for (const auto& model : external_constraints_)
       {
         auto alg_names = model.algebraic_variable_names_func_();
         if (alg_names.empty())
@@ -518,7 +518,7 @@ namespace micm
       external_constraint_jacobian_functions_.clear();
       external_constraint_param_functions_.clear();
       external_constraint_init_functions_.clear();
-      for (const auto& model : external_constraint_models_)
+      for (const auto& model : external_constraints_)
       {
         auto alg_names = model.algebraic_variable_names_func_();
         if (alg_names.empty())

--- a/include/micm/external_model.hpp
+++ b/include/micm/external_model.hpp
@@ -126,20 +126,16 @@
 ///
 /// @section external_model_usage Usage
 ///
-/// **1. Add the external model to the system:**
+/// **1. Set up the external model:**
 /// ```cpp
 /// auto aerosol_model = MyAerosolModel(...);
-/// auto system = micm::System({
-///   .gas_phase_ = gas_phase,
-///   .external_models_ = { aerosol_model }
-/// });
 /// ```
 ///
-/// **2. Add the external model's processes (and optionally constraints) to the solver:**
+/// **2. Add the external model to the solver:**
 /// ```cpp
 /// auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(params)
 ///   .SetSystem(system)
-///   .AddExternalModel(aerosol_model)  // wraps processes AND constraints automatically
+///   .AddExternalModel(aerosol_model)  // registers state variables, processes, and constraints (optional)
 ///   .Build();
 /// ```
 ///
@@ -177,10 +173,10 @@ namespace micm
   ///
   /// This struct encapsulates an external model's state definition (variables and parameters) and provides
   /// a type-erased interface that MICM can use to query the model's state requirements. Instances are
-  /// constructed automatically when an external model is added to a System via the `external_models_` field.
+  /// constructed automatically when an external model is passed to `SolverBuilder::AddExternalModel()`.
   ///
   /// @note Users typically do not construct this directly; instead, pass external model instances to
-  ///       `micm::System` and they will be wrapped automatically.
+  ///       `SolverBuilder::AddExternalModel()` and they will be wrapped automatically.
   struct ExternalModelSystem
   {
     /// @brief Type-erased function returning the state size (number of variables, number of parameters)
@@ -296,27 +292,6 @@ namespace micm
             state_parameter_indices, state_variable_indices, jacobian);
       };
     }
-  };
-
-  /// @brief Concept to detect whether an external model provides process methods
-  ///
-  /// A model satisfies `HasProcesses` if it provides `SpeciesUsed()` and
-  /// `NonZeroJacobianElements()`.
-  template<typename T>
-  concept HasProcesses = requires(const T& m, const std::unordered_map<std::string, std::size_t>& map) {
-    { m.SpeciesUsed() } -> std::same_as<std::set<std::string>>;
-    { m.NonZeroJacobianElements(map) } -> std::same_as<std::set<std::pair<std::size_t, std::size_t>>>;
-  };
-
-  /// @brief Concept to detect whether an external model provides constraint methods
-  ///
-  /// A model satisfies `HasConstraints` if it provides at least `ConstraintAlgebraicVariableNames()`
-  /// and `ConstraintSpeciesDependencies()`. At runtime, the model may return empty sets to indicate
-  /// that constraints are not active for a given configuration.
-  template<typename T>
-  concept HasConstraints = requires(const T& m) {
-    { m.ConstraintAlgebraicVariableNames() } -> std::same_as<std::set<std::string>>;
-    { m.ConstraintSpeciesDependencies() } -> std::same_as<std::set<std::string>>;
   };
 
   /// @brief Concept to detect whether an external model provides constraint parameter initialization
@@ -453,5 +428,38 @@ namespace micm
         { return [](const DenseMatrixPolicy&, DenseMatrixPolicy&) {}; };
       }
     }
+  };
+
+  /// @brief Concept to detect whether an external model provides state variable/parameter information
+  ///
+  /// A model satisfies `HasState` if it provides `StateSize()`, `StateVariableNames()`, and
+  /// `StateParameterNames()`. Models satisfying this concept contribute additional state variables
+  /// to the solver when passed to `AddExternalModel()`.
+  template<typename T>
+  concept HasState = requires(const T& m) {
+    { m.StateSize() } -> std::same_as<std::tuple<std::size_t, std::size_t>>;
+    { m.StateVariableNames() } -> std::same_as<std::set<std::string>>;
+    { m.StateParameterNames() } -> std::same_as<std::set<std::string>>;
+  };
+
+  /// @brief Concept to detect whether an external model provides process methods
+  ///
+  /// A model satisfies `HasProcesses` if it provides `SpeciesUsed()` and
+  /// `NonZeroJacobianElements()`.
+  template<typename T>
+  concept HasProcesses = requires(const T& m, const std::unordered_map<std::string, std::size_t>& map) {
+    { m.SpeciesUsed() } -> std::same_as<std::set<std::string>>;
+    { m.NonZeroJacobianElements(map) } -> std::same_as<std::set<std::pair<std::size_t, std::size_t>>>;
+  };
+
+  /// @brief Concept to detect whether an external model provides constraint methods
+  ///
+  /// A model satisfies `HasConstraints` if it provides at least `ConstraintAlgebraicVariableNames()`
+  /// and `ConstraintSpeciesDependencies()`. At runtime, the model may return empty sets to indicate
+  /// that constraints are not active for a given configuration.
+  template<typename T>
+  concept HasConstraints = requires(const T& m) {
+    { m.ConstraintAlgebraicVariableNames() } -> std::same_as<std::set<std::string>>;
+    { m.ConstraintSpeciesDependencies() } -> std::same_as<std::set<std::string>>;
   };
 }  // namespace micm

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -44,11 +44,12 @@ namespace micm
     std::vector<std::size_t> jacobian_flat_ids_;
     std::vector<uint8_t> is_algebraic_variable_;  // uint8_t instead of bool for CUDA compatibility
     std::unordered_map<std::string, std::size_t> variable_map_;
-    std::vector<ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>> external_models_;
+
+    std::vector<ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>> external_process_sets_;
     std::vector<std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)>>
-        external_model_forcing_functions_;
+        external_forcing_functions_;
     std::vector<std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)>>
-        external_model_jacobian_functions_;
+        external_jacobian_functions_;
 
    public:
     /// @brief Default constructor
@@ -65,15 +66,15 @@ namespace micm
     /// @brief Constructs a ProcessSet as above, but also includes contributions from external models
     /// @param processes A list of processes, each with reactants and products
     /// @param variable_map A map from species names to their corresponding index in the solver's state
-    /// @param external_models A list of external models that provide additional processes and Jacobian contributions
+    /// @param external_process_sets A list of external process sets that provide additional processes and Jacobian contributions
     /// @throws std::system_error If a reactant or product name in a process is not found in variable_map
     ProcessSet(
         const std::vector<Process>& processes,
         const std::unordered_map<std::string, std::size_t>& variable_map,
-        const std::vector<ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>>& external_models)
+        const std::vector<ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>>& external_process_sets)
         : ProcessSet(processes, variable_map)
     {
-      external_models_ = external_models;
+      external_process_sets_ = external_process_sets;
     }
 
     virtual ~ProcessSet() = default;
@@ -261,11 +262,11 @@ namespace micm
       prod_id += number_of_products_[i_rxn];
     }
 
-    // Add Jacobian elements from external models
-    for (const auto& model : external_models_)
+    // Add Jacobian elements from external process sets
+    for (const auto& process_set : external_process_sets_)
     {
-      auto model_jac_elements = model.non_zero_jacobian_elements_func_(variable_map_);
-      ids.insert(model_jac_elements.begin(), model_jac_elements.end());
+      auto external_jac_elements = process_set.non_zero_jacobian_elements_func_(variable_map_);
+      ids.insert(external_jac_elements.begin(), external_jac_elements.end());
     }
     return ids;
   }
@@ -319,14 +320,14 @@ namespace micm
       const std::unordered_map<std::string, std::size_t>& state_variable_indices,
       const SparseMatrixPolicy& jacobian)
   {
-    external_model_forcing_functions_.clear();
-    external_model_jacobian_functions_.clear();
-    for (const auto& model : external_models_)
+    external_forcing_functions_.clear();
+    external_jacobian_functions_.clear();
+    for (const auto& process_set : external_process_sets_)
     {
-      external_model_forcing_functions_.push_back(
-          model.get_forcing_function_(state_parameter_indices, state_variable_indices));
-      external_model_jacobian_functions_.push_back(
-          model.get_jacobian_function_(state_parameter_indices, state_variable_indices, jacobian));
+      external_forcing_functions_.push_back(
+          process_set.get_forcing_function_(state_parameter_indices, state_variable_indices));
+      external_jacobian_functions_.push_back(
+          process_set.get_jacobian_function_(state_parameter_indices, state_variable_indices, jacobian));
     }
   }
 
@@ -384,7 +385,7 @@ namespace micm
     }
 
     // Add forcing contributions from external models
-    for (const auto& add_forcing_function : external_model_forcing_functions_)
+    for (const auto& add_forcing_function : external_forcing_functions_)
     {
       add_forcing_function(state.custom_rate_parameters_, state_variables, forcing);
     }
@@ -457,7 +458,7 @@ namespace micm
     }
 
     // Add forcing contributions from external models
-    for (const auto& add_forcing_function : external_model_forcing_functions_)
+    for (const auto& add_forcing_function : external_forcing_functions_)
     {
       add_forcing_function(state.custom_rate_parameters_, state_variables, forcing);
     }
@@ -526,7 +527,7 @@ namespace micm
     }
 
     // Add Jacobian contributions from external models
-    for (const auto& add_jacobian_function : external_model_jacobian_functions_)
+    for (const auto& add_jacobian_function : external_jacobian_functions_)
     {
       add_jacobian_function(state.custom_rate_parameters_, state_variables, jacobian);
     }
@@ -611,7 +612,7 @@ namespace micm
     }
 
     // Add Jacobian contributions from external models
-    for (const auto& add_jacobian_function : external_model_jacobian_functions_)
+    for (const auto& add_jacobian_function : external_jacobian_functions_)
     {
       add_jacobian_function(state.custom_rate_parameters_, state_variables, jacobian);
     }
@@ -635,11 +636,11 @@ namespace micm
       }
     }
 
-    // Include species used in external models
-    for (const auto& model : external_models_)
+    // Include species used in external process sets
+    for (const auto& process_set : external_process_sets_)
     {
-      auto model_species_used = model.species_used_func_();
-      used_species.insert(model_species_used.begin(), model_species_used.end());
+      auto external_species_used = process_set.species_used_func_();
+      used_species.insert(external_species_used.begin(), external_species_used.end());
     }
 
     return used_species;

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -126,7 +126,7 @@ namespace micm
 
     /// @brief Add an external model (state variables, processes, and/or constraints)
     ///
-    /// The model must satisfy HasState (state variables and parameters are registered with the solver).
+    /// If the model satisfies HasState, its state variables and parameters are registered with the solver.
     /// The model must satisfy at least one of HasProcesses (process wrappers are created) or
     /// HasConstraints (constraint wrappers are created).
     /// @param model The external model (taken by value; caller decides whether to copy or move)
@@ -135,13 +135,11 @@ namespace micm
     SolverBuilder& AddExternalModel(ExternalModel model)
     {
       static_assert(
-          HasState<ExternalModel>,
-          "External model passed to AddExternalModel() must implement StateSize, StateVariableNames, and StateParameterNames");
-      static_assert(
           HasProcesses<ExternalModel> || HasConstraints<ExternalModel>,
           "External model passed to AddExternalModel() must satisfy at least HasProcesses or HasConstraints");
 
-      external_systems_.emplace_back(ExternalModelSystem{ model });
+      if constexpr (HasState<ExternalModel>)
+        external_systems_.emplace_back(ExternalModelSystem{ model });
 
       if constexpr (HasProcesses<ExternalModel> && HasConstraints<ExternalModel>)
       {

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -54,9 +54,12 @@ namespace micm
     SolverParametersPolicy options_;
     System system_;
     std::vector<Process> reactions_;
-    std::vector<ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>> external_models_;
-    std::vector<ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>> external_constraint_models_;
     std::vector<Constraint> constraints_;
+    
+    std::vector<ExternalModelSystem> external_systems_;
+    std::vector<ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>> external_process_sets_;
+    std::vector<ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>> external_constraints_;
+    
     bool ignore_unused_species_ = true;
     bool reorder_state_ = true;
     bool valid_system_ = false;
@@ -70,13 +73,8 @@ namespace micm
     {
     }
 
-    // Copy constructor
-    SolverBuilder(const SolverBuilder& other) = default;
-
-    // Copy assignment
-    SolverBuilder& operator=(const SolverBuilder& other) = default;
-
-    // Default move operations
+    SolverBuilder(const SolverBuilder&) = default;
+    SolverBuilder& operator=(const SolverBuilder&) = default;
     SolverBuilder(SolverBuilder&&) = default;
     SolverBuilder& operator=(SolverBuilder&&) = default;
 
@@ -96,41 +94,6 @@ namespace micm
     SolverBuilder& SetReactions(const std::vector<Process>& reactions)
     {
       reactions_ = reactions;
-      return *this;
-    }
-
-    /// @brief Add an external model (processes and/or constraints)
-    ///
-    /// If the model satisfies the HasProcesses concept, process wrappers are created.
-    /// If the model satisfies the HasConstraints concept, constraint wrappers are created.
-    /// At least one of the two concepts must be satisfied.
-    /// @param model The external model (taken by value; caller decides whether to copy or move)
-    /// @return Updated SolverBuilder
-    template<class ExternalModel>
-    SolverBuilder& AddExternalModel(ExternalModel model)
-    {
-      static_assert(
-          HasProcesses<ExternalModel> || HasConstraints<ExternalModel>,
-          "External model passed to AddExternalModel() must satisfy at least HasProcesses or HasConstraints");
-
-      if constexpr (HasProcesses<ExternalModel> && HasConstraints<ExternalModel>)
-      {
-        // Model has both — copy for one wrapper, move for the other
-        auto model_copy = model;
-        external_models_.emplace_back(
-            ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>{ std::move(model_copy) });
-        external_constraint_models_.emplace_back(
-            ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>{ std::move(model) });
-      }
-      else if constexpr (HasProcesses<ExternalModel>)
-      {
-        external_models_.emplace_back(ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>{ std::move(model) });
-      }
-      else
-      {
-        external_constraint_models_.emplace_back(
-            ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>{ std::move(model) });
-      }
       return *this;
     }
 
@@ -161,11 +124,70 @@ namespace micm
       return *this;
     }
 
+    /// @brief Add an external model (state variables, processes, and/or constraints)
+    ///
+    /// The model must satisfy HasState (state variables and parameters are registered with the solver).
+    /// The model must satisfy at least one of HasProcesses (process wrappers are created) or
+    /// HasConstraints (constraint wrappers are created).
+    /// @param model The external model (taken by value; caller decides whether to copy or move)
+    /// @return Updated SolverBuilder
+    template<class ExternalModel>
+    SolverBuilder& AddExternalModel(ExternalModel model)
+    {
+      static_assert(
+          HasState<ExternalModel>,
+          "External model passed to AddExternalModel() must implement StateSize, StateVariableNames, and StateParameterNames");
+      static_assert(
+          HasProcesses<ExternalModel> || HasConstraints<ExternalModel>,
+          "External model passed to AddExternalModel() must satisfy at least HasProcesses or HasConstraints");
+
+      external_systems_.emplace_back(ExternalModelSystem{ model });
+
+      if constexpr (HasProcesses<ExternalModel> && HasConstraints<ExternalModel>)
+      {
+        external_process_sets_.emplace_back(
+            ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>{ model });
+        external_constraints_.emplace_back(
+            ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>{ std::move(model) });
+      }
+      else if constexpr (HasProcesses<ExternalModel>)
+      {
+        external_process_sets_.emplace_back(ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>{ std::move(model) });
+      }
+      else
+      {
+        external_constraints_.emplace_back(
+            ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>{ std::move(model) });
+      }
+      return *this;
+    }
+
     /// @brief Creates an instance of Solver with a properly configured ODE solver
     /// @return An instance of Solver
     auto Build();
 
    protected:
+    /// @brief Returns the total state size: gas phase + all external model state variables
+    std::size_t MergedStateSize() const
+    {
+      std::size_t n = system_.StateSize();
+      for (const auto& m : external_systems_)
+        n += std::get<0>(m.state_size_func_());
+      return n;
+    }
+
+    /// @brief Returns all unique species names: gas phase first, then external model variables
+    std::vector<std::string> MergedUniqueNames() const
+    {
+      auto names = system_.UniqueNames();
+      for (const auto& m : external_systems_)
+      {
+        auto model_names = m.variable_names_func_();
+        names.insert(names.end(), model_names.begin(), model_names.end());
+      }
+      return names;
+    }
+
     /// @brief Checks for unused species
     /// @param rates The rates policy instance containing information about processes
     /// @throws std::system_error if an unused species is found

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -34,15 +34,15 @@ namespace micm
       used_species.insert(constraint.AlgebraicSpecies());
     }
     // Include species referenced by external model constraints
-    for (const auto& model : external_constraint_models_)
+    for (const auto& constraint : external_constraints_)
     {
-      auto deps = model.species_dependencies_func_();
+      auto deps = constraint.species_dependencies_func_();
       used_species.insert(deps.begin(), deps.end());
-      auto alg_names = model.algebraic_variable_names_func_();
+      auto alg_names = constraint.algebraic_variable_names_func_();
       used_species.insert(alg_names.begin(), alg_names.end());
     }
 
-    auto available_species = system_.UniqueNames();
+    auto available_species = this->MergedUniqueNames();
     std::sort(available_species.begin(), available_species.end());
     std::set<std::string> unused_species;
     std::set_difference(
@@ -79,29 +79,28 @@ namespace micm
       StatePolicy>::GetSpeciesMap() const
   {
     std::unordered_map<std::string, std::size_t> species_map;
-    std::function<std::string(const std::vector<std::string>& variables, const std::size_t i)> state_reordering;
     std::size_t index = 0;
-    for (auto& name : system_.UniqueNames())
+
+    auto all_names = this->MergedUniqueNames();
+    for (auto& name : all_names)
       species_map[name] = index++;
 
     if (reorder_state_)
     {
       // get unsorted Jacobian non-zero elements
-      auto unsorted_rates = RatesPolicy(reactions_, species_map, external_models_);
+      auto unsorted_rates = RatesPolicy(reactions_, species_map, external_process_sets_);
       auto unsorted_jac_elements = unsorted_rates.NonZeroJacobianElements();
 
       using Matrix = typename DenseMatrixPolicy::IntMatrix;
-      Matrix unsorted_jac_non_zeros(system_.StateSize(), system_.StateSize(), 0);
+      const auto n = this->MergedStateSize();
+      Matrix unsorted_jac_non_zeros(n, n, 0);
       for (auto& elem : unsorted_jac_elements)
         unsorted_jac_non_zeros[elem.first][elem.second] = 1;
       auto reorder_map = DiagonalMarkowitzReorder<Matrix>(unsorted_jac_non_zeros);
 
-      state_reordering = [=](const std::vector<std::string>& variables, const std::size_t i)
-      { return variables[reorder_map[i]]; };
-
       index = 0;
-      for (auto& name : system_.UniqueNames(state_reordering))
-        species_map[name] = index++;
+      for (std::size_t i = 0; i < all_names.size(); ++i)
+        species_map[all_names[reorder_map[i]]] = index++;
     }
 
     return species_map;
@@ -148,9 +147,9 @@ namespace micm
     }
 
     // Include custom parameter labels from external models
-    for (const auto& model : system_.external_models_)
+    for (const auto& sys : external_systems_)
     {
-      auto param_names = model.parameter_names_func_();
+      auto param_names = sys.parameter_names_func_();
       for (const auto& label : param_names)
         add_param(label, "external_model");
     }
@@ -221,7 +220,7 @@ namespace micm
           MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_MISSING_CHEMICAL_SYSTEM, "Missing chemical system.");
     }
 
-    std::size_t number_of_species = this->system_.StateSize();
+    std::size_t number_of_species = this->MergedStateSize();
     if (number_of_species == 0)
     {
       throw MicmException(
@@ -237,7 +236,7 @@ namespace micm
     };
     if constexpr (is_cuda_policy)
     {
-      if (!constraints_.empty() || !external_constraint_models_.empty())
+      if (!constraints_.empty() || !external_constraints_.empty())
       {
         throw MicmException(
             MICM_ERROR_CATEGORY_SOLVER,
@@ -291,7 +290,7 @@ namespace micm
 
     // Build ProcessSet
     auto species_map = this->GetSpeciesMap();
-    RatesPolicy rates(reactions_, species_map, external_models_);
+    RatesPolicy rates(reactions_, species_map, external_process_sets_);
     this->UnusedSpeciesCheck(rates);
     auto nonzero_elements = rates.NonZeroJacobianElements();
 
@@ -344,10 +343,10 @@ namespace micm
     }
 
     // Resolve external model constraints (runtime activation)
-    if (!external_constraint_models_.empty())
+    if (!external_constraints_.empty())
     {
-      auto ext_constraint_models_copy = external_constraint_models_;
-      constraint_set.SetExternalConstraintModels(std::move(ext_constraint_models_copy));
+      auto external_constraints_copy = external_constraints_;
+      constraint_set.SetExternalConstraintModels(std::move(external_constraints_copy));
       constraint_set.ResolveExternalConstraints(species_map);
 
       // Add external constraint parameter names to the params map
@@ -398,9 +397,9 @@ namespace micm
     // VectorIndex at setup time and need these elements to exist in the sparse matrix.
     if (!algebraic_variable_ids.empty())
     {
-      for (const auto& model : external_models_)
+      for (const auto& process_set : external_process_sets_)
       {
-        auto ext_process_elements = model.non_zero_jacobian_elements_func_(species_map);
+        auto ext_process_elements = process_set.non_zero_jacobian_elements_func_(species_map);
         for (const auto& elem : ext_process_elements)
         {
           if (algebraic_variable_ids.count(elem.first) > 0)
@@ -431,10 +430,10 @@ namespace micm
     rates.SetJacobianFlatIds(jacobian);
     rates.SetExternalModelFunctions(params_map, species_map, jacobian);
 
-    // Compile external model update functions now that params_map is finalized
-    for (const auto& model : external_models_)
+    // Compile external process set update functions now that params_map is finalized
+    for (const auto& process_set : external_process_sets_)
     {
-      update_state_param_funcs.push_back(model.update_state_parameters_function_(params_map));
+      update_state_param_funcs.push_back(process_set.update_state_parameters_function_(params_map));
     }
 
     std::vector<std::function<void(const DenseMatrixPolicy&, DenseMatrixPolicy&)>> init_constraint_param_funcs;

--- a/include/micm/system/system.hpp
+++ b/include/micm/system/system.hpp
@@ -2,143 +2,61 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <micm/external_model.hpp>
 #include <micm/system/phase.hpp>
-#include <micm/system/species.hpp>
 
 #include <functional>
-#include <memory>
-#include <set>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace micm
 {
 
-  struct SystemParameters
-  {
-    /// @brief  @brief The gas phase
-    Phase gas_phase_{};
-    /// @brief External models (e.g., aerosol models) that provide additional components to the system
-    std::vector<ExternalModelSystem> external_models_{};
-  };
-
-  /// @brief Represents the complete chemical state of a grid cell
-  ///        Includes the gas phase and other associated phases, each with their own set of species.
+  /// @brief Defines the gas-phase species available in the chemical system
   class System
   {
    public:
     /// @brief The gas phase, defining a set of species present in the system
     Phase gas_phase_;
-    /// @brief External models (e.g., aerosol models) that provide additional components to the system
-    std::vector<ExternalModelSystem> external_models_;
 
-    /// @brief Default constructor
     System() = default;
 
-    /// @brief Parameterized constructor
     System(const Phase& gas_phase)
-        : gas_phase_(gas_phase),
-          external_models_()
+        : gas_phase_(gas_phase)
     {
     }
 
-    /// @brief Constructor with external models
-    template<typename... ExternalModels>
-    System(const Phase& gas_phase, ExternalModels&&... external_models)
-        : gas_phase_(gas_phase),
-          external_models_{ ExternalModelSystem{ std::forward<ExternalModels>(external_models) }... }
+    /// @brief Returns the number of gas-phase state variables
+    size_t StateSize() const
     {
-      if (StateSize() != UniqueNames().size())
-      {
-        throw std::invalid_argument(
-            "Mismatch between system state size and number of unique names. Likely duplicate species names.");
-      }
+      return gas_phase_.StateSize();
     }
 
-    /// @brief Copy constructor
-    System(const System&) = default;
-
-    /// @brief Move constructor
-    System(System&&) = default;
-
-    /// @brief Constructor from SystemParameters
-    System(const SystemParameters& parameters)
-        : gas_phase_(parameters.gas_phase_),
-          external_models_(parameters.external_models_)
-    {
-      if (StateSize() != UniqueNames().size())
-      {
-        throw std::invalid_argument(
-            "Mismatch between system state size and number of unique names. Likely duplicate species names.");
-      }
-    }
-
-    /// @brief Copy assignment operator
-    System& operator=(const System&) = default;
-
-    /// @brief Move assignment operator
-    System& operator=(System&&) = default;
-
-    /// @brief Returns the number of doubles required to store the system state
-    size_t StateSize() const;
-
-    /// @brief Returns a set of unique species names
+    /// @brief Returns the unique gas-phase species names
     /// @return vector of unique state variable names
-    std::vector<std::string> UniqueNames() const;
+    std::vector<std::string> UniqueNames() const
+    {
+      return UniqueNames(nullptr);
+    }
 
-    /// @brief Returns a set of unique species names
-    /// @param f Function used to apply specific order to unique names
+    /// @brief Returns the unique gas-phase species names, optionally reordered
+    /// @param f Function used to apply a specific order to unique names
     /// @return vector of unique state variable names
     std::vector<std::string> UniqueNames(
-        const std::function<std::string(const std::vector<std::string>& variables, const std::size_t i)> f) const;
+        const std::function<std::string(const std::vector<std::string>& variables, const std::size_t i)> f) const
+    {
+      auto names = gas_phase_.SpeciesNames();
+
+      if (f)
+      {
+        std::vector<std::string> reordered;
+        reordered.reserve(names.size());
+        for (std::size_t i = 0; i < names.size(); ++i)
+          reordered.push_back(f(names, i));
+        return reordered;
+      }
+
+      return names;
+    }
   };
-
-  inline size_t System::StateSize() const
-  {
-    std::size_t state_size = gas_phase_.StateSize();
-    for (const auto& model : external_models_)
-    {
-      state_size += std::get<0>(model.state_size_func_());
-    }
-
-    return state_size;
-  }
-
-  inline std::vector<std::string> System::UniqueNames() const
-  {
-    return UniqueNames(nullptr);
-  }
-
-  inline std::vector<std::string> System::UniqueNames(
-      const std::function<std::string(const std::vector<std::string>& variables, const std::size_t i)> f) const
-  {
-    std::vector<std::string> names;
-    names.reserve(StateSize());
-
-    // Exclude phase name for gas phase species to maintain consistency with prior behavior
-    // e.g., "O3" instead of "GAS.O3"
-    auto gas_names = gas_phase_.SpeciesNames();
-    names.insert(names.end(), std::make_move_iterator(gas_names.begin()), std::make_move_iterator(gas_names.end()));
-
-    // Include names from external models
-    for (const auto& model : external_models_)
-    {
-      auto model_names = model.variable_names_func_();
-      names.insert(names.end(), model_names.begin(), model_names.end());
-    }
-
-    if (f)
-    {
-      std::vector<std::string> reordered;
-      reordered.reserve(names.size());
-      for (std::size_t i = 0; i < names.size(); ++i)
-        reordered.push_back(f(names, i));
-      return reordered;
-    }
-
-    return names;
-  }
 
 }  // namespace micm

--- a/test/integration/aerosol_model_policy.hpp
+++ b/test/integration/aerosol_model_policy.hpp
@@ -39,8 +39,8 @@ CreateSystemWithStubAerosolModels()
   auto aerosol_1 = StubAerosolModel("STUB1", std::vector<micm::Phase>({ quux, corge }), rate_constants);
   auto aerosol_2 = AnotherStubAerosolModel("STUB2", std::vector<micm::Phase>({ quux, corge }));
 
-  // Create a system containing the gas phase and both aerosol models
-  auto system = micm::System({ .gas_phase_ = gas, .external_models_ = { aerosol_1, aerosol_2 } });
+  // Create a system containing the gas phase (external model state is registered via AddExternalModel)
+  auto system = micm::System(gas);
 
   return { system, aerosol_1, aerosol_2, phases };
 }
@@ -52,7 +52,11 @@ void test_state_includes_stub_aerosol_model(BuilderPolicy builder)
   auto [system, aerosol_1, aerosol_2, phases] = CreateSystemWithStubAerosolModels();
 
   // Create a solver for the system (without processes for simplicity)
-  auto solver = builder.SetSystem(system).SetIgnoreUnusedSpecies(true).Build();
+  auto solver = builder.SetSystem(system)
+                    .AddExternalModel(aerosol_1)
+                    .AddExternalModel(aerosol_2)
+                    .SetIgnoreUnusedSpecies(true)
+                    .Build();
 
   // Get a state and ensure that the size and labels match expectations
   auto state = solver.GetState();
@@ -95,7 +99,11 @@ void test_update_state_with_stub_aerosol_model(BuilderPolicy builder)
   auto [system, aerosol_1, aerosol_2, phases] = CreateSystemWithStubAerosolModels();
 
   // Create a solver for the system (without processes for simplicity)
-  auto solver = builder.SetSystem(system).SetIgnoreUnusedSpecies(true).Build();
+  auto solver = builder.SetSystem(system)
+                    .AddExternalModel(aerosol_1)
+                    .AddExternalModel(aerosol_2)
+                    .SetIgnoreUnusedSpecies(true)
+                    .Build();
 
   // Get a state and set some values
   auto state = solver.GetState();
@@ -165,7 +173,11 @@ void test_update_multi_cell_state_with_stub_aerosol_model(BuilderPolicy builder)
   auto [system, aerosol_1, aerosol_2, phases] = CreateSystemWithStubAerosolModels();
 
   // Create a solver for the system (without processes for simplicity)
-  auto solver = builder.SetSystem(system).SetIgnoreUnusedSpecies(true).Build();
+  auto solver = builder.SetSystem(system)
+                    .AddExternalModel(aerosol_1)
+                    .AddExternalModel(aerosol_2)
+                    .SetIgnoreUnusedSpecies(true)
+                    .Build();
 
   const std::size_t num_cells = 3;
 
@@ -359,9 +371,10 @@ void test_solve_with_stub_aerosol_model_1(BuilderPolicy builder, double base_rel
 {
   auto [system, aerosol_1, aerosol_2, phases] = CreateSystemWithStubAerosolModels();
 
-  // Create a solver for the system with processes that use the aerosol models
+  // Create a solver for the system with both aerosol models
   auto solver = builder.SetSystem(system)
-                    .AddExternalModel(aerosol_1)  // excluding aerosol 2 process for this test
+                    .AddExternalModel(aerosol_1)
+                    .AddExternalModel(aerosol_2)
                     .SetIgnoreUnusedSpecies(true)
                     .Build();
 
@@ -491,9 +504,10 @@ void test_solve_with_stub_aerosol_model_1_multi_cell(BuilderPolicy builder, doub
 {
   auto [system, aerosol_1, aerosol_2, phases] = CreateSystemWithStubAerosolModels();
 
-  // Create a solver for the system with processes that use the aerosol models
+  // Create a solver for the system with both aerosol models
   auto solver = builder.SetSystem(system)
-                    .AddExternalModel(aerosol_1)  // excluding aerosol 2 process for this test
+                    .AddExternalModel(aerosol_1)
+                    .AddExternalModel(aerosol_2)
                     .SetIgnoreUnusedSpecies(true)
                     .Build();
 

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -406,7 +406,7 @@ void test_analytical_troe(
                          .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2 };
-  builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
+  builder.SetSystem(micm::System(gas_phase )).SetReactions(processes);
 
   test_simple_system<BuilderPolicy>(
       "troe",
@@ -500,7 +500,7 @@ void test_analytical_stiff_troe(
                          .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2, r3, r4, r5 };
-  builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
+  builder.SetSystem(micm::System(gas_phase )).SetReactions(processes);
 
   test_simple_stiff_system<BuilderPolicy>(
       "troe",
@@ -563,7 +563,7 @@ void test_analytical_photolysis(
                          .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2 };
-  builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
+  builder.SetSystem(micm::System(gas_phase )).SetReactions(processes);
 
   std::unordered_map<std::string, std::vector<double>> custom_parameters = {
     { "photoA", std::vector<double>(NUM_CELLS, 2e-3) }, { "photoB", std::vector<double>(NUM_CELLS, 3e-3) }
@@ -649,7 +649,7 @@ void test_analytical_stiff_photolysis(
                          .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2, r3, r4, r5 };
-  builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
+  builder.SetSystem(micm::System(gas_phase )).SetReactions(processes);
 
   std::unordered_map<std::string, std::vector<double>> custom_parameters = {
     { "photoA1B", std::vector<double>(NUM_CELLS, 2e-3) },
@@ -722,7 +722,7 @@ void test_analytical_ternary_chemical_activation(
                          .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2 };
-  builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
+  builder.SetSystem(micm::System(gas_phase )).SetReactions(processes);
 
   test_simple_system<BuilderPolicy>(
       "ternary_chemical_activation",
@@ -818,7 +818,7 @@ void test_analytical_stiff_ternary_chemical_activation(
                          .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2, r3, r4, r5 };
-  builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
+  builder.SetSystem(micm::System(gas_phase )).SetReactions(processes);
 
   test_simple_stiff_system<BuilderPolicy>(
       "ternary_chemical_activation",
@@ -882,7 +882,7 @@ void test_analytical_tunneling(
                          .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2 };
-  builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
+  builder.SetSystem(micm::System(gas_phase )).SetReactions(processes);
 
   test_simple_system<BuilderPolicy>(
       "tunneling",
@@ -965,7 +965,7 @@ void test_analytical_stiff_tunneling(
                          .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2, r3, r4, r5 };
-  builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
+  builder.SetSystem(micm::System(gas_phase )).SetReactions(processes);
 
   test_simple_stiff_system<BuilderPolicy>(
       "tunneling",
@@ -1024,7 +1024,7 @@ void test_analytical_arrhenius(
           .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2 };
-  builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
+  builder.SetSystem(micm::System(gas_phase )).SetReactions(processes);
 
   test_simple_system<BuilderPolicy>(
       "arrhenius",
@@ -1108,7 +1108,7 @@ void test_analytical_stiff_arrhenius(
                          .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2, r3, r4, r5 };
-  builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
+  builder.SetSystem(micm::System(gas_phase )).SetReactions(processes);
 
   test_simple_stiff_system<BuilderPolicy>(
       "arrhenius",
@@ -1177,7 +1177,7 @@ void test_analytical_branched(
                          .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2 };
-  builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
+  builder.SetSystem(micm::System(gas_phase )).SetReactions(processes);
 
   test_simple_system<BuilderPolicy>(
       "branched",
@@ -1293,7 +1293,7 @@ void test_analytical_stiff_branched(
                          .Build();
 
   auto processes = std::vector<micm::Process>{ r1, r2, r3, r4, r5 };
-  builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase })).SetReactions(processes);
+  builder.SetSystem(micm::System(gas_phase )).SetReactions(processes);
 
   test_simple_stiff_system<BuilderPolicy>(
       "branched",
@@ -1384,7 +1384,7 @@ void test_analytical_robertson(
 
   auto processes = std::vector<micm::Process>{ r1, r2, r3 };
   auto solver = builder.SetReorderState(false)
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions(processes)
                     .Build();
 
@@ -1570,7 +1570,7 @@ void test_analytical_oregonator(
 
   auto processes = std::vector<micm::Process>{ r1, r2, r3, r4, r5 };
   auto solver = builder.SetReorderState(false)
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions(processes)
                     .Build();
 
@@ -1801,7 +1801,7 @@ void test_analytical_hires(
 
   auto processes = std::vector<micm::Process>{ r1, r2, r3, r4, r5, r6, r7, r8, r9 };
   auto solver = builder.SetReorderState(false)
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions(processes)
                     .Build();
 
@@ -1974,7 +1974,7 @@ void test_analytical_e5(
 
   auto processes = std::vector<micm::Process>{ r1, r2, r3, r4 };
   auto solver = builder.SetReorderState(false)
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions(processes)
                     .Build();
 

--- a/test/integration/analytical_surface_rxn_policy.hpp
+++ b/test/integration/analytical_surface_rxn_policy.hpp
@@ -50,7 +50,7 @@ void test_analytical_surface_rxn(
   micm::Phase gas_phase{ "gas", { gas_foo, gas_bar, gas_baz } };
 
   // System
-  micm::System chemical_system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+  micm::System chemical_system = micm::System(gas_phase );
 
   // Rate
   micm::SurfaceRateConstantParameters surface{ .label_ = "foo",

--- a/test/integration/terminator.hpp
+++ b/test/integration/terminator.hpp
@@ -39,7 +39,7 @@ void TestTerminator(BuilderPolicy& builder, std::size_t number_of_grid_cells)
                              .SetRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = k2 })
                              .Build();
 
-  auto solver = builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+  auto solver = builder.SetSystem(micm::System(gas_phase ))
                     .SetReactions(std::vector<micm::Process>{ toy_r1, toy_r2 })
                     .Build();
   auto state = solver.GetState(number_of_grid_cells);

--- a/test/integration/test_chapman_integration.cpp
+++ b/test/integration/test_chapman_integration.cpp
@@ -73,7 +73,7 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
   auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
 
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ r1, r2, r3, r4, photo_1, photo_2, photo_3 })
                     .SetIgnoreUnusedSpecies(true)
                     .Build();

--- a/test/integration/test_dae_algebraic_error_insensitivity.cpp
+++ b/test/integration/test_dae_algebraic_error_insensitivity.cpp
@@ -89,7 +89,7 @@ namespace
 
     auto options = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
-                      .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+                      .SetSystem(System(gas_phase ))
                       .SetReactions({ rxn })
                       .SetConstraints(std::move(constraints))
                       .SetReorderState(false)

--- a/test/integration/test_dae_constraint_overshoot.cpp
+++ b/test/integration/test_dae_constraint_overshoot.cpp
@@ -62,7 +62,7 @@ TEST(DAEConstraintOvershoot, AlgebraicVariableStaysNonNegative)
 
   auto options = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
-                    .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(System(gas_phase ))
                     .SetReactions({ rxn })
                     .SetConstraints(std::move(constraints))
                     .SetReorderState(false)
@@ -163,7 +163,7 @@ TEST(DAEConstraintOvershoot, EquilibriumPlusConservation)
 
   auto options = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
-                    .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(System(gas_phase ))
                     .SetReactions({ rxn })
                     .SetConstraints(std::move(constraints))
                     .SetReorderState(false)
@@ -257,7 +257,7 @@ TEST(DAEConstraintOvershoot, AllRosenbrockOrdersConstrained)
     constraints.push_back(LinearConstraint("mass_conservation", C, { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, C_total));
 
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(options)
-                      .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+                      .SetSystem(System(gas_phase ))
                       .SetReactions({ rxn })
                       .SetConstraints(std::move(constraints))
                       .SetReorderState(false)

--- a/test/integration/test_equilibrium_constraint.cpp
+++ b/test/integration/test_equilibrium_constraint.cpp
@@ -53,7 +53,7 @@ TEST(EquilibriumIntegration, SetConstraintsAPIWorks)
   // Build solver with constraints
   auto options = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
-                    .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(System(gas_phase ))
                     .SetReactions({ rxn })
                     .SetConstraints(std::move(constraints))
                     .SetReorderState(false)
@@ -145,7 +145,7 @@ TEST(EquilibriumIntegration, SetConstraintsAPIMultipleConstraints)
   // Build solver with multiple constraints
   auto options = RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
-                    .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(System(gas_phase ))
                     .SetReactions({ rxn1, rxn2 })
                     .SetConstraints(std::move(constraints))
                     .SetReorderState(false)
@@ -218,7 +218,7 @@ TEST(EquilibriumIntegration, DAESolveWithConstraint)
 
   auto options = RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
-                    .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(System(gas_phase ))
                     .SetReactions({ rxn })
                     .SetConstraints(std::move(constraints))
                     .SetReorderState(false)
@@ -316,7 +316,7 @@ TEST(EquilibriumIntegration, DAESolveWithConstraintAndReorderState)
 
   auto options = RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
-                    .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(System(gas_phase ))
                     .SetReactions({ rxn })
                     .SetConstraints(std::move(constraints))
                     .SetReorderState(true)
@@ -398,7 +398,7 @@ TEST(EquilibriumIntegration, DAESolveWithTwoCoupledConstraints)
 
   auto options = RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
-                    .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(System(gas_phase ))
                     .SetReactions({ rxn })
                     .SetConstraints(std::move(constraints))
                     .SetReorderState(false)
@@ -485,7 +485,7 @@ TEST(EquilibriumIntegration, DAESolveWithNonUnitStoichiometry)
 
   auto options = RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
-                    .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(System(gas_phase ))
                     .SetReactions({ rxn })
                     .SetConstraints(std::move(constraints))
                     .SetReorderState(false)

--- a/test/integration/test_external_model_constraints.cpp
+++ b/test/integration/test_external_model_constraints.cpp
@@ -326,7 +326,7 @@ TEST(ExternalModelConstraints, AddExternalModelWithConstraints)
   double total = 1.0;
   StubAerosolWithConstraints aerosol(0.01, total);
 
-  auto system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase, .external_models_ = { aerosol } });
+  auto system = micm::System(gas_phase );
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
@@ -358,7 +358,7 @@ TEST(ExternalModelConstraints, AddExternalModelProcessOnly)
   // No total_mass → constraints disabled
   StubAerosolWithConstraints aerosol(0.01);
 
-  auto system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase, .external_models_ = { aerosol } });
+  auto system = micm::System(gas_phase );
 
   auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
@@ -388,7 +388,7 @@ TEST(ExternalModelConstraints, DAESolveEnforcesConservation)
   double k = 0.1;
   StubAerosolWithConstraints aerosol(k, total);
 
-  auto system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase, .external_models_ = { aerosol } });
+  auto system = micm::System(gas_phase );
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
@@ -449,7 +449,7 @@ TEST(ExternalModelConstraints, CombinedBuiltInAndExternalConstraints)
                           .SetPhase(gas_phase)
                           .Build();
 
-  auto system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase, .external_models_ = { aerosol } });
+  auto system = micm::System(gas_phase );
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
@@ -480,7 +480,7 @@ TEST(ExternalModelConstraints, AddExternalModelOnlyStandardRosenbrock)
 
   StubAerosolWithConstraints aerosol(0.01);
 
-  auto system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase, .external_models_ = { aerosol } });
+  auto system = micm::System(gas_phase );
 
   auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
   // Add only processes (constraints are not enabled with standard Rosenbrock parameters)
@@ -504,7 +504,7 @@ TEST(ExternalModelConstraints, AddExternalModelConstraintsOnly)
   double total = 1.0;
   StubAerosolWithConstraints aerosol(0.01, total);
 
-  auto system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase, .external_models_ = { aerosol } });
+  auto system = micm::System(gas_phase );
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
@@ -543,7 +543,7 @@ TEST(ExternalModelConstraints, MultiGridCell)
   double total = 1.0;
   StubAerosolWithConstraints aerosol(0.1, total);
 
-  auto system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase, .external_models_ = { aerosol } });
+  auto system = micm::System(gas_phase );
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
@@ -635,7 +635,7 @@ namespace
 
     auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
     auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
-                      .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                      .SetSystem(micm::System(gas_phase ))
                       .SetReactions({ rxn_ab, rxn_bc, rxn_cb })
                       .SetReorderState(false)
                       .Build();
@@ -686,7 +686,7 @@ namespace
 
     auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
     auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
-                      .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                      .SetSystem(micm::System(gas_phase ))
                       .SetReactions({ rxn_ab })
                       .AddExternalModel(eq_model)
                       .SetReorderState(false)
@@ -734,7 +734,7 @@ namespace
 
     auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
     auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
-                      .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                      .SetSystem(micm::System(gas_phase ))
                       .SetReactions({ rxn_ab })
                       .AddExternalModel(eq_model)
                       .SetReorderState(false)
@@ -845,7 +845,7 @@ TEST(ExternalModelConstraints, BuiltInVsExternalModelConstraintStepByStep)
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto builtin_solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
-                            .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                            .SetSystem(micm::System(gas_phase ))
                             .SetReactions({ rxn_ab })
                             .SetConstraints(std::move(constraints))
                             .SetReorderState(false)
@@ -854,7 +854,7 @@ TEST(ExternalModelConstraints, BuiltInVsExternalModelConstraintStepByStep)
   // External model constraint solver
   EquilibriumConstraintModel eq_model("B", "C", K_EQ);
   auto ext_solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
-                        .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                        .SetSystem(micm::System(gas_phase ))
                         .SetReactions({ rxn_ab })
                         .AddExternalModel(eq_model)
                         .SetReorderState(false)
@@ -927,7 +927,7 @@ TEST(ExternalModelConstraints, MultiEquilibriumKineticVsComposedConstraints)
   auto D = micm::Species("D");
   micm::Phase gas_phase{ "gas", { A, B, C, D } };
 
-  auto system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+  auto system = micm::System(gas_phase );
 
   // ── Kinetic system ──
   micm::Process rxn_ab = micm::ChemicalReactionBuilder()
@@ -1061,7 +1061,7 @@ TEST(ExternalModelConstraints, ProcessJacobianElementInAlgebraicRowSurvivesFilte
   double k = 0.1;
   StubAerosolWithSolvent aerosol(k, total);
 
-  auto system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase, .external_models_ = { aerosol } });
+  auto system = micm::System(gas_phase );
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
 
@@ -1379,7 +1379,7 @@ TEST(ExternalModelConstraints, TemperatureDependentConstraintParameter)
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ rxn_ab })
                     .AddExternalModel(eq_model)
                     .SetReorderState(false)

--- a/test/integration/test_integrated_reaction_rates.cpp
+++ b/test/integration/test_integrated_reaction_rates.cpp
@@ -34,7 +34,7 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
   auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
 
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ r1, r2 })
                     .Build();
 

--- a/test/integration/test_linear_constraint.cpp
+++ b/test/integration/test_linear_constraint.cpp
@@ -76,7 +76,7 @@ TEST(DAESolveWithConstraint, TerminatorAndRobertson)
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
 
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions(processes)
                     .SetConstraints(std::move(constraints))
                     .SetReorderState(false)

--- a/test/regression/RosenbrockChapman/util.hpp
+++ b/test/regression/RosenbrockChapman/util.hpp
@@ -87,7 +87,7 @@ auto getChapmanSolver(SolverBuilderPolicy& builder)
   micm::Phase gas_phase = createGasPhase();
   std::vector<micm::Process> processes = createProcesses(gas_phase);
 
-  return builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+  return builder.SetSystem(micm::System(gas_phase ))
       .SetReactions(std::move(processes))
       .Build();
 }

--- a/test/regression/regression_policy.hpp
+++ b/test/regression/regression_policy.hpp
@@ -147,7 +147,7 @@ void test_flow_tube(
 
   auto processes = std::vector<micm::Process>{ r1, r2, r3 };
   auto solver = builder.SetReorderState(false)
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions(processes)
                     .Build();
 

--- a/test/tutorial/test_README_example.cpp
+++ b/test/tutorial/test_README_example.cpp
@@ -13,7 +13,7 @@ int main(const int argc, const char *argv[])
 
   Phase gas_phase{ "gas", std::vector<PhaseSpecies>{ foo, bar, baz } };
 
-  System chemical_system{ SystemParameters{ .gas_phase_ = gas_phase } };
+  System chemical_system(gas_phase );
 
   Process r1 = ChemicalReactionBuilder()
                    .SetReactants({ foo })

--- a/test/tutorial/test_README_example.cpp
+++ b/test/tutorial/test_README_example.cpp
@@ -13,7 +13,7 @@ int main(const int argc, const char *argv[])
 
   Phase gas_phase{ "gas", std::vector<PhaseSpecies>{ foo, bar, baz } };
 
-  System chemical_system(gas_phase );
+  System chemical_system(gas_phase);
 
   Process r1 = ChemicalReactionBuilder()
                    .SetReactants({ foo })

--- a/test/tutorial/test_multiple_grid_cells.cpp
+++ b/test/tutorial/test_multiple_grid_cells.cpp
@@ -39,7 +39,7 @@ int main()
 
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
                     micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ r1, r2, r3 })
                     .Build();
 

--- a/test/tutorial/test_openmp.cpp
+++ b/test/tutorial/test_openmp.cpp
@@ -93,7 +93,7 @@ int main()
                          .Build();
 
   auto reactions = std::vector<micm::Process>{ r1, r2, r3 };
-  auto chemical_system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+  auto chemical_system = micm::System(gas_phase );
 
   std::vector<std::vector<double>> results(n_threads);
 

--- a/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_no_user_defined_by_hand.cpp
@@ -113,7 +113,7 @@ int main(const int argc, const char* argv[])
                    .SetPhase(gas_phase)
                    .Build();
 
-  auto chemical_system = System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+  auto chemical_system = System(gas_phase );
   auto reactions = std::vector<micm::Process>{ r1, r2, r3, r4, r5, r6, r7 };
 
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(

--- a/test/tutorial/test_rate_constants_user_defined_by_hand.cpp
+++ b/test/tutorial/test_rate_constants_user_defined_by_hand.cpp
@@ -132,7 +132,7 @@ int main(const int argc, const char* argv[])
                     .SetPhase(gas_phase)
                     .Build();
 
-  auto chemical_system = System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+  auto chemical_system = System(gas_phase );
   auto reactions = std::vector<micm::Process>{ r1, r2, r3, r4, r5, r6, r7, r8, r9, r10 };
 
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(

--- a/test/tutorial/test_solver_configuration.cpp
+++ b/test/tutorial/test_solver_configuration.cpp
@@ -108,7 +108,7 @@ int main()
                    .SetPhase(gas_phase)
                    .Build();
 
-  auto system = System(SystemParameters{ .gas_phase_ = gas_phase });
+  auto system = System(gas_phase );
   auto reactions = std::vector<Process>{ r1, r2, r3 };
 
   auto two_stage = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(

--- a/test/tutorial/test_solver_results.cpp
+++ b/test/tutorial/test_solver_results.cpp
@@ -40,7 +40,7 @@ int main()
 
   auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
                     micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(System(gas_phase ))
                     .SetReactions({ r1, r2, r3 })
                     .Build();
 

--- a/test/tutorial/test_vectorized_matrix_solver.cpp
+++ b/test/tutorial/test_vectorized_matrix_solver.cpp
@@ -77,7 +77,7 @@ int main()
                    .Build();
 
   auto params = RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
-  auto system = System(SystemParameters{ .gas_phase_ = gas_phase });
+  auto system = System(gas_phase );
   auto reactions = std::vector<Process>{ r1, r2, r3 };
   const std::size_t number_of_grid_cells = 3;
 

--- a/test/unit/cuda/process/test_cuda_rate_constants.cpp
+++ b/test/unit/cuda/process/test_cuda_rate_constants.cpp
@@ -50,7 +50,7 @@ TEST(CudaRateConstants, Arrhenius)
                      .Build();
 
   auto solver = GpuBuilder(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ process })
                     .Build();
 
@@ -86,7 +86,7 @@ TEST(CudaRateConstants, Troe)
                      .Build();
 
   auto solver = GpuBuilder(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ process })
                     .Build();
 
@@ -117,7 +117,7 @@ TEST(CudaRateConstants, TernaryChemicalActivation)
                      .Build();
 
   auto solver = GpuBuilder(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ process })
                     .Build();
 
@@ -148,7 +148,7 @@ TEST(CudaRateConstants, BranchedAlkoxy)
                      .Build();
 
   auto solver = GpuBuilder(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ process })
                     .Build();
 
@@ -181,7 +181,7 @@ TEST(CudaRateConstants, BranchedNitrate)
                      .Build();
 
   auto solver = GpuBuilder(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ process })
                     .Build();
 
@@ -211,7 +211,7 @@ TEST(CudaRateConstants, Tunneling)
                      .Build();
 
   auto solver = GpuBuilder(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ process })
                     .Build();
 
@@ -248,7 +248,7 @@ TEST(CudaRateConstants, TaylorSeries)
                      .Build();
 
   auto solver = GpuBuilder(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ process })
                     .Build();
 
@@ -277,7 +277,7 @@ TEST(CudaRateConstants, Reversible)
                      .Build();
 
   auto solver = GpuBuilder(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ process })
                     .Build();
 
@@ -306,7 +306,7 @@ TEST(CudaRateConstants, UserDefined)
                      .Build();
 
   auto solver = GpuBuilder(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ process })
                     .Build();
 
@@ -344,7 +344,7 @@ TEST(CudaRateConstants, Surface)
                      .Build();
 
   auto solver = GpuBuilder(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(micm::System(gas_phase ))
                     .SetReactions({ process })
                     .Build();
 

--- a/test/unit/cuda/solver/test_cuda_solver_builder.cpp
+++ b/test/unit/cuda/solver/test_cuda_solver_builder.cpp
@@ -32,7 +32,7 @@ namespace
                          .SetRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .B_ = 0, .C_ = 55 })
                          .SetPhase(gas_phase)
                          .Build();
-  micm::System the_system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+  micm::System the_system = micm::System(gas_phase );
   std::vector<micm::Process> reactions = { r1, r2 };
 }  // namespace
 

--- a/test/unit/openmp/test_openmp.cpp
+++ b/test/unit/openmp/test_openmp.cpp
@@ -42,7 +42,7 @@ TEST(OpenMP, OneSolverManyStates)
                          .Build();
 
   auto reactions = std::vector<micm::Process>{ r1, r2, r3 };
-  auto chemical_system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+  auto chemical_system = micm::System(gas_phase );
 
   std::vector<std::vector<double>> results(n_threads);
 

--- a/test/unit/solver/test_backward_euler.cpp
+++ b/test/unit/solver/test_backward_euler.cpp
@@ -35,7 +35,7 @@ namespace
                          .SetPhase(gas_phase)
                          .Build();
 
-  auto the_system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+  auto the_system = micm::System(gas_phase );
   std::vector<micm::Process> reactions = { r1, r2 };
 }  // namespace
 

--- a/test/unit/solver/test_constraint_initialization.cpp
+++ b/test/unit/solver/test_constraint_initialization.cpp
@@ -46,7 +46,7 @@ struct SimpleConstrainedSystem
         std::vector<StoichSpecies>{ { C, 1.0 } },
         VantHoffParam{ .K_HLC_ref = K_eq, .delta_H = delta_H }));
 
-    return builder.SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+    return builder.SetSystem(System(gas_phase ))
         .SetReactions({ rxn })
         .SetConstraints(std::move(constraints))
         .SetReorderState(false)
@@ -170,7 +170,7 @@ TEST(ConstraintInitialization, PureODESystemUnaffected)
 
   auto options = RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
-                    .SetSystem(System(SystemParameters{ .gas_phase_ = gas_phase }))
+                    .SetSystem(System(gas_phase ))
                     .SetReactions({ rxn })
                     .SetReorderState(false)
                     .Build();

--- a/test/unit/solver/test_rosenbrock.cpp
+++ b/test/unit/solver/test_rosenbrock.cpp
@@ -81,7 +81,7 @@ void testNormalizedErrorIncludesAllVariables(SolverBuilderPolicy builder, std::s
       std::vector<micm::StoichSpecies>{ micm::StoichSpecies(C, 1.0) },
       micm::VantHoffParam{ .K_HLC_ref = 10.0, .delta_H = -2400.0 }));
 
-  auto solver = builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+  auto solver = builder.SetSystem(micm::System(gas_phase ))
                     .SetReactions({ reaction })
                     .SetConstraints(std::move(constraints))
                     .SetReorderState(false)
@@ -167,7 +167,7 @@ TEST(RosenbrockSolver, CanSetTolerances)
   {
     auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(
                       micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                      .SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+                      .SetSystem(micm::System(gas_phase ))
                       .SetReactions(std::vector<micm::Process>{ r1 })
                       .Build();
     auto state = solver.GetState(number_of_grid_cells);

--- a/test/unit/solver/test_rosenbrock_solver_policy.hpp
+++ b/test/unit/solver/test_rosenbrock_solver_policy.hpp
@@ -51,7 +51,7 @@ SolverBuilderPolicy getSolver(SolverBuilderPolicy builder)
                          .SetRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 3.5e-6 })
                          .Build();
 
-  return builder.SetSystem(micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase }))
+  return builder.SetSystem(micm::System(gas_phase ))
       .SetReactions(std::vector<micm::Process>{ r1, r2, r3 })
       .SetReorderState(false);
 }

--- a/test/unit/solver/test_solver_builder.cpp
+++ b/test/unit/solver/test_solver_builder.cpp
@@ -35,7 +35,7 @@ namespace
                          .SetRateConstant(micm::ArrheniusRateConstantParameters{ .A_ = 3.3e-11, .B_ = 0, .C_ = 55 })
                          .SetPhase(gas_phase)
                          .Build();
-  micm::System the_system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+  micm::System the_system = micm::System(gas_phase );
   std::vector<micm::Process> reactions = { r1, r2 };
 }  // namespace
 
@@ -50,7 +50,7 @@ TEST(SolverBuilder, ThrowsUnusedSpecies)
 {
   auto d = micm::Species("D");
   micm::Phase phase_with_unused{ "gas", std::vector<micm::PhaseSpecies>{ a, b, c, d } };
-  micm::System system_with_unused = micm::System(micm::SystemParameters{ .gas_phase_ = phase_with_unused });
+  micm::System system_with_unused = micm::System(phase_with_unused );
 
   try
   {

--- a/test/unit/solver/test_solver_lambda_rate_constant.cpp
+++ b/test/unit/solver/test_solver_lambda_rate_constant.cpp
@@ -35,7 +35,7 @@ TEST(Solver, GetLambdaRateConstantByNameCanOverrideLambda)
                                .SetPhase(gas_phase)
                                .Build();
 
-  auto system = micm::System(micm::SystemParameters{ .gas_phase_ = gas_phase });
+  auto system = micm::System(gas_phase );
 
   auto solver = micm::CpuSolverBuilder<micm::BackwardEulerSolverParameters>(micm::BackwardEulerSolverParameters{})
                     .SetSystem(system)

--- a/test/unit/solver/test_state.cpp
+++ b/test/unit/solver/test_state.cpp
@@ -283,7 +283,6 @@ TEST(State, SetSingleConcentration)
 
 TEST(State, SetConcentrationByElementSingleValue)
 {
-  micm::SystemParameters params;
 
   micm::State state{ micm::StateParameters{
                          .number_of_rate_constants_ = 10,
@@ -301,7 +300,6 @@ TEST(State, SetConcentrationByElementSingleValue)
 
 TEST(State, SetConcentrationByElementVector)
 {
-  micm::SystemParameters params;
   micm::State state{ micm::StateParameters{
                          .number_of_rate_constants_ = 10,
                          .variable_names_{ "foo", "bar", "baz", "quz" },

--- a/test/unit/system/test_system.cpp
+++ b/test/unit/system/test_system.cpp
@@ -17,7 +17,7 @@ TEST(System, ConstructorWithAllParameters)
   PhaseSpecies gas_bar(bar);
 
   Phase gas_phase("gas", std::vector<PhaseSpecies>({ gas_foo, gas_bar }));
-  System system = { SystemParameters{ .gas_phase_ = gas_phase } };
+  System system(gas_phase );
 
   EXPECT_EQ(system.gas_phase_.phase_species_.size(), 2);
 
@@ -43,7 +43,7 @@ TEST(System, ConstructorWithParameterizedSpecies)
   PhaseSpecies gas_param_species(param_species);
 
   Phase gas_phase("gas", std::vector<PhaseSpecies>({ gas_foo, gas_bar, gas_param_species }));
-  System system = { SystemParameters{ .gas_phase_ = gas_phase } };
+  System system(gas_phase );
 
   EXPECT_EQ(system.gas_phase_.phase_species_.size(), 3);
   EXPECT_EQ(system.StateSize(), 3 - 1);  // One parameterized species


### PR DESCRIPTION
System takes model in its constructor, but the solver builder also requires calling AddExternalModel(model). This makes the builder API redundant and confusing.
```C++
// Current
auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                    RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                    .SetSystem(System(gas_phase, model));
                    .AddExternalModel(model)
                    .Build();

// This PR
auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                    RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                    .SetSystem(System(gas_phase));
                    .AddExternalModel(model)
                    .Build();
```

This PR:
- Makes `AddExternalModel` responsible for capturing variable/parameter names and size of external model state.
- `System` defines a gas system only.
- `SolverBuilder::AddExternalModel` stores both the state-query wrapper and the compute wrappers. During `Build()`, it updates the `species_map` with external model contributions before constructing the rates/constraint objects.
- Renames variables to maintain consistency
```yaml
external_models                     -> external_process_sets
external_constraint_models_         -> external_constraints_
                                    -> external_systems_ (added)
external_model_forcing_functions_   -> external_forcing_functions_
external_model_jacobian_functions_  -> external_jacobian_functions_
```
- Removes struct `SystemParameters` that only contains gas_phase now
- Closes #983