### PR TITLE
addressing redundant inline

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,6 +54,7 @@ Checks: >
   # explicitly enabled checks
   readability-braces-around-statements,
   readability-identifier-naming,
+  readability-redundant-inline-specifier,
   # explicitly disabled checks
   -readability-identifier-length,
   -readability-convert-member-functions-to-static,

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -566,7 +566,7 @@ namespace micm
       /// @brief Get an element reference for the current row in this group (ColumnView)
       template<DenseMatrixColumnView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetRowElement(Arg&& arg)
+      decltype(auto) GetRowElement(Arg&& arg)
       {
         auto* source_matrix = arg.GetMatrix();
         return source_matrix->data_[row_ * source_matrix->y_dim_ + arg.ColumnIndex()];
@@ -575,7 +575,7 @@ namespace micm
       /// @brief Get an element reference for the current row in this group (RowVariable)
       template<BlockVariableView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetRowElement(Arg&& arg)
+      decltype(auto) GetRowElement(Arg&& arg)
       {
         return arg.Get();
       }
@@ -583,7 +583,7 @@ namespace micm
       /// @brief Get an element reference for the current row in this group (Vector-like)
       template<VectorLike Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetRowElement(Arg&& arg)
+      decltype(auto) GetRowElement(Arg&& arg)
       {
         return arg[row_];
       }
@@ -783,7 +783,7 @@ namespace micm
     /// @brief Get an element reference for a row (ColumnView)
     template<DenseMatrixColumnView Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetRowElement(std::size_t row, Arg&& arg)
+    decltype(auto) GetRowElement(std::size_t row, Arg&& arg)
     {
       auto* source_matrix = arg.GetMatrix();
       return source_matrix->data_[row * source_matrix->y_dim_ + arg.ColumnIndex()];
@@ -792,7 +792,7 @@ namespace micm
     /// @brief Get an element reference for a row (RowVariable)
     template<BlockVariableView Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetRowElement(std::size_t row, Arg&& arg)
+    decltype(auto) GetRowElement(std::size_t row, Arg&& arg)
     {
       return arg.Get();
     }
@@ -800,7 +800,7 @@ namespace micm
     /// @brief Get an element reference for a row (Vector-like)
     template<VectorLike Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetRowElement(std::size_t row, Arg&& arg)
+    decltype(auto) GetRowElement(std::size_t row, Arg&& arg)
     {
       return arg[row];
     }
@@ -808,7 +808,7 @@ namespace micm
     /// @brief Get a const element reference for a row (ColumnView) - const version
     template<DenseMatrixColumnView Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetRowElement(std::size_t row, Arg&& arg) const
+    decltype(auto) GetRowElement(std::size_t row, Arg&& arg) const
     {
       auto* source_matrix = arg.GetMatrix();
       return source_matrix->data_[row * source_matrix->y_dim_ + arg.ColumnIndex()];
@@ -817,7 +817,7 @@ namespace micm
     /// @brief Get a const element reference for a row (RowVariable) - const version
     template<BlockVariableView Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetRowElement(std::size_t row, Arg&& arg) const
+    decltype(auto) GetRowElement(std::size_t row, Arg&& arg) const
     {
       return arg.Get();
     }
@@ -825,7 +825,7 @@ namespace micm
     /// @brief Get a const element reference for a row (Vector-like) - const version
     template<VectorLike Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetRowElement(std::size_t row, Arg&& arg) const
+    decltype(auto) GetRowElement(std::size_t row, Arg&& arg) const
     {
       return arg[row];
     }

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -663,7 +663,7 @@ namespace micm
     /// @brief Get an element reference for a block (BlockView)
     template<SparseMatrixBlockView Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetBlockElement(std::size_t block, Arg&& arg)
+    decltype(auto) GetBlockElement(std::size_t block, Arg&& arg)
     {
       auto* source_matrix = arg.GetMatrix();
       constexpr std::size_t L = OrderingPolicy::GroupVectorSize();
@@ -686,7 +686,7 @@ namespace micm
     /// @brief Get an element reference for a block (BlockVariable)
     template<BlockVariableView Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetBlockElement(std::size_t block, Arg&& arg)
+    decltype(auto) GetBlockElement(std::size_t block, Arg&& arg)
     {
       return arg.Get();
     }
@@ -694,7 +694,7 @@ namespace micm
     /// @brief Get an element reference for a block (Vector-like)
     template<VectorLike Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetBlockElement(std::size_t block, Arg&& arg)
+    decltype(auto) GetBlockElement(std::size_t block, Arg&& arg)
     {
       return arg[block];
     }

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
@@ -173,7 +173,7 @@ namespace micm
       /// @brief Get element from sparse matrix ConstBlockView
       template<SparseMatrixBlockView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         auto* source_matrix = arg.GetMatrix();
         std::size_t elem_position = arg.ElementPosition();
@@ -187,7 +187,7 @@ namespace micm
       /// For standard ordering: compatible with standard Matrix or VectorMatrix with L=1
       template<DenseMatrixColumnView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         auto* source_matrix = arg.GetMatrix();
         // Verify L=1 for VectorMatrix types
@@ -203,7 +203,7 @@ namespace micm
       /// @brief Get element from BlockVariable
       template<BlockVariableView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         return arg.Get();
       }
@@ -211,7 +211,7 @@ namespace micm
       /// @brief Get element from Vector-like
       template<VectorLike Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         return arg[group_];
       }
@@ -272,7 +272,7 @@ namespace micm
       /// @brief Get element from sparse matrix BlockView
       template<SparseMatrixBlockView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         auto* source_matrix = arg.GetMatrix();
         std::size_t elem_position = arg.ElementPosition();
@@ -286,7 +286,7 @@ namespace micm
       /// For standard ordering: compatible with standard Matrix or VectorMatrix with L=1
       template<DenseMatrixColumnView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         auto* source_matrix = arg.GetMatrix();
         // Verify L=1 for VectorMatrix types
@@ -302,7 +302,7 @@ namespace micm
       /// @brief Get element from BlockVariable
       template<BlockVariableView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         return arg.Get();
       }
@@ -310,7 +310,7 @@ namespace micm
       /// @brief Get element from Vector-like
       template<VectorLike Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         return arg[group_];
       }

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
@@ -172,7 +172,7 @@ namespace micm
       /// @brief Get element from sparse matrix ConstBlockView
       template<SparseMatrixBlockView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         auto* source_matrix = arg.GetMatrix();
         std::size_t elem_position = arg.ElementPosition();
