### PR TITLE
correcting clang tidy file, fixing more braces, unnecessary value param

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -53,7 +53,7 @@
 #   std::next calls. All are safe within realistic problem sizes for a chemistry
 #   solver. Too noisy for the benefit.
 
-Checks: >
+Checks: |
   # disable all checks
   -*,
   # explicitly enabled checks
@@ -61,8 +61,9 @@ Checks: >
   readability-identifier-naming,
   readability-redundant-inline-specifier,
   readability-qualified-auto,
+  performance-unnecessary-value-param,
   # explicitly disabled checks
-  -readability-redundant-member-init
+  -readability-redundant-member-init,
   -readability-identifier-length,
   -readability-convert-member-functions-to-static,
   -readability-magic-numbers,

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        version: [19.1.0, 20.1.0]
+        version: [20.1.0]
 
     steps:
       - uses: actions/checkout@v4

--- a/include/micm/constraint/constraint_set.hpp
+++ b/include/micm/constraint/constraint_set.hpp
@@ -223,7 +223,9 @@ namespace micm
             [&](auto& c)
             {
               for (auto& label : c.parameters_)
+              {
                 param_names.insert(label);
+              }
             },
             each.constraint_);
       }
@@ -242,9 +244,13 @@ namespace micm
         DenseMatrixPolicy& forcing) const
     {
       for (const auto& forcing_fn : constraint_forcing_functions_)
+      {
         forcing_fn(state_variables, state_parameters, forcing);
+      }
       for (const auto& forcing_fn : external_constraint_forcing_functions_)
+      {
         forcing_fn(state_variables, state_parameters, forcing);
+      }
     }
 
     /// @brief Subtract constraint Jacobian terms from Jacobian matrix
@@ -259,9 +265,13 @@ namespace micm
         SparseMatrixPolicy& jacobian) const
     {
       for (const auto& jacobian_fn : constraint_jacobian_functions_)
+      {
         jacobian_fn(state_variables, state_parameters, jacobian);
+      }
       for (const auto& jacobian_fn : external_constraint_jacobian_functions_)
+      {
         jacobian_fn(state_variables, state_parameters, jacobian);
+      }
     }
 
     /// @brief Set algebraic variable error estimates using step changes
@@ -272,7 +282,9 @@ namespace micm
     void SetAlgebraicErrors(DenseMatrixPolicy& Yerror, const DenseMatrixPolicy& Y, const DenseMatrixPolicy& Ynew) const
     {
       if (algebraic_error_function_)
+      {
         algebraic_error_function_(Yerror, Y, Ynew);
+      }
     }
 
     /// @brief Returns positions of all non-zero Jacobian elements for constraint rows
@@ -418,7 +430,9 @@ namespace micm
       {
         auto alg_names = model.algebraic_variable_names_func_();
         if (alg_names.empty())
+        {
           continue;
+        }
         auto model_ids = model.non_zero_jacobian_elements_func_(variable_map);
         ids.insert(model_ids.begin(), model_ids.end());
         // Ensure diagonal elements exist for algebraic rows
@@ -426,7 +440,9 @@ namespace micm
         {
           auto it = variable_map.find(name);
           if (it != variable_map.end())
+          {
             ids.insert(std::make_pair(it->second, it->second));
+          }
         }
       }
       return ids;
@@ -442,15 +458,19 @@ namespace micm
       {
         auto alg_names = model.algebraic_variable_names_func_();
         if (alg_names.empty())
+        {
           continue;
+        }
         auto param_names = model.state_parameter_names_func_();
         for (const auto& name : param_names)
         {
           if (!seen.insert(name).second)
+          {
             throw MicmException(
                 MICM_ERROR_CATEGORY_CONSTRAINT,
                 MICM_CONSTRAINT_ERROR_CODE_DUPLICATE_PARAMETER,
                 "Duplicate external constraint parameter name across models: " + name);
+          }
           names.push_back(name);
         }
       }
@@ -473,15 +493,19 @@ namespace micm
       {
         auto alg_names = model.algebraic_variable_names_func_();
         if (alg_names.empty())
+        {
           continue;
+        }
         auto init_names = model.initialize_constraint_parameter_names_func_();
         for (const auto& name : init_names)
         {
           if (!seen.insert(name).second)
+          {
             throw MicmException(
                 MICM_ERROR_CATEGORY_CONSTRAINT,
                 MICM_CONSTRAINT_ERROR_CODE_DUPLICATE_PARAMETER,
                 "Duplicate external initialize constraint parameter name across models: " + name);
+          }
           names.push_back(name);
         }
       }
@@ -501,7 +525,9 @@ namespace micm
     void InitializeConstraintParameters(const DenseMatrixPolicy& state_variables, DenseMatrixPolicy& state_parameters) const
     {
       for (const auto& init_func : external_constraint_init_functions_)
+      {
         init_func(state_variables, state_parameters);
+      }
     }
 
     /// @brief Pre-compiles external constraint residual, Jacobian, and parameter update functions
@@ -522,7 +548,9 @@ namespace micm
       {
         auto alg_names = model.algebraic_variable_names_func_();
         if (alg_names.empty())
+        {
           continue;
+        }
         external_constraint_param_functions_.push_back(model.update_state_parameters_function_(state_parameter_indices));
         external_constraint_forcing_functions_.push_back(
             model.get_residual_function_(state_parameter_indices, state_variable_indices));

--- a/include/micm/cuda/process/cuda_process_set.hpp
+++ b/include/micm/cuda/process/cuda_process_set.hpp
@@ -173,7 +173,9 @@ namespace micm
       : ProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>(processes, variable_map, external_models)
   {
     if (!external_models.empty())
+    {
       throw std::runtime_error("CudaProcessSet does not currently support external models.");
+    }
     InitDevStruct();
   }
 

--- a/include/micm/cuda/process/cuda_reaction_rate_store.hpp
+++ b/include/micm/cuda/process/cuda_reaction_rate_store.hpp
@@ -59,7 +59,9 @@ namespace micm
     {
       FreeDevice(d_ptr);
       if (host_vec.empty())
+      {
         return;
+      }
       auto* stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
       CHECK_CUDA_ERROR(cudaMallocAsync(&d_ptr, sizeof(T) * host_vec.size(), stream), "cudaMalloc");
       CHECK_CUDA_ERROR(
@@ -191,7 +193,9 @@ namespace micm
       {
         std::vector<std::size_t> rc_indices(mults.size());
         for (std::size_t i = 0; i < mults.size(); ++i)
+        {
           rc_indices[i] = mults[i].rc_index_;
+        }
         auto* stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
         CHECK_CUDA_ERROR(cudaMallocAsync(&d_mult_rc_indices_, sizeof(std::size_t) * mults.size(), stream), "cudaMalloc");
         CHECK_CUDA_ERROR(
@@ -212,7 +216,9 @@ namespace micm
     {
       const auto& mults = cpu_store.parameterized_multipliers_;
       if (mults.empty())
+      {
         return nullptr;
+      }
 
       const std::size_t n_mults = mults.size();
       const std::size_t n_cells = conditions.size();
@@ -221,13 +227,19 @@ namespace micm
 
       std::vector<double> host_vals(n_vals, 0.0);
       for (std::size_t g = 0; g < n_groups; ++g)
+      {
         for (std::size_t i = 0; i < n_mults; ++i)
+        {
           for (std::size_t j = 0; j < L; ++j)
           {
             const std::size_t cell = g * L + j;
             if (cell < n_cells)
+            {
               host_vals[g * n_mults * L + i * L + j] = mults[i].evaluate_(conditions[cell]);
+            }
           }
+        }
+      }
 
       auto* stream = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
       if (n_vals > d_mult_vals_capacity_)

--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
@@ -51,7 +51,7 @@ namespace micm
     CudaLinearSolverInPlace(
         const SparseMatrixPolicy& matrix,
         typename SparseMatrixPolicy::value_type initial_value,
-        const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)> create_lu_decomp)
+        const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)>&& create_lu_decomp)
         : LinearSolverInPlace<SparseMatrixPolicy, LuDecompositionPolicy>(matrix, initial_value, create_lu_decomp)
     {
       LinearSolverInPlaceParam hoststruct;

--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -68,7 +68,9 @@ namespace micm
       this->param_.number_of_elements_ = this->data_.size();
       this->param_.vector_length_ = L;
       if (this->param_.number_of_elements_ != 0)
+      {
         CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
+      }
     }
 
     CudaDenseMatrix(std::size_t x_dim, std::size_t y_dim)
@@ -78,7 +80,9 @@ namespace micm
       this->param_.number_of_grid_cells_ = x_dim;
       this->param_.vector_length_ = L;
       if (this->param_.number_of_elements_ != 0)
+      {
         CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
+      }
     }
 
     CudaDenseMatrix(std::size_t x_dim, std::size_t y_dim, T initial_value)
@@ -94,7 +98,7 @@ namespace micm
       }
     }
 
-    CudaDenseMatrix(const std::vector<std::vector<T>> other)
+    CudaDenseMatrix(const std::vector<std::vector<T>>& other)
         : VectorMatrix<T, L>(other)
     {
       this->param_.number_of_grid_cells_ = 0;
@@ -105,7 +109,9 @@ namespace micm
         this->param_.number_of_elements_ += inner_vector.size();
       }
       if (this->param_.number_of_elements_ != 0)
+      {
         CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->param_.number_of_elements_), "cudaMalloc");
+      }
     }
 
     CudaDenseMatrix(const CudaDenseMatrix& other)

--- a/include/micm/cuda/util/cuda_sparse_matrix.hpp
+++ b/include/micm/cuda/util/cuda_sparse_matrix.hpp
@@ -40,7 +40,9 @@ namespace micm
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
       this->param_.vector_length_ = this->VECTOR_LENGTH;
       if (!indexing_only)
+      {
         CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->data_.size()), "cudaMalloc");
+      }
     }
 
     CudaSparseMatrix<T, OrderingPolicy>& operator=(const SparseMatrixBuilder<T, OrderingPolicy>& builder)
@@ -49,7 +51,9 @@ namespace micm
       this->param_.number_of_grid_cells_ = this->number_of_blocks_;
       this->param_.vector_length_ = this->VECTOR_LENGTH;
       if (this->data_.size() != 0)
+      {
         CHECK_CUDA_ERROR(micm::cuda::MallocVector<T>(this->param_, this->data_.size()), "cudaMalloc");
+      }
       return *this;
     }
 

--- a/include/micm/cuda/util/cuda_util.cuh
+++ b/include/micm/cuda/util/cuda_util.cuh
@@ -22,14 +22,14 @@ namespace micm
     /// @param file File where error occurred
     /// @param line Line number where error occurred
     /// @param str Additional string to print with error message
-    void CheckCudaError(cudaError_t err, const char* file, int line, std::string str);
+    void CheckCudaError(cudaError_t err, const char* file, int line, const std::string& str);
 
     /// @brief Checks for cuBLAS errors and prints error message if any
     /// @param err Error code to check
     /// @param file File where error occurred
     /// @param line Line number where error occurred
     /// @param str Additional string to print with error message
-    void CheckCublasError(cublasStatus_t err, const char* file, int line, std::string str);
+    void CheckCublasError(cublasStatus_t err, const char* file, int line, const std::string& str);
 
     /// @brief Get the cuBLAS handle for the current device
     cublasHandle_t& GetCublasHandle();

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -156,9 +156,13 @@ namespace micm
       for (const auto& reactant : reaction.reactants_)
       {
         if (reactant.IsParameterized())
+        {
           continue;  // Skip reactants that are parameterizations
+        }
         if (variable_map.count(reactant.name_) < 1)
+        {
           throw MicmException(MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_REACTANT_DOES_NOT_EXIST, reactant.name_);
+        }
         reactant_ids_.push_back(variable_map.at(reactant.name_));
         ++number_of_reactants;
       }
