### PR TITLE
Decrease solver builder runtime and memory usage

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4'
+          xcode-version: '26.0'
 
       - name: Run Cmake 
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}

--- a/include/micm/process/chemical_reaction_builder.hpp
+++ b/include/micm/process/chemical_reaction_builder.hpp
@@ -56,11 +56,8 @@ namespace micm
     ChemicalReactionBuilder& SetPhase(const Phase& phase)
     {
       // Store only the phase NAME, not a copy of all of the phase's species. A
-      // reaction needs to know which phase it belongs to (by name); the species
-      // membership lives on the System, which is what the solver actually reads.
-      // Copying the full phase into every reaction is O(reactions x species) in
-      // memory and is catastrophic for large mechanisms (e.g. a ~7,500-species
-      // GECKO-A mechanism with ~42,000 reactions copies ~114 GB of species here).
+      // reaction needs to know which phase it is. Actually, this isn't required, and this
+      // will be removed in #1025
       phase_ = Phase(phase.name_, {});
       return *this;
     }

--- a/include/micm/process/chemical_reaction_builder.hpp
+++ b/include/micm/process/chemical_reaction_builder.hpp
@@ -55,7 +55,13 @@ namespace micm
     /// @return Reference to the builder
     ChemicalReactionBuilder& SetPhase(const Phase& phase)
     {
-      phase_ = phase;
+      // Store only the phase NAME, not a copy of all of the phase's species. A
+      // reaction needs to know which phase it belongs to (by name); the species
+      // membership lives on the System, which is what the solver actually reads.
+      // Copying the full phase into every reaction is O(reactions x species) in
+      // memory and is catastrophic for large mechanisms (e.g. a ~7,500-species
+      // GECKO-A mechanism with ~42,000 reactions copies ~114 GB of species here).
+      phase_ = Phase(phase.name_, {});
       return *this;
     }
 

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -187,70 +187,83 @@ namespace micm
       number_of_products_.push_back(number_of_products);
     }
 
-    // Set up process information for Jacobian calculations
-
-    // The variable_map is sorted by index
-    std::vector<std::pair<std::string, std::size_t>> sorted_names(variable_map.begin(), variable_map.end());
-    std::sort(sorted_names.begin(), sorted_names.end(), [](const auto& a, const auto& b) { return a.second < b.second; });
-
-    // For every independent variable (species), if the species is used as a reactant in a process,
-    // create a ProcessInfo record to track Jacobian contributions
-    for (const auto& independent_variable : sorted_names)
+    // Set up process information for Jacobian calculations.
+    //
+    // For every independent variable (species) used as a reactant in a process, create a
+    // ProcessInfo record. Rather than scanning every process for every species
+    // (O(species x reactions), which is prohibitive for large mechanisms), collect
+    // (independent_id, process_id) jobs in a SINGLE pass over the processes and then
+    // stable-sort them by independent_id. The emitted records are then ordered by
+    // independent variable and then by process -- identical to the species-by-species
+    // scan -- but the cost is O(reactions x reactants + J log J) instead of
+    // O(species x reactions).
+    std::vector<std::pair<std::size_t, std::size_t>> jacobian_jobs;  // (independent_id, i_process)
+    for (std::size_t i_process = 0; i_process < processes.size(); ++i_process)
     {
-      for (std::size_t i_process = 0; i_process < processes.size(); ++i_process)
+      const auto& reaction = processes[i_process].process_;
+      for (const auto& ind_reactant : reaction.reactants_)
       {
-        const auto& reaction = processes[i_process].process_;
-        for (const auto& ind_reactant : reaction.reactants_)
+        auto it = variable_map.find(ind_reactant.name_);
+        if (it == variable_map.end())
         {
-          if (ind_reactant.name_ != independent_variable.first)
-          {
-            continue;
-          }
-          ProcessInfo info;
-          info.process_id_ = i_process;
-          info.independent_id_ = independent_variable.second;
-          info.number_of_dependent_reactants_ = 0;
-          info.number_of_products_ = 0;
-
-          // Collect other (dependent) reactants and products
-          bool found = false;
-          for (const auto& reactant : reaction.reactants_)
-          {
-            if (reactant.IsParameterized())
-            {
-              continue;  // Skip reactants that are parameterizations
-            }
-            if (variable_map.count(reactant.name_) < 1)
-            {
-              throw MicmException(
-                  MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_REACTANT_DOES_NOT_EXIST, reactant.name_);
-            }
-            if (variable_map.at(reactant.name_) == independent_variable.second && !found)
-            {
-              found = true;
-              continue;
-            }
-            jacobian_reactant_ids_.push_back(variable_map.at(reactant.name_));
-            ++info.number_of_dependent_reactants_;
-          }
-          for (const auto& product : reaction.products_)
-          {
-            if (product.species_.IsParameterized())
-            {
-              continue;  // Skip products that are parameterizations
-            }
-            if (variable_map.count(product.species_.name_) < 1)
-            {
-              throw MicmException(
-                  MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_PRODUCT_DOES_NOT_EXIST, product.species_.name_);
-            }
-            jacobian_product_ids_.push_back(variable_map.at(product.species_.name_));
-            jacobian_yields_.push_back(product.coefficient_);
-            ++info.number_of_products_;
-          }
-          jacobian_process_info_.push_back(info);
+          continue;
         }
+        jacobian_jobs.emplace_back(it->second, i_process);
       }
+    }
+    std::stable_sort(
+        jacobian_jobs.begin(),
+        jacobian_jobs.end(),
+        [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    for (const auto& job : jacobian_jobs)
+    {
+      const std::size_t independent_id = job.first;
+      const std::size_t i_process = job.second;
+      const auto& reaction = processes[i_process].process_;
+      ProcessInfo info;
+      info.process_id_ = i_process;
+      info.independent_id_ = independent_id;
+      info.number_of_dependent_reactants_ = 0;
+      info.number_of_products_ = 0;
+
+      // Collect other (dependent) reactants and products
+      bool found = false;
+      for (const auto& reactant : reaction.reactants_)
+      {
+        if (reactant.IsParameterized())
+        {
+          continue;  // Skip reactants that are parameterizations
+        }
+        if (variable_map.count(reactant.name_) < 1)
+        {
+          throw MicmException(
+              MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_REACTANT_DOES_NOT_EXIST, reactant.name_);
+        }
+        if (variable_map.at(reactant.name_) == independent_id && !found)
+        {
+          found = true;
+          continue;
+        }
+        jacobian_reactant_ids_.push_back(variable_map.at(reactant.name_));
+        ++info.number_of_dependent_reactants_;
+      }
+      for (const auto& product : reaction.products_)
+      {
+        if (product.species_.IsParameterized())
+        {
+          continue;  // Skip products that are parameterizations
+        }
+        if (variable_map.count(product.species_.name_) < 1)
+        {
+          throw MicmException(
+              MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_PRODUCT_DOES_NOT_EXIST, product.species_.name_);
+        }
+        jacobian_product_ids_.push_back(variable_map.at(product.species_.name_));
+        jacobian_yields_.push_back(product.coefficient_);
+        ++info.number_of_products_;
+      }
+      jacobian_process_info_.push_back(info);
     }
   };
 

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -194,10 +194,10 @@ namespace micm
     // (O(species x reactions), which is prohibitive for large mechanisms), collect
     // (independent_id, process_id) jobs in a SINGLE pass over the processes and then
     // stable-sort them by independent_id. The emitted records are then ordered by
-    // independent variable and then by process -- identical to the species-by-species
-    // scan -- but the cost is O(reactions x reactants + J log J) instead of
+    // independent variable and then by process which is identical to the species-by-species
+    // scan, but the cost is O(reactions x reactants + J log J) instead of
     // O(species x reactions).
-    std::vector<std::pair<std::size_t, std::size_t>> jacobian_jobs;  // (independent_id, i_process)
+    std::vector<std::pair<std::size_t, std::size_t>> jacobian_columns;  // (independent_id, i_process)
     for (std::size_t i_process = 0; i_process < processes.size(); ++i_process)
     {
       const auto& reaction = processes[i_process].process_;
@@ -208,18 +208,18 @@ namespace micm
         {
           continue;
         }
-        jacobian_jobs.emplace_back(it->second, i_process);
+        jacobian_columns.emplace_back(it->second, i_process);
       }
     }
     std::stable_sort(
-        jacobian_jobs.begin(),
-        jacobian_jobs.end(),
+        jacobian_columns.begin(),
+        jacobian_columns.end(),
         [](const auto& a, const auto& b) { return a.first < b.first; });
 