@@ -186,7 +186,7 @@ namespace micm
       /// For standard ordering: compatible with standard Matrix or VectorMatrix with L=1
       template<DenseMatrixColumnView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         auto* source_matrix = arg.GetMatrix();
         // Verify L=1 for VectorMatrix types
@@ -202,7 +202,7 @@ namespace micm
       /// @brief Get element from BlockVariable
       template<BlockVariableView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         return arg.Get();
       }
@@ -210,7 +210,7 @@ namespace micm
       /// @brief Get element from Vector-like
       template<VectorLike Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         return arg[group_];
       }
@@ -271,7 +271,7 @@ namespace micm
       /// @brief Get element from sparse matrix BlockView
       template<SparseMatrixBlockView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         auto* source_matrix = arg.GetMatrix();
         std::size_t elem_position = arg.ElementPosition();
@@ -285,7 +285,7 @@ namespace micm
       /// For standard ordering: compatible with standard Matrix or VectorMatrix with L=1
       template<DenseMatrixColumnView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         auto* source_matrix = arg.GetMatrix();
         // Verify L=1 for VectorMatrix types
@@ -301,7 +301,7 @@ namespace micm
       /// @brief Get element from BlockVariable
       template<BlockVariableView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         return arg.Get();
       }
@@ -309,7 +309,7 @@ namespace micm
       /// @brief Get element from Vector-like
       template<VectorLike Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         return arg[group_];
       }

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
@@ -181,7 +181,7 @@ namespace micm
       /// @brief Get element from sparse matrix ConstBlockView
       template<SparseMatrixBlockView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         // Calculate the actual block index from group and block_in_group
         std::size_t block = group_ * L + block_in_group;
@@ -328,7 +328,7 @@ namespace micm
       /// @brief Get element from sparse matrix BlockView
       template<SparseMatrixBlockView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         // Calculate the actual block index from group and block_in_group
         std::size_t block = group_ * L + block_in_group;

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
@@ -187,7 +187,7 @@ namespace micm
       /// @brief Get element from sparse matrix ConstBlockView
       template<SparseMatrixBlockView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         // Calculate the actual block index from group and block_in_group
         std::size_t block = group_ * L + block_in_group;
@@ -334,7 +334,7 @@ namespace micm
       /// @brief Get element from sparse matrix BlockView
       template<SparseMatrixBlockView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         // Calculate the actual block index from group and block_in_group
         std::size_t block = group_ * L + block_in_group;

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -599,7 +599,7 @@ namespace micm
       /// @brief Get a const element reference for a specific row in this group (ColumnView)
       template<DenseMatrixColumnView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetRowElement(std::size_t row_in_group, Arg&& arg) const