@@ -166,10 +170,14 @@ namespace micm
       for (const auto& product : reaction.products_)
       {
         if (product.species_.IsParameterized())
+        {
           continue;  // Skip products that are parameterizations
+        }
         if (variable_map.count(product.species_.name_) < 1)
+        {
           throw MicmException(
               MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_PRODUCT_DOES_NOT_EXIST, product.species_.name_);
+        }
         product_ids_.push_back(variable_map.at(product.species_.name_));
         yields_.push_back(product.coefficient_);
         ++number_of_products;
@@ -195,7 +203,9 @@ namespace micm
         for (const auto& ind_reactant : reaction.reactants_)
         {
           if (ind_reactant.name_ != independent_variable.first)
+          {
             continue;
+          }
           ProcessInfo info;
           info.process_id_ = i_process;
           info.independent_id_ = independent_variable.second;
@@ -207,10 +217,14 @@ namespace micm
           for (const auto& reactant : reaction.reactants_)
           {
             if (reactant.IsParameterized())
+            {
               continue;  // Skip reactants that are parameterizations
+            }
             if (variable_map.count(reactant.name_) < 1)
+            {
               throw MicmException(
                   MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_REACTANT_DOES_NOT_EXIST, reactant.name_);
+            }
             if (variable_map.at(reactant.name_) == independent_variable.second && !found)
             {
               found = true;
@@ -222,10 +236,14 @@ namespace micm
           for (const auto& product : reaction.products_)
           {
             if (product.species_.IsParameterized())
+            {
               continue;  // Skip products that are parameterizations
+            }
             if (variable_map.count(product.species_.name_) < 1)
+            {
               throw MicmException(
                   MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_PRODUCT_DOES_NOT_EXIST, product.species_.name_);
+            }
             jacobian_product_ids_.push_back(variable_map.at(product.species_.name_));
             jacobian_yields_.push_back(product.coefficient_);
             ++info.number_of_products_;
@@ -497,7 +515,9 @@ namespace micm
       {
         double d_rate_d_ind = cell_rate_constants[process_info.process_id_];
         for (std::size_t i_react = 0; i_react < process_info.number_of_dependent_reactants_; ++i_react)
+        {
           d_rate_d_ind *= cell_state[react_id[i_react]];
+        }
 
         for (std::size_t i_dep = 0; i_dep < process_info.number_of_dependent_reactants_; ++i_dep)
         {
@@ -575,7 +595,9 @@ namespace micm
           auto v_state_variables_it = v_state_variables.begin() + idx_state_variables;
           auto v_d_rate_d_ind_it = d_rate_d_ind.begin();
           for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+          {
             *(v_d_rate_d_ind_it++) *= *(v_state_variables_it++);
+          }
         }
         for (std::size_t i_dep = 0; i_dep < process_info.number_of_dependent_reactants_; ++i_dep)
         {
@@ -585,7 +607,9 @@ namespace micm
             auto v_jacobian_it = v_jacobian.begin() + offset_jacobian + *flat_id;
             auto v_d_rate_d_ind_it = d_rate_d_ind.begin();
             for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+            {
               *(v_jacobian_it++) += *(v_d_rate_d_ind_it++);
+            }
           }
           ++flat_id;
         }
@@ -595,7 +619,9 @@ namespace micm
           auto v_jacobian_it = v_jacobian.begin() + offset_jacobian + *flat_id;
           auto v_d_rate_d_ind_it = d_rate_d_ind.begin();
           for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+          {
             *(v_jacobian_it++) += *(v_d_rate_d_ind_it++);
+          }
         }
         ++flat_id;
 
@@ -608,7 +634,9 @@ namespace micm
             auto yield_value = yield[i_dep];
             auto v_d_rate_d_ind_it = d_rate_d_ind.begin();
             for (std::size_t i_cell = 0; i_cell < L; ++i_cell)
+            {
               *(v_jacobian_it++) -= yield_value * *(v_d_rate_d_ind_it++);
+            }
           }
           ++flat_id;
         }

--- a/include/micm/process/reaction_rate_store.hpp
+++ b/include/micm/process/reaction_rate_store.hpp
@@ -140,8 +140,12 @@ namespace micm
         {  // parameterized-reactant multiplier
           std::vector<std::function<double(const Conditions&)>> param_funcs;
           for (const auto& reactant : reaction.reactants_)
+          {
             if (reactant.IsParameterized())
+            {
               param_funcs.push_back(reactant.parameterize_);
+            }
+          }
 
           if (!param_funcs.empty())
           {
@@ -149,7 +153,9 @@ namespace micm
                                                          {
                                                            double val = 1.0;
                                                            for (const auto& f : pf)
+                                                           {
                                                              val *= f(cond);
+                                                           }
                                                            return val;
                                                          },
                                                          rc_index });
@@ -208,10 +214,12 @@ namespace micm
         {
           SurfaceRateConstantData data;
           if (!p->phase_species_.diffusion_coefficient_.has_value())
+          {
             throw MicmException(
                 MICM_ERROR_CATEGORY_SPECIES,
                 MICM_SPECIES_ERROR_CODE_PROPERTY_NOT_FOUND,
                 "Diffusion coefficient for species '" + p->phase_species_.species_.name_ + "' is not defined");
+          }
           data.diffusion_coefficient_ = p->phase_species_.diffusion_coefficient_.value();
           double mw = p->phase_species_.species_.GetProperty<double>(property_keys::MOLECULAR_WEIGHT);
           data.mean_free_speed_factor_ = 8.0 * constants::GAS_CONSTANT / (M_PI * mw);
@@ -258,7 +266,9 @@ namespace micm
           {
             const auto& cond = state.conditions_[i_group * L + i_cell];
             for (const auto& entry : store.lambda_entries_)
+            {
               v_rc[rc_base + entry.rc_index_ * L + i_cell] = entry.source_->lambda_function_(cond);
+            }
           }
         }
       }
@@ -268,7 +278,9 @@ namespace micm
         {
           const auto& cond = state.conditions_[i_cell];
           for (const auto& entry : store.lambda_entries_)
+          {
             state.rate_constants_[i_cell][entry.rc_index_] = entry.source_->lambda_function_(cond);
+          }
         }
       }
     }

--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -95,7 +95,7 @@ namespace micm
     LinearSolver(
         const SparseMatrixPolicy& matrix,
         typename SparseMatrixPolicy::value_type initial_value,
-        const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)> create_lu_decomp);
+        const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)>& create_lu_decomp);
 
     virtual ~LinearSolver() = default;
 

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -8,8 +8,9 @@ namespace micm
   {
     const std::size_t order = matrix.NumRows();
     std::vector<std::size_t> perm(order);
-    for (std::size_t i = 0; i < order; ++i)
+    for (std::size_t i = 0; i < order; ++i) {
       perm[i] = i;
+}
     MatrixPolicy pattern = matrix;
     for (std::size_t row = 0; row < (order - 1); ++row)
     {
@@ -34,10 +35,12 @@ namespace micm
       // Swap row and max_row
       if (max_row != row)
       {
-        for (std::size_t i = row; i < order; ++i)
+        for (std::size_t i = row; i < order; ++i) {
           std::swap(pattern[row][i], pattern[max_row][i]);
-        for (std::size_t i = row; i < order; ++i)
+}
+        for (std::size_t i = row; i < order; ++i) {
           std::swap(pattern[i][row], pattern[i][max_row]);
+}
         std::swap(perm[row], perm[max_row]);
       }
       for (std::size_t col = row + 1; col < order; ++col)
@@ -70,7 +73,7 @@ namespace micm
   inline LinearSolver<SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::LinearSolver(
       const SparseMatrixPolicy& matrix,
       typename SparseMatrixPolicy::value_type initial_value,
-      const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)> create_lu_decomp)
+      const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)>& create_lu_decomp)
       : nLij_Lii_(),
         Lij_yj_(),
         nUij_Uii_(),
@@ -201,13 +204,15 @@ namespace micm
           {
             const std::size_t Lij_yj_first = (*Lij_yj).first;
             const std::size_t Lij_yj_second_times_n_cells = (*Lij_yj).second * n_cells;
-            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
               y_elem[i_cell] -= L_group[Lij_yj_first + i_cell] * x_group[Lij_yj_second_times_n_cells + i_cell];
+}
             ++Lij_yj;
           }
           const std::size_t nLij_Lii_second = nLij_Lii.second;
-          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
             y_elem[i_cell] /= L_group[nLij_Lii_second + i_cell];
+}
           y_elem += n_cells;
         }
       }
@@ -223,13 +228,15 @@ namespace micm
           {
             const std::size_t Uij_xj_first = (*Uij_xj).first;
             const std::size_t Uij_xj_second_times_n_cells = (*Uij_xj).second * n_cells;
-            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
               x_elem[i_cell] -= U_group[Uij_xj_first + i_cell] * x_group[Uij_xj_second_times_n_cells + i_cell];
+}
             ++Uij_xj;
           }
           const std::size_t nUij_Uii_second = nUij_Uii.second;
-          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
             x_elem[i_cell] /= U_group[nUij_Uii_second + i_cell];
+}
 
           // don't iterate before the beginning of the vector
           const std::size_t x_elem_distance = std::distance(x.AsVector().begin(), x_elem);

--- a/include/micm/solver/linear_solver_in_place.hpp
+++ b/include/micm/solver/linear_solver_in_place.hpp
@@ -64,7 +64,7 @@ namespace micm
     LinearSolverInPlace(
         const SparseMatrixPolicy& matrix,
         typename SparseMatrixPolicy::value_type initial_value,
-        const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)> create_lu_decomp);
+        const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)>& create_lu_decomp);
 
     virtual ~LinearSolverInPlace() = default;
 

--- a/include/micm/solver/linear_solver_in_place.inl
+++ b/include/micm/solver/linear_solver_in_place.inl
@@ -18,7 +18,7 @@ namespace micm
   inline LinearSolverInPlace<SparseMatrixPolicy, LuDecompositionPolicy>::LinearSolverInPlace(
       const SparseMatrixPolicy& matrix,
       typename SparseMatrixPolicy::value_type initial_value,
-      const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)> create_lu_decomp)
+      const std::function<LuDecompositionPolicy(const SparseMatrixPolicy&)>& create_lu_decomp)
       : nLij_(),
         Lij_yj_(),
         nUij_Uii_(),
@@ -141,8 +141,9 @@ namespace micm
             auto LU_group_it = LU_group + Lij_yj_first;
             auto x_group_it = x_group + Lij_yj_second_times_n_cells;
             auto y_elem_it = y_elem;
-            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
               *(y_elem_it++) -= *(LU_group_it++) * *(x_group_it++);
+}
             ++Lij_yj;
           }
           y_elem += n_cells;
@@ -163,15 +164,17 @@ namespace micm
             auto LU_group_it = LU_group + Uij_xj_first;
             auto x_group_it = x_group + Uij_xj_second_times_n_cells;
             auto x_elem_it = x_elem;
-            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
               *(x_elem_it++) -= *(LU_group_it++) * *(x_group_it++);
+}
             ++Uij_xj;
           }
           const std::size_t nUij_Uii_second = nUij_Uii.second;
           auto LU_group_it = LU_group + nUij_Uii_second;
           auto x_elem_it = x_elem;
-          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
             *(x_elem_it++) /= *(LU_group_it++);
+}
 
           // don't iterate before the beginning of the vector
           const std::size_t x_elem_distance = std::distance(x.AsVector().begin(), x_elem);

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -269,15 +269,17 @@ namespace micm
           {
             const std::size_t lij_ujk_first = lij_ujk->first;
             const std::size_t lij_ujk_second = lij_ujk->second;
-            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
               U_vector[uik_nkj_first + i_cell] -= L_vector[lij_ujk_first + i_cell] * U_vector[lij_ujk_second + i_cell];
+}
             ++lij_ujk;
           }
           ++uik_nkj;
         }
         // Lower triangular matrix
-        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
           L_vector[lki_nkj->first + i_cell] = 1.0;
+}
         ++lki_nkj;
         for (std::size_t iL = 0; iL < inLU.first; ++iL)
         {
@@ -295,8 +297,9 @@ namespace micm
           {
             const std::size_t lkj_uji_first = lkj_uji->first;
             const std::size_t lkj_uji_second = lkj_uji->second;
-            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
               L_vector[lki_nkj_first + i_cell] -= L_vector[lkj_uji_first + i_cell] * U_vector[lkj_uji_second + i_cell];
+}
             ++lkj_uji;
           }
           const std::size_t uii_deref = *uii;

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -202,8 +202,9 @@ namespace micm
             auto ALU_vector_aik_njk_it = ALU_vector + aik_njk->first;
             auto ALU_vector_aij_ajk_first_it = ALU_vector + aij_ajk->first;
             auto ALU_vector_aij_ajk_second_it = ALU_vector + aij_ajk->second;
-            for (std::size_t i = 0; i < n_cells; ++i)
+            for (std::size_t i = 0; i < n_cells; ++i) {
               *(ALU_vector_aik_njk_it++) -= *(ALU_vector_aij_ajk_first_it++) * *(ALU_vector_aij_ajk_second_it++);
+}
             ++aij_ajk;
           }
           ++aik_njk;
@@ -217,14 +218,16 @@ namespace micm
             auto ALU_vector_aki_nji_it = ALU_vector + aki_nji->first;
             auto ALU_vector_akj_aji_first_it = ALU_vector + akj_aji->first;
             auto ALU_vector_akj_aji_second_it = ALU_vector + akj_aji->second;
