### PR TITLE
Fix DOI badge image source so it renders on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Model Independent Chemical Module. MICM can be used to configure and solve atmos
 [![Mac](https://github.com/NCAR/micm/actions/workflows/mac.yml/badge.svg)](https://github.com/NCAR/micm/actions/workflows/mac.yml)
 [![Ubuntu](https://github.com/NCAR/micm/actions/workflows/ubuntu.yml/badge.svg)](https://github.com/NCAR/micm/actions/workflows/ubuntu.yml)
 [![codecov](https://codecov.io/gh/NCAR/micm/branch/main/graph/badge.svg?token=ATGO4DKTMY)](https://codecov.io/gh/NCAR/micm)
-[![DOI](https://zenodo.org/badge/294492778.svg)](https://doi.org/10.5281/zenodo.8377911)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8377911.svg)](https://doi.org/10.5281/zenodo.8377911)
 [![FAIR checklist badge](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=31&a=32113&i=22322&r=123)
 
 <p align="center">


### PR DESCRIPTION
This actually fixes the DOI badge.

The DOI badge doesn't render on the GitHub README. PR #1021 attempted a fix but changed only the badge's **link target** (the click destination), not the **image source** — so the broken badge persisted.

## Root cause

Markdown badge syntax is `[![alt](IMAGE_URL)](LINK_URL)`. The displayed badge is `IMAGE_URL`, which was untouched by #1021.

The image URL `https://zenodo.org/badge/294492778.svg` serves a **302 redirect** with `cache-control: no-cache` and tight rate limiting. GitHub renders README images through its Camo proxy, which fetches and caches them server-side; the redirect + no-cache + rate limiting causes Camo's fetch to fail and cache a broken result.

## Fix

Point the image at the static, non-redirecting badge URL, which returns `200 OK` directly:

```
https://zenodo.org/badge/DOI/10.5281/zenodo.8377911.svg
```

Both the image and link now reference the same concept DOI (`8377911`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)