### PR TITLE
addressing readability-qualified-auto

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -60,6 +60,7 @@ Checks: >
   readability-braces-around-statements,
   readability-identifier-naming,
   readability-redundant-inline-specifier,
+  readability-qualified-auto,
   # explicitly disabled checks
   -readability-identifier-length,
   -readability-convert-member-functions-to-static,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -104,8 +104,14 @@ CheckOptions:
     value:           CamelCase
   - key:             readability-identifier-naming.GlobalConstantCase
     value:           UPPER_CASE
+    # Allow Google-style 'k'-prefixed constants (e.g. kConditions) used in tests.
+  - key:             readability-identifier-naming.GlobalConstantIgnoredRegexp
+    value:           '^k[A-Z][A-Za-z0-9_]*$'
   - key:             readability-identifier-naming.TemplateParameterCase
     value:           CamelCase
+    # CUDA tests use 'cuda_matrix_vector_length' as a template parameter name.
+  - key:             readability-identifier-naming.TemplateParameterIgnoredRegexp
+    value:           '^cuda_matrix_vector_length$'
   - key:             readability-implicit-bool-conversion.AllowIntegerConditions
     value:           1
   - key:             readability-implicit-bool-conversion.AllowPointerConditions

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -19,13 +19,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Scan includes
-        continue-on-error: true
         run: docker build --target scan-includes --progress=plain -f docker/Dockerfile.clang-tidy .
 
       - name: Scan CUDA source
-        continue-on-error: true
         run: docker build --target scan-cuda-source --progress=plain -f docker/Dockerfile.clang-tidy .
 
       - name: Scan Test files
-        continue-on-error: true
         run: docker build --target scan-tests --progress=plain -f docker/Dockerfile.clang-tidy .