-            for (std::size_t i = 0; i < n_cells; ++i)
+            for (std::size_t i = 0; i < n_cells; ++i) {
               *(ALU_vector_aki_nji_it++) -= *(ALU_vector_akj_aji_first_it++) * *(ALU_vector_akj_aji_second_it++);
+}
             ++akj_aji;
           }
           auto ALU_vector_aki_nji_it = ALU_vector + aki_nji->first;
           auto ALU_vector_nik_nki_aii_it = ALU_vector + std::get<2>(nik_nki_aii);
-          for (std::size_t i = 0; i < n_cells; ++i)
+          for (std::size_t i = 0; i < n_cells; ++i) {
             *(ALU_vector_aki_nji_it++) /= *(ALU_vector_nik_nki_aii_it++);
+}
           ++aki_nji;
         }
       }

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -40,8 +40,9 @@ namespace micm
       {
         if (matrix.IsZero(j, i))
         {
-          if (!LU.second.IsZero(j, i))
+          if (!LU.second.IsZero(j, i)) {
             fill_uji_.push_back(LU.second.VectorIndex(0, j, i));
+}
           continue;
         }
         uji_aji_.push_back(std::make_pair(LU.second.VectorIndex(0, j, i), matrix.VectorIndex(0, j, i)));
@@ -52,8 +53,9 @@ namespace micm
       {
         if (matrix.IsZero(j, i))
         {
-          if (!LU.first.IsZero(j, i))
+          if (!LU.first.IsZero(j, i)) {
             fill_lji_.push_back(LU.first.VectorIndex(0, j, i));
+}
           continue;
         }
         lji_aji_.push_back(std::make_pair(LU.first.VectorIndex(0, j, i), matrix.VectorIndex(0, j, i)));
@@ -128,20 +130,25 @@ namespace micm
     std::set<std::pair<std::size_t, std::size_t>> L_ids, U_ids;
     for (std::size_t i = 0; i < n; ++i)
     {
-      for (std::size_t j = i; j < n; ++j)
-        if (!A.IsZero(i, j))
+      for (std::size_t j = i; j < n; ++j) {
+        if (!A.IsZero(i, j)) {
           U_ids.insert(std::make_pair(i, j));
+}
+}
       L_ids.insert(std::make_pair(i, i));
-      for (std::size_t j = 0; j < i; ++j)
-        if (!A.IsZero(i, j))
+      for (std::size_t j = 0; j < i; ++j) {
+        if (!A.IsZero(i, j)) {
           L_ids.insert(std::make_pair(i, j));
+}
+}
     }
     for (std::size_t i = 0; i < n; ++i)
     {
       for (std::size_t j = i + 1; j < n; ++j)
       {
-        if (!A.IsZero(j, i))
+        if (!A.IsZero(j, i)) {
           L_ids.insert(std::make_pair(j, i));
+}
       }
       for (std::size_t k = i + 1; k < n; ++k)
       {
@@ -149,12 +156,16 @@ namespace micm
         {
           continue;
         }
-        for (std::size_t j = i + 1; j <= k; ++j)
-          if (std::find(L_ids.begin(), L_ids.end(), std::make_pair(j, i)) != L_ids.end())
+        for (std::size_t j = i + 1; j <= k; ++j) {
+          if (std::find(L_ids.begin(), L_ids.end(), std::make_pair(j, i)) != L_ids.end()) {
             U_ids.insert(std::make_pair(j, k));
-        for (std::size_t j = k + 1; j < n; ++j)
-          if (std::find(L_ids.begin(), L_ids.end(), std::make_pair(j, i)) != L_ids.end())
+}
+}
+        for (std::size_t j = k + 1; j < n; ++j) {
+          if (std::find(L_ids.begin(), L_ids.end(), std::make_pair(j, i)) != L_ids.end()) {
             L_ids.insert(std::make_pair(j, k));
+}
+}
       }
     }
     auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
@@ -206,10 +217,12 @@ namespace micm
           ++lji_aji;
         }
       }
-      for (const auto& fill_uji : fill_uji_)
+      for (const auto& fill_uji : fill_uji_) {
         U_vector[fill_uji] = 0;
-      for (const auto& fill_lji : fill_lji_)
+}
+      for (const auto& fill_lji : fill_lji_) {
         L_vector[fill_lji] = 0;
+}
       for (std::size_t i = 0; i < n; ++i)
       {
         auto Uii_inverse = 1.0 / U_vector[std::get<0>(*uii_nj_nk)];
@@ -268,29 +281,37 @@ namespace micm
       {
         for (std::size_t i = 0; i < std::get<1>(lii_nuji_nlji); ++i)
         {
-          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
             U_vector[uji_aji->first + i_cell] = A_vector[uji_aji->second + i_cell];
+}
           ++uji_aji;
         }
-        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
           L_vector[std::get<0>(lii_nuji_nlji) + i_cell] = 1.0;
+}
         for (std::size_t i = 0; i < std::get<2>(lii_nuji_nlji); ++i)
         {
-          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+          for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
             L_vector[lji_aji->first + i_cell] = A_vector[lji_aji->second + i_cell];
+}
           ++lji_aji;
         }
       }
-      for (const auto& fill_uji : fill_uji_)
-        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+      for (const auto& fill_uji : fill_uji_) {
+        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
           U_vector[fill_uji + i_cell] = 0;
-      for (const auto& fill_lji : fill_lji_)
-        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+}
+}
+      for (const auto& fill_lji : fill_lji_) {
+        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
           L_vector[fill_lji + i_cell] = 0;
+}
+}
       for (std::size_t i = 0; i < n; ++i)
       {
-        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
           Uii_inverse[i_cell] = 1.0 / U_vector[std::get<0>(*uii_nj_nk) + i_cell];
+}
         for (std::size_t ij = 0; ij < std::get<1>(*uii_nj_nk); ++ij)
         {
           for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -81,20 +81,28 @@ namespace micm
     std::set<std::pair<std::size_t, std::size_t>> ALU_ids;
     for (std::size_t i = 0; i < n; ++i)
     {
-      for (std::size_t j = 0; j < n; ++j)
-        if (!A.IsZero(i, j))
+      for (std::size_t j = 0; j < n; ++j) {
+        if (!A.IsZero(i, j)) {
           ALU_ids.insert(std::make_pair(i, j));
+}
+}
     }
     for (std::size_t i = 0; i < n; ++i)
     {
-      for (std::size_t j = i + 1; j < n; ++j)
-        if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(j, i)) != ALU_ids.end())
+      for (std::size_t j = i + 1; j < n; ++j) {
+        if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(j, i)) != ALU_ids.end()) {
           ALU_ids.insert(std::make_pair(j, i));
-      for (std::size_t k = i + 1; k < n; ++k)
-        if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(i, k)) != ALU_ids.end())
-          for (std::size_t j = i + 1; j < n; ++j)
-            if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(j, i)) != ALU_ids.end())
+}
+}
+      for (std::size_t k = i + 1; k < n; ++k) {
+        if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(i, k)) != ALU_ids.end()) {
+          for (std::size_t j = i + 1; j < n; ++j) {
+            if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(j, i)) != ALU_ids.end()) {
               ALU_ids.insert(std::make_pair(j, k));
+}
+}
+}
+}
     }
     auto ALU_builder = SparseMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
     for (const auto& pair : ALU_ids)
@@ -162,14 +170,16 @@ namespace micm
       {
         auto Aii_inverse_it = Aii_inverse.begin();
         auto ALU_vector_it = ALU_vector + std::get<0>(aii_nji_nki);
-        for (std::size_t i = 0; i < n_cells; ++i)
+        for (std::size_t i = 0; i < n_cells; ++i) {
           *(Aii_inverse_it++) = 1.0 / *(ALU_vector_it++);
+}
         for (std::size_t ij = 0; ij < std::get<1>(aii_nji_nki); ++ij)
         {
           auto ALU_vector_it = ALU_vector + *aji;
           auto Aii_inverse_it = Aii_inverse.begin();
-          for (std::size_t i = 0; i < n_cells; ++i)
+          for (std::size_t i = 0; i < n_cells; ++i) {
             *(ALU_vector_it++) *= *(Aii_inverse_it++);
+}
           ++aji;
         }
         for (std::size_t ik = 0; ik < std::get<2>(aii_nji_nki); ++ik)
@@ -180,8 +190,9 @@ namespace micm
             auto ALU_vector_first_it = ALU_vector + ajk_aji->first;
             auto ALU_vector_second_it = ALU_vector + ajk_aji->second;
             auto ALU_vector_aik_it = ALU_vector + aik;
-            for (std::size_t i = 0; i < n_cells; ++i)
+            for (std::size_t i = 0; i < n_cells; ++i) {
               *(ALU_vector_first_it++) -= *(ALU_vector_second_it++) * *(ALU_vector_aik_it++);
+}
             ++ajk_aji;
           }
           ++aik_njk;

--- a/include/micm/solver/rosenbrock_solver_parameters.hpp
+++ b/include/micm/solver/rosenbrock_solver_parameters.hpp
@@ -102,32 +102,46 @@ namespace micm
     std::cout << "h_start: " << h_start_ << std::endl;
     std::cout << "new_function_evaluation: ";
     for (bool val : new_function_evaluation_)
+    {
       std::cout << val << " ";
+    }
     std::cout << std::endl;
     std::cout << "estimator_of_local_order: " << estimator_of_local_order_ << std::endl;
     std::cout << "a: ";
     for (double val : a_)
+    {
       std::cout << val << " ";
+    }
     std::cout << std::endl;
     std::cout << "c: ";
     for (double val : c_)
+    {
       std::cout << val << " ";
+    }
     std::cout << std::endl;
     std::cout << "m: ";
     for (double val : m_)
+    {
       std::cout << val << " ";
+    }
     std::cout << std::endl;
     std::cout << "e: ";
     for (double val : e_)
+    {
       std::cout << val << " ";
+    }
     std::cout << std::endl;
     std::cout << "alpha: ";
     for (double val : alpha_)
+    {
       std::cout << val << " ";
+    }
     std::cout << std::endl;
     std::cout << "gamma: ";
     for (double val : gamma_)
+    {
       std::cout << val << " ";
+    }
     std::cout << std::endl;
     std::cout << "absolute_tolerance: ";
   }

--- a/include/micm/solver/rosenbrock_temporary_variables.hpp
+++ b/include/micm/solver/rosenbrock_temporary_variables.hpp
@@ -40,7 +40,9 @@ namespace micm
     {
       K_.reserve(solver_parameters.stages_);
       for (std::size_t i = 0; i < solver_parameters.stages_; ++i)
+      {
         K_.emplace_back(number_of_grid_cells, state_parameters.number_of_species_);
+      }
     }
   };
 }  // namespace micm

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <type_traits>
+#include <utility>
 
 namespace micm
 {
@@ -59,7 +60,7 @@ namespace micm
         const std::vector<std::function<void(const std::vector<micm::Conditions>&, DenseMatrixType&)>>&
             update_state_parameters_functions)
         : solver_(std::move(solver)),
-          state_parameters_(state_parameters),
+          state_parameters_(std::move(state_parameters)),
           solver_parameters_(solver_parameters),
           processes_(std::move(processes)),
           system_(std::move(system)),
@@ -83,7 +84,7 @@ namespace micm
         const std::vector<std::function<void(const DenseMatrixType&, DenseMatrixType&)>>&
             initialize_constraint_parameters_functions)
         : solver_(std::move(solver)),
-          state_parameters_(state_parameters),
+          state_parameters_(std::move(state_parameters)),
           solver_parameters_(solver_parameters),
           processes_(std::move(processes)),
           system_(std::move(system)),
