### PR TITLE
Clang tidy: equals default, pass-by-value for move semantics

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -65,6 +65,7 @@ Checks: |
   performance-noexcept-move-constructor,
   clang-diagnostic-error,
   modernize-use-equals-default,
+  modernize-pass-by-value,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -63,6 +63,8 @@ Checks: |
   readability-qualified-auto,
   performance-unnecessary-value-param,
   performance-noexcept-move-constructor,
+  clang-diagnostic-error,
+  modernize-use-equals-default,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/include/micm/constraint/types/linear_constraint.hpp
+++ b/include/micm/constraint/types/linear_constraint.hpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <string>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 namespace micm
@@ -51,11 +52,11 @@ namespace micm
     /// @param terms Vector of StoichSpecies (species, coefficient) in the linear sum
     /// @param constant The value that sum(coeff[i] * [species[i]]) should equal
     LinearConstraint(
-        const std::string& name,
+        std::string  name,
         const Species& algebraic_species,
         const std::vector<StoichSpecies>& terms,
         double constant)
-        : name_(name),
+        : name_(std::move(name)),
           algebraic_species_(algebraic_species),
           terms_(terms),
           constant_(constant)

--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
@@ -19,7 +19,7 @@ namespace micm
     LinearSolverInPlaceParam devstruct_;
 
     /// This is the default constructor, taking no arguments;
-    CudaLinearSolverInPlace(){};
+    CudaLinearSolverInPlace() = default;
 
     CudaLinearSolverInPlace(const CudaLinearSolverInPlace&) = delete;
     CudaLinearSolverInPlace& operator=(const CudaLinearSolverInPlace&) = delete;

--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
@@ -18,7 +18,7 @@ namespace micm
     LuDecomposeMozartInPlaceParam devstruct_;
 
     /// This is the default constructor, taking no arguments;
-    CudaLuDecompositionMozartInPlace(){};
+    CudaLuDecompositionMozartInPlace() = default;
 
     CudaLuDecompositionMozartInPlace(const CudaLuDecompositionMozartInPlace&) = delete;
     CudaLuDecompositionMozartInPlace& operator=(const CudaLuDecompositionMozartInPlace&) = delete;

--- a/include/micm/cuda/solver/cuda_rosenbrock.hpp
+++ b/include/micm/cuda/solver/cuda_rosenbrock.hpp
@@ -42,7 +42,7 @@ namespace micm
     };
 
     /// @brief Default constructor
-    CudaRosenbrockSolver(){};
+    CudaRosenbrockSolver() = default;
 
     /// @brief Builds a CUDA Rosenbrock solver for the given system and solver parameters
     /// @param linear_solver Linear solver
@@ -60,7 +60,7 @@ namespace micm
 
     /// This is the destructor that will free the device memory of
     ///   the constant data from the class "CudaRosenbrockSolver"
-    ~CudaRosenbrockSolver(){};
+    ~CudaRosenbrockSolver() = default;
 
     /// @brief Computes [alpha * I - jacobian] on the GPU
     /// @tparam SparseMatrixPolicy

--- a/include/micm/process/chemical_reaction.hpp
+++ b/include/micm/process/chemical_reaction.hpp
@@ -16,6 +16,7 @@
 #include <micm/system/species.hpp>
 #include <micm/system/stoich_species.hpp>
 
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -56,11 +57,11 @@ namespace micm
         std::vector<Species> reactants,
         std::vector<StoichSpecies> products,
         RateConstantVariant rate_constant,
-        const Phase& phase)
+        Phase  phase)
         : reactants_(std::move(reactants)),
           products_(std::move(products)),
           rate_constant_(std::move(rate_constant)),
-          phase_(phase)
+          phase_(std::move(phase))
     {
     }
   };

--- a/include/micm/solver/linear_solver.hpp
+++ b/include/micm/solver/linear_solver.hpp
@@ -76,7 +76,7 @@ namespace micm
 
    public:
     /// @brief default constructor
-    LinearSolver(){};
+    LinearSolver()= default;
 
     LinearSolver(const LinearSolver&) = delete;
     LinearSolver& operator=(const LinearSolver&) = delete;

--- a/include/micm/solver/linear_solver_in_place.hpp
+++ b/include/micm/solver/linear_solver_in_place.hpp
@@ -45,7 +45,7 @@ namespace micm
 
    public:
     /// @brief default constructor
