### PR TITLE
ignoring clang-tidy's readability-redundant-member-init check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -62,6 +62,7 @@ Checks: >
   readability-redundant-inline-specifier,
   readability-qualified-auto,
   # explicitly disabled checks
+  -readability-redundant-member-init
   -readability-identifier-length,
   -readability-convert-member-functions-to-static,
   -readability-magic-numbers,


### PR DESCRIPTION
Closes #1015 

I think we should ignore this one. This would mean any class/struct member that has a default initialization at declaration with another default initialization in the class constructor would need to have the initialization in the constructor removed. That would make it hard to keep track of what is where, and I don't think it's worth worrying about that.