@@ -127,7 +128,9 @@ namespace micm
     SolverResult Solve(double time_step, StatePolicy& state)
     {
       for (const auto& init_func : initialize_constraint_parameters_functions_)
+      {
         init_func(state.variables_, state.custom_rate_parameters_);
+      }
       auto result = solver_.Solve(time_step, state, solver_parameters_);
       PostSolveClamp(state);
       return result;
@@ -138,7 +141,9 @@ namespace micm
     {
       solver_parameters_ = params;
       for (const auto& init_func : initialize_constraint_parameters_functions_)
+      {
         init_func(state.variables_, state.custom_rate_parameters_);
+      }
       auto result = solver_.Solve(time_step, state, params);
       PostSolveClamp(state);
       return result;
@@ -209,7 +214,9 @@ namespace micm
       // External update functions must run first: they populate custom_rate_parameters_
       // which user-defined and surface rate constants read during calculation.
       for (const auto& update_func : update_state_parameters_functions_)
+      {
         update_func(state.conditions_, state.custom_rate_parameters_);
+      }
 
       // Dispatch to GPU path if the RatesPolicy (e.g. CudaProcessSet) exposes
       // GpuCalculateRateConstants; otherwise use the CPU path.
@@ -237,7 +244,9 @@ namespace micm
         if (const auto* params = std::get_if<LambdaRateConstantParameters>(&reaction.rate_constant_))
         {
           if (params->label_ == name)
+          {
             return *params;
+          }
         }
       }
       throw MicmException(
@@ -254,9 +263,15 @@ namespace micm
       if (state.constraint_size_ > 0)
       {
         for (std::size_t i_cell = 0; i_cell < state.variables_.NumRows(); ++i_cell)
+        {
           for (std::size_t i_var = 0; i_var < state.variables_.NumColumns(); ++i_var)
+          {
             if (state.upper_left_identity_diagonal_[i_var] > 0.0)
+            {
               state.variables_[i_cell][i_var] = std::max(0.0, state.variables_[i_cell][i_var]);
+            }
+          }
+        }
       }
       else
       {

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -139,7 +139,9 @@ namespace micm
           "External model passed to AddExternalModel() must satisfy at least HasProcesses or HasConstraints");
 
       if constexpr (HasState<ExternalModel>)
+      {
         external_systems_.emplace_back(ExternalModelSystem{ model });
+      }
 
       if constexpr (HasProcesses<ExternalModel> && HasConstraints<ExternalModel>)
       {
@@ -170,7 +172,9 @@ namespace micm
     {
       std::size_t n = system_.StateSize();
       for (const auto& m : external_systems_)
+      {
         n += std::get<0>(m.state_size_func_());
+      }
       return n;
     }
 

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -29,8 +29,9 @@ namespace micm
     // Include species referenced by constraints (dependencies and algebraic targets)
     for (const auto& constraint : constraints_)
     {
-      for (const auto& dep : constraint.SpeciesDependencies())
+      for (const auto& dep : constraint.SpeciesDependencies()) {
         used_species.insert(dep);
+}
       used_species.insert(constraint.AlgebraicSpecies());
     }
     // Include species referenced by external model constraints
@@ -54,8 +55,9 @@ namespace micm
     if (unused_species.size() > 0)
     {
       std::string err_msg = "Unused species in chemical system:";
-      for (const auto& species : unused_species)
+      for (const auto& species : unused_species) {
         err_msg += " '" + species + "'";
+}
       err_msg += ".";
       throw MicmException(MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_UNUSED_SPECIES, err_msg);
     }
@@ -82,8 +84,9 @@ namespace micm
     std::size_t index = 0;
 
     auto all_names = this->MergedUniqueNames();
-    for (auto& name : all_names)
+    for (auto& name : all_names) {
       species_map[name] = index++;
+}
 
     if (reorder_state_)
     {
@@ -94,13 +97,15 @@ namespace micm
       using Matrix = typename DenseMatrixPolicy::IntMatrix;
       const auto n = this->MergedStateSize();
       Matrix unsorted_jac_non_zeros(n, n, 0);
-      for (auto& elem : unsorted_jac_elements)
+      for (auto& elem : unsorted_jac_elements) {
         unsorted_jac_non_zeros[elem.first][elem.second] = 1;
+}
       auto reorder_map = DiagonalMarkowitzReorder<Matrix>(unsorted_jac_non_zeros);
 
       index = 0;
-      for (std::size_t i = 0; i < all_names.size(); ++i)
+      for (std::size_t i = 0; i < all_names.size(); ++i) {
         species_map[all_names[reorder_map[i]]] = index++;
+}
     }
 
     return species_map;
@@ -129,17 +134,18 @@ namespace micm
     auto add_param = [&params, &duplicates](const std::string& label, const std::string& source)
     {
       auto [it, added] = params.emplace(label, params.size());
-      if (!added)
+      if (!added) {
         duplicates.push_back(label + " (from " + source + ")");
+}
     };
 
     // Include custom parameter labels from chemical reactions
     for (const auto& reaction : reactions_)
     {
       const auto& process = reaction.process_;
-      if (const auto* ud = std::get_if<UserDefinedRateConstantParameters>(&process.rate_constant_))
+      if (const auto* ud = std::get_if<UserDefinedRateConstantParameters>(&process.rate_constant_)) {
         add_param(ud->label_, "reaction");
-      else if (const auto* surf = std::get_if<SurfaceRateConstantParameters>(&process.rate_constant_))
+      } else if (const auto* surf = std::get_if<SurfaceRateConstantParameters>(&process.rate_constant_))
       {
         add_param(surf->label_ + ".effective radius [m]", "reaction");
         add_param(surf->label_ + ".particle number concentration [# m-3]", "reaction");
@@ -150,16 +156,18 @@ namespace micm
     for (const auto& sys : external_systems_)
     {
       auto param_names = sys.parameter_names_func_();
-      for (const auto& label : param_names)
+      for (const auto& label : param_names) {
         add_param(label, "external_model");
+}
     }
 
     if (!duplicates.empty())
     {
       std::ostringstream oss;
       oss << "Duplicate parameter labels detected:\n";
-      for (const auto& d : duplicates)
+      for (const auto& d : duplicates) {
         oss << "  - " << d << "\n";
+}
 
       throw MicmException(MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_DUPLICATE_PARAMETER, oss.str());
     }
@@ -262,26 +270,27 @@ namespace micm
                 [](const auto& v) -> int
                 {
                   using T = std::decay_t<decltype(v)>;
-                  if constexpr (std::is_same_v<T, ArrheniusRateConstantParameters>)
+                  if constexpr (std::is_same_v<T, ArrheniusRateConstantParameters>) {
                     return 0;
-                  else if constexpr (std::is_same_v<T, TroeRateConstantParameters>)
+                  } else if constexpr (std::is_same_v<T, TroeRateConstantParameters>) {
                     return 1;
-                  else if constexpr (std::is_same_v<T, TernaryChemicalActivationRateConstantParameters>)
+                  } else if constexpr (std::is_same_v<T, TernaryChemicalActivationRateConstantParameters>) {
                     return 2;
-                  else if constexpr (std::is_same_v<T, BranchedRateConstantParameters>)
+                  } else if constexpr (std::is_same_v<T, BranchedRateConstantParameters>) {
                     return 3;
-                  else if constexpr (std::is_same_v<T, TunnelingRateConstantParameters>)
+                  } else if constexpr (std::is_same_v<T, TunnelingRateConstantParameters>) {
                     return 4;
-                  else if constexpr (std::is_same_v<T, TaylorSeriesRateConstantParameters>)
+                  } else if constexpr (std::is_same_v<T, TaylorSeriesRateConstantParameters>) {
                     return 5;
-                  else if constexpr (std::is_same_v<T, ReversibleRateConstantParameters>)
+                  } else if constexpr (std::is_same_v<T, ReversibleRateConstantParameters>) {
                     return 6;
-                  else if constexpr (std::is_same_v<T, UserDefinedRateConstantParameters>)
+                  } else if constexpr (std::is_same_v<T, UserDefinedRateConstantParameters>) {
                     return 7;
-                  else if constexpr (std::is_same_v<T, SurfaceRateConstantParameters>)
+                  } else if constexpr (std::is_same_v<T, SurfaceRateConstantParameters>) {
                     return 8;
-                  else
+                  } else {
                     return 9;  // LambdaRateConstantParameters
+}
                 },
                 p.process_.rate_constant_);
           };
@@ -327,8 +336,9 @@ namespace micm
 
       algebraic_variable_ids = constraint_set.AlgebraicVariableIds();
       rates.SetAlgebraicVariableIds(algebraic_variable_ids);
-      for (const auto variable_id : algebraic_variable_ids)
+      for (const auto variable_id : algebraic_variable_ids) {
         mass_matrix_diagonal[variable_id] = 0.0;
+}
 
       // Filter kinetic sparsity entries from algebraic rows (they will be entirely replaced by constraints)
       for (auto it = nonzero_elements.begin(); it != nonzero_elements.end();)
@@ -416,8 +426,9 @@ namespace micm
         auto ext_process_elements = process_set.non_zero_jacobian_elements_func_(species_map);
         for (const auto& elem : ext_process_elements)
         {
-          if (algebraic_variable_ids.count(elem.first) > 0)
+          if (algebraic_variable_ids.count(elem.first) > 0) {
             nonzero_elements.insert(elem);
+}
         }
       }
     }
@@ -432,14 +443,16 @@ namespace micm
     }
 
     std::vector<std::string> variable_names{ number_of_species };
-    for (auto& species_pair : species_map)
+    for (auto& species_pair : species_map) {
       variable_names[species_pair.second] = species_pair.first;
+}
 
     // Build the params map after the constraint set is created,
     // since it adds its parameters to the map.
     std::vector<std::string> labels{ params_map.size() };
-    for (auto& param_pair : params_map)
+    for (auto& param_pair : params_map) {
       labels[param_pair.second] = param_pair.first;
+}
 
     rates.SetJacobianFlatIds(jacobian);
     rates.SetExternalModelFunctions(params_map, species_map, jacobian);

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -192,8 +192,9 @@ namespace micm
   inline double& State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::
       VariableProxy::operator[](std::size_t grid_cell_index)
   {
-    if (grid_cell_index >= state_.number_of_grid_cells_)
+    if (grid_cell_index >= state_.number_of_grid_cells_) {
       throw std::out_of_range("Grid cell index out of range");
+}
     return state_.variables_[grid_cell_index][index_];
   }
 
@@ -206,8 +207,9 @@ namespace micm
   inline const double& State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::
       VariableProxy::operator[](std::size_t grid_cell_index) const
   {
-    if (grid_cell_index >= state_.number_of_grid_cells_)
+    if (grid_cell_index >= state_.number_of_grid_cells_) {
       throw std::out_of_range("Grid cell index out of range");
+}
     return state_.variables_[grid_cell_index][index_];
   }
 
@@ -239,8 +241,9 @@ namespace micm
   inline const double& State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::
       ConstVariableProxy::operator[](std::size_t grid_cell_index) const
   {
-    if (grid_cell_index >= state_.number_of_grid_cells_)
+    if (grid_cell_index >= state_.number_of_grid_cells_) {
       throw std::out_of_range("Grid cell index out of range");
+}
     return state_.variables_[grid_cell_index][index_];
   }
 
@@ -346,11 +349,13 @@ namespace micm
         absolute_tolerance_(parameters.absolute_tolerance_)
   {
     std::size_t index = 0;
-    for (auto& name : variable_names_)
+    for (auto& name : variable_names_) {
       variable_map_[name] = index++;
+}
     index = 0;
-    for (const auto& label : parameters.custom_rate_parameter_labels_)
+    for (const auto& label : parameters.custom_rate_parameter_labels_) {
       custom_rate_parameter_map_[label] = index++;
+}
 
     if (!parameters.mass_matrix_diagonal_.empty())
     {
@@ -401,8 +406,9 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::operator[](
           std::size_t index)
   {
-    if (index >= state_size_)
+    if (index >= state_size_) {
       throw std::out_of_range("Variable index out of range");
+}
     return VariableProxy(*this, index);
   }
 
@@ -417,8 +423,9 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::operator[](
           std::size_t index) const
   {
-    if (index >= state_size_)
+    if (index >= state_size_) {
       throw std::out_of_range("Variable index out of range");
+}
     return ConstVariableProxy(*this, index);
   }
 
@@ -499,8 +506,9 @@ namespace micm
       const std::unordered_map<std::string, std::vector<double>>& species_to_concentration)
   {
     const std::size_t num_grid_cells = conditions_.size();
-    for (const auto& pair : species_to_concentration)
+    for (const auto& pair : species_to_concentration) {
       SetConcentration({ pair.first }, pair.second);
+}
   }
 
   template<
@@ -656,8 +664,9 @@ namespace micm
   State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::SetCustomRateParameters(
       const std::unordered_map<std::string, std::vector<double>>& parameters)
   {
-    for (const auto& pair : parameters)
+    for (const auto& pair : parameters) {
       SetCustomRateParameter(pair.first, pair.second);
+}
   }
 
   template<

--- a/include/micm/system/phase.hpp
+++ b/include/micm/system/phase.hpp
@@ -74,8 +74,12 @@ namespace micm
     {
       std::vector<std::string> names{};
       for (const auto& phase_species : phase_species_)
+      {
         if (!phase_species.species_.IsParameterized())
+        {
           names.push_back(name_ + '.' + phase_species.species_.name_);
+        }
+      }
       return names;
     }
 
@@ -84,8 +88,12 @@ namespace micm
     {
       std::vector<std::string> names{};
       for (const auto& phase_species : phase_species_)
+      {
         if (!phase_species.species_.IsParameterized())
+        {
           names.push_back(phase_species.species_.name_);
+        }
+      }
       return names;
     }
   };