-    for (const auto& job : jacobian_jobs)
+    for (const auto& column : jacobian_columns)
     {
-      const std::size_t independent_id = job.first;
-      const std::size_t i_process = job.second;
+      const std::size_t independent_id = column.first;
+      const std::size_t i_process = column.second;
       const auto& reaction = processes[i_process].process_;
       ProcessInfo info;
       info.process_id_ = i_process;
@@ -228,6 +228,7 @@ namespace micm
       info.number_of_products_ = 0;
 
       // Collect other (dependent) reactants and products
+      // because our reactants can be duplicated, (2B could be 2B or B + B), we need to detect when we've already seen a reactant
       bool found = false;
       for (const auto& reactant : reaction.reactants_)
       {
@@ -235,17 +236,13 @@ namespace micm
         {
           continue;  // Skip reactants that are parameterizations
         }
-        if (variable_map.count(reactant.name_) < 1)
-        {
-          throw MicmException(
-              MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_REACTANT_DOES_NOT_EXIST, reactant.name_);
-        }
-        if (variable_map.at(reactant.name_) == independent_id && !found)
+        const std::size_t id = variable_map.at(reactant.name_);
+        if (id == independent_id && !found)
         {
           found = true;
           continue;
         }
-        jacobian_reactant_ids_.push_back(variable_map.at(reactant.name_));
+        jacobian_reactant_ids_.push_back(id);
         ++info.number_of_dependent_reactants_;
       }
       for (const auto& product : reaction.products_)
@@ -253,11 +250,6 @@ namespace micm
         if (product.species_.IsParameterized())
         {
           continue;  // Skip products that are parameterizations
-        }
-        if (variable_map.count(product.species_.name_) < 1)
-        {
-          throw MicmException(
-              MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_PRODUCT_DOES_NOT_EXIST, product.species_.name_);
         }
         jacobian_product_ids_.push_back(variable_map.at(product.species_.name_));
         jacobian_yields_.push_back(product.coefficient_);

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -8,27 +8,45 @@
 namespace micm
 {
   // Diagonal Markowitz (minimum-degree) reordering on a SPARSE adjacency representation.
-  // This produces the same minimum-degree-quality ordering as the dense Markowitz scan but
-  // runs in ~O(order^2 + fill) instead of O(order^3), which is essential for large
-  // mechanisms (thousands of species). Returns perm where perm[new_index] = old_index.
+  //
+  // This is the same algorithm as the classic dense Markowitz scan -- it selects, at each
+  // elimination step, the remaining pivot with the lowest Markowitz cost (row_deg-1)*(col_deg-1)
+  // and accounts for the fill that eliminating it introduces -- and it produces an ordering of
+  // identical minimum-degree quality. Only the representation differs, which is why it looks
+  // nothing like the dense version:
+  //   * The dense version mutates an order x order pattern matrix, recomputes every candidate's
+  //     row/column degree by re-scanning the trailing submatrix each step, and physically swaps
+  //     rows/columns to move the chosen pivot into place -- O(order^3) time, O(order^2) memory.
+  //   * This version stores the sparsity pattern as a directed graph (edge v->c iff
+  //     matrix[v][c] != 0), keeps the degrees up to date incrementally, and marks eliminated
+  //     nodes with an `alive` flag instead of moving anything -- ~O(order^2 + fill) time, with
+  //     memory proportional to nonzeros + fill. This is essential for large mechanisms (thousands
+  //     of species), where the dense form is intractable.
+  //
+  // Returns perm where perm[new_index] = old_index.
   template<class MatrixPolicy>
   inline std::vector<std::size_t> DiagonalMarkowitzReorder(const MatrixPolicy& matrix)
   {
     const std::size_t order = matrix.NumRows();
-    // out_nb[v] = { c : edge v->c }, in_nb[c] = { v : edge v->c }, over the remaining nodes.
-    std::vector<std::set<std::size_t>> out_nb(order), in_nb(order);
+    assert(order == matrix.NumColumns() && "Markowitz reorder requires a square matrix");
+    // output_neighbors[v] = { c : edge v->c }, incoming_neighbors[c] = { v : edge v->c }, over the remaining nodes.
+    std::vector<std::set<std::size_t>> output_neighbors(order), incoming_neighbors(order);
     for (std::size_t i = 0; i < order; ++i)
+    {
       for (std::size_t j = 0; j < order; ++j)
+      {
         if (matrix[i][j] != 0)
         {
-          out_nb[i].insert(j);
-          in_nb[j].insert(i);
+          output_neighbors[i].insert(j);
+          incoming_neighbors[j].insert(i);
         }
+      }
+    }
     std::vector<std::size_t> row_deg(order), col_deg(order);
     for (std::size_t v = 0; v < order; ++v)
     {
-      row_deg[v] = out_nb[v].size();
-      col_deg[v] = in_nb[v].size();
+      row_deg[v] = output_neighbors[v].size();
+      col_deg[v] = incoming_neighbors[v].size();
     }
     std::vector<char> alive(order, 1);
     std::vector<std::size_t> perm;
@@ -42,7 +60,9 @@ namespace micm
       for (std::size_t v = 0; v < order; ++v)
       {
         if (!alive[v])
+        {
           continue;
+        }
         const std::size_t cost = (row_deg[v] - 1) * (col_deg[v] - 1);
         if (pivot == order || cost < best_cost)
         {
@@ -53,30 +73,48 @@ namespace micm
       perm.push_back(pivot);
       alive[pivot] = 0;
       std::vector<std::size_t> cols, ins;
-      for (std::size_t c : out_nb[pivot])
+      for (std::size_t c : output_neighbors[pivot])
+      {
         if (c != pivot && alive[c])
+        {
           cols.push_back(c);
-      for (std::size_t i : in_nb[pivot])
+        }
+      }
+      for (std::size_t i : incoming_neighbors[pivot])
+      {
         if (i != pivot && alive[i])
+        {
           ins.push_back(i);
-      // Fill: each in-neighbor of the pivot now connects to each out-neighbor of the pivot.
+        }
+      }
+      // Fill: eliminating the pivot couples everything that pointed into it with everything it
+      // pointed out to. Concretely, for every live in-neighbor i (edge i->pivot) and every live
+      // out-neighbor c (edge pivot->c), a new edge i->c must exist in the factored matrix. This
+      // is the sparse equivalent of the dense version's "OR the pivot row down each column"
+      // fill step. insert(c).second is true only when the edge is genuinely new, so degrees are
+      // bumped exactly once per introduced fill element -- keeping row_deg/col_deg exact without
+      // any rescan.
       for (std::size_t i : ins)
+      {
         for (std::size_t c : cols)
-          if (out_nb[i].insert(c).second)
+        {
+          if (output_neighbors[i].insert(c).second)
           {
             ++row_deg[i];
-            in_nb[c].insert(i);
+            incoming_neighbors[c].insert(i);
             ++col_deg[c];
           }
+        }
+      }
       // Drop the eliminated pivot from its live neighbors' degree counts.
       for (std::size_t c : cols)
       {
-        in_nb[c].erase(pivot);
+        incoming_neighbors[c].erase(pivot);
         --col_deg[c];
       }
       for (std::size_t i : ins)
       {
-        out_nb[i].erase(pivot);
+        output_neighbors[i].erase(pivot);
         --row_deg[i];
       }
     }

--- a/include/micm/solver/linear_solver.inl
+++ b/include/micm/solver/linear_solver.inl
@@ -1,57 +1,83 @@
 // Copyright (C) 2023-2026 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
+#include <limits>
+#include <set>
+#include <vector>
+
 namespace micm
 {
+  // Diagonal Markowitz (minimum-degree) reordering on a SPARSE adjacency representation.
+  // This produces the same minimum-degree-quality ordering as the dense Markowitz scan but
+  // runs in ~O(order^2 + fill) instead of O(order^3), which is essential for large
+  // mechanisms (thousands of species). Returns perm where perm[new_index] = old_index.
   template<class MatrixPolicy>
   inline std::vector<std::size_t> DiagonalMarkowitzReorder(const MatrixPolicy& matrix)
   {
     const std::size_t order = matrix.NumRows();
-    std::vector<std::size_t> perm(order);
-    for (std::size_t i = 0; i < order; ++i) {
-      perm[i] = i;
-}
-    MatrixPolicy pattern = matrix;
-    for (std::size_t row = 0; row < (order - 1); ++row)
+    // out_nb[v] = { c : edge v->c }, in_nb[c] = { v : edge v->c }, over the remaining nodes.
+    std::vector<std::set<std::size_t>> out_nb(order), in_nb(order);
+    for (std::size_t i = 0; i < order; ++i)
+      for (std::size_t j = 0; j < order; ++j)
+        if (matrix[i][j] != 0)
+        {
+          out_nb[i].insert(j);
+          in_nb[j].insert(i);
+        }
+    std::vector<std::size_t> row_deg(order), col_deg(order);
+    for (std::size_t v = 0; v < order; ++v)
     {
-      std::size_t beta = std::pow((order - 1), 2);
-      std::size_t max_row = row;
-      for (std::size_t col = row; col < order; ++col)
+      row_deg[v] = out_nb[v].size();
+      col_deg[v] = in_nb[v].size();
+    }
+    std::vector<char> alive(order, 1);
+    std::vector<std::size_t> perm;
+    perm.reserve(order);
+    for (std::size_t step = 0; step < order; ++step)
+    {
+      // Select the remaining node with minimum Markowitz cost (row_deg-1)*(col_deg-1).
+      // The diagonal keeps every live node's degrees >= 1, so the subtraction never underflows.
+      std::size_t pivot = order;
+      std::size_t best_cost = std::numeric_limits<std::size_t>::max();
+      for (std::size_t v = 0; v < order; ++v)
       {
-        std::size_t count_a = 0;
-        std::size_t count_b = 0;
-        for (std::size_t i = row; i < order; ++i)
+        if (!alive[v])
+          continue;
+        const std::size_t cost = (row_deg[v] - 1) * (col_deg[v] - 1);
+        if (pivot == order || cost < best_cost)
         {
-          count_a += (pattern[col][i] == 0 ? 0 : 1);
-          count_b += (pattern[i][col] == 0 ? 0 : 1);
-        }
-        std::size_t count = (count_a - 1) * (count_b - 1);
-        if (count < beta)
-        {
-          beta = count;
-          max_row = col;
+          best_cost = cost;
+          pivot = v;
         }
       }
-      // Swap row and max_row
-      if (max_row != row)
-      {
-        for (std::size_t i = row; i < order; ++i) {
-          std::swap(pattern[row][i], pattern[max_row][i]);
-}
-        for (std::size_t i = row; i < order; ++i) {
-          std::swap(pattern[i][row], pattern[i][max_row]);
-}
-        std::swap(perm[row], perm[max_row]);
-      }
-      for (std::size_t col = row + 1; col < order; ++col)
-      {
-        if (pattern[row][col])
-        {
-          for (std::size_t i = row + 1; i < order; ++i)
+      perm.push_back(pivot);
+      alive[pivot] = 0;
+      std::vector<std::size_t> cols, ins;
+      for (std::size_t c : out_nb[pivot])
+        if (c != pivot && alive[c])
+          cols.push_back(c);
+      for (std::size_t i : in_nb[pivot])
+        if (i != pivot && alive[i])
+          ins.push_back(i);
+      // Fill: each in-neighbor of the pivot now connects to each out-neighbor of the pivot.
+      for (std::size_t i : ins)
+        for (std::size_t c : cols)
+          if (out_nb[i].insert(c).second)
           {
-            pattern[i][col] = pattern[i][row] || pattern[i][col];
+            ++row_deg[i];
+            in_nb[c].insert(i);
+            ++col_deg[c];
           }
-        }
+      // Drop the eliminated pivot from its live neighbors' degree counts.
+      for (std::size_t c : cols)
+      {
+        in_nb[c].erase(pivot);
+        --col_deg[c];
+      }
+      for (std::size_t i : ins)
+      {
+        out_nb[i].erase(pivot);
+        --row_deg[i];
       }
     }
     return perm;

--- a/include/micm/solver/lu_decomposition_doolittle.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle.hpp
@@ -129,16 +129,16 @@ namespace micm
     struct FillPattern
     {
       /// Sorted non-zero positions of the L and U factors (used to build the matrices)
-      std::set<std::pair<std::size_t, std::size_t>> L_ids, U_ids;
-      /// Non-zero structure of the input matrix A: Arow[r] = sorted columns,
-      /// Acol[c] = sorted rows
-      std::vector<std::vector<std::size_t>> Arow, Acol;
-      /// Lrow[i] = sorted columns j < i where L[i][j] != 0
-      std::vector<std::vector<std::size_t>> Lrow;
-      /// Urow[i] = sorted columns k >= i where U[i][k] != 0
-      std::vector<std::vector<std::size_t>> Urow;
-      /// Lcol[i] = sorted rows k > i where L[k][i] != 0
-      std::vector<std::vector<std::size_t>> Lcol;
+      std::set<std::pair<std::size_t, std::size_t>> L_ids_, U_ids_;
+      /// Non-zero structure of the input matrix A: Arow_[r] = sorted columns,
+      /// Acol_[c] = sorted rows
+      std::vector<std::vector<std::size_t>> Arow_, Acol_;
+      /// Lrow_[i] = sorted columns j < i where L[i][j] != 0
+      std::vector<std::vector<std::size_t>> Lrow_;
+      /// Urow_[i] = sorted columns k >= i where U[i][k] != 0
+      std::vector<std::vector<std::size_t>> Urow_;
+      /// Lcol_[i] = sorted rows k > i where L[k][i] != 0
+      std::vector<std::vector<std::size_t>> Lcol_;
     };
 
     /// @brief Compute the sparse LU fill pattern of A in time proportional to the

--- a/include/micm/solver/lu_decomposition_doolittle.hpp
+++ b/include/micm/solver/lu_decomposition_doolittle.hpp
@@ -122,6 +122,34 @@ namespace micm
     void Decompose(const SparseMatrixPolicy& A, auto& L, auto& U) const;
 
    protected:
+    /// @brief Sparse LU fill pattern of A together with the row/column adjacency
+    /// needed to build the decomposition index arrays without scanning the dense
+    /// (i, k, j) grid. Shared by GetLUMatrices (which only needs the id sets) and
+    /// Initialize (which also walks the adjacency).
+    struct FillPattern
+    {
+      /// Sorted non-zero positions of the L and U factors (used to build the matrices)
+      std::set<std::pair<std::size_t, std::size_t>> L_ids, U_ids;
+      /// Non-zero structure of the input matrix A: Arow[r] = sorted columns,
+      /// Acol[c] = sorted rows
+      std::vector<std::vector<std::size_t>> Arow, Acol;
+      /// Lrow[i] = sorted columns j < i where L[i][j] != 0
+      std::vector<std::vector<std::size_t>> Lrow;
+      /// Urow[i] = sorted columns k >= i where U[i][k] != 0
+      std::vector<std::vector<std::size_t>> Urow;
+      /// Lcol[i] = sorted rows k > i where L[k][i] != 0
+      std::vector<std::vector<std::size_t>> Lcol;
+    };
+
+    /// @brief Compute the sparse LU fill pattern of A in time proportional to the
+    /// number of non-zeros in the factors (plus an O(n^2) scan of the sparse input A),
+    /// rather than the O(n^3) dense triple loop.
+    /// @param A Sparse matrix that will be decomposed
+    /// @return Fill pattern and adjacency of A, L and U
+    template<class SparseMatrixPolicy>
+      requires(SparseMatrixConcept<SparseMatrixPolicy>)
+    static FillPattern ComputeFillPattern(const SparseMatrixPolicy& A);
+
     /// @brief Initialize arrays for the LU decomposition
     /// @param A Sparse matrix to decompose
     template<class SparseMatrixPolicy, class LMatrixPolicy = SparseMatrixPolicy, class UMatrixPolicy = SparseMatrixPolicy>

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -31,11 +31,11 @@ namespace micm
   {
     std::size_t n = A.NumRows();
     FillPattern fp;
-    fp.Arow.assign(n, {});
-    fp.Acol.assign(n, {});
-    fp.Lrow.assign(n, {});
-    fp.Urow.assign(n, {});
-    fp.Lcol.assign(n, {});
+    fp.Arow_.assign(n, {});
+    fp.Acol_.assign(n, {});
+    fp.Lrow_.assign(n, {});
+    fp.Urow_.assign(n, {});
+    fp.Lcol_.assign(n, {});
 
     // Non-zero structure of the (sparse) input matrix A. Its rows are short, so the
     // O(n^2) IsZero scan here costs O(n * nnz(A)) -- negligible next to the dense
@@ -46,8 +46,8 @@ namespace micm
       {
         if (!A.IsZero(r, c))
         {
-          fp.Arow[r].push_back(c);
-          fp.Acol[c].push_back(r);
+          fp.Arow_[r].push_back(c);
+          fp.Acol_[c].push_back(r);
         }
       }
     }
@@ -73,39 +73,59 @@ namespace micm
       // Upper triangular matrix: columns k >= i that are non-zero in U row i.
       touched.clear();
       mark(i);  // unit/diagonal entry U[i][i]
-      for (std::size_t k : fp.Arow[i])
+      for (std::size_t k : fp.Arow_[i])
+      {
         if (k >= i)
+        {
           mark(k);
-      for (std::size_t j : fp.Lrow[i])    // j < i, L[i][j] != 0
-        for (std::size_t k : fp.Urow[j])  // k >= j, U[j][k] != 0
+        }
+      }
+      for (std::size_t j : fp.Lrow_[i])  // j < i, L[i][j] != 0
+      {
+        for (std::size_t k : fp.Urow_[j])  // k >= j, U[j][k] != 0
+        {
           if (k >= i)
+          {
             mark(k);
+          }
+        }
+      }
       std::sort(touched.begin(), touched.end());
       for (std::size_t k : touched)
       {
-        fp.U_ids.insert(std::make_pair(i, k));
-        fp.Urow[i].push_back(k);
+        fp.U_ids_.insert(std::make_pair(i, k));
+        fp.Urow_[i].push_back(k);
         Ucol[k].push_back(i);
         seen[k] = 0;
       }
 
       // Lower triangular matrix: rows k > i non-zero in L column i, plus the unit
       // diagonal L[i][i].
-      fp.L_ids.insert(std::make_pair(i, i));
+      fp.L_ids_.insert(std::make_pair(i, i));
       touched.clear();
-      for (std::size_t k : fp.Acol[i])
+      for (std::size_t k : fp.Acol_[i])
+      {
         if (k > i)
+        {
           mark(k);
-      for (std::size_t j : Ucol[i])       // j < i, U[j][i] != 0
-        for (std::size_t k : fp.Lcol[j])  // k > j, L[k][j] != 0
+        }
+      }
+      for (std::size_t j : Ucol[i])  // j < i, U[j][i] != 0
+      {
+        for (std::size_t k : fp.Lcol_[j])  // k > j, L[k][j] != 0
+        {
           if (k > i)
+          {
             mark(k);
+          }
+        }
+      }
       std::sort(touched.begin(), touched.end());
       for (std::size_t k : touched)
       {
-        fp.L_ids.insert(std::make_pair(k, i));
-        fp.Lcol[i].push_back(k);
-        fp.Lrow[k].push_back(i);
+        fp.L_ids_.insert(std::make_pair(k, i));
+        fp.Lcol_[i].push_back(k);
+        fp.Lrow_[k].push_back(i);
         seen[k] = 0;
       }
     }
@@ -121,12 +141,12 @@ namespace micm
     // Build the (indexing-only) L and U matrices from the fill pattern so we can map
     // (row, column) positions to data-vector indices below.
     auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(matrix.NumberOfBlocks()).InitialValue(initial_value);
-    for (const auto& pair : fp.L_ids)
+    for (const auto& pair : fp.L_ids_)
     {
       L_builder = L_builder.WithElement(pair.first, pair.second);
     }
     auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(matrix.NumberOfBlocks()).InitialValue(initial_value);
-    for (const auto& pair : fp.U_ids)
+    for (const auto& pair : fp.U_ids_)
     {
       U_builder = U_builder.WithElement(pair.first, pair.second);
     }
@@ -141,20 +161,20 @@ namespace micm
     {
       std::pair<std::size_t, std::size_t> iLU(0, 0);
       // Upper triangular matrix: iterate only the non-zero columns of U row i.
-      for (std::size_t k : fp.Urow[i])
+      for (std::size_t k : fp.Urow_[i])
       {
         std::size_t nkj = 0;
         // j < i with L[i][j] != 0 and U[j][k] != 0, in ascending j order.
-        for (std::size_t j : fp.Lrow[i])
+        for (std::size_t j : fp.Lrow_[i])
         {
-          if (!contains(fp.Urow[j], k))
+          if (!contains(fp.Urow_[j], k))
           {
             continue;
           }
           ++nkj;
           lij_ujk_.push_back(std::make_pair(LU.first.VectorIndex(0, i, j), LU.second.VectorIndex(0, j, k)));
         }
-        if (contains(fp.Arow[i], k))
+        if (contains(fp.Arow_[i], k))
         {
           do_aik_.push_back(true);
           aik_.push_back(matrix.VectorIndex(0, i, k));
@@ -168,25 +188,25 @@ namespace micm
       }
       // Lower triangular matrix: iterate only the non-zero rows of L column i.
       lki_nkj_.push_back(std::make_pair(LU.first.VectorIndex(0, i, i), 0));
-      for (std::size_t k : fp.Lcol[i])
+      for (std::size_t k : fp.Lcol_[i])
       {
         std::size_t nkj = 0;
-        // j < i with L[k][j] != 0 and U[j][i] != 0, in ascending j order. Lrow[k] is
+        // j < i with L[k][j] != 0 and U[j][i] != 0, in ascending j order. Lrow_[k] is
         // sorted, so stop once j reaches i.
-        for (std::size_t j : fp.Lrow[k])
+        for (std::size_t j : fp.Lrow_[k])
         {
           if (j >= i)
           {
             break;
           }
-          if (!contains(fp.Urow[j], i))
+          if (!contains(fp.Urow_[j], i))
           {
             continue;
           }
           ++nkj;
           lkj_uji_.push_back(std::make_pair(LU.first.VectorIndex(0, k, j), LU.second.VectorIndex(0, j, i)));
         }
-        if (contains(fp.Acol[i], k))
+        if (contains(fp.Acol_[i], k))
         {
           do_aki_.push_back(true);
           aki_.push_back(matrix.VectorIndex(0, k, i));
@@ -214,12 +234,12 @@ namespace micm
     std::size_t n = A.NumRows();
     FillPattern fp = ComputeFillPattern(A);
     auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
-    for (const auto& pair : fp.L_ids)
+    for (const auto& pair : fp.L_ids_)
     {
       L_builder = L_builder.WithElement(pair.first, pair.second);
     }
     auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
-    for (const auto& pair : fp.U_ids)
+    for (const auto& pair : fp.U_ids_)
     {
       U_builder = U_builder.WithElement(pair.first, pair.second);
     }
@@ -337,17 +357,19 @@ namespace micm
           {
             const std::size_t lij_ujk_first = lij_ujk->first;
             const std::size_t lij_ujk_second = lij_ujk->second;
-            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            {
               U_vector[uik_nkj_first + i_cell] -= L_vector[lij_ujk_first + i_cell] * U_vector[lij_ujk_second + i_cell];
-}
+            }
             ++lij_ujk;
           }
           ++uik_nkj;
         }
         // Lower triangular matrix
-        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
+        for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+        {
           L_vector[lki_nkj->first + i_cell] = 1.0;
-}
+        }
         ++lki_nkj;
         for (std::size_t iL = 0; iL < inLU.first; ++iL)
         {
@@ -365,9 +387,10 @@ namespace micm
           {
             const std::size_t lkj_uji_first = lkj_uji->first;
             const std::size_t lkj_uji_second = lkj_uji->second;
-            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell) {
+            for (std::size_t i_cell = 0; i_cell < n_cells; ++i_cell)
+            {
               L_vector[lki_nkj_first + i_cell] -= L_vector[lkj_uji_first + i_cell] * U_vector[lkj_uji_second + i_cell];
-}
+            }
             ++lkj_uji;
           }
           const std::size_t uii_deref = *uii;

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -25,86 +25,175 @@ namespace micm
     return lu_decomp;
   }
 
+  template<class SparseMatrixPolicy>
+    requires(SparseMatrixConcept<SparseMatrixPolicy>)
+  inline LuDecompositionDoolittle::FillPattern LuDecompositionDoolittle::ComputeFillPattern(const SparseMatrixPolicy& A)
+  {
+    std::size_t n = A.NumRows();
+    FillPattern fp;
+    fp.Arow.assign(n, {});
+    fp.Acol.assign(n, {});
+    fp.Lrow.assign(n, {});
+    fp.Urow.assign(n, {});
+    fp.Lcol.assign(n, {});
+
+    // Non-zero structure of the (sparse) input matrix A. Its rows are short, so the
+    // O(n^2) IsZero scan here costs O(n * nnz(A)) -- negligible next to the dense
+    // O(n^3) loop this whole routine replaces.
+    for (std::size_t r = 0; r < n; ++r)
+    {
+      for (std::size_t c = 0; c < n; ++c)
+      {
+        if (!A.IsZero(r, c))
+        {
+          fp.Arow[r].push_back(c);
+          fp.Acol[c].push_back(r);
+        }
+      }
+    }
+
+    // Symbolic factorization processed one row at a time in increasing-i order. By
+    // the time row i is reached, L[i][.] (j<i), U[j][.] and L[.][j] (j<i) are known,
+    // so the fill of U row i and L column i is found by walking only the relevant
+    // non-zeros: U[i][k] fills iff A[i][k] != 0, k == i, or some j<i has L[i][j] and
+    // U[j][k]; L[k][i] fills iff A[k][i] != 0 or some j<i has L[k][j] and U[j][i].
+    std::vector<std::vector<std::size_t>> Ucol(n);  // Ucol[i] = rows j<i where U[j][i] != 0, ascending
+    std::vector<char> seen(n, 0);
+    std::vector<std::size_t> touched;
+    auto mark = [&](std::size_t k)
+    {
+      if (!seen[k])
+      {
+        seen[k] = 1;
+        touched.push_back(k);
+      }
+    };
+    for (std::size_t i = 0; i < n; ++i)
+    {
+      // Upper triangular matrix: columns k >= i that are non-zero in U row i.
+      touched.clear();
+      mark(i);  // unit/diagonal entry U[i][i]
+      for (std::size_t k : fp.Arow[i])
+        if (k >= i)
+          mark(k);
+      for (std::size_t j : fp.Lrow[i])    // j < i, L[i][j] != 0
+        for (std::size_t k : fp.Urow[j])  // k >= j, U[j][k] != 0
+          if (k >= i)
+            mark(k);
+      std::sort(touched.begin(), touched.end());
+      for (std::size_t k : touched)
+      {
+        fp.U_ids.insert(std::make_pair(i, k));
+        fp.Urow[i].push_back(k);
+        Ucol[k].push_back(i);
+        seen[k] = 0;
+      }
+
+      // Lower triangular matrix: rows k > i non-zero in L column i, plus the unit
+      // diagonal L[i][i].
+      fp.L_ids.insert(std::make_pair(i, i));
+      touched.clear();
+      for (std::size_t k : fp.Acol[i])
+        if (k > i)
+          mark(k);
+      for (std::size_t j : Ucol[i])       // j < i, U[j][i] != 0
+        for (std::size_t k : fp.Lcol[j])  // k > j, L[k][j] != 0
+          if (k > i)
+            mark(k);
+      std::sort(touched.begin(), touched.end());
+      for (std::size_t k : touched)
+      {
+        fp.L_ids.insert(std::make_pair(k, i));
+        fp.Lcol[i].push_back(k);
+        fp.Lrow[k].push_back(i);
+        seen[k] = 0;
+      }
+    }
+    return fp;
+  }
+
   template<class SparseMatrixPolicy, class LMatrixPolicy, class UMatrixPolicy>
     requires(SparseMatrixConcept<SparseMatrixPolicy>)
   inline void LuDecompositionDoolittle::Initialize(const SparseMatrixPolicy& matrix, auto initial_value)
   {
     std::size_t n = matrix.NumRows();
-    auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, true);
-    // O(1) membership bitmaps so the O(n^3) index-building loops below avoid a
-    // per-probe IsZero() linear row scan. Built once from the (sparse) patterns of
-    // A, L and U; the one-time O(n^2) scan is negligible next to the loops it feeds.
-    std::vector<char> in_A(n * n, 0), in_L(n * n, 0), in_U(n * n, 0);
-    for (std::size_t r = 0; r < n; ++r)
+    FillPattern fp = ComputeFillPattern(matrix);
+    // Build the (indexing-only) L and U matrices from the fill pattern so we can map
+    // (row, column) positions to data-vector indices below.
+    auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(matrix.NumberOfBlocks()).InitialValue(initial_value);
+    for (const auto& pair : fp.L_ids)
     {
-      for (std::size_t c = 0; c < n; ++c)
-      {
-        if (!matrix.IsZero(r, c))
-          in_A[r * n + c] = 1;
-        if (!LU.first.IsZero(r, c))
-          in_L[r * n + c] = 1;
-        if (!LU.second.IsZero(r, c))
-          in_U[r * n + c] = 1;
-      }
+      L_builder = L_builder.WithElement(pair.first, pair.second);
     }
-    for (std::size_t i = 0; i < matrix.NumRows(); ++i)
+    auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(matrix.NumberOfBlocks()).InitialValue(initial_value);
+    for (const auto& pair : fp.U_ids)
+    {
+      U_builder = U_builder.WithElement(pair.first, pair.second);
+    }
+    std::pair<LMatrixPolicy, UMatrixPolicy> LU(LMatrixPolicy(L_builder, true), UMatrixPolicy(U_builder, true));
+
+    // O(1)-amortized membership on the sorted adjacency rows; bounded by the
+    // factorization's own operation count (times a log factor) rather than O(n^3).
+    auto contains = [](const std::vector<std::size_t>& v, std::size_t x)
+    { return std::binary_search(v.begin(), v.end(), x); };
+
+    for (std::size_t i = 0; i < n; ++i)
     {
       std::pair<std::size_t, std::size_t> iLU(0, 0);
-      // Upper triangular matrix
-      for (std::size_t k = i; k < n; ++k)
+      // Upper triangular matrix: iterate only the non-zero columns of U row i.
+      for (std::size_t k : fp.Urow[i])
       {
         std::size_t nkj = 0;
-        for (std::size_t j = 0; j < i; ++j)
+        // j < i with L[i][j] != 0 and U[j][k] != 0, in ascending j order.
+        for (std::size_t j : fp.Lrow[i])
         {
-          if (!in_L[i * n + j] || !in_U[j * n + k])
+          if (!contains(fp.Urow[j], k))
           {
             continue;
           }
           ++nkj;
           lij_ujk_.push_back(std::make_pair(LU.first.VectorIndex(0, i, j), LU.second.VectorIndex(0, j, k)));
         }
-        if (!in_A[i * n + k])
-        {
-          if (nkj == 0 && k != i)
-          {
-            continue;
-          }
-          do_aik_.push_back(false);
-        }
-        else
+        if (contains(fp.Arow[i], k))
         {
           do_aik_.push_back(true);
           aik_.push_back(matrix.VectorIndex(0, i, k));
         }
+        else
+        {
+          do_aik_.push_back(false);
+        }
         uik_nkj_.push_back(std::make_pair(LU.second.VectorIndex(0, i, k), nkj));
         ++(iLU.second);
       }
-      // Lower triangular matrix
+      // Lower triangular matrix: iterate only the non-zero rows of L column i.
       lki_nkj_.push_back(std::make_pair(LU.first.VectorIndex(0, i, i), 0));
-      for (std::size_t k = i + 1; k < n; ++k)
+      for (std::size_t k : fp.Lcol[i])
       {
         std::size_t nkj = 0;
-        for (std::size_t j = 0; j < i; ++j)
+        // j < i with L[k][j] != 0 and U[j][i] != 0, in ascending j order. Lrow[k] is
+        // sorted, so stop once j reaches i.
+        for (std::size_t j : fp.Lrow[k])
         {
-          if (!in_L[k * n + j] || !in_U[j * n + i])
+          if (j >= i)
+          {
+            break;
+          }
+          if (!contains(fp.Urow[j], i))
           {
             continue;
           }
           ++nkj;
           lkj_uji_.push_back(std::make_pair(LU.first.VectorIndex(0, k, j), LU.second.VectorIndex(0, j, i)));
         }
-        if (!in_A[k * n + i])
-        {
-          if (nkj == 0)
-          {
-            continue;
-          }
-          do_aki_.push_back(false);
-        }
-        else
+        if (contains(fp.Acol[i], k))
         {
           do_aki_.push_back(true);
           aki_.push_back(matrix.VectorIndex(0, k, i));
+        }
+        else
+        {
+          do_aki_.push_back(false);
         }
         uii_.push_back(LU.second.VectorIndex(0, i, i));
         lki_nkj_.push_back(std::make_pair(LU.first.VectorIndex(0, k, i), nkj));
@@ -123,66 +212,14 @@ namespace micm
       bool indexing_only)
   {
     std::size_t n = A.NumRows();
-    std::set<std::pair<std::size_t, std::size_t>> L_ids, U_ids;
-    // Dense membership bitmaps give O(1) lookups in the inner fill loops below;
-    // std::set::find is O(log) and is called up to O(n^3) times. The sets are kept
-    // for their sorted iteration when the L and U matrices are built. Memory is
-    // O(n^2) bytes, which is negligible compared to the factorization itself.
-    std::vector<char> in_L(n * n, 0), in_U(n * n, 0);
-    auto add_L = [&](std::size_t r, std::size_t c)
-    {
-      L_ids.insert(std::make_pair(r, c));
-      in_L[r * n + c] = 1;
-    };
-    auto add_U = [&](std::size_t r, std::size_t c)
-    {
-      U_ids.insert(std::make_pair(r, c));
-      in_U[r * n + c] = 1;
-    };
-    for (std::size_t i = 0; i < n; ++i)
-    {
-      // Upper triangular matrix
-      for (std::size_t k = i; k < n; ++k)
-      {
-        if (!A.IsZero(i, k) || k == i)
-        {
-          add_U(i, k);
-          continue;
-        }
-        for (std::size_t j = 0; j < i; ++j)
-        {
-          if (in_L[i * n + j] && in_U[j * n + k])
-          {
-            add_U(i, k);
-            break;
-          }
-        }
-      }
-      // Lower triangular matrix
-      for (std::size_t k = i; k < n; ++k)
-      {
-        if (!A.IsZero(k, i) || k == i)
-        {
-          add_L(k, i);
-          continue;
-        }
-        for (std::size_t j = 0; j < i; ++j)
-        {
-          if (in_L[k * n + j] && in_U[j * n + i])
-          {
-            add_L(k, i);
-            break;
-          }
-        }
-      }
-    }
+    FillPattern fp = ComputeFillPattern(A);
     auto L_builder = LMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
-    for (const auto& pair : L_ids)
+    for (const auto& pair : fp.L_ids)
     {
       L_builder = L_builder.WithElement(pair.first, pair.second);
     }
     auto U_builder = UMatrixPolicy::Create(n).SetNumberOfBlocks(A.NumberOfBlocks()).InitialValue(initial_value);
-    for (const auto& pair : U_ids)
+    for (const auto& pair : fp.U_ids)
     {
       U_builder = U_builder.WithElement(pair.first, pair.second);
     }

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -31,6 +31,22 @@ namespace micm
   {
     std::size_t n = matrix.NumRows();
     auto LU = GetLUMatrices<SparseMatrixPolicy, LMatrixPolicy, UMatrixPolicy>(matrix, initial_value, true);
+    // O(1) membership bitmaps so the O(n^3) index-building loops below avoid a
+    // per-probe IsZero() linear row scan. Built once from the (sparse) patterns of
+    // A, L and U; the one-time O(n^2) scan is negligible next to the loops it feeds.
+    std::vector<char> in_A(n * n, 0), in_L(n * n, 0), in_U(n * n, 0);
+    for (std::size_t r = 0; r < n; ++r)
+    {
+      for (std::size_t c = 0; c < n; ++c)
+      {
+        if (!matrix.IsZero(r, c))
+          in_A[r * n + c] = 1;
+        if (!LU.first.IsZero(r, c))
+          in_L[r * n + c] = 1;
+        if (!LU.second.IsZero(r, c))
+          in_U[r * n + c] = 1;
+      }
+    }
     for (std::size_t i = 0; i < matrix.NumRows(); ++i)
     {
       std::pair<std::size_t, std::size_t> iLU(0, 0);
@@ -40,14 +56,14 @@ namespace micm
         std::size_t nkj = 0;
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (LU.first.IsZero(i, j) || LU.second.IsZero(j, k))
+          if (!in_L[i * n + j] || !in_U[j * n + k])
           {
             continue;
           }
           ++nkj;
           lij_ujk_.push_back(std::make_pair(LU.first.VectorIndex(0, i, j), LU.second.VectorIndex(0, j, k)));
         }
-        if (matrix.IsZero(i, k))
+        if (!in_A[i * n + k])
         {
           if (nkj == 0 && k != i)
           {
@@ -70,14 +86,14 @@ namespace micm
         std::size_t nkj = 0;
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (LU.first.IsZero(k, j) || LU.second.IsZero(j, i))
+          if (!in_L[k * n + j] || !in_U[j * n + i])
           {
             continue;
           }
           ++nkj;
           lkj_uji_.push_back(std::make_pair(LU.first.VectorIndex(0, k, j), LU.second.VectorIndex(0, j, i)));
         }
-        if (matrix.IsZero(k, i))
+        if (!in_A[k * n + i])
         {
           if (nkj == 0)
           {
@@ -108,6 +124,21 @@ namespace micm
   {
     std::size_t n = A.NumRows();
     std::set<std::pair<std::size_t, std::size_t>> L_ids, U_ids;
+    // Dense membership bitmaps give O(1) lookups in the inner fill loops below;
+    // std::set::find is O(log) and is called up to O(n^3) times. The sets are kept
+    // for their sorted iteration when the L and U matrices are built. Memory is
+    // O(n^2) bytes, which is negligible compared to the factorization itself.
+    std::vector<char> in_L(n * n, 0), in_U(n * n, 0);
+    auto add_L = [&](std::size_t r, std::size_t c)
+    {
+      L_ids.insert(std::make_pair(r, c));
+      in_L[r * n + c] = 1;
+    };
+    auto add_U = [&](std::size_t r, std::size_t c)
+    {
+      U_ids.insert(std::make_pair(r, c));
+      in_U[r * n + c] = 1;
+    };
     for (std::size_t i = 0; i < n; ++i)
     {
       // Upper triangular matrix
@@ -115,14 +146,14 @@ namespace micm
       {
         if (!A.IsZero(i, k) || k == i)
         {
-          U_ids.insert(std::make_pair(i, k));
+          add_U(i, k);
           continue;
         }
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (L_ids.find(std::make_pair(i, j)) != L_ids.end() && U_ids.find(std::make_pair(j, k)) != U_ids.end())
+          if (in_L[i * n + j] && in_U[j * n + k])
           {
-            U_ids.insert(std::make_pair(i, k));
+            add_U(i, k);
             break;
           }
         }
@@ -132,14 +163,14 @@ namespace micm
       {
         if (!A.IsZero(k, i) || k == i)
         {
-          L_ids.insert(std::make_pair(k, i));
+          add_L(k, i);
           continue;
         }
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (L_ids.find(std::make_pair(k, j)) != L_ids.end() && U_ids.find(std::make_pair(j, i)) != U_ids.end())
+          if (in_L[k * n + j] && in_U[j * n + i])
           {
-            L_ids.insert(std::make_pair(k, i));
+            add_L(k, i);
             break;
           }
         }


### PR DESCRIPTION
After creating the [gecko converstion tool](https://github.com/NCAR/music-box/pull/481), I was able to attempt to run some gecko mechanisms in music box. 

However, the largest one has ~44000 reactions and ~8500 species. On initialization, MICM was attempting to allocate > 130 GB on my computer (probably more, I killed the job when it got that large). After fixing the memory ballooning, we were at < 1GB of memory to startup, but taking > 20 minutes to initialize the LU decomposition data (again, killed after 20 minutes). This is because the `IsZero` function in our sparse matrix has to do a linear scan.

This PR
- reduce memory usage by not copying every species onto every reaction
- prebuilds a cache of which elements are zero or not in the sparse matrices so that runtime is reduced in the LU deomposition using the new `FillPattern` struct
- refactor the diangonal markowitz ordering to work on sparse matrices rather than dense matrices by representing the matrix as an adjacency graph