-    LinearSolverInPlace(){};
+    LinearSolverInPlace()= default;
 
     LinearSolverInPlace(const LinearSolverInPlace&) = delete;
     LinearSolverInPlace& operator=(const LinearSolverInPlace&) = delete;

--- a/include/micm/solver/lu_decomposition_doolittle.inl
+++ b/include/micm/solver/lu_decomposition_doolittle.inl
@@ -5,8 +5,7 @@ namespace micm
 {
 
   inline LuDecompositionDoolittle::LuDecompositionDoolittle()
-  {
-  }
+  = default;
 
   template<class SparseMatrixPolicy, class LMatrixPolicy, class UMatrixPolicy>
     requires(SparseMatrixConcept<SparseMatrixPolicy>)

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -5,8 +5,7 @@ namespace micm
 {
 
   inline LuDecompositionDoolittleInPlace::LuDecompositionDoolittleInPlace()
-  {
-  }
+  = default;
 
   template<class SparseMatrixPolicy>
     requires(SparseMatrixConcept<SparseMatrixPolicy>)

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -5,8 +5,7 @@ namespace micm
 {
 
   inline LuDecompositionMozart::LuDecompositionMozart()
-  {
-  }
+  = default;
 
   template<class SparseMatrixPolicy, class LMatrixPolicy, class UMatrixPolicy>
     requires(SparseMatrixConcept<SparseMatrixPolicy>)

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -5,8 +5,7 @@ namespace micm
 {
 
   inline LuDecompositionMozartInPlace::LuDecompositionMozartInPlace()
-  {
-  }
+  = default;
 
   template<class SparseMatrixPolicy>
     requires(SparseMatrixConcept<SparseMatrixPolicy>)

--- a/include/micm/system/phase.hpp
+++ b/include/micm/system/phase.hpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <optional>
+#include <utility>
 #include <vector>
 
 namespace micm
@@ -67,8 +68,8 @@ namespace micm
     Phase& operator=(Phase&&) noexcept = default;
 
     /// @brief Create a phase with a name and a set of species
-    Phase(const std::string& name, const std::vector<PhaseSpecies>& phase_species)
-        : name_(name),
+    Phase(std::string  name, const std::vector<PhaseSpecies>& phase_species)
+        : name_(std::move(name)),
           phase_species_(phase_species)
     {
     }

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -89,12 +89,8 @@ namespace micm
   }
 
   inline Species::Species(const Species& other)
-      : name_(other.name_),
-        properties_string_(other.properties_string_),
-        properties_double_(other.properties_double_),
-        properties_int_(other.properties_int_),
-        properties_bool_(other.properties_bool_),
-        parameterize_(other.parameterize_){};
+      
+        = default;
 
   inline Species::Species(const std::string& name)
       : name_(name){};

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -10,6 +10,7 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace micm
@@ -47,12 +48,12 @@ namespace micm
 
     /// @brief Construct a species by name only
     /// @param name The name of the species
-    Species(const std::string& name);
+    Species(std::string  name);
 
     /// @brief Construct a species by name and properties
     /// @param name The name of the species
     /// @param properties The properties of the species
-    Species(const std::string& name, const std::map<std::string, double>& properties);
+    Species(std::string  name, const std::map<std::string, double>& properties);
 
     /// @brief Returns whether a species is parameterized
     bool IsParameterized() const;
@@ -92,11 +93,11 @@ namespace micm
       
         = default;
 
-  inline Species::Species(const std::string& name)
-      : name_(name){};
+  inline Species::Species(std::string  name)
+      : name_(std::move(name)){};
 
-  inline Species::Species(const std::string& name, const std::map<std::string, double>& properties)
-      : name_(name),
+  inline Species::Species(std::string  name, const std::map<std::string, double>& properties)
+      : name_(std::move(name)),
         properties_double_(properties){};
 
   inline bool Species::IsParameterized() const

--- a/include/micm/system/system.hpp
+++ b/include/micm/system/system.hpp
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace micm
@@ -20,8 +21,8 @@ namespace micm
 
     System() = default;
 
-    System(const Phase& gas_phase)
-        : gas_phase_(gas_phase)
+    System(Phase  gas_phase)
+        : gas_phase_(std::move(gas_phase))
     {
     }
 

--- a/test/integration/stub_aerosol_1.hpp
+++ b/test/integration/stub_aerosol_1.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 // some parameters used in the test
@@ -35,8 +36,8 @@ class StubAerosolModel
     double baz_mode1_to_mode2_quux_;  // rate constant for baz mode 1 to baz mode 2 conversion
   };
   StubAerosolModel() = delete;
-  StubAerosolModel(const std::string& name, const std::vector<micm::Phase>& phases, const RateConstants& rate_constants)
-      : name_(name),
+  StubAerosolModel(std::string  name, const std::vector<micm::Phase>& phases, const RateConstants& rate_constants)
+      : name_(std::move(name)),
         phases_(phases),
         rate_constants_(rate_constants)
   {

--- a/test/integration/stub_aerosol_2.hpp
+++ b/test/integration/stub_aerosol_2.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 // Second stubbed aerosol model implementation
@@ -28,8 +29,8 @@ class AnotherStubAerosolModel
 {
  public:
   AnotherStubAerosolModel() = delete;
-  AnotherStubAerosolModel(const std::string& name, const std::vector<micm::Phase>& phases)
-      : name_(name),
+  AnotherStubAerosolModel(std::string  name, const std::vector<micm::Phase>& phases)
+      : name_(std::move(name)),
         phases_(phases)
   {
   }

--- a/test/integration/test_external_model_constraints.cpp
+++ b/test/integration/test_external_model_constraints.cpp
@@ -11,6 +11,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <utility>
 
 /// @brief Constraint-only external model that enforces K_eq * [reactant] - [product] = 0
 ///
@@ -21,9 +22,9 @@
 class EquilibriumConstraintModel
 {
  public:
-  EquilibriumConstraintModel(const std::string& reactant, const std::string& product, double K_eq)
-      : reactant_(reactant),
-        product_(product),
+  EquilibriumConstraintModel(std::string  reactant, std::string  product, double K_eq)
+      : reactant_(std::move(reactant)),
+        product_(std::move(product)),
         K_eq_(K_eq)
   {
   }
@@ -118,14 +119,14 @@ class ConservativeEquilibriumConstraintModel
 {
  public:
   ConservativeEquilibriumConstraintModel(
-      const std::string& a,
-      const std::string& b,
-      const std::string& c,
+      std::string  a,
+      std::string  b,
+      std::string  c,
       double K_eq,
       double total)
-      : species_a_(a),
-        species_b_(b),
-        species_c_(c),
+      : species_a_(std::move(a)),
+        species_b_(std::move(b)),
+        species_c_(std::move(c)),
         K_eq_(K_eq),
         total_(total)
   {
@@ -234,8 +235,8 @@ class ConservativeEquilibriumConstraintModel
 class MassConservationModel
 {
  public:
-  MassConservationModel(const std::string& controlled_species, const std::vector<std::string>& all_species, double total)
-      : controlled_species_(controlled_species),
+  MassConservationModel(std::string  controlled_species, const std::vector<std::string>& all_species, double total)
+      : controlled_species_(std::move(controlled_species)),
         all_species_(all_species),
         total_(total)
   {
@@ -1271,12 +1272,12 @@ class TemperatureDependentEquilibriumModel
 {
  public:
   TemperatureDependentEquilibriumModel(
-      const std::string& reactant,
+      std::string  reactant,
       const std::string& product,
       double K_eq_ref,
       double delta_H_over_R,
       double T_ref = 298.15)
-      : reactant_(reactant),
+      : reactant_(std::move(reactant)),
         product_(product),
         K_eq_ref_(K_eq_ref),
         delta_H_over_R_(delta_H_over_R),

--- a/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
+++ b/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
@@ -228,8 +228,7 @@ namespace micm
   }
 
   inline ChapmanODESolver::~ChapmanODESolver()
-  {
-  }
+  = default;
 
   inline void ChapmanODESolver::ThreeStageRosenbrock()
   {


### PR DESCRIPTION
Partially addresses #997

Enables [modernize-use-equals-default](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html), [modernize-pass-by-value](https://clang.llvm.org/extra/clang-tidy/checks/modernize/pass-by-value.html)

- many of the constructors now use the default constructor
- many of the constructos pass arguments by value instead of const references to enable more move semantics

ran
```bash
cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
  -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang
run-clang-tidy -p build -fix '/Users/kshores/Documents/micm/(include|src|test)' 
```