+      decltype(auto) GetRowElement(std::size_t row_in_group, Arg&& arg) const
       {
         auto* source_matrix = arg.GetMatrix();
         // VectorMatrix layout: data_[(group * y_dim_ + column) * L + row_in_group]
@@ -609,7 +609,7 @@ namespace micm
       /// @brief Get a const element reference for a specific row in this group (RowVariable)
       template<BlockVariableView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetRowElement(std::size_t row_in_group, Arg&& arg) const
+      decltype(auto) GetRowElement(std::size_t row_in_group, Arg&& arg) const
       {
         return arg.Get()[row_in_group];
       }
@@ -617,7 +617,7 @@ namespace micm
       /// @brief Get a const element reference for a specific row in this group (Vector-like)
       template<VectorLike Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetRowElement(std::size_t row_in_group, Arg&& arg) const
+      decltype(auto) GetRowElement(std::size_t row_in_group, Arg&& arg) const
       {
         return arg[group_ * L + row_in_group];
       }
@@ -684,7 +684,7 @@ namespace micm
       /// @brief Get an element reference for a specific row in this group (ColumnView)
       template<DenseMatrixColumnView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetRowElement(std::size_t row_in_group, Arg&& arg)
+      decltype(auto) GetRowElement(std::size_t row_in_group, Arg&& arg)
       {
         auto* source_matrix = arg.GetMatrix();
         // VectorMatrix layout: data_[(group * y_dim_ + column) * L + row_in_group]
@@ -694,7 +694,7 @@ namespace micm
       /// @brief Get an element reference for a specific row in this group (RowVariable)
       template<BlockVariableView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetRowElement(std::size_t row_in_group, Arg&& arg)
+      decltype(auto) GetRowElement(std::size_t row_in_group, Arg&& arg)
       {
         return arg.Get()[row_in_group];
       }
@@ -702,7 +702,7 @@ namespace micm
       /// @brief Get an element reference for a specific row in this group (Vector-like)
       template<VectorLike Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetRowElement(std::size_t row_in_group, Arg&& arg)
+      decltype(auto) GetRowElement(std::size_t row_in_group, Arg&& arg)
       {
         return arg[group_ * L + row_in_group];
       }
@@ -951,7 +951,7 @@ namespace micm
     /// @brief Get an element reference for a row (ColumnView)
     template<DenseMatrixColumnView Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetRowElement(std::size_t row, std::size_t group, std::size_t row_in_group, Arg&& arg)
+    decltype(auto) GetRowElement(std::size_t row, std::size_t group, std::size_t row_in_group, Arg&& arg)
     {
       auto* source_matrix = arg.GetMatrix();
       // VectorMatrix layout: data_[(group * y_dim_ + column) * L + row_in_group]
@@ -961,7 +961,7 @@ namespace micm
     /// @brief Get an element reference for a row (RowVariable)
     template<BlockVariableView Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetRowElement(std::size_t row, std::size_t group, std::size_t row_in_group, Arg&& arg)
+    decltype(auto) GetRowElement(std::size_t row, std::size_t group, std::size_t row_in_group, Arg&& arg)
     {
       return arg.Get()[row_in_group];
     }
@@ -969,7 +969,7 @@ namespace micm
     /// @brief Get an element reference for a row (Vector-like)
     template<VectorLike Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetRowElement(std::size_t row, std::size_t group, std::size_t row_in_group, Arg&& arg)
+    decltype(auto) GetRowElement(std::size_t row, std::size_t group, std::size_t row_in_group, Arg&& arg)
     {
       return arg[row];
     }
@@ -977,7 +977,7 @@ namespace micm
     /// @brief Get a const element reference for a row (ColumnView) - const version
     template<DenseMatrixColumnView Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetRowElement(std::size_t row, std::size_t group, std::size_t row_in_group, Arg&& arg) const
+    decltype(auto) GetRowElement(std::size_t row, std::size_t group, std::size_t row_in_group, Arg&& arg) const
     {
       auto* source_matrix = arg.GetMatrix();
       // VectorMatrix layout: data_[(group * y_dim_ + column) * L + row_in_group]
@@ -987,7 +987,7 @@ namespace micm
     /// @brief Get a const element reference for a row (RowVariable) - const version
     template<BlockVariableView Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetRowElement(std::size_t row, std::size_t group, std::size_t row_in_group, Arg&& arg) const
+    decltype(auto) GetRowElement(std::size_t row, std::size_t group, std::size_t row_in_group, Arg&& arg) const
     {
       return arg.Get()[row_in_group];
     }
@@ -995,7 +995,7 @@ namespace micm
     /// @brief Get a const element reference for a row (Vector-like) - const version
     template<VectorLike Arg>
     [[gnu::always_inline]]
-    inline decltype(auto) GetRowElement(std::size_t row, std::size_t group, std::size_t row_in_group, Arg&& arg) const
+    decltype(auto) GetRowElement(std::size_t row, std::size_t group, std::size_t row_in_group, Arg&& arg) const
     {
       return arg[row];
     }


### PR DESCRIPTION
Closes #1009

Ran 
```bash
cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
run-clang-tidy -checks='-*,readability-redundant-inline-specifier' -p build -fix
cd build
rm -rf _deps
make -j
```

- Fixes all `readability-redundant-inline-specifier` issues identified by clang tidy
- enables checking `readability-redundant-inline-specifier` in all future PRs