--- a/docker/Dockerfile.clang-tidy
+++ b/docker/Dockerfile.clang-tidy
@@ -72,11 +72,12 @@ RUN find src -type f \( -name '*.cu' -o -name '*.hpp' -o -name '*.h' -o -name '*
           --extra-arg="-Iinclude/"
 
 # -----------------------------------------------------------------------------
-# scan-tests: unit, integration, and tutorial tests (excluding CUDA-only and JIT files)
+# scan-tests: unit and integration tests (excluding tutorial, JIT, and OpenMP
+# tests -- the latter need -fopenmp/libomp to parse and are scanned separately)
 # Run locally: docker build --target scan-tests --progress=plain -f docker/Dockerfile.clang-tidy .
 FROM build-cuda AS scan-tests
 RUN find test -type f \( -name '*.hpp' -o -name '*.h' -o -name '*.cpp' -o -name '*.cu' \) \
-        ! -path '*/tutorial/*' ! -path '*jit*' \
+        ! -path '*/tutorial/*' ! -path '*jit*' ! -path '*/openmp/*' \
       | xargs clang-tidy-22 \
           -p ./cuda-build/ \
           --config-file=./.clang-tidy \

--- a/docker/Dockerfile.clang-tidy
+++ b/docker/Dockerfile.clang-tidy
@@ -74,7 +74,6 @@ RUN find test -type f \( -name '*.hpp' -o -name '*.h' -o -name '*.cpp' -o -name 
       | xargs clang-tidy \
           -p ./cuda-build/ \
           --config-file=./.clang-tidy \
-          --allow-no-checks \
           --header-filter="$(pwd)/include/.*" \
           --extra-arg="-std=c++20" \
           --extra-arg="--cuda-gpu-arch=sm_70" \

--- a/docker/Dockerfile.clang-tidy
+++ b/docker/Dockerfile.clang-tidy
@@ -35,7 +35,7 @@ FROM install AS build-cuda
 # via --cuda-path.
 RUN cmake \
       -DCMAKE_CUDA_COMPILER=clang++ \
-      -DCMAKE_CUDA_FLAGS="--cuda-host-only --cuda-path=/usr --no-cuda-version-check" \
+      -DCMAKE_CUDA_FLAGS="--cuda-host-only --cuda-path=/usr" \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
       -DMICM_GPU_TYPE=v100 \
       -B./cuda-build \

--- a/docker/Dockerfile.clang-tidy
+++ b/docker/Dockerfile.clang-tidy
@@ -1,5 +1,6 @@
 FROM ubuntu:24.04 AS install
 
+# Ubuntu 24.04's default clang-tidy is v18, update to clang 22
 RUN apt -y update \
     && apt -y install \
         cmake \
@@ -7,11 +8,16 @@ RUN apt -y update \
         git \
         make \
         nvidia-cuda-toolkit \
-        clang \
-        clang-tidy \
         llvm-dev \
         libomp-dev \
         build-essential \
+        wget \
+        gnupg \
+        ca-certificates \
+    && wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+    && echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" > /etc/apt/sources.list.d/llvm.list \
+    && apt -y update \
+    && apt -y install clang-22 clang-tidy-22 \
     && apt clean all
 
 COPY . /micm/
@@ -34,7 +40,7 @@ FROM install AS build-cuda
 # so no device toolchain (libdevice/ptxas) is needed, only the CUDA headers found
 # via --cuda-path.
 RUN cmake \
-      -DCMAKE_CUDA_COMPILER=clang++ \
+      -DCMAKE_CUDA_COMPILER=clang++-22 \
       -DCMAKE_CUDA_FLAGS="--cuda-host-only --cuda-path=/usr" \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
       -DMICM_GPU_TYPE=v100 \
@@ -46,7 +52,7 @@ RUN cmake \
 # Run locally: docker build --target scan-includes --progress=plain -f docker/Dockerfile.clang-tidy .
 FROM build-cpu AS scan-includes
 RUN find include -type f \( -name '*.hpp' -o -name '*.h' \) \
-      | xargs clang-tidy \
+      | xargs clang-tidy-22 \
           -p ./build/ \
           --config-file=./.clang-tidy \
           --header-filter="$(pwd)/include/.*" \
@@ -58,7 +64,7 @@ RUN find include -type f \( -name '*.hpp' -o -name '*.h' \) \
 # Run locally: docker build --target scan-cuda-source --progress=plain -f docker/Dockerfile.clang-tidy .
 FROM build-cuda AS scan-cuda-source
 RUN find src -type f \( -name '*.cu' -o -name '*.hpp' -o -name '*.h' -o -name '*.cpp' \) \
-      | xargs clang-tidy \
+      | xargs clang-tidy-22 \
           -p ./cuda-build/ \
           --config-file=./.clang-tidy \
           --header-filter="$(pwd)/include/.*" \
@@ -71,7 +77,7 @@ RUN find src -type f \( -name '*.cu' -o -name '*.hpp' -o -name '*.h' -o -name '*
 FROM build-cuda AS scan-tests
 RUN find test -type f \( -name '*.hpp' -o -name '*.h' -o -name '*.cpp' -o -name '*.cu' \) \
         ! -path '*/tutorial/*' ! -path '*jit*' \
-      | xargs clang-tidy \
+      | xargs clang-tidy-22 \
           -p ./cuda-build/ \
           --config-file=./.clang-tidy \
           --header-filter="$(pwd)/include/.*" \

--- a/docker/Dockerfile.clang-tidy
+++ b/docker/Dockerfile.clang-tidy
@@ -27,12 +27,15 @@ RUN cmake \
 
 # -----------------------------------------------------------------------------
 FROM install AS build-cuda
-# CUDA configure: nvidia-cuda-toolkit puts nvcc at /usr/bin/nvcc but cmake's
-# check_language(CUDA) auto-detection does not find it there; pass it explicitly.
-# Note: this stage will fail on arm64 hosts (e.g. Apple Silicon) due to an
-# incompatibility between Ubuntu's nvcc and ARM SVE system headers.
+# CUDA configure for clang-tidy: clang-tidy parses .cu with its own clang
+# frontend (it never invokes nvcc), so use clang as the CUDA compiler. That makes
+# the generated compile_commands.json natively clang-parseable -- no nvcc-only
+# flags to strip afterwards. --cuda-host-only keeps compilation to the host pass
+# so no device toolchain (libdevice/ptxas) is needed, only the CUDA headers found
+# via --cuda-path.
 RUN cmake \
-      -DCMAKE_CUDA_COMPILER=/usr/bin/nvcc \
+      -DCMAKE_CUDA_COMPILER=clang++ \
+      -DCMAKE_CUDA_FLAGS="--cuda-host-only --cuda-path=/usr --no-cuda-version-check" \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
       -DMICM_GPU_TYPE=v100 \
       -B./cuda-build \
@@ -60,7 +63,6 @@ RUN find src -type f \( -name '*.cu' -o -name '*.hpp' -o -name '*.h' -o -name '*
           --config-file=./.clang-tidy \
           --header-filter="$(pwd)/include/.*" \
           --extra-arg="-std=c++20" \
-          --extra-arg="--cuda-gpu-arch=sm_70" \
           --extra-arg="-Iinclude/"
 
 # -----------------------------------------------------------------------------
@@ -74,6 +76,5 @@ RUN find test -type f \( -name '*.hpp' -o -name '*.h' -o -name '*.cpp' -o -name 
           --config-file=./.clang-tidy \
           --header-filter="$(pwd)/include/.*" \
           --extra-arg="-std=c++20" \
-          --extra-arg="--cuda-gpu-arch=sm_70" \
           --extra-arg="-Iinclude/" \
           --extra-arg="-isystem./cuda-build/_deps/googletest-src/googletest/include"

--- a/docker/Dockerfile.clang-tidy
+++ b/docker/Dockerfile.clang-tidy
@@ -46,7 +46,6 @@ RUN find include -type f \( -name '*.hpp' -o -name '*.h' \) \
       | xargs clang-tidy \
           -p ./build/ \
           --config-file=./.clang-tidy \
-          --allow-no-checks \
           --header-filter="$(pwd)/include/.*" \
           --extra-arg="-std=c++20" \
           --extra-arg="-Iinclude/"
@@ -59,7 +58,6 @@ RUN find src -type f \( -name '*.cu' -o -name '*.hpp' -o -name '*.h' -o -name '*
       | xargs clang-tidy \
           -p ./cuda-build/ \
           --config-file=./.clang-tidy \
-          --allow-no-checks \
           --header-filter="$(pwd)/include/.*" \
           --extra-arg="-std=c++20" \
           --extra-arg="--cuda-gpu-arch=sm_70" \

--- a/include/micm/constraint/constraint_set.hpp
+++ b/include/micm/constraint/constraint_set.hpp
@@ -217,7 +217,7 @@ namespace micm
     {
       std::unordered_set<std::string> param_names;
 
-      for (auto& each : constraints_)
+      for (const auto& each : constraints_)
       {
         std::visit(
             [&](auto& c)

--- a/include/micm/cuda/process/cuda_reaction_rate_store.hpp
+++ b/include/micm/cuda/process/cuda_reaction_rate_store.hpp
@@ -60,7 +60,7 @@ namespace micm
       FreeDevice(d_ptr);
       if (host_vec.empty())
         return;
-      auto stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+      auto *stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
       CHECK_CUDA_ERROR(cudaMallocAsync(&d_ptr, sizeof(T) * host_vec.size(), stream), "cudaMalloc");
       CHECK_CUDA_ERROR(
           cudaMemcpyAsync(d_ptr, host_vec.data(), sizeof(T) * host_vec.size(), cudaMemcpyHostToDevice, stream),
@@ -72,7 +72,7 @@ namespace micm
     {
       if (d_ptr)
       {
-        auto stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+        auto *stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
         CHECK_CUDA_ERROR(cudaFreeAsync(d_ptr, stream), "cudaFree");
         d_ptr = nullptr;
       }
@@ -192,7 +192,7 @@ namespace micm
         std::vector<std::size_t> rc_indices(mults.size());
         for (std::size_t i = 0; i < mults.size(); ++i)
           rc_indices[i] = mults[i].rc_index_;
-        auto stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+        auto *stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
         CHECK_CUDA_ERROR(cudaMallocAsync(&d_mult_rc_indices_, sizeof(std::size_t) * mults.size(), stream), "cudaMalloc");
         CHECK_CUDA_ERROR(
             cudaMemcpyAsync(
@@ -229,7 +229,7 @@ namespace micm
               host_vals[g * n_mults * L + i * L + j] = mults[i].evaluate_(conditions[cell]);
           }
 
-      auto stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+      auto *stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
       if (n_vals > d_mult_vals_capacity_)
       {
         FreeDevice(d_mult_vals_);
@@ -246,7 +246,7 @@ namespace micm
     /// @return Device pointer valid until the next call to UploadConditions.
     const Conditions* UploadConditions(const std::vector<Conditions>& conditions)
     {
-      auto stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+      auto *stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
       if (conditions.size() > d_conditions_capacity_)
       {
         FreeDevice(d_conditions_);

--- a/include/micm/cuda/util/cuda_sparse_matrix.hpp
+++ b/include/micm/cuda/util/cuda_sparse_matrix.hpp
@@ -22,7 +22,7 @@ namespace micm
     using IntMatrix = CudaSparseMatrix<int, OrderingPolicy>;
     using value_type = T;
     // Access vector length via OrderingPolicy::GroupVectorSize()
-    static constexpr std::size_t vector_length_ = OrderingPolicy::GroupVectorSize();
+    static constexpr std::size_t VECTOR_LENGTH = OrderingPolicy::GroupVectorSize();
 
    private:
     CudaMatrixParam param_;
@@ -38,7 +38,7 @@ namespace micm
         : SparseMatrix<T, OrderingPolicy>(builder, indexing_only)
     {
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
-      this->param_.vector_length_ = this->vector_length_;
+      this->param_.vector_length_ = this->VECTOR_LENGTH;
       if (!indexing_only)
         CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->data_.size()), "cudaMalloc");
     }
@@ -47,7 +47,7 @@ namespace micm
     {
       SparseMatrix<T, OrderingPolicy>::operator=(builder);
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
-      this->param_.vector_length_ = this->vector_length_;
+      this->param_.vector_length_ = this->VECTOR_LENGTH;
       if (this->data_.size() != 0)
         CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->data_.size()), "cudaMalloc");
       return *this;

--- a/include/micm/solver/backward_euler.inl
+++ b/include/micm/solver/backward_euler.inl
@@ -164,7 +164,7 @@ namespace micm
   {
     double small = parameters.small_;
     double rel_tol = relative_tolerance;
-    auto& abs_tol = absolute_tolerance;
+    const auto& abs_tol = absolute_tolerance;
     auto residual_iter = residual.AsVector().begin();
     auto Yn1_iter = Yn1.AsVector().begin();
     const std::size_t n_elem = residual.NumRows() * residual.NumColumns();
@@ -193,7 +193,7 @@ namespace micm
   {
     double small = parameters.small_;
     double rel_tol = relative_tolerance;
-    auto& abs_tol = absolute_tolerance;
+    const auto& abs_tol = absolute_tolerance;
     auto residual_iter = residual.AsVector().begin();
     auto Yn1_iter = Yn1.AsVector().begin();
     const std::size_t n_elem = residual.NumRows() * residual.NumColumns();

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -141,7 +141,7 @@ namespace micm
       {
         auto y_elem = y_cell.begin();
         auto Lij_yj = Lij_yj_.begin();
-        for (auto& nLij_Lii : nLij_Lii_)
+        for (const auto& nLij_Lii : nLij_Lii_)
         {
           for (std::size_t i = 0; i < nLij_Lii.first; ++i)
           {
@@ -156,7 +156,7 @@ namespace micm
       {
         auto x_elem = std::next(x_cell.end(), -1);
         auto Uij_xj = Uij_xj_.begin();
-        for (auto& nUij_Uii : nUij_Uii_)
+        for (const auto& nUij_Uii : nUij_Uii_)
         {
           // x_elem starts out as y_elem from the previous loop
           for (std::size_t i = 0; i < nUij_Uii.first; ++i)
@@ -195,7 +195,7 @@ namespace micm
       {
         auto y_elem = x_group;
         auto Lij_yj = Lij_yj_.begin();
-        for (auto& nLij_Lii : nLij_Lii_)
+        for (const auto& nLij_Lii : nLij_Lii_)
         {
           for (std::size_t i = 0; i < nLij_Lii.first; ++i)
           {
@@ -216,7 +216,7 @@ namespace micm
       {
         auto x_elem = std::next(x_group, x.GroupSize() - n_cells);
         auto Uij_xj = Uij_xj_.begin();
-        for (auto& nUij_Uii : nUij_Uii_)
+        for (const auto& nUij_Uii : nUij_Uii_)
         {
           // x_elem starts out as y_elem from the previous loop
           for (std::size_t i = 0; i < nUij_Uii.first; ++i)

--- a/include/micm/solver/linear_solver_in_place.inl
+++ b/include/micm/solver/linear_solver_in_place.inl
@@ -80,7 +80,7 @@ namespace micm
       {
         auto y_elem = y_cell.begin();
         auto Lij_yj = Lij_yj_.begin();
-        for (auto& nLij : nLij_)
+        for (const auto& nLij : nLij_)
         {
           for (std::size_t i = 0; i < nLij; ++i)
           {
@@ -95,7 +95,7 @@ namespace micm
       {
         auto x_elem = std::next(x_cell.end(), -1);
         auto Uij_xj = Uij_xj_.begin();
-        for (auto& nUij_Uii : nUij_Uii_)
+        for (const auto& nUij_Uii : nUij_Uii_)
         {
           // x_elem starts out as y_elem from the previous loop
           for (std::size_t i = 0; i < nUij_Uii.first; ++i)
@@ -132,7 +132,7 @@ namespace micm
       {
         auto y_elem = x_group;
         auto Lij_yj = Lij_yj_.begin();
-        for (auto& nLij : nLij_)
+        for (const auto& nLij : nLij_)
         {
           for (std::size_t i = 0; i < nLij; ++i)
           {
@@ -153,7 +153,7 @@ namespace micm
       {
         auto x_elem = std::next(x_group, x.GroupSize() - n_cells);
         auto Uij_xj = Uij_xj_.begin();
-        for (auto& nUij_Uii : nUij_Uii_)
+        for (const auto& nUij_Uii : nUij_Uii_)
         {
           // x_elem starts out as y_elem from the previous loop
           for (std::size_t i = 0; i < nUij_Uii.first; ++i)

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -146,12 +146,12 @@ namespace micm
       }
     }
     auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
-    for (auto& pair : L_ids)
+    for (const auto& pair : L_ids)
     {
       L_builder = L_builder.WithElement(pair.first, pair.second);
     }
     auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
-    for (auto& pair : U_ids)
+    for (const auto& pair : U_ids)
     {
       U_builder = U_builder.WithElement(pair.first, pair.second);
     }

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -126,7 +126,7 @@ namespace micm
       }
     }
     auto ALU_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
-    for (auto& pair : ALU_ids)
+    for (const auto& pair : ALU_ids)
     {
       ALU_builder = ALU_builder.WithElement(pair.first, pair.second);
     }

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -158,12 +158,12 @@ namespace micm
       }
     }
     auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
-    for (auto& pair : L_ids)
+    for (const auto& pair : L_ids)
     {
       L_builder = L_builder.WithElement(pair.first, pair.second);
     }
     auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
-    for (auto& pair : U_ids)
+    for (const auto& pair : U_ids)
     {
       U_builder = U_builder.WithElement(pair.first, pair.second);
     }
@@ -192,7 +192,7 @@ namespace micm
       auto ujk_lji = ujk_lji_.begin();
       auto ljk_lji = ljk_lji_.begin();
 
-      for (auto& lii_nuji_nlji : lii_nuji_nlji_)
+      for (const auto& lii_nuji_nlji : lii_nuji_nlji_)
       {
         for (std::size_t i = 0; i < std::get<1>(lii_nuji_nlji); ++i)
         {
@@ -206,9 +206,9 @@ namespace micm
           ++lji_aji;
         }
       }
-      for (auto& fill_uji : fill_uji_)
+      for (const auto& fill_uji : fill_uji_)
         U_vector[fill_uji] = 0;
-      for (auto& fill_lji : fill_lji_)
+      for (const auto& fill_lji : fill_lji_)
         L_vector[fill_lji] = 0;
       for (std::size_t i = 0; i < n; ++i)
       {
@@ -264,7 +264,7 @@ namespace micm
       auto ujk_lji = ujk_lji_.begin();
       auto ljk_lji = ljk_lji_.begin();
       const std::size_t n_cells = std::min(A_GroupVectorSize, A_BlockSize - i_group * A_GroupVectorSize);
-      for (auto& lii_nuji_nlji : lii_nuji_nlji_)
+      for (const auto& lii_nuji_nlji : lii_nuji_nlji_)
       {
         for (std::size_t i = 0; i < std::get<1>(lii_nuji_nlji); ++i)
         {
@@ -281,10 +281,10 @@ namespace micm
           ++lji_aji;
         }
       }
-      for (auto& fill_uji : fill_uji_)
+      for (const auto& fill_uji : fill_uji_)
         for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
           U_vector[fill_uji + i_cell] = 0;
-      for (auto& fill_lji : fill_lji_)
+      for (const auto& fill_lji : fill_lji_)
         for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
           L_vector[fill_lji + i_cell] = 0;
       for (std::size_t i = 0; i < n; ++i)

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -97,7 +97,7 @@ namespace micm
               ALU_ids.insert(std::make_pair(j, k));
     }
     auto ALU_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
-    for (auto& pair : ALU_ids)
+    for (const auto& pair : ALU_ids)
     {
       ALU_builder = ALU_builder.WithElement(pair.first, pair.second);
     }

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -54,7 +54,7 @@ namespace micm
     if (unused_species.size() > 0)
     {
       std::string err_msg = "Unused species in chemical system:";
-      for (auto& species : unused_species)
+      for (const auto& species : unused_species)
         err_msg += " '" + species + "'";
       err_msg += ".";
       throw MicmException(MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_UNUSED_SPECIES, err_msg);
@@ -137,9 +137,9 @@ namespace micm
     for (const auto& reaction : reactions_)
     {
       const auto& process = reaction.process_;
-      if (auto* ud = std::get_if<UserDefinedRateConstantParameters>(&process.rate_constant_))
+      if (const auto* ud = std::get_if<UserDefinedRateConstantParameters>(&process.rate_constant_))
         add_param(ud->label_, "reaction");
-      else if (auto* surf = std::get_if<SurfaceRateConstantParameters>(&process.rate_constant_))
+      else if (const auto* surf = std::get_if<SurfaceRateConstantParameters>(&process.rate_constant_))
       {
         add_param(surf->label_ + ".effective radius [m]", "reaction");
         add_param(surf->label_ + ".particle number concentration [# m-3]", "reaction");
@@ -187,9 +187,9 @@ namespace micm
           const
   {
     tolerances = std::vector<double>(species_map.size(), 1e-3);
-    for (auto& phase_species : system_.gas_phase_.phase_species_)
+    for (const auto& phase_species : system_.gas_phase_.phase_species_)
     {
-      auto& species = phase_species.species_;
+      const auto& species = phase_species.species_;
       if (species.HasProperty("absolute tolerance"))
       {
         tolerances[species_map.at(species.name_)] = species.template GetProperty<double>("absolute tolerance");

--- a/include/micm/solver/solver_result.hpp
+++ b/include/micm/solver/solver_result.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace micm
 {

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -349,7 +349,7 @@ namespace micm
     for (auto& name : variable_names_)
       variable_map_[name] = index++;
     index = 0;
-    for (auto& label : parameters.custom_rate_parameter_labels_)
+    for (const auto& label : parameters.custom_rate_parameter_labels_)
       custom_rate_parameter_map_[label] = index++;
 
     if (!parameters.mass_matrix_diagonal_.empty())
@@ -656,7 +656,7 @@ namespace micm
   State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::SetCustomRateParameters(
       const std::unordered_map<std::string, std::vector<double>>& parameters)
   {
-    for (auto& pair : parameters)
+    for (const auto& pair : parameters)
       SetCustomRateParameter(pair.first, pair.second);
   }
 

--- a/include/micm/util/jacobian.hpp
+++ b/include/micm/util/jacobian.hpp
@@ -17,7 +17,7 @@ namespace micm
       bool indexing_only)
   {
     auto builder = SparseMatrixPolicy::Create(state_size).SetNumberOfBlocks(number_of_grid_cells);
-    for (auto& elem : nonzero_jacobian_elements)
+    for (const auto& elem : nonzero_jacobian_elements)
       builder = builder.WithElement(elem.first, elem.second);
     // Always include diagonal elements
     for (std::size_t i = 0; i < state_size; ++i)

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -499,7 +499,7 @@ namespace micm
       /// @brief Get a const element reference for the current row in this group (ColumnView)
       template<DenseMatrixColumnView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetRowElement(Arg&& arg) const
+      decltype(auto) GetRowElement(Arg&& arg) const
       {
         auto* source_matrix = arg.GetMatrix();
         return source_matrix->data_[row_ * source_matrix->y_dim_ + arg.ColumnIndex()];
@@ -508,7 +508,7 @@ namespace micm
       /// @brief Get a const element reference for the current row in this group (RowVariable)
       template<BlockVariableView Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetRowElement(Arg&& arg) const
+      decltype(auto) GetRowElement(Arg&& arg) const
       {
         return arg.Get();
       }
@@ -516,7 +516,7 @@ namespace micm
       /// @brief Get a const element reference for the current row in this group (Vector-like)
       template<VectorLike Arg>
       [[gnu::always_inline]]
-      inline decltype(auto) GetRowElement(Arg&& arg) const
+      decltype(auto) GetRowElement(Arg&& arg) const
       {
         return arg[row_];
       }

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
@@ -402,7 +402,7 @@ namespace micm
       std::vector<std::size_t> ids;
       ids.reserve(non_zero_elements.size());
       std::set<std::pair<std::size_t, std::size_t>> column_ordered_pairs;
-      for (auto& elem : non_zero_elements)
+      for (const auto& elem : non_zero_elements)
         column_ordered_pairs.insert(std::make_pair(elem.second, elem.first));
       std::transform(
           column_ordered_pairs.begin(),
@@ -423,9 +423,9 @@ namespace micm
       std::size_t total_elem = 0;
       std::size_t curr_col = 0;
       std::set<std::pair<std::size_t, std::size_t>> column_ordered_pairs;
-      for (auto& elem : non_zero_elements)
+      for (const auto& elem : non_zero_elements)
         column_ordered_pairs.insert(std::make_pair(elem.second, elem.first));
-      for (auto& elem : column_ordered_pairs)
+      for (const auto& elem : column_ordered_pairs)
       {
         while (curr_col < elem.first)
           starts[(curr_col++) + 1] = total_elem;

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
@@ -418,7 +418,7 @@ namespace micm
       std::vector<std::size_t> starts(block_size + 1, 0);
       std::size_t total_elem = 0;
       std::size_t curr_row = 0;
-      for (auto& elem : non_zero_elements)
+      for (const auto& elem : non_zero_elements)
       {
         while (curr_row < elem.first)
           starts[(curr_row++) + 1] = total_elem;

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
@@ -197,7 +197,7 @@ namespace micm
       template<DenseMatrixColumnView Arg>
         requires HasTieredGrouping<std::remove_pointer_t<decltype(std::declval<Arg>().GetMatrix())>>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         // Calculate the actual block index from group and block_in_group
         std::size_t block = group_ * L + block_in_group;
@@ -216,7 +216,7 @@ namespace micm
       template<DenseMatrixColumnView Arg>
         requires HasSimpleGrouping<std::remove_pointer_t<decltype(std::declval<Arg>().GetMatrix())>>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         // Calculate the actual block index from group and block_in_group
         std::size_t block = group_ * L + block_in_group;
@@ -230,7 +230,7 @@ namespace micm
       template<BlockVariableView Arg>
         requires(L > 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         // Vector ordering: BlockVariable has array storage
         return arg.Get()[block_in_group];
@@ -240,7 +240,7 @@ namespace micm
       template<BlockVariableView Arg>
         requires(L == 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         // L=1 case: BlockVariable has single value storage
         return arg.Get();
@@ -250,7 +250,7 @@ namespace micm
       template<VectorLike Arg>
         requires(L > 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         return arg[group_ * L + block_in_group];
       }
@@ -259,7 +259,7 @@ namespace micm
       template<VectorLike Arg>
         requires(L == 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         return arg[group_];
       }
@@ -344,7 +344,7 @@ namespace micm
       template<DenseMatrixColumnView Arg>
         requires HasTieredGrouping<std::remove_pointer_t<decltype(std::declval<Arg>().GetMatrix())>>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         // Calculate the actual block index from group and block_in_group
         std::size_t block = group_ * L + block_in_group;
@@ -363,7 +363,7 @@ namespace micm
       template<DenseMatrixColumnView Arg>
         requires HasSimpleGrouping<std::remove_pointer_t<decltype(std::declval<Arg>().GetMatrix())>>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         // Calculate the actual block index from group and block_in_group
         std::size_t block = group_ * L + block_in_group;
@@ -377,7 +377,7 @@ namespace micm
       template<BlockVariableView Arg>
         requires(L > 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         // Vector ordering: BlockVariable has array storage
         return arg.Get()[block_in_group];
@@ -387,7 +387,7 @@ namespace micm
       template<BlockVariableView Arg>
         requires(L == 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         // L=1 case: BlockVariable has single value storage
         return arg.Get();
@@ -397,7 +397,7 @@ namespace micm
       template<VectorLike Arg>
         requires(L > 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         return arg[group_ * L + block_in_group];
       }
@@ -406,7 +406,7 @@ namespace micm
       template<VectorLike Arg>
         requires(L == 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         return arg[group_];
       }
@@ -532,7 +532,7 @@ namespace micm
       std::set<std::pair<std::size_t, std::size_t>> column_ordered_pairs;
       for (const auto& elem : non_zero_elements)
         column_ordered_pairs.insert(std::make_pair(elem.second, elem.first));
-      for (auto& elem : column_ordered_pairs)
+      for (const auto& elem : column_ordered_pairs)
       {
         while (curr_row < elem.first)
           starts[(curr_row++) + 1] = total_elem;

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
@@ -203,7 +203,7 @@ namespace micm
       template<DenseMatrixColumnView Arg>
         requires HasTieredGrouping<std::remove_pointer_t<decltype(std::declval<Arg>().GetMatrix())>>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         // Calculate the actual block index from group and block_in_group
         std::size_t block = group_ * L + block_in_group;
@@ -222,7 +222,7 @@ namespace micm
       template<DenseMatrixColumnView Arg>
         requires HasSimpleGrouping<std::remove_pointer_t<decltype(std::declval<Arg>().GetMatrix())>>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         // Calculate the actual block index from group and block_in_group
         std::size_t block = group_ * L + block_in_group;
@@ -236,7 +236,7 @@ namespace micm
       template<BlockVariableView Arg>
         requires(L > 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         // Vector ordering: BlockVariable has array storage
         return arg.Get()[block_in_group];
@@ -246,7 +246,7 @@ namespace micm
       template<BlockVariableView Arg>
         requires(L == 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         // L=1 case: BlockVariable has single value storage
         return arg.Get();
@@ -256,7 +256,7 @@ namespace micm
       template<VectorLike Arg>
         requires(L > 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         return arg[group_ * L + block_in_group];
       }
@@ -265,7 +265,7 @@ namespace micm
       template<VectorLike Arg>
         requires(L == 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg) const
       {
         return arg[group_];
       }
@@ -350,7 +350,7 @@ namespace micm
       template<DenseMatrixColumnView Arg>
         requires HasTieredGrouping<std::remove_pointer_t<decltype(std::declval<Arg>().GetMatrix())>>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         // Calculate the actual block index from group and block_in_group
         std::size_t block = group_ * L + block_in_group;
@@ -369,7 +369,7 @@ namespace micm
       template<DenseMatrixColumnView Arg>
         requires HasSimpleGrouping<std::remove_pointer_t<decltype(std::declval<Arg>().GetMatrix())>>
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         // Calculate the actual block index from group and block_in_group
         std::size_t block = group_ * L + block_in_group;
@@ -383,7 +383,7 @@ namespace micm
       template<BlockVariableView Arg>
         requires(L > 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         // Vector ordering: BlockVariable has array storage
         return arg.Get()[block_in_group];
@@ -393,7 +393,7 @@ namespace micm
       template<BlockVariableView Arg>
         requires(L == 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         // L=1 case: BlockVariable has single value storage
         return arg.Get();
@@ -403,7 +403,7 @@ namespace micm
       template<VectorLike Arg>
         requires(L > 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         return arg[group_ * L + block_in_group];
       }
@@ -412,7 +412,7 @@ namespace micm
       template<VectorLike Arg>
         requires(L == 1)
       [[gnu::always_inline]]
-      inline decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
+      decltype(auto) GetBlockElement(std::size_t block_in_group, Arg&& arg)
       {
         return arg[group_];
       }
@@ -530,7 +530,7 @@ namespace micm
       std::vector<std::size_t> starts(block_size + 1, 0);
       std::size_t total_elem = 0;
       std::size_t curr_row = 0;
-      for (auto& elem : non_zero_elements)
+      for (const auto& elem : non_zero_elements)
       {
         while (curr_row < elem.first)
           starts[(curr_row++) + 1] = total_elem;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,10 @@ if(NOT ${MICM_GPU_TYPE} STREQUAL "None")
     PUBLIC CUDA::cudart CUDA::cublas
   )
   
-  target_compile_options(micm_cuda PRIVATE --expt-relaxed-constexpr)
+  # --expt-relaxed-constexpr is nvcc-only; guard it so non-nvcc CUDA compilers
+  # (e.g. clang, used by the clang-tidy CI to generate parseable compile commands)
+  # don't choke on it.
+  target_compile_options(micm_cuda PRIVATE $<$<CUDA_COMPILER_ID:NVIDIA>:--expt-relaxed-constexpr>)
   set_property(TARGET micm_cuda PROPERTY CUDA_STANDARD 20)
 
   add_subdirectory(process)

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -167,7 +167,7 @@ namespace micm
       /// Create a struct whose members contain the addresses in the device memory.
       ProcessSetParam devstruct;
 
-      auto cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+      auto *cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
 
       /// Allocate memory space on the device
       CHECK_CUDA_ERROR(
@@ -238,7 +238,7 @@ namespace micm
       std::size_t jacobian_yields_bytes = sizeof(double) * hoststruct.jacobian_yields_size_;
       std::size_t jacobian_flat_ids_bytes = sizeof(std::size_t) * hoststruct.jacobian_flat_ids_size_;
 
-      auto cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+      auto *cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
 
       /// Allocate memory space on the device
       CHECK_CUDA_ERROR(
@@ -304,7 +304,7 @@ namespace micm
     {
       std::size_t algebraic_variable_bytes = sizeof(uint8_t) * hoststruct.algebraic_variable_size_;
 
-      auto cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+      auto *cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
 
       CHECK_CUDA_ERROR(
           cudaMemcpyAsync(
@@ -322,7 +322,7 @@ namespace micm
     ///   members of class "CudaProcessSet" on the device
     void FreeConstData(ProcessSetParam& devstruct)
     {
-      auto cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
+      auto *cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
 
       if (devstruct.number_of_reactants_ != nullptr)
         CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_reactants_, cuda_stream_id), "cudaFree");

--- a/src/solver/linear_solver_in_place.cu
+++ b/src/solver/linear_solver_in_place.cu
@@ -49,8 +49,8 @@ namespace micm
             {
               const std::size_t d_Lij_yj_first = (*d_Lij_yj).first;
               const std::size_t d_Lij_yj_second_times_vector_length = (*d_Lij_yj).second * cuda_matrix_vector_length;
-              auto d_ALU_ptr = d_ALU + d_Lij_yj_first;
-              auto d_x_ptr = d_x + d_Lij_yj_second_times_vector_length;
+              auto *d_ALU_ptr = d_ALU + d_Lij_yj_first;
+              auto *d_x_ptr = d_x + d_Lij_yj_second_times_vector_length;
               d_y[local_tid] -= d_ALU_ptr[local_tid] * d_x_ptr[local_tid];
               ++d_Lij_yj;
             }
@@ -66,12 +66,12 @@ namespace micm
             const std::size_t j_lim = d_nUij_Uii[i].first;
             for (int j = 0; j < j_lim; ++j)
             {
-              auto d_ALU_ptr = d_ALU + (*d_Uij_xj).first;
-              auto d_x_ptr = d_x + (*d_Uij_xj).second * cuda_matrix_vector_length;
+              auto *d_ALU_ptr = d_ALU + (*d_Uij_xj).first;
+              auto *d_x_ptr = d_x + (*d_Uij_xj).second * cuda_matrix_vector_length;
               d_y[local_tid] -= d_ALU_ptr[local_tid] * d_x_ptr[local_tid];
               ++d_Uij_xj;
             }
-            auto d_ALU_ptr = d_ALU + d_nUij_Uii[i].second;
+            auto *d_ALU_ptr = d_ALU + d_nUij_Uii[i].second;
             d_y[local_tid] /= d_ALU_ptr[local_tid];
             d_y -= cuda_matrix_vector_length;
           }

--- a/src/solver/lu_decomposition_mozart_in_place.cu
+++ b/src/solver/lu_decomposition_mozart_in_place.cu
@@ -33,12 +33,12 @@ namespace micm
       {
         for (int i = 0; i < d_aii_nji_nki_size; ++i)
         {
-          auto& d_aii_nji_nki_elem = d_aii_nji_nki[i];
-          auto d_Aii = d_ALU + std::get<0>(d_aii_nji_nki_elem);
+          const auto& d_aii_nji_nki_elem = d_aii_nji_nki[i];
+          auto *d_Aii = d_ALU + std::get<0>(d_aii_nji_nki_elem);
           auto d_Aii_inverse = 1.0 / d_Aii[local_tid];
           for (int ij = 0; ij < std::get<1>(d_aii_nji_nki_elem); ++ij)
           {
-            auto d_ALU_ji = d_ALU + *d_aji + local_tid;
+            auto *d_ALU_ji = d_ALU + *d_aji + local_tid;
             *d_ALU_ji *= d_Aii_inverse;
             ++d_aji;
           }
@@ -48,9 +48,9 @@ namespace micm
             const std::size_t d_aik_njk_second = std::get<1>(*d_aik_njk);
             for (std::size_t ijk = 0; ijk < d_aik_njk_second; ++ijk)
             {
-              auto d_ALU_first = d_ALU + d_ajk_aji->first + local_tid;
-              auto d_ALU_second = d_ALU + d_ajk_aji->second + local_tid;
-              auto d_ALU_aik = d_ALU + d_aik_njk_first + local_tid;
+              auto *d_ALU_first = d_ALU + d_ajk_aji->first + local_tid;
+              auto *d_ALU_second = d_ALU + d_ajk_aji->second + local_tid;
+              auto *d_ALU_aik = d_ALU + d_aik_njk_first + local_tid;
               *d_ALU_first -= *d_ALU_second * *d_ALU_aik;
               ++d_ajk_aji;
             }

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <micm/CPU.hpp>
 
 #include <gtest/gtest.h>

--- a/test/integration/analytical_surface_rxn_policy.hpp
+++ b/test/integration/analytical_surface_rxn_policy.hpp
@@ -1,3 +1,7 @@
+#pragma once
+
+#include "analytical_policy.hpp"  // RelativeError
+
 #include <micm/CPU.hpp>
 
 #include <gtest/gtest.h>

--- a/test/integration/test_external_model_constraints.cpp
+++ b/test/integration/test_external_model_constraints.cpp
@@ -254,7 +254,7 @@ class MassConservationModel
   {
     auto i_ctrl = state_indices.at(controlled_species_);
     std::set<std::pair<std::size_t, std::size_t>> elements;
-    for (auto& sp : all_species_)
+    for (const auto& sp : all_species_)
       elements.insert({ i_ctrl, state_indices.at(sp) });
     return elements;
   }
@@ -278,7 +278,7 @@ class MassConservationModel
   {
     auto i_ctrl = var.at(controlled_species_);
     std::vector<std::size_t> indices;
-    for (auto& sp : all_species_)
+    for (const auto& sp : all_species_)
       indices.push_back(var.at(sp));
     double tot = total_;
     return [=](const DenseMatrixPolicy& state, const DenseMatrixPolicy&, DenseMatrixPolicy& forcing)
@@ -301,7 +301,7 @@ class MassConservationModel
   {
     auto i_ctrl = var.at(controlled_species_);
     std::vector<std::size_t> indices;
-    for (auto& sp : all_species_)
+    for (const auto& sp : all_species_)
       indices.push_back(var.at(sp));
     return [=](const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy& jac)
     {
@@ -1120,7 +1120,7 @@ TEST(ExternalModelFiniteDifferenceJacobian, ProcessForcingJacobian)
   auto nz_elements = aerosol.NonZeroJacobianElements(var_map);
 
   auto builder = SparseMatrixFD::Create(num_species).SetNumberOfBlocks(2).InitialValue(0.0);
-  for (auto& elem : nz_elements)
+  for (const auto& elem : nz_elements)
     builder = builder.WithElement(elem.first, elem.second);
   SparseMatrixFD analytical_jac{ builder };
 
@@ -1168,7 +1168,7 @@ TEST(ExternalModelFiniteDifferenceJacobian, ConstraintResidualJacobian)
   auto nz_elements = aerosol.NonZeroConstraintJacobianElements(var_map);
 
   auto builder = SparseMatrixFD::Create(num_species).SetNumberOfBlocks(2).InitialValue(0.0);
-  for (auto& elem : nz_elements)
+  for (const auto& elem : nz_elements)
     builder = builder.WithElement(elem.first, elem.second);
   SparseMatrixFD analytical_jac{ builder };
 
@@ -1209,7 +1209,7 @@ TEST(ExternalModelFiniteDifferenceJacobian, EquilibriumConstraintModelJacobian)
   auto nz_elements = model.NonZeroConstraintJacobianElements(var_map);
 
   auto builder = SparseMatrixFD::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
-  for (auto& elem : nz_elements)
+  for (const auto& elem : nz_elements)
     builder = builder.WithElement(elem.first, elem.second);
   SparseMatrixFD analytical_jac{ builder };
 

--- a/test/unit/constraint/type/test_equilibrium.cpp
+++ b/test/unit/constraint/type/test_equilibrium.cpp
@@ -247,7 +247,7 @@ TEST(EquilibriumConstraint, ResidualComputationThroughConstraintSet)
   {
     builder = builder.WithElement(i, i);
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
   StandardSparseMatrix jacobian{ builder };
@@ -322,7 +322,7 @@ TEST(EquilibriumConstraint, JacobianComputationThroughConstraintSet)
   {
     builder = builder.WithElement(i, i);  // Diagonals
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
   StandardSparseMatrix jacobian{ builder };
@@ -386,7 +386,7 @@ TEST(EquilibriumConstraint, ComplexStoichiometryResidual)
   {
     builder = builder.WithElement(i, i);
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
   StandardSparseMatrix jacobian{ builder };
@@ -441,7 +441,7 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianSimple)
   {
     builder = builder.WithElement(i, i);
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
@@ -508,7 +508,7 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianComplexStoichiometry)
   {
     builder = builder.WithElement(i, i);
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);

--- a/test/unit/constraint/type/test_linear.cpp
+++ b/test/unit/constraint/type/test_linear.cpp
@@ -144,7 +144,7 @@ TEST(LinearConstraint, ResidualComputationThroughConstraintSet)
   {
     builder = builder.WithElement(i, i);
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
   StandardSparseMatrix jacobian{ builder };
@@ -210,7 +210,7 @@ TEST(LinearConstraint, JacobianComputationThroughConstraintSet)
   {
     builder = builder.WithElement(i, i);  // Diagonals
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
   StandardSparseMatrix jacobian{ builder };
@@ -267,7 +267,7 @@ TEST(LinearConstraint, WeightedSumResidualAndJacobian)
   {
     builder = builder.WithElement(i, i);
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
   StandardSparseMatrix jacobian{ builder };
@@ -339,7 +339,7 @@ TEST(LinearConstraint, ThreeSpeciesConservationResidual)
   {
     builder = builder.WithElement(i, i);
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
   StandardSparseMatrix jacobian{ builder };
@@ -402,7 +402,7 @@ TEST(LinearConstraint, ZeroConstantResidual)
   {
     builder = builder.WithElement(i, i);
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
   StandardSparseMatrix jacobian{ builder };
@@ -463,7 +463,7 @@ TEST(LinearConstraint, FractionalCoefficientsResidualAndJacobian)
   {
     builder = builder.WithElement(i, i);
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
   StandardSparseMatrix jacobian{ builder };
@@ -520,7 +520,7 @@ TEST(LinearConstraint, JacobianIndependentOfConcentrations)
   {
     builder = builder.WithElement(i, i);
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
 
   StandardSparseMatrix jacobian{ builder };
@@ -587,7 +587,7 @@ TEST(LinearConstraint, FiniteDifferenceJacobianSimpleConservation)
   {
     builder = builder.WithElement(i, i);
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
@@ -651,7 +651,7 @@ TEST(LinearConstraint, FiniteDifferenceJacobianWeightedSum)
   {
     builder = builder.WithElement(i, i);
   }
-  for (auto& elem : non_zero_elements)
+  for (const auto& elem : non_zero_elements)
     builder = builder.WithElement(elem.first, elem.second);
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);

--- a/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_column.cpp
+++ b/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_column.cpp
@@ -64,7 +64,7 @@ TEST(CudaSparseMatrix, CopyAssignmentZeroMatrixAddOne)
   auto param = matrix.AsDeviceParam();
   micm::cuda::AddOneDriver(param);
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
@@ -74,33 +74,33 @@ TEST(CudaSparseMatrix, CopyAssignmentZeroMatrixAddOne)
   EXPECT_EQ(2, matrix.AsVector().size());
   EXPECT_EQ(2, oneMatrix.AsVector().size());
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
 
   matrix.CopyToHost();
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 1.0);
   }
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
 
   oneMatrix.CopyToHost();
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 1.0);
   }
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 1.0);
   }
@@ -123,22 +123,22 @@ TEST(CudaSparseMatrix, CopyAssignmentConstZeroMatrixAddOne)
 
   EXPECT_EQ(matrix.AsVector().size(), 2);
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
 
   oneMatrix.CopyToHost();
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 1.0);
   }
@@ -161,7 +161,7 @@ TEST(CudaSparseMatrix, MoveAssignmentConstZeroMatrixAddOne)
   }
 
   EXPECT_EQ(2, oneMatrix.AsVector().size());
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
@@ -170,14 +170,14 @@ TEST(CudaSparseMatrix, MoveAssignmentConstZeroMatrixAddOne)
   auto param = oneMatrix.AsDeviceParam();
   micm::cuda::AddOneDriver(param);
 
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
 
   oneMatrix.CopyToHost();
 
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 1.0);
   }
@@ -193,7 +193,7 @@ TEST(CudaSparseMatrix, MoveAssignmentZeroMatrixAddOne)
   micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrderingCompressedSparseColumn<1>> matrix{ builder };
 
   EXPECT_EQ(2, matrix.AsVector().size());
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
@@ -202,7 +202,7 @@ TEST(CudaSparseMatrix, MoveAssignmentZeroMatrixAddOne)
   auto param = matrix.AsDeviceParam();
   micm::cuda::AddOneDriver(param);
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
@@ -214,14 +214,14 @@ TEST(CudaSparseMatrix, MoveAssignmentZeroMatrixAddOne)
         "The 'd_data_' pointer of oneMatrix is not initialized to a null pointer in the move constructor.");
   }
 
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
 
   oneMatrix.CopyToHost();
 
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 1.0);
   }

--- a/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_row.cpp
+++ b/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_row.cpp
@@ -64,7 +64,7 @@ TEST(CudaSparseMatrix, CopyAssignmentZeroMatrixAddOne)
   auto param = matrix.AsDeviceParam();
   micm::cuda::AddOneDriver(param);
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
@@ -74,33 +74,33 @@ TEST(CudaSparseMatrix, CopyAssignmentZeroMatrixAddOne)
   EXPECT_EQ(2, matrix.AsVector().size());
   EXPECT_EQ(2, oneMatrix.AsVector().size());
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
 
   matrix.CopyToHost();
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 1.0);
   }
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
 
   oneMatrix.CopyToHost();
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 1.0);
   }
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 1.0);
   }
@@ -123,22 +123,22 @@ TEST(CudaSparseMatrix, CopyAssignmentConstZeroMatrixAddOne)
 
   EXPECT_EQ(matrix.AsVector().size(), 2);
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
 
   oneMatrix.CopyToHost();
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 1.0);
   }
@@ -161,7 +161,7 @@ TEST(CudaSparseMatrix, MoveAssignmentConstZeroMatrixAddOne)
   }
 
   EXPECT_EQ(2, oneMatrix.AsVector().size());
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
@@ -170,14 +170,14 @@ TEST(CudaSparseMatrix, MoveAssignmentConstZeroMatrixAddOne)
   auto param = oneMatrix.AsDeviceParam();
   micm::cuda::AddOneDriver(param);
 
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
 
   oneMatrix.CopyToHost();
 
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 1.0);
   }
@@ -193,7 +193,7 @@ TEST(CudaSparseMatrix, MoveAssignmentZeroMatrixAddOne)
   micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrderingCompressedSparseRow<1>> matrix{ builder };
 
   EXPECT_EQ(2, matrix.AsVector().size());
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
@@ -202,7 +202,7 @@ TEST(CudaSparseMatrix, MoveAssignmentZeroMatrixAddOne)
   auto param = matrix.AsDeviceParam();
   micm::cuda::AddOneDriver(param);
 
-  for (auto& elem : matrix.AsVector())
+  for (const auto& elem : matrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
@@ -214,14 +214,14 @@ TEST(CudaSparseMatrix, MoveAssignmentZeroMatrixAddOne)
         "The 'd_data_' pointer of oneMatrix is not initialized to a null pointer in the move constructor.");
   }
 
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 0.0);
   }
 
   oneMatrix.CopyToHost();
 
-  for (auto& elem : oneMatrix.AsVector())
+  for (const auto& elem : oneMatrix.AsVector())
   {
     EXPECT_EQ(elem, 1.0);
   }

--- a/test/unit/version/test_version.cpp
+++ b/test/unit/version/test_version.cpp
@@ -4,7 +4,7 @@
 
 TEST(Version, FullVersion)
 {
-  auto version = micm::GetMicmVersion();
+  const auto *version = micm::GetMicmVersion();
 }
 
 TEST(Version, VersionMajor)


### PR DESCRIPTION
Closes #1013

Ran 
```bash
cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
      -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
      -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang

  run-clang-tidy -p build -fix \
      '/Users/kshores/Documents/micm/(include|src|test)'
```

- Fixes all  `readability-qualified-auto`
- I guess I missed some`readability-redundant-inline-specifier` issues in #1010, but this catches the rest
- also actually allows the clang tidy action to fail the pr by removing `continue-on-error: true`
- configured cmake to use clang to compile the cuda code (because that's an option apparently) so that clang tidy could parse the cuda files
- updated clang tidy's version to 22