### PR TITLE
ignoring narrowing conversions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -47,6 +47,11 @@
 # -cert-err58-cpp / -cert-msc51-cpp:
 #   err58 fires on static storage with non-trivial constructors;
 #   msc51 is a Windows-specific RNG check.
+#
+# -bugprone-narrowing-conversions:
+#   Fires on size_t->double in math expressions and unsigned->ptrdiff_t in
+#   std::next calls. All are safe within realistic problem sizes for a chemistry
+#   solver. Too noisy for the benefit.
 
 Checks: >
   # disable all checks
@@ -65,6 +70,7 @@ Checks: >
   -readability-function-cognitive-complexity,
   -bugprone-signal-handler,
   -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
   -cert-err58-cpp,
   -cert-msc51-cpp,
   -performance-enum-size,

--- a/test/regression/regression_policy.hpp
+++ b/test/regression/regression_policy.hpp
@@ -57,7 +57,7 @@ void WriteCsv(
   }
 }
 
-std::pair<std::vector<std::string>, std::vector<std::vector<double>>> read_csv(const std::string& filename)
+std::pair<std::vector<std::string>, std::vector<std::vector<double>>> ReadCsv(const std::string& filename)
 {
   std::ifstream file(filename);
   if (file.is_open())
@@ -195,7 +195,7 @@ void TestFlowTube(
   // writeCSV(expected_results_path, header, model_concentrations, times);
 
   // Check that the results we got match exactly to those we expect
-  auto [header_out, data_out] = read_csv(expected_results_path);
+  auto [header_out, data_out] = ReadCsv(expected_results_path);
 
   EXPECT_EQ(header, header_out);
   EXPECT_EQ(model_concentrations.size(), data_out.size());


### PR DESCRIPTION
Closes #1011 

In this case, I chose to ignore all narrowing conversions. In practice, we would not run a chemistry system that would make these issues matter.

Ran
```
  cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
      -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
      -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang

  run-clang-tidy -p build -fix \
      '/Users/kshores/Documents/micm/(include|src|test)'
```