--- a/include/micm/system/system.hpp
+++ b/include/micm/system/system.hpp
@@ -42,7 +42,7 @@ namespace micm
     /// @param f Function used to apply a specific order to unique names
     /// @return vector of unique state variable names
     std::vector<std::string> UniqueNames(
-        const std::function<std::string(const std::vector<std::string>& variables, const std::size_t i)> f) const
+        const std::function<std::string(const std::vector<std::string>& variables, const std::size_t i)>& f) const
     {
       auto names = gas_phase_.SpeciesNames();
 
@@ -51,7 +51,9 @@ namespace micm
         std::vector<std::string> reordered;
         reordered.reserve(names.size());
         for (std::size_t i = 0; i < names.size(); ++i)
+        {
           reordered.push_back(f(names, i));
+        }
         return reordered;
       }
 

--- a/include/micm/util/jacobian.hpp
+++ b/include/micm/util/jacobian.hpp
@@ -18,7 +18,9 @@ namespace micm
   {
     auto builder = SparseMatrixPolicy::Create(state_size).SetNumberOfBlocks(number_of_grid_cells);
     for (const auto& elem : nonzero_jacobian_elements)
+    {
       builder = builder.WithElement(elem.first, elem.second);
+    }
     // Always include diagonal elements
     for (std::size_t i = 0; i < state_size; ++i)
     {

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -238,7 +238,9 @@ namespace micm
               {
                 std::size_t x_dim = other.size();
                 if (x_dim == 0)
+                {
                   return std::vector<T>(0);
+                }
                 std::size_t y_dim = other[0].size();
                 std::vector<T> data(x_dim * y_dim);
                 auto elem = data.begin();
@@ -320,7 +322,9 @@ namespace micm
     {
       auto x_iter = x.AsVector().begin();
       for (auto& y : data_)
+      {
         y += alpha * (*(x_iter++));
+      }
     }
 
     /// @brief For each element of the matrix, perform y = max(y, x), where x is a scalar constant
@@ -328,7 +332,9 @@ namespace micm
     void Max(const T& x)
     {
       for (auto& y : data_)
+      {
         y = std::max(y, x);
+      }
     }
 
     /// @brief For each element of the matrix, perform y = min(y, x), where x is a scalar constant
@@ -336,36 +342,46 @@ namespace micm
     void Min(const T& x)
     {
       for (auto& y : data_)
+      {
         y = std::min(y, x);
+      }
     }
 
-    void ForEach(const std::function<void(T&, const T&)> f, const Matrix& a)
+    void ForEach(const std::function<void(T&, const T&)>& f, const Matrix& a)
     {
       auto a_iter = a.AsVector().begin();
       for (auto& elem : data_)
+      {
         f(elem, *(a_iter++));
+      }
     }
 
-    void ForEach(const std::function<void(T&, const T&, const T&)> f, const Matrix& a, const Matrix& b)
+    void ForEach(const std::function<void(T&, const T&, const T&)>& f, const Matrix& a, const Matrix& b)
     {
       auto a_iter = a.AsVector().begin();
       auto b_iter = b.AsVector().begin();
       for (auto& elem : data_)
+      {
         f(elem, *(a_iter++), *(b_iter++));
+      }
     }
 
     // Copy the values from the other matrix into this one
     void Copy(const Matrix& other)
     {
       if (other.AsVector().size() != this->data_.size())
+      {
         throw std::runtime_error("Both matrices must have the same size.");
+      }
       this->data_.assign(other.AsVector().begin(), other.AsVector().end());
     }
 
     void Swap(Matrix& other)
     {
       if (other.AsVector().size() != this->data_.size())
+      {
         throw std::runtime_error("Both matrices must have the same size.");
+      }
       data_.swap(other.AsVector());
     }
 

--- a/include/micm/util/sparse_matrix.hpp
+++ b/include/micm/util/sparse_matrix.hpp
@@ -379,9 +379,13 @@ namespace micm
             }
           }
           if (matrix.IsZero(j, matrix.block_size_ - 1))
+          {
             os << "0" << std::endl;
+          }
           else
+          {
             os << matrix[i][j][matrix.block_size_ - 1] << std::endl;
+          }
         }
       }
       return os;
@@ -396,9 +400,15 @@ namespace micm
       {
         os << "Block " << i << std::endl;
         for (std::size_t j = 0; j < block_size_; ++j)
+        {
           for (std::size_t k = 0; k < block_size_; ++k)
+          {
             if (!this->IsZero(j, k))
+            {
               os << j << ", " << k << ", " << (*this)[i][j][k] << std::endl;
+            }
+          }
+        }
       }
     }
 

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_column.hpp
@@ -37,7 +37,7 @@ namespace micm
     SparseMatrixStandardOrderingCompressedSparseColumn(
         std::size_t number_of_blocks,
         std::size_t block_size,
-        std::set<std::pair<std::size_t, std::size_t>> non_zero_elements)
+        const std::set<std::pair<std::size_t, std::size_t>>& non_zero_elements)
         : column_ids_(ColumnIdsVector(block_size, non_zero_elements)),
           column_start_(ColumnStartVector(block_size, non_zero_elements)),
           diagonal_ids_(DiagonalIndices(number_of_blocks, 0))
@@ -45,7 +45,7 @@ namespace micm
     }
 
     SparseMatrixStandardOrderingCompressedSparseColumn& operator=(
-        const std::tuple<std::size_t, std::size_t, std::set<std::pair<std::size_t, std::size_t>>> number_size_elements)
+        const std::tuple<std::size_t, std::size_t, std::set<std::pair<std::size_t, std::size_t>>>& number_size_elements)
     {
       column_ids_ = ColumnIdsVector(std::get<1>(number_size_elements), std::get<2>(number_size_elements));
       column_start_ = ColumnStartVector(std::get<1>(number_size_elements), std::get<2>(number_size_elements));
@@ -91,8 +91,12 @@ namespace micm
     {
       for (std::size_t block_start = 0; block_start < number_of_blocks * column_ids_.size();
            block_start += column_ids_.size())
+      {
         for (const auto& i : diagonal_ids_)
+        {
           data[block_start + i] += value;
+        }
+      }
     }
 
     /// @brief Convert row and column indices to vector index within a block
@@ -133,8 +137,12 @@ namespace micm
       std::vector<std::size_t> indices;
       indices.reserve(column_start_.size() - 1);
       for (std::size_t i = 0; i < column_start_.size() - 1; ++i)
+      {
         if (!IsZero(i, i))
+        {
           indices.push_back(VectorIndex(number_of_blocks, block_id, i, i));
+        }
+      }
       return indices;
     }
 
@@ -397,13 +405,15 @@ namespace micm
     /// @param non_zero_elements Set of non-zero elements in the matrix
     static std::vector<std::size_t> ColumnIdsVector(
         const std::size_t block_size,
-        const std::set<std::pair<std::size_t, std::size_t>> non_zero_elements)
+        const std::set<std::pair<std::size_t, std::size_t>>& non_zero_elements)
     {
       std::vector<std::size_t> ids;
       ids.reserve(non_zero_elements.size());
       std::set<std::pair<std::size_t, std::size_t>> column_ordered_pairs;
       for (const auto& elem : non_zero_elements)
+      {
         column_ordered_pairs.insert(std::make_pair(elem.second, elem.first));
+      }
       std::transform(
           column_ordered_pairs.begin(),
           column_ordered_pairs.end(),
@@ -417,23 +427,29 @@ namespace micm
     /// @param non_zero_elements Set of non-zero elements in the matrix
     static std::vector<std::size_t> ColumnStartVector(
         const std::size_t block_size,
-        const std::set<std::pair<std::size_t, std::size_t>> non_zero_elements)
+        const std::set<std::pair<std::size_t, std::size_t>>& non_zero_elements)
     {
       std::vector<std::size_t> starts(block_size + 1, 0);
       std::size_t total_elem = 0;
       std::size_t curr_col = 0;
       std::set<std::pair<std::size_t, std::size_t>> column_ordered_pairs;
       for (const auto& elem : non_zero_elements)
+      {
         column_ordered_pairs.insert(std::make_pair(elem.second, elem.first));
+      }
       for (const auto& elem : column_ordered_pairs)
       {
         while (curr_col < elem.first)
+        {
           starts[(curr_col++) + 1] = total_elem;
+        }
         ++total_elem;
       }
       // Fill all remaining entries from curr_col + 1 to block_size
       for (std::size_t i = curr_col + 1; i <= block_size; ++i)
+      {
         starts[i] = total_elem;
+      }
       return starts;
     }
 

--- a/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_standard_ordering_compressed_sparse_row.hpp
@@ -37,7 +37,7 @@ namespace micm
     SparseMatrixStandardOrderingCompressedSparseRow(
         std::size_t number_of_blocks,
         std::size_t block_size,
-        std::set<std::pair<std::size_t, std::size_t>> non_zero_elements)
+        const std::set<std::pair<std::size_t, std::size_t>>& non_zero_elements)
         : row_ids_(RowIdsVector(block_size, non_zero_elements)),
           row_start_(RowStartVector(block_size, non_zero_elements)),
           diagonal_ids_(DiagonalIndices(number_of_blocks, 0))
@@ -45,7 +45,7 @@ namespace micm
     }
 
     SparseMatrixStandardOrderingCompressedSparseRow& operator=(
-        const std::tuple<std::size_t, std::size_t, std::set<std::pair<std::size_t, std::size_t>>> number_size_elements)
+        const std::tuple<std::size_t, std::size_t, std::set<std::pair<std::size_t, std::size_t>>>& number_size_elements)
     {
       row_ids_ = RowIdsVector(std::get<1>(number_size_elements), std::get<2>(number_size_elements));
       row_start_ = RowStartVector(std::get<1>(number_size_elements), std::get<2>(number_size_elements));
@@ -90,8 +90,12 @@ namespace micm
     void AddToDiagonal(const std::size_t number_of_blocks, auto& data, auto value) const
     {
       for (std::size_t block_start = 0; block_start < number_of_blocks * row_ids_.size(); block_start += row_ids_.size())
+      {
         for (const auto& i : diagonal_ids_)
+        {
           data[block_start + i] += value;
+        }
+      }
     }
 
     /// @brief Convert row and column indices to a vector index within a block
@@ -132,8 +136,12 @@ namespace micm
       std::vector<std::size_t> indices;
       indices.reserve(row_start_.size() - 1);
       for (std::size_t i = 0; i < row_start_.size() - 1; ++i)
+      {
         if (!IsZero(i, i))
+        {
           indices.push_back(VectorIndex(number_of_blocks, block_id, i, i));
+        }
+      }
       return indices;
     }
 
@@ -396,7 +404,7 @@ namespace micm
     /// @param non_zero_elements Set of non-zero elements in the matrix
     static std::vector<std::size_t> RowIdsVector(
         const std::size_t block_size,
-        const std::set<std::pair<std::size_t, std::size_t>> non_zero_elements)
+        const std::set<std::pair<std::size_t, std::size_t>>& non_zero_elements)
     {
       std::vector<std::size_t> ids;
       ids.reserve(non_zero_elements.size());
@@ -413,7 +421,7 @@ namespace micm
     /// @param non_zero_elements Set of non-zero elements in the matrix
     static std::vector<std::size_t> RowStartVector(
         const std::size_t block_size,
-        const std::set<std::pair<std::size_t, std::size_t>> non_zero_elements)
+        const std::set<std::pair<std::size_t, std::size_t>>& non_zero_elements)
     {
       std::vector<std::size_t> starts(block_size + 1, 0);
       std::size_t total_elem = 0;
@@ -421,12 +429,16 @@ namespace micm
       for (const auto& elem : non_zero_elements)
       {
         while (curr_row < elem.first)
+        {
           starts[(curr_row++) + 1] = total_elem;
+        }
         ++total_elem;
       }
       // Fill all remaining entries from curr_row + 1 to block_size
       for (std::size_t i = curr_row + 1; i <= block_size; ++i)
+      {
         starts[i] = total_elem;
+      }
       return starts;
     }
 

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
@@ -43,7 +43,7 @@ namespace micm
     SparseMatrixVectorOrderingCompressedSparseColumn(
         std::size_t number_of_blocks,
         std::size_t block_size,
-        std::set<std::pair<std::size_t, std::size_t>> non_zero_elements)
+        const std::set<std::pair<std::size_t, std::size_t>>& non_zero_elements)
         : column_ids_(ColumnIdsVector(block_size, non_zero_elements)),
           column_start_(ColumnStartVector(block_size, non_zero_elements)),
           diagonal_ids_(DiagonalIndices(number_of_blocks, 0))
@@ -51,7 +51,7 @@ namespace micm
     }
 
     SparseMatrixVectorOrderingCompressedSparseColumn& operator=(
-        const std::tuple<std::size_t, std::size_t, std::set<std::pair<std::size_t, std::size_t>>> number_size_elements)
+        const std::tuple<std::size_t, std::size_t, std::set<std::pair<std::size_t, std::size_t>>>& number_size_elements)
     {
       column_ids_ = ColumnIdsVector(std::get<1>(number_size_elements), std::get<2>(number_size_elements));
       column_start_ = ColumnStartVector(std::get<1>(number_size_elements), std::get<2>(number_size_elements));
@@ -101,7 +101,9 @@ namespace micm
         {
           auto elem = std::next(data.begin(), i_group * column_ids_.size() + i);
           for (std::size_t i_block = 0; i_block < L; ++i_block)
+          {
             elem[i_block] += value;
+          }
         }
       }
     }
@@ -140,8 +142,12 @@ namespace micm
       std::vector<std::size_t> indices;
       indices.reserve(column_start_.size() - 1);
       for (std::size_t i = 0; i < column_start_.size() - 1; ++i)
+      {
         if (!IsZero(i, i))
+        {
           indices.push_back(VectorIndex(number_of_blocks, block_id, i, i));
+        }
+      }
       return indices;
     }
 
@@ -509,7 +515,9 @@ namespace micm
       ids.reserve(non_zero_elements.size());
       std::set<std::pair<std::size_t, std::size_t>> column_ordered_pairs;
       for (const auto& elem : non_zero_elements)
+      {
         column_ordered_pairs.insert(std::make_pair(elem.second, elem.first));
+      }
       std::transform(
           column_ordered_pairs.begin(),
           column_ordered_pairs.end(),
@@ -531,16 +539,22 @@ namespace micm
       std::size_t curr_row = 0;
       std::set<std::pair<std::size_t, std::size_t>> column_ordered_pairs;
       for (const auto& elem : non_zero_elements)
+      {
         column_ordered_pairs.insert(std::make_pair(elem.second, elem.first));
+      }
       for (const auto& elem : column_ordered_pairs)
       {
         while (curr_row < elem.first)
+        {
           starts[(curr_row++) + 1] = total_elem;
+        }
         ++total_elem;
       }
       // Fill all remaining entries from curr_row + 1 to block_size
       for (std::size_t i = curr_row + 1; i <= block_size; ++i)
+      {
         starts[i] = total_elem;
+      }
       return starts;
     }
 

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
@@ -44,7 +44,7 @@ namespace micm
     SparseMatrixVectorOrderingCompressedSparseRow(
         std::size_t number_of_blocks,
         std::size_t block_size,
-        std::set<std::pair<std::size_t, std::size_t>> non_zero_elements)
+        const std::set<std::pair<std::size_t, std::size_t>>& non_zero_elements)
         : row_ids_(RowIdsVector(block_size, non_zero_elements)),
           row_start_(RowStartVector(block_size, non_zero_elements)),
           diagonal_ids_(DiagonalIndices(number_of_blocks, 0))
@@ -52,7 +52,7 @@ namespace micm
     }
 
     SparseMatrixVectorOrderingCompressedSparseRow& operator=(
-        const std::tuple<std::size_t, std::size_t, std::set<std::pair<std::size_t, std::size_t>>> number_size_elements)
+        const std::tuple<std::size_t, std::size_t, std::set<std::pair<std::size_t, std::size_t>>>& number_size_elements)
     {
       row_ids_ = RowIdsVector(std::get<1>(number_size_elements), std::get<2>(number_size_elements));
       row_start_ = RowStartVector(std::get<1>(number_size_elements), std::get<2>(number_size_elements));
@@ -102,7 +102,9 @@ namespace micm
         {
           auto elem = std::next(data.begin(), i_group * row_ids_.size() + i);
           for (std::size_t i_block = 0; i_block < L; ++i_block)
+          {
             elem[i_block] += value;
+          }
         }
       }
     }
@@ -146,8 +148,12 @@ namespace micm
       std::vector<std::size_t> indices;
       indices.reserve(row_start_.size() - 1);
       for (std::size_t i = 0; i < row_start_.size() - 1; ++i)
+      {
         if (!IsZero(i, i))
+        {
           indices.push_back(VectorIndex(number_of_blocks, block_id, i, i));
+        }
+      }
       return indices;
     }
 
@@ -508,7 +514,7 @@ namespace micm
     /// @param non_zero_elements Set of non-zero elements in the matrix
     static std::vector<std::size_t> RowIdsVector(
         const std::size_t block_size,
-        const std::set<std::pair<std::size_t, std::size_t>> non_zero_elements)
+        const std::set<std::pair<std::size_t, std::size_t>>& non_zero_elements)
     {
       std::vector<std::size_t> ids;
       ids.reserve(non_zero_elements.size());
@@ -525,7 +531,7 @@ namespace micm
     /// @param non_zero_elements Set of non-zero elements in the matrix
     static std::vector<std::size_t> RowStartVector(
         const std::size_t block_size,
-        const std::set<std::pair<std::size_t, std::size_t>> non_zero_elements)
+        const std::set<std::pair<std::size_t, std::size_t>>& non_zero_elements)
     {
       std::vector<std::size_t> starts(block_size + 1, 0);
       std::size_t total_elem = 0;
@@ -533,12 +539,16 @@ namespace micm
       for (const auto& elem : non_zero_elements)
       {
         while (curr_row < elem.first)
+        {
           starts[(curr_row++) + 1] = total_elem;
+        }
         ++total_elem;
       }
       // Fill all remaining entries from curr_row + 1 to block_size
       for (std::size_t i = curr_row + 1; i <= block_size; ++i)
+      {
         starts[i] = total_elem;
+      }
       return starts;
     }
 

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -251,7 +251,9 @@ namespace micm
               {
                 std::size_t x_dim = other.size();
                 if (x_dim == 0)
+                {
                   return std::vector<T>(0);
+                }
                 std::size_t y_dim = other[0].size();
                 std::vector<T> data(std::ceil(x_dim / (double)L) * L * y_dim);
                 std::size_t i_row = 0;
@@ -384,7 +386,9 @@ namespace micm
     void Max(const T& x)
     {
       for (auto& y : data_)
+      {
         y = std::max(y, x);
+      }
     }
 
     /// @brief For each element of the VectorMatrix, perform y = min(y, x), where x is a scalar constant
@@ -392,10 +396,12 @@ namespace micm
     void Min(const T& x)
     {
       for (auto& y : data_)
+      {
         y = std::min(y, x);
+      }
     }
 
-    void ForEach(const std::function<void(T&, const T&)> f, const VectorMatrix& a)
+    void ForEach(const std::function<void(T&, const T&)>& f, const VectorMatrix& a)
     {
       auto this_iter = data_.begin();
       auto a_iter = a.AsVector().begin();
@@ -414,7 +420,7 @@ namespace micm
       }
     }
 
-    void ForEach(const std::function<void(T&, const T&, const T&)> f, const VectorMatrix& a, const VectorMatrix& b)
+    void ForEach(const std::function<void(T&, const T&, const T&)>& f, const VectorMatrix& a, const VectorMatrix& b)
     {
       auto this_iter = data_.begin();
       auto a_iter = a.AsVector().begin();
@@ -441,14 +447,18 @@ namespace micm
     void Copy(const VectorMatrix& other)
     {
       if (other.AsVector().size() != this->data_.size())
+      {
         throw std::runtime_error("Both vector matrices must have the same size.");
+      }
       this->data_.assign(other.AsVector().begin(), other.AsVector().end());
     }
 
     void Swap(VectorMatrix& other)
     {
       if (other.AsVector().size() != this->data_.size())
+      {
         throw std::runtime_error("Both vector matrices must have the same size.");
+      }
       data_.swap(other.AsVector());
     }
 

--- a/src/process/cuda_rate_constant_kernel.cu
+++ b/src/process/cuda_rate_constant_kernel.cu
@@ -43,20 +43,34 @@ namespace micm
       auto out = [&](std::size_t offset, std::size_t i) -> double* { return &rc_base[(offset + i) * L + local_tid]; };
 
       for (std::size_t i = 0; i < store.n_arrhenius_; ++i)
+      {
         *out(0, i) = micm::CalculateArrhenius(store.d_arrhenius_[i], temperature, pressure);
+      }
       for (std::size_t i = 0; i < store.n_troe_; ++i)
+      {
         *out(store.troe_offset_, i) = micm::CalculateTroe(store.d_troe_[i], temperature, air_density);
+      }
       for (std::size_t i = 0; i < store.n_ternary_; ++i)
+      {
         *out(store.ternary_offset_, i) =
             micm::CalculateTernaryChemicalActivation(store.d_ternary_[i], temperature, air_density);
+      }
       for (std::size_t i = 0; i < store.n_branched_; ++i)
+      {
         *out(store.branched_offset_, i) = micm::CalculateBranched(store.d_branched_[i], temperature, air_density);
+      }
       for (std::size_t i = 0; i < store.n_tunneling_; ++i)
+      {
         *out(store.tunneling_offset_, i) = micm::CalculateTunneling(store.d_tunneling_[i], temperature);
+      }
       for (std::size_t i = 0; i < store.n_taylor_; ++i)
+      {
         *out(store.taylor_offset_, i) = micm::CalculateTaylorSeries(store.d_taylor_[i], temperature, pressure);
+      }
       for (std::size_t i = 0; i < store.n_reversible_; ++i)
+      {
         *out(store.reversible_offset_, i) = micm::CalculateReversible(store.d_reversible_[i], temperature);
+      }
       for (std::size_t i = 0; i < store.n_user_defined_; ++i)
       {
         const micm::UserDefinedRateConstantData& p = store.d_user_defined_[i];
@@ -72,7 +86,9 @@ namespace micm
             cp_base[(p.custom_param_base_index_ + 1) * L + local_tid]);
       }
       for (std::size_t i = 0; i < store.n_multipliers_; ++i)
+      {
         rc_base[store.d_mult_rc_indices_[i] * L + local_tid] *= mv_base[i * L + local_tid];
+      }
     }
 
     /// @brief Calculate all analytic rate constants for every grid cell (one thread per cell).
@@ -96,7 +112,9 @@ namespace micm
       const std::size_t local_tid = tid % L;
 
       if (tid >= n_cells)
+      {
         return;
+      }
 
       const double temperature = d_conditions[tid].temperature_;
       const double pressure = d_conditions[tid].pressure_;
@@ -123,7 +141,9 @@ namespace micm
     {
       const std::size_t n_cells = rc_param.number_of_grid_cells_;
       if (n_cells == 0)
+      {
         return;
+      }
 
       const std::size_t L = rc_param.vector_length_;
       const std::size_t n_groups = (n_cells + L - 1) / L;

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -325,27 +325,49 @@ namespace micm
       auto* cuda_stream_id = micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0);
 
       if (devstruct.number_of_reactants_ != nullptr)
+      {
         CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_reactants_, cuda_stream_id), "cudaFree");
+      }
       if (devstruct.reactant_ids_ != nullptr)
+      {
         CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.reactant_ids_, cuda_stream_id), "cudaFree");
+      }
       if (devstruct.number_of_products_ != nullptr)
+      {
         CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.number_of_products_, cuda_stream_id), "cudaFree");
+      }
       if (devstruct.product_ids_ != nullptr)
+      {
         CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.product_ids_, cuda_stream_id), "cudaFree");
+      }
       if (devstruct.yields_ != nullptr)
+      {
         CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.yields_, cuda_stream_id), "cudaFree");
+      }
       if (devstruct.is_algebraic_variable_ != nullptr)
+      {
         CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.is_algebraic_variable_, cuda_stream_id), "cudaFree");
+      }
       if (devstruct.jacobian_process_info_ != nullptr)
+      {
         CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_process_info_, cuda_stream_id), "cudaFree");
+      }
       if (devstruct.jacobian_reactant_ids_ != nullptr)
+      {
         CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_reactant_ids_, cuda_stream_id), "cudaFree");
+      }
       if (devstruct.jacobian_product_ids_ != nullptr)
+      {
         CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_product_ids_, cuda_stream_id), "cudaFree");
+      }
       if (devstruct.jacobian_yields_ != nullptr)
+      {
         CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_yields_, cuda_stream_id), "cudaFree");
+      }
       if (devstruct.jacobian_flat_ids_ != nullptr)
