### PR TITLE
Clang tidy performance

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -62,6 +62,7 @@ Checks: |
   readability-redundant-inline-specifier,
   readability-qualified-auto,
   performance-unnecessary-value-param,
+  performance-noexcept-move-constructor,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -43,8 +43,7 @@ jobs:
     strategy:
       matrix:
         compiler:
-          - { cpp: g++-14, c: gcc-14}
-          - { cpp: g++-13, c: gcc-13}
+          - { cpp: g++-15, c: gcc-15}
           - { cpp: clang++, c: clang}
         build_type: [Release]
     env:

--- a/include/micm/cuda/process/cuda_process_set.hpp
+++ b/include/micm/cuda/process/cuda_process_set.hpp
@@ -32,13 +32,13 @@ namespace micm
 
     CudaProcessSet(const CudaProcessSet&) = delete;
     CudaProcessSet& operator=(const CudaProcessSet&) = delete;
-    CudaProcessSet(CudaProcessSet&& other)
+    CudaProcessSet(CudaProcessSet&& other) noexcept
         : ProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>(std::move(other)),
           cuda_rate_store_(std::move(other.cuda_rate_store_))
     {
       std::swap(this->devstruct_, other.devstruct_);
     };
-    CudaProcessSet& operator=(CudaProcessSet&& other)
+    CudaProcessSet& operator=(CudaProcessSet&& other) noexcept
     {
       ProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>::operator=(std::move(other));
       std::swap(this->devstruct_, other.devstruct_);

--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
@@ -23,13 +23,13 @@ namespace micm
 
     CudaLinearSolverInPlace(const CudaLinearSolverInPlace&) = delete;
     CudaLinearSolverInPlace& operator=(const CudaLinearSolverInPlace&) = delete;
-    CudaLinearSolverInPlace(CudaLinearSolverInPlace&& other)
+    CudaLinearSolverInPlace(CudaLinearSolverInPlace&& other) noexcept
         : LinearSolverInPlace<SparseMatrixPolicy, LuDecompositionPolicy>(std::move(other))
     {
       std::swap(this->devstruct_, other.devstruct_);
     };
 
-    CudaLinearSolverInPlace& operator=(CudaLinearSolverInPlace&& other)
+    CudaLinearSolverInPlace& operator=(CudaLinearSolverInPlace&& other) noexcept
     {
       LinearSolverInPlace<SparseMatrixPolicy, LuDecompositionPolicy>::operator=(std::move(other));
       std::swap(this->devstruct_, other.devstruct_);

--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
@@ -22,13 +22,13 @@ namespace micm
 
     CudaLuDecompositionMozartInPlace(const CudaLuDecompositionMozartInPlace&) = delete;
     CudaLuDecompositionMozartInPlace& operator=(const CudaLuDecompositionMozartInPlace&) = delete;
-    CudaLuDecompositionMozartInPlace(CudaLuDecompositionMozartInPlace&& other)
+    CudaLuDecompositionMozartInPlace(CudaLuDecompositionMozartInPlace&& other) noexcept
         : LuDecompositionMozartInPlace(std::move(other))
     {
       std::swap(this->devstruct_, other.devstruct_);
     };
 
-    CudaLuDecompositionMozartInPlace& operator=(CudaLuDecompositionMozartInPlace&& other)
+    CudaLuDecompositionMozartInPlace& operator=(CudaLuDecompositionMozartInPlace&& other) noexcept
     {
       LuDecompositionMozartInPlace::operator=(std::move(other));
       std::swap(this->devstruct_, other.devstruct_);

--- a/include/micm/cuda/solver/cuda_rosenbrock.hpp
+++ b/include/micm/cuda/solver/cuda_rosenbrock.hpp
@@ -28,14 +28,14 @@ namespace micm
 
     CudaRosenbrockSolver(const CudaRosenbrockSolver&) = delete;
     CudaRosenbrockSolver& operator=(const CudaRosenbrockSolver&) = delete;
-    CudaRosenbrockSolver(CudaRosenbrockSolver&& other)
+    CudaRosenbrockSolver(CudaRosenbrockSolver&& other) noexcept
         : AbstractRosenbrockSolver<
               RatesPolicy,
               LinearSolverPolicy,
               ConstraintSetPolicy,
               CudaRosenbrockSolver<RatesPolicy, LinearSolverPolicy, ConstraintSetPolicy>>(std::move(other)){};
 
-    CudaRosenbrockSolver& operator=(CudaRosenbrockSolver&& other)
+    CudaRosenbrockSolver& operator=(CudaRosenbrockSolver&& other) noexcept
     {
       RosenbrockSolver<RatesPolicy, LinearSolverPolicy, ConstraintSetPolicy>::operator=(std::move(other));
       return *this;

--- a/include/micm/cuda/solver/cuda_state.hpp
+++ b/include/micm/cuda/solver/cuda_state.hpp
@@ -75,7 +75,7 @@ namespace micm
     };
 
     /// @brief Move constructor
-    CudaState(CudaState&& other)
+    CudaState(CudaState&& other) noexcept
         : State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy>(std::move(other))
     {
       absolute_tolerance_param_ = other.absolute_tolerance_param_;
@@ -87,7 +87,7 @@ namespace micm
     }
 
     /// @brief Move assignment operator
-    CudaState& operator=(CudaState&& other)
+    CudaState& operator=(CudaState&& other) noexcept
     {
       if (this != &other)
       {

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -98,7 +98,7 @@ namespace micm
       }
     }
 
-    Solver(Solver&& other)
+    Solver(Solver&& other) noexcept         
         : solver_(std::move(other.solver_)),
           processes_(std::move(other.processes_)),
           state_parameters_(other.state_parameters_),
@@ -112,7 +112,7 @@ namespace micm
 
     Solver& operator=(const Solver&) = delete;
 
-    Solver& operator=(Solver&& other)
+    Solver& operator=(Solver&& other) noexcept     
     {
       std::swap(this->solver_, other.solver_);
       state_parameters_ = other.state_parameters_;

--- a/test/integration/analytical_policy.hpp
+++ b/test/integration/analytical_policy.hpp
@@ -135,9 +135,9 @@ void TestSimpleSystem(
     double absolute_tolerances,
     const std::function<double(double temperature, double pressure, double air_density)>& calculate_k1,
     const std::function<double(double temperature, double pressure, double air_density)>& calculate_k2,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve,
-    std::unordered_map<std::string, std::vector<double>> custom_parameters = {})
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve,
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve,
+    const std::unordered_map<std::string, std::vector<double>>& custom_parameters = {})
 {
   auto solver = builder.Build();
 
@@ -252,9 +252,9 @@ void TestSimpleStiffSystem(
     double absolute_tolerances,
     const std::function<double(double temperature, double pressure, double air_density)>& calculate_k1,
     const std::function<double(double temperature, double pressure, double air_density)>& calculate_k2,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve,
-    std::unordered_map<std::string, std::vector<double>> custom_parameters = {})
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve,
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve,
+    const std::unordered_map<std::string, std::vector<double>>& custom_parameters = {})
 {
   auto solver = builder.Build();
 
@@ -368,9 +368,9 @@ template<class BuilderPolicy>
 void TestAnalyticalTroe(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-10,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -438,9 +438,9 @@ template<class BuilderPolicy>
 void TestAnalyticalStiffTroe(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-5,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -532,9 +532,9 @@ template<class BuilderPolicy>
 void TestAnalyticalPhotolysis(
     BuilderPolicy builder,
     double absolute_tolerances = 2e-6,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -594,9 +594,9 @@ template<class BuilderPolicy>
 void TestAnalyticalStiffPhotolysis(
     BuilderPolicy builder,
     double absolute_tolerances = 2e-5,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -682,9 +682,9 @@ template<class BuilderPolicy>
 void TestAnalyticalTernaryChemicalActivation(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-08,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -754,9 +754,9 @@ template<class BuilderPolicy>
 void TestAnalyticalStiffTernaryChemicalActivation(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-6,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -850,9 +850,9 @@ template<class BuilderPolicy>
 void TestAnalyticalTunneling(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-8,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -910,9 +910,9 @@ template<class BuilderPolicy>
 void TestAnalyticalStiffTunneling(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-6,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -993,9 +993,9 @@ template<class BuilderPolicy>
 void TestAnalyticalArrhenius(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-9,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -1052,9 +1052,9 @@ template<class BuilderPolicy>
 void TestAnalyticalStiffArrhenius(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-6,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -1136,9 +1136,9 @@ template<class BuilderPolicy>
 void TestAnalyticalBranched(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-13,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -1223,9 +1223,9 @@ template<class BuilderPolicy>
 void TestAnalyticalStiffBranched(
     BuilderPolicy builder,
     double absolute_tolerances = 1e-6,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -1339,9 +1339,9 @@ template<class BuilderPolicy>
 void TestAnalyticalRobertson(
     BuilderPolicy builder,
     double relative_tolerance = 1e-8,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -1490,9 +1490,9 @@ template<class BuilderPolicy>
 void TestAnalyticalOregonator(
     BuilderPolicy builder,
     double relative_tolerance = 1e-4,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -1695,9 +1695,9 @@ template<class BuilderPolicy>
 void TestAnalyticalHires(
     BuilderPolicy builder,
     double absolute_tolerance = 1e-8,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*
@@ -1902,9 +1902,9 @@ template<class BuilderPolicy>
 void TestAnalyticalE5(
     BuilderPolicy builder,
     double relative_tolerance = 1e-8,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*

--- a/test/integration/analytical_surface_rxn_policy.hpp
+++ b/test/integration/analytical_surface_rxn_policy.hpp
@@ -10,9 +10,9 @@ template<class BuilderPolicy>
 void TestAnalyticalSurfaceRxn(
     BuilderPolicy& builder,
     double tolerance = 1e-8,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   // parameters, from CAMP/test/unit_rxn_data/test_rxn_surface.F90

--- a/test/regression/regression_policy.hpp
+++ b/test/regression/regression_policy.hpp
@@ -105,9 +105,9 @@ template<class BuilderPolicy>
 void TestFlowTube(
     BuilderPolicy builder,
     const std::string& expected_results_path,
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> prepare_for_solve =
+    const const std::function<void(typename BuilderPolicy::StatePolicyType&)>&& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    std::function<void(typename BuilderPolicy::StatePolicyType&)> postpare_for_solve =
+    const const std::function<void(typename BuilderPolicy::StatePolicyType&)>&& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*

--- a/test/regression/regression_policy.hpp
+++ b/test/regression/regression_policy.hpp
@@ -105,9 +105,9 @@ template<class BuilderPolicy>
 void TestFlowTube(
     BuilderPolicy builder,
     const std::string& expected_results_path,
-    const const std::function<void(typename BuilderPolicy::StatePolicyType&)>&& prepare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& prepare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {},
-    const const std::function<void(typename BuilderPolicy::StatePolicyType&)>&& postpare_for_solve =
+    const std::function<void(typename BuilderPolicy::StatePolicyType&)>& postpare_for_solve =
         [](typename BuilderPolicy::StatePolicyType& state) {})
 {
   /*

--- a/test/unit/solver/test_linear_solver_in_place_policy.hpp
+++ b/test/unit/solver/test_linear_solver_in_place_policy.hpp
@@ -9,10 +9,10 @@
 
 template<typename T, class MatrixPolicy, class SparseMatrixPolicy>
 void CheckResults(
-    const SparseMatrixPolicy A,
-    const MatrixPolicy b,
-    const MatrixPolicy x,
-    const std::function<void(const T, const T)> f)
+    const SparseMatrixPolicy& A,
+    const MatrixPolicy& b,
+    const MatrixPolicy& x,
+    const std::function<void(const T, const T)>& f)
 {
   T result;
   EXPECT_EQ(A.NumberOfBlocks(), b.NumRows());

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -46,7 +46,7 @@ void CheckResults(
     const SparseMatrixPolicy A,
     const MatrixPolicy b,
     const MatrixPolicy x,
-    const std::function<void(const T, const T)> f)
+    const std::function<void(const T, const T)>& f)
 {
   T result;
   EXPECT_EQ(A.NumberOfBlocks(), b.NumRows());

--- a/test/unit/solver/test_linear_solver_policy.hpp
+++ b/test/unit/solver/test_linear_solver_policy.hpp
@@ -43,9 +43,9 @@ void CopyToHostDense(MatrixPolicy& matrix)
 
 template<typename T, class MatrixPolicy, class SparseMatrixPolicy>
 void CheckResults(
-    const SparseMatrixPolicy A,
-    const MatrixPolicy b,
-    const MatrixPolicy x,
+    const SparseMatrixPolicy& A,
+    const MatrixPolicy& b,
+    const MatrixPolicy& x,
     const std::function<void(const T, const T)>& f)
 {
   T result;

--- a/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_in_place_policy.hpp
@@ -8,7 +8,7 @@
 #include <random>
 
 template<typename T, class SparseMatrixPolicy>
-void CheckResults(const SparseMatrixPolicy& A, const SparseMatrixPolicy& LU, const std::function<void(const T, const T)> f)
+void CheckResults(const SparseMatrixPolicy& A, const SparseMatrixPolicy& LU, const std::function<void(const T, const T)>& f)
 {
   EXPECT_EQ(A.NumberOfBlocks(), LU.NumberOfBlocks());
   for (std::size_t i_block = 0; i_block < A.NumberOfBlocks(); ++i_block)

--- a/test/unit/solver/test_lu_decomposition_policy.hpp
+++ b/test/unit/solver/test_lu_decomposition_policy.hpp
@@ -12,7 +12,7 @@ void CheckResults(
     const SparseMatrixPolicy& A,
     const SparseMatrixPolicy& L,
     const SparseMatrixPolicy& U,
-    const std::function<void(const T, const T)> f)
+    const std::function<void(const T, const T)>& f)
 {
   EXPECT_EQ(A.NumberOfBlocks(), L.NumberOfBlocks());
   EXPECT_EQ(A.NumberOfBlocks(), U.NumberOfBlocks());


### PR DESCRIPTION
Checks for constructors/functions without the ability to take advantage of rvalue references (moved values)

Happily, we were only missing them in tests!

Partially addresses #997

Ran
```
cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \                               
      -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
      -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang

  run-clang-tidy -p build -fix \
      '/Users/kshores/Documents/micm/(include|src|test)'
```