### PR TITLE
Update MICM version in preparation for release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -23,8 +23,6 @@ assignees: ''
   cmake -B build -S .
   ```
   This forces CMake to write the correct version file into the include directory.
-- [ ] Open `docs/sources/_static/switcher.json`
-  - The first object points to the stable version — update its `name` to the new version number
 - [ ] Update the version number in `CITATION.cff`
 - [ ] On GitHub, merge `main` into `release` — **do NOT squash and merge**
   - Alternatively, merge locally and push: `git checkout release && git merge main && git push`

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '26.0'
 
       - name: Run Cmake 
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4'
+          xcode-version: latest-stable
 
       - name: Run Cmake 
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: If you use this software, please cite it as below.
 title: Model Independent Chemistry Module (MICM)
-version: v3.12.0
+version: v3.13.0
 doi: "10.5281/zenodo.10472189"
 authors:
   - family-names: Dawson

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 # project and version must be on the same line so that the docs can extract it
-project(micm VERSION 3.12.0 LANGUAGES CXX)
+project(micm VERSION 3.13.0 LANGUAGES CXX)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ int main(const int argc, const char *argv[])
 
 To build and run the example using GNU (assuming the default install location):
 ```
-g++ -o foo_chem foo_chem.cpp -I/usr/local/micm-3.12.0/include -std=c++20
+g++ -o foo_chem foo_chem.cpp -I/usr/local/micm-3.13.0/include -std=c++20
 ./foo_chem
 ```
 

--- a/include/micm/version.hpp
+++ b/include/micm/version.hpp
@@ -10,7 +10,7 @@ extern "C" {
 
   inline const char* GetMicmVersion()
   {
-    return "3.12.0";
+    return "3.13.0";
   }
   inline unsigned GetMicmVersionMajor()
   {
@@ -18,7 +18,7 @@ extern "C" {
   }
   inline unsigned GetMicmVersionMinor()
   {
-    return 12+0;
+    return 13+0;
   }
   inline unsigned GetMicmVersionPatch()
   {


### PR DESCRIPTION
- Update MICM version in preparation for release
- Remove an action item from the release issue template that is no longer applicable 
- Related issue: #1020 