+      {
         CHECK_CUDA_ERROR(cudaFreeAsync(devstruct.jacobian_flat_ids_, cuda_stream_id), "cudaFree");
+      }
     }
 
     void SubtractJacobianTermsKernelDriver(

--- a/src/solver/linear_solver_in_place.cu
+++ b/src/solver/linear_solver_in_place.cu
@@ -155,17 +155,25 @@ namespace micm
     void FreeConstData(LinearSolverInPlaceParam& devstruct)
     {
       if (devstruct.nLij_ != nullptr)
+      {
         CHECK_CUDA_ERROR(
             cudaFreeAsync(devstruct.nLij_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
+      }
       if (devstruct.Lij_yj_ != nullptr)
+      {
         CHECK_CUDA_ERROR(
             cudaFreeAsync(devstruct.Lij_yj_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
+      }
       if (devstruct.nUij_Uii_ != nullptr)
+      {
         CHECK_CUDA_ERROR(
             cudaFreeAsync(devstruct.nUij_Uii_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
+      }
       if (devstruct.Uij_xj_ != nullptr)
+      {
         CHECK_CUDA_ERROR(
             cudaFreeAsync(devstruct.Uij_xj_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
+      }
     }
 
     void

--- a/src/solver/lu_decomposition_mozart_in_place.cu
+++ b/src/solver/lu_decomposition_mozart_in_place.cu
@@ -138,18 +138,26 @@ namespace micm
     void FreeConstData(LuDecomposeMozartInPlaceParam& devstruct)
     {
       if (devstruct.aii_nji_nki_ != nullptr)
+      {
         CHECK_CUDA_ERROR(
             cudaFreeAsync(devstruct.aii_nji_nki_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)),
             "cudaFree");
+      }
       if (devstruct.aji_ != nullptr)
+      {
         CHECK_CUDA_ERROR(
             cudaFreeAsync(devstruct.aji_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
+      }
       if (devstruct.aik_njk_ != nullptr)
+      {
         CHECK_CUDA_ERROR(
             cudaFreeAsync(devstruct.aik_njk_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
+      }
       if (devstruct.ajk_aji_ != nullptr)
+      {
         CHECK_CUDA_ERROR(
             cudaFreeAsync(devstruct.ajk_aji_, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)), "cudaFree");
+      }
     }
 
     void DecomposeKernelDriver(CudaMatrixParam& ALU_param, const LuDecomposeParam& devstruct)

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -160,7 +160,9 @@ namespace micm
 
       // Let the thread 0 of this threadblock write its result to output array, inexed by this threadblock
       if (l_tid == 0)
+      {
         d_errors_output[blockIdx.x] = sdata[0];
+      }
     }
 
     // CUDA kernel to compute the scaled vectors

--- a/src/util/cuda_util.cu
+++ b/src/util/cuda_util.cu
@@ -7,7 +7,7 @@ namespace micm
 {
   namespace cuda
   {
-    void CheckCudaError(cudaError_t err, const char* file, int line, std::string str)
+    void CheckCudaError(cudaError_t err, const char* file, int line, const std::string& str)
     {
       if (err != cudaSuccess)
       {
@@ -16,7 +16,7 @@ namespace micm
       }
     }
 
-    void CheckCublasError(cublasStatus_t err, const char* file, int line, std::string str)
+    void CheckCublasError(cublasStatus_t err, const char* file, int line, const std::string& str)
     {
       if (err != CUBLAS_STATUS_SUCCESS)
       {

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -133,8 +133,8 @@ void TestSimpleSystem(
     const std::string& test_label,
     BuilderPolicy builder,
     double absolute_tolerances,
-    std::function<double(double temperature, double pressure, double air_density)> calculate_k1,
-    std::function<double(double temperature, double pressure, double air_density)> calculate_k2,
+    const std::function<double(double temperature, double pressure, double air_density)>& calculate_k1,
+    const std::function<double(double temperature, double pressure, double air_density)>& calculate_k2,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve,
     std::unordered_map<std::string, std::vector<double>> custom_parameters = {})
@@ -250,8 +250,8 @@ void TestSimpleStiffSystem(
     const std::string& test_label,
     BuilderPolicy builder,
     double absolute_tolerances,
-    std::function<double(double temperature, double pressure, double air_density)> calculate_k1,
-    std::function<double(double temperature, double pressure, double air_density)> calculate_k2,
+    const std::function<double(double temperature, double pressure, double air_density)>& calculate_k1,
+    const std::function<double(double temperature, double pressure, double air_density)>& calculate_k2,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve,
     std::unordered_map<std::string, std::vector<double>> custom_parameters = {})

--- a/test/integration/stub_aerosol_1.hpp
+++ b/test/integration/stub_aerosol_1.hpp
@@ -59,11 +59,17 @@ class StubAerosolModel
     auto phase1_names = phases_[0].UniqueNames();
     auto phase2_names = phases_[1].UniqueNames();
     for (const auto& name : phase1_names)
+    {
       names.insert(name_ + ".MODE1." + name);
+    }
     for (const auto& name : phase1_names)
+    {
       names.insert(name_ + ".MODE2." + name);
+    }
     for (const auto& name : phase2_names)
+    {
       names.insert(name_ + ".MODE2." + name);
+    }
     return names;
   }
   std::set<std::string> StateParameterNames() const

--- a/test/integration/stub_aerosol_2.hpp
+++ b/test/integration/stub_aerosol_2.hpp
@@ -57,15 +57,23 @@ class AnotherStubAerosolModel
     auto phase2_names = phases_[1].UniqueNames();
     names.insert(name_ + ".MODE1.NUMBER");  // number concentration for mode 1
     for (const auto& name : phase1_names)
+    {
       names.insert(name_ + ".MODE1." + name);
+    }
     names.insert(name_ + ".MODE2.NUMBER");  // number concentration for mode 2
     for (const auto& name : phase2_names)
+    {
       names.insert(name_ + ".MODE2." + name);
+    }
     names.insert(name_ + ".MODE3.NUMBER");  // number concentration for mode 3
     for (const auto& name : phase1_names)
+    {
       names.insert(name_ + ".MODE3." + name);
+    }
     for (const auto& name : phase2_names)
+    {
       names.insert(name_ + ".MODE3." + name);
+    }
     return names;
   }
   std::set<std::string> StateParameterNames() const

--- a/test/integration/stub_aerosol_with_constraints.hpp
+++ b/test/integration/stub_aerosol_with_constraints.hpp
@@ -125,14 +125,18 @@ class StubAerosolWithConstraints
   std::set<std::string> ConstraintAlgebraicVariableNames() const
   {
     if (!total_mass_.has_value())
+    {
       return {};
+    }
     return { "AEROSOL.A_AQ" };
   }
 
   std::set<std::string> ConstraintSpeciesDependencies() const
   {
     if (!total_mass_.has_value())
+    {
       return {};
+    }
     return { "A_GAS", "AEROSOL.A_AQ" };
   }
 
@@ -140,7 +144,9 @@ class StubAerosolWithConstraints
       const std::unordered_map<std::string, std::size_t>& state_indices) const
   {
     if (!total_mass_.has_value())
+    {
       return {};
+    }
     auto i_gas = state_indices.at("A_GAS");
     auto i_aq = state_indices.at("AEROSOL.A_AQ");
     // Constraint row is i_aq, depends on both A_GAS and A_AQ

--- a/test/integration/test_external_model_constraints.cpp
+++ b/test/integration/test_external_model_constraints.cpp
@@ -72,7 +72,9 @@ class EquilibriumConstraintModel
     return [=](const DenseMatrixPolicy& state, const DenseMatrixPolicy&, DenseMatrixPolicy& forcing)
     {
       for (std::size_t i = 0; i < state.NumRows(); ++i)
+      {
         forcing[i][i_p] = K * state[i][i_r] - state[i][i_p];
+      }
     };
   }
 
@@ -255,7 +257,9 @@ class MassConservationModel
     auto i_ctrl = state_indices.at(controlled_species_);
     std::set<std::pair<std::size_t, std::size_t>> elements;
     for (const auto& sp : all_species_)
+    {
       elements.insert({ i_ctrl, state_indices.at(sp) });
+    }
     return elements;
   }
 
@@ -279,7 +283,9 @@ class MassConservationModel
     auto i_ctrl = var.at(controlled_species_);
     std::vector<std::size_t> indices;
     for (const auto& sp : all_species_)
+    {
       indices.push_back(var.at(sp));
+    }
     double tot = total_;
     return [=](const DenseMatrixPolicy& state, const DenseMatrixPolicy&, DenseMatrixPolicy& forcing)
     {
@@ -287,7 +293,9 @@ class MassConservationModel
       {
         double sum = 0.0;
         for (auto idx : indices)
+        {
           sum += state[i][idx];
+        }
         forcing[i][i_ctrl] = sum - tot;
       }
     };
@@ -302,12 +310,18 @@ class MassConservationModel
     auto i_ctrl = var.at(controlled_species_);
     std::vector<std::size_t> indices;
     for (const auto& sp : all_species_)
+    {
       indices.push_back(var.at(sp));
+    }
     return [=](const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy& jac)
     {
       for (std::size_t i = 0; i < jac.NumberOfBlocks(); ++i)
+      {
         for (auto idx : indices)
+        {
           jac[i][i_ctrl][idx] -= 1.0;  // dG/d[species] = 1
+        }
+      }
     };
   }
 
@@ -1121,7 +1135,9 @@ TEST(ExternalModelFiniteDifferenceJacobian, ProcessForcingJacobian)
 
   auto builder = SparseMatrixFD::Create(num_species).SetNumberOfBlocks(2).InitialValue(0.0);
   for (const auto& elem : nz_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
   SparseMatrixFD analytical_jac{ builder };
 
   auto jacobian_fn = aerosol.JacobianFunction<DenseMatrix, SparseMatrixFD>(param_map, var_map, analytical_jac);
@@ -1169,7 +1185,9 @@ TEST(ExternalModelFiniteDifferenceJacobian, ConstraintResidualJacobian)
 
   auto builder = SparseMatrixFD::Create(num_species).SetNumberOfBlocks(2).InitialValue(0.0);
   for (const auto& elem : nz_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
   SparseMatrixFD analytical_jac{ builder };
 
   auto jacobian_fn = aerosol.ConstraintJacobianFunction<DenseMatrix, SparseMatrixFD>(param_map, var_map, analytical_jac);
@@ -1210,7 +1228,9 @@ TEST(ExternalModelFiniteDifferenceJacobian, EquilibriumConstraintModelJacobian)
 
   auto builder = SparseMatrixFD::Create(num_species).SetNumberOfBlocks(1).InitialValue(0.0);
   for (const auto& elem : nz_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
   SparseMatrixFD analytical_jac{ builder };
 
   auto jacobian_fn = model.ConstraintJacobianFunction<DenseMatrix, SparseMatrixFD>(param_map, var_map, analytical_jac);
@@ -1318,7 +1338,9 @@ class TemperatureDependentEquilibriumModel
     return [=](const DenseMatrixPolicy& state, const DenseMatrixPolicy& params, DenseMatrixPolicy& forcing)
     {
       for (std::size_t i = 0; i < state.NumRows(); ++i)
+      {
         forcing[i][i_p] = params[i][i_K] * state[i][i_r] - state[i][i_p];
+      }
     };
   }
 

--- a/test/regression/RosenbrockChapman/regression_test_dforce_dy_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_dforce_dy_policy.hpp
@@ -51,7 +51,9 @@ void TestJacobian(SolverPolicy& solver)
     std::vector<double> rate_constants = state.rate_constants_[i];
     std::vector<double> variables(state.variables_.NumColumns());
     for (std::size_t j{}; j < state.variables_.NumColumns(); ++j)
+    {
       variables[j] = state.variables_[i][state.variable_map_[fixed_solver.SpeciesNames()[j]]];
+    }
     std::vector<double> fixed_jacobian = fixed_solver.DforceDy(rate_constants, variables, number_density_air);
 
     EXPECT_EQ(fixed_jacobian.size(), hardcoded_positions.size());

--- a/test/regression/RosenbrockChapman/regression_test_p_force_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_p_force_policy.hpp
@@ -66,7 +66,9 @@ void TestForcing(SolverPolicy& solver)
     std::vector<double> rate_constants = state.rate_constants_[i];
     std::vector<double> variables(state.variables_.NumColumns());
     for (std::size_t j{}; j < state.variables_.NumColumns(); ++j)
+    {
       variables[j] = state.variables_[i][state.variable_map_[fixed_solver.SpeciesNames()[j]]];
+    }
     std::vector<double> fixed_forcing = fixed_solver.Force(rate_constants, variables, number_density_air);
 
     EXPECT_EQ(forcing.NumColumns(), fixed_forcing.size());

--- a/test/regression/RosenbrockChapman/regression_test_solve_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_solve_policy.hpp
@@ -43,11 +43,15 @@ void TestSolve(SolverPolicy& solver, double relative_tolerance = 1.0e-8)
   for (int i = 0; i < 3; ++i)
   {
     for (int j = 0; j < 3; ++j)
+    {
       fixed_state.custom_rate_parameters_[0][j] = photo_rates[i][j];
+    }
     fixed_state.conditions_[0].temperature_ = state.conditions_[i].temperature_;
     fixed_state.conditions_[0].pressure_ = state.conditions_[i].pressure_;
     for (int j = 0; j < fixed_state.variables_.NumColumns(); ++j)
+    {
       fixed_state.variables_[0][j] = variables[i][state.variable_map_[fixed_solver.SpeciesNames()[j]]];
+    }
     fixed_solver.UpdateState(fixed_state);
     fixed_results[i] = fixed_solver.Solve(0.0, 500.0, fixed_state);
   }

--- a/test/regression/regression_policy.hpp
+++ b/test/regression/regression_policy.hpp
@@ -104,11 +104,11 @@ std::pair<std::vector<std::string>, std::vector<std::vector<double>>> ReadCsv(co
 template<class BuilderPolicy>
 void TestFlowTube(
     BuilderPolicy builder,
-    std::string expected_results_path,
+    const std::string& expected_results_path,
     std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {},
+        [](typename BuilderPolicy::StatePolicyType& state) { },
     std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
-        [](typename BuilderPolicy::StatePolicyType& state) {})
+        [](typename BuilderPolicy::StatePolicyType& state) { })
 {
   /*
    * SOA1 ->                                , k1 = 0.01

--- a/test/unit/constraint/test_constraint_set_policy.hpp
+++ b/test/unit/constraint/test_constraint_set_policy.hpp
@@ -168,7 +168,9 @@ void TestAddForcingTerms()
     builder = builder.WithElement(i, i);
   }
   for (auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
   SparseMatrixPolicy jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
 
@@ -226,7 +228,9 @@ void TestSubtractJacobianTerms()
     builder = builder.WithElement(i, i);  // Diagonals
   }
   for (auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   SparseMatrixPolicy jacobian{ builder };
 
@@ -347,7 +351,9 @@ void TestThreeDStateOneConstraint()
     builder = builder.WithElement(i, i);
   }
   for (auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   SparseMatrixPolicy jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
@@ -462,7 +468,9 @@ void TestFourDStateTwoConstraints()
     builder = builder.WithElement(i, i);
   }
   for (auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   SparseMatrixPolicy jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
@@ -600,7 +608,9 @@ void TestCoupledConstraintsSharedSpecies()
     builder = builder.WithElement(i, i);
   }
   for (auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   SparseMatrixPolicy jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
@@ -668,7 +678,9 @@ void TestVectorizedMatricesRespectGridCellIndexing()
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   SparseMatrixPolicy jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);

--- a/test/unit/constraint/type/test_equilibrium.cpp
+++ b/test/unit/constraint/type/test_equilibrium.cpp
@@ -248,7 +248,9 @@ TEST(EquilibriumConstraint, ResidualComputationThroughConstraintSet)
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
@@ -323,7 +325,9 @@ TEST(EquilibriumConstraint, JacobianComputationThroughConstraintSet)
     builder = builder.WithElement(i, i);  // Diagonals
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   StandardSparseMatrix jacobian{ builder };
 
@@ -387,7 +391,9 @@ TEST(EquilibriumConstraint, ComplexStoichiometryResidual)
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
@@ -442,7 +448,9 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianSimple)
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, std::size_t> state_parameter_indices = { { "eq", 0 } };
@@ -509,7 +517,9 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianComplexStoichiometry)
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, std::size_t> state_parameter_indices = { { "dissociation", 0 } };

--- a/test/unit/constraint/type/test_linear.cpp
+++ b/test/unit/constraint/type/test_linear.cpp
@@ -145,7 +145,9 @@ TEST(LinearConstraint, ResidualComputationThroughConstraintSet)
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
@@ -211,7 +213,9 @@ TEST(LinearConstraint, JacobianComputationThroughConstraintSet)
     builder = builder.WithElement(i, i);  // Diagonals
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   StandardSparseMatrix jacobian{ builder };
 
@@ -268,7 +272,9 @@ TEST(LinearConstraint, WeightedSumResidualAndJacobian)
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
@@ -340,7 +346,9 @@ TEST(LinearConstraint, ThreeSpeciesConservationResidual)
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
@@ -403,7 +411,9 @@ TEST(LinearConstraint, ZeroConstantResidual)
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
@@ -464,7 +474,9 @@ TEST(LinearConstraint, FractionalCoefficientsResidualAndJacobian)
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
@@ -521,7 +533,9 @@ TEST(LinearConstraint, JacobianIndependentOfConcentrations)
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
 
   StandardSparseMatrix jacobian{ builder };
 
@@ -588,7 +602,9 @@ TEST(LinearConstraint, FiniteDifferenceJacobianSimpleConservation)
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
@@ -652,7 +668,9 @@ TEST(LinearConstraint, FiniteDifferenceJacobianWeightedSum)
     builder = builder.WithElement(i, i);
   }
   for (const auto& elem : non_zero_elements)
+  {
     builder = builder.WithElement(elem.first, elem.second);
+  }
   StandardSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, std::size_t> state_parameter_indices;

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -39,25 +39,45 @@ static void SortLikeBuilder(std::vector<Process>& procs)
               {
                 using T = std::decay_t<decltype(v)>;
                 if constexpr (std::is_same_v<T, ArrheniusRateConstantParameters>)
+                {
                   return 0;
+                }
                 else if constexpr (std::is_same_v<T, TroeRateConstantParameters>)
+                {
                   return 1;
+                }
                 else if constexpr (std::is_same_v<T, TernaryChemicalActivationRateConstantParameters>)
+                {
                   return 2;
+                }
                 else if constexpr (std::is_same_v<T, BranchedRateConstantParameters>)
+                {
                   return 3;
+                }
                 else if constexpr (std::is_same_v<T, TunnelingRateConstantParameters>)
+                {
                   return 4;
+                }
                 else if constexpr (std::is_same_v<T, TaylorSeriesRateConstantParameters>)
+                {
                   return 5;
+                }
                 else if constexpr (std::is_same_v<T, ReversibleRateConstantParameters>)
+                {
                   return 6;
+                }
                 else if constexpr (std::is_same_v<T, UserDefinedRateConstantParameters>)
+                {
                   return 7;
+                }
                 else if constexpr (std::is_same_v<T, SurfaceRateConstantParameters>)
+                {
                   return 8;
+                }
                 else
+                {
                   return 9;
+                }
               },
               p.process_.rate_constant_);
         };

--- a/test/unit/process/test_process_set_policy.hpp
+++ b/test/unit/process/test_process_set_policy.hpp
@@ -229,11 +229,15 @@ void TestRandomSystem(std::size_t n_cells, std::size_t n_reactions, std::size_t 
   RatesPolicy set = RatesPolicy(processes, state.variable_map_);
 
   for (auto& elem : state.variables_.AsVector())
+  {
     elem = get_double();
+  }
 
   DenseMatrixPolicy rate_constants{ n_cells, n_reactions };
   for (auto& elem : rate_constants.AsVector())
+  {
     elem = get_double();
+  }
   DenseMatrixPolicy forcing{ n_cells, n_species, 1000.0 };
   state.rate_constants_ = rate_constants;
 

--- a/test/unit/process/test_reaction_rate_store.cpp
+++ b/test/unit/process/test_reaction_rate_store.cpp
@@ -27,12 +27,14 @@ using namespace micm;
 namespace
 {
   // Helper to create a minimal gas phase with species
-  Phase MakeGasPhase(std::vector<Species> species)
+  Phase MakeGasPhase(const std::vector<Species>& species)
   {
     std::vector<PhaseSpecies> ps;
     ps.reserve(species.size());
-    for (auto& s : species)
+    for (const auto& s : species)
+    {
       ps.emplace_back(s);
+    }
     return Phase{ "gas", ps };
   }
 
@@ -47,25 +49,45 @@ namespace
           {
             using T = std::decay_t<decltype(v)>;
             if constexpr (std::is_same_v<T, ArrheniusRateConstantParameters>)
+            {
               return 0;
+            }
             else if constexpr (std::is_same_v<T, TroeRateConstantParameters>)
+            {
               return 1;
+            }
             else if constexpr (std::is_same_v<T, TernaryChemicalActivationRateConstantParameters>)
+            {
               return 2;
+            }
             else if constexpr (std::is_same_v<T, BranchedRateConstantParameters>)
+            {
               return 3;
+            }
             else if constexpr (std::is_same_v<T, TunnelingRateConstantParameters>)
+            {
               return 4;
+            }
             else if constexpr (std::is_same_v<T, TaylorSeriesRateConstantParameters>)
+            {
               return 5;
+            }
             else if constexpr (std::is_same_v<T, ReversibleRateConstantParameters>)
+            {
               return 6;
+            }
             else if constexpr (std::is_same_v<T, UserDefinedRateConstantParameters>)
+            {
               return 7;
+            }
             else if constexpr (std::is_same_v<T, SurfaceRateConstantParameters>)
+            {
               return 8;
+            }
             else
+            {
               return 9;
+            }
           },
           p.process_.rate_constant_);
     };

--- a/test/unit/solver/test_linear_solver.cpp
+++ b/test/unit/solver/test_linear_solver.cpp
@@ -39,7 +39,9 @@ TEST(LinearSolver, StandardOrderingAgnosticToInitialValue)
 {
   double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
   for (auto initial_value : initial_values)
+  {
     TestExtremeInitialValue<DenseMatrixTest, SparseMatrixTest, micm::LinearSolver<SparseMatrixTest>>(5, initial_value);
+  }
 }
 
 using Group1VectorMatrix = micm::VectorMatrix<FloatingPointType, 1>;

--- a/test/unit/solver/test_linear_solver_in_place.cpp
+++ b/test/unit/solver/test_linear_solver_in_place.cpp
@@ -39,8 +39,10 @@ TEST(LinearSolverInPlace, StandardOrderingAgnosticToInitialValue)
 {
   double initial_values[5] = { -INFINITY, -1.0, 0.0, 1.0, INFINITY };
   for (auto initial_value : initial_values)
+  {
     TestExtremeInitialValue<DenseMatrixTest, SparseMatrixTest, micm::LinearSolverInPlace<SparseMatrixTest>>(
         5, initial_value);
+  }
 }
 
 using Group1VectorMatrix = micm::VectorMatrix<FloatingPointType, 1>;

--- a/test/unit/system/test_system.cpp
+++ b/test/unit/system/test_system.cpp
@@ -57,7 +57,7 @@ TEST(System, ConstructorWithParameterizedSpecies)
   EXPECT_EQ(name_set, expected_set);
 
   std::vector<int> reorder{ 1, 0 };
-  auto reordered_names = system.UniqueNames([&](const std::vector<std::string> variables, const std::size_t i)
+  auto reordered_names = system.UniqueNames([&](const std::vector<std::string>& variables, const std::size_t i)
                                             { return variables[reorder[i]]; });
   EXPECT_EQ(reordered_names.size(), 2);
   EXPECT_EQ(reordered_names[0], names[1]);

--- a/test/unit/util/test_matrix_policy.hpp
+++ b/test/unit/util/test_matrix_policy.hpp
@@ -1392,7 +1392,9 @@ std::tuple<MatrixPolicy<double>, std::vector<double>> TestMutableVector()
   std::vector<double> vec = { 5.0, 10.0, 15.0 };
 
   for (std::size_t i = 0; i < 3; ++i)
+  {
     matrix[i][0] = static_cast<double>(i + 1);
+  }
 
   auto func = MatrixPolicy<double>::Function(
       [](auto&& m, auto&& v)

--- a/test/unit/util/test_sparse_matrix_policy.hpp
+++ b/test/unit/util/test_sparse_matrix_policy.hpp
@@ -1967,7 +1967,9 @@ std::tuple<SparseMatrixPolicy<double, OrderingPolicy>, std::vector<double>> Test
   std::vector<double> vec = { 5.0, 10.0, 15.0 };
 
   for (int block = 0; block < 3; ++block)
+  {
     matrix[block][0][1] = static_cast<double>(block + 1);
+  }
 
   auto func = SparseMatrixPolicy<double, OrderingPolicy>::Function(
       [](auto&& m, auto&& v)


### PR DESCRIPTION
Close #1018 

Ran
```
cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \                               
      -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
      -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang

  run-clang-tidy -p build -fix \
      '/Users/kshores/Documents/micm/(include|src|test)'
```

this PR
- actually enables performance-unnecessary-value-param, readability-braces-around-statements, and CUDA
  readability-qualified-auto
  - The `.clang-tidy` `Checks:` block used a folded scalar (`>`) that broke `#`-comment parsing, silently disabling `performance-unnecessary-value-param` and `readability-braces-around-statements`; 
  - switched to literal `|` with trailing commas to enable them.
- all silently failing checks were applied
