### PR TITLE
Clang modernize performance

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -67,6 +67,7 @@ Checks: |
   modernize-use-equals-default,
   modernize-pass-by-value,
   modernize-concat-nested-namespaces,
+  performance-inefficient-algorithm,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -68,6 +68,7 @@ Checks: |
   modernize-pass-by-value,
   modernize-concat-nested-namespaces,
   performance-inefficient-algorithm,
+  readability-container-contains,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -66,6 +66,7 @@ Checks: |
   clang-diagnostic-error,
   modernize-use-equals-default,
   modernize-pass-by-value,
+  modernize-concat-nested-namespaces,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/include/micm/cuda/process/cuda_process_set.cuh
+++ b/include/micm/cuda/process/cuda_process_set.cuh
@@ -4,9 +4,8 @@
 
 #include <micm/cuda/util/cuda_param.hpp>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     /// This is the function that will copy the constant data
     ///   members of class "ProcessSet" to the device, except
@@ -41,5 +40,4 @@ namespace micm
         const CudaMatrixParam& state_variables_param,
         CudaMatrixParam& jacobian_param,
         const ProcessSetParam& devstruct);
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/include/micm/cuda/process/cuda_rate_constant_kernel.cuh
+++ b/include/micm/cuda/process/cuda_rate_constant_kernel.cuh
@@ -59,9 +59,8 @@ struct CudaReactionRateStoreParam
   std::size_t n_multipliers_ = 0;
 };
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     /// @brief Launch the rate constant kernel.  Lambda entries are not touched.
     /// @param d_mult_vals  Per-step interleaved multiplier values [group * n_mults * L + mult * L + lane].
@@ -72,5 +71,4 @@ namespace micm
         CudaMatrixParam& rc_param,
         const CudaMatrixParam& cp_param,
         const double* d_mult_vals);
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.cuh
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.cuh
@@ -4,9 +4,8 @@
 
 #include <micm/cuda/util/cuda_param.hpp>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     /// This is the host function that will call the CUDA kernel
     ///   to perform the "solve" function on the device
@@ -20,5 +19,4 @@ namespace micm
     /// This is the function that will delete the constant data
     ///   members of class "CudaLinearSolverInPlace" on the device
     void FreeConstData(LinearSolverInPlaceParam& devstruct);
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.cuh
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.cuh
@@ -4,9 +4,8 @@
 
 #include <micm/cuda/util/cuda_param.hpp>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     /// This is the host function that will call the CUDA kernel
     ///   to perform LU decomposition on the device
@@ -20,5 +19,4 @@ namespace micm
     ///   members of class "CudaLuDecompositionMozartInPlace" on the device
     void FreeConstData(LuDecomposeMozartInPlaceParam& devstruct);
 
-  }  // end of namespace cuda
-}  // end of namespace micm
+  }  // end of namespace micm::cuda

--- a/include/micm/cuda/solver/cuda_rosenbrock.cuh
+++ b/include/micm/cuda/solver/cuda_rosenbrock.cuh
@@ -7,9 +7,8 @@
 
 #include <cublas_v2.h>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     /// @brief Compute alpha - J[i] for each element i at the diagonal of Jacobian matrix
     /// @param jacobian_param Dimensions and device data pointers for the Jacobian
@@ -35,5 +34,4 @@ namespace micm
         const CudaMatrixParam& absolute_tolerance_param,
         const double relative_tolerance,
         CudaErrorParam& errors_param);
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/include/micm/cuda/util/cuda_matrix.cuh
+++ b/include/micm/cuda/util/cuda_matrix.cuh
@@ -8,9 +8,8 @@
 
 #include <vector>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     /// @brief Allocate memory on device
     /// @param vectorMatrix Reference to struct containing information about allocated memory
@@ -72,5 +71,4 @@ namespace micm
     /// @param val Value to fill the matrix with
     template<typename T>
     cudaError_t FillCudaMatrix(CudaMatrixParam& param, T val);
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/include/micm/cuda/util/cuda_util.cuh
+++ b/include/micm/cuda/util/cuda_util.cuh
@@ -13,9 +13,8 @@
 #define CHECK_CUDA_ERROR(err, msg)   micm::cuda::CheckCudaError(err, __FILE__, __LINE__, msg)
 #define CHECK_CUBLAS_ERROR(err, msg) micm::cuda::CheckCublasError(err, __FILE__, __LINE__, msg)
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     /// @brief Checks for CUDA errors and prints error message if any
     /// @param err Error code to check
@@ -81,5 +80,4 @@ namespace micm
 
       std::mutex mutex_;
     };
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -159,7 +159,7 @@ namespace micm
         {
           continue;  // Skip reactants that are parameterizations
         }
-        if (variable_map.count(reactant.name_) < 1)
+        if (!variable_map.contains(reactant.name_))
         {
           throw MicmException(MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_REACTANT_DOES_NOT_EXIST, reactant.name_);
         }
@@ -173,7 +173,7 @@ namespace micm
         {
           continue;  // Skip products that are parameterizations
         }
-        if (variable_map.count(product.species_.name_) < 1)
+        if (!variable_map.contains(product.species_.name_))
         {
           throw MicmException(
               MICM_ERROR_CATEGORY_PROCESS, MICM_PROCESS_ERROR_CODE_PRODUCT_DOES_NOT_EXIST, product.species_.name_);

--- a/include/micm/solver/lu_decomposition_doolittle_in_place.inl
+++ b/include/micm/solver/lu_decomposition_doolittle_in_place.inl
@@ -98,7 +98,7 @@ namespace micm
         }
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (ALU_ids.find(std::make_pair(i, j)) != ALU_ids.end() && ALU_ids.find(std::make_pair(j, k)) != ALU_ids.end())
+          if (ALU_ids.contains(std::make_pair(i, j)) && ALU_ids.contains(std::make_pair(j, k)))
           {
             ALU_ids.insert(std::make_pair(i, k));
             break;
@@ -115,7 +115,7 @@ namespace micm
         }
         for (std::size_t j = 0; j < i; ++j)
         {
-          if (ALU_ids.find(std::make_pair(k, j)) != ALU_ids.end() && ALU_ids.find(std::make_pair(j, i)) != ALU_ids.end())
+          if (ALU_ids.contains(std::make_pair(k, j)) && ALU_ids.contains(std::make_pair(j, i)))
           {
             ALU_ids.insert(std::make_pair(k, i));
             break;

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -157,20 +157,20 @@ namespace micm
       }
       for (std::size_t k = i + 1; k < n; ++k)
       {
-        if (!(std::find(U_ids.begin(), U_ids.end(), std::make_pair(i, k)) != U_ids.end()))
+        if (!(U_ids.find(std::make_pair(i, k)) != U_ids.end()))
         {
           continue;
         }
         for (std::size_t j = i + 1; j <= k; ++j)
         {
-          if (std::find(L_ids.begin(), L_ids.end(), std::make_pair(j, i)) != L_ids.end())
+          if (L_ids.find(std::make_pair(j, i)) != L_ids.end())
           {
             U_ids.insert(std::make_pair(j, k));
           }
         }
         for (std::size_t j = k + 1; j < n; ++j)
         {
-          if (std::find(L_ids.begin(), L_ids.end(), std::make_pair(j, i)) != L_ids.end())
+          if (L_ids.find(std::make_pair(j, i)) != L_ids.end())
           {
             L_ids.insert(std::make_pair(j, k));
           }

--- a/include/micm/solver/lu_decomposition_mozart.inl
+++ b/include/micm/solver/lu_decomposition_mozart.inl
@@ -157,20 +157,20 @@ namespace micm
       }
       for (std::size_t k = i + 1; k < n; ++k)
       {
-        if (!(U_ids.find(std::make_pair(i, k)) != U_ids.end()))
+        if (!(U_ids.contains(std::make_pair(i, k))))
         {
           continue;
         }
         for (std::size_t j = i + 1; j <= k; ++j)
         {
-          if (L_ids.find(std::make_pair(j, i)) != L_ids.end())
+          if (L_ids.contains(std::make_pair(j, i)))
           {
             U_ids.insert(std::make_pair(j, k));
           }
         }
         for (std::size_t j = k + 1; j < n; ++j)
         {
-          if (L_ids.find(std::make_pair(j, i)) != L_ids.end())
+          if (L_ids.contains(std::make_pair(j, i)))
           {
             L_ids.insert(std::make_pair(j, k));
           }

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -91,18 +91,18 @@ namespace micm
     {
       for (std::size_t j = i + 1; j < n; ++j)
       {
-        if (ALU_ids.find(std::make_pair(j, i)) != ALU_ids.end())
+        if (ALU_ids.contains(std::make_pair(j, i)))
         {
           ALU_ids.insert(std::make_pair(j, i));
         }
       }
       for (std::size_t k = i + 1; k < n; ++k)
       {
-        if (ALU_ids.find(std::make_pair(i, k)) != ALU_ids.end())
+        if (ALU_ids.contains(std::make_pair(i, k)))
         {
           for (std::size_t j = i + 1; j < n; ++j)
           {
-            if (ALU_ids.find(std::make_pair(j, i)) != ALU_ids.end())
+            if (ALU_ids.contains(std::make_pair(j, i)))
             {
               ALU_ids.insert(std::make_pair(j, k));
             }

--- a/include/micm/solver/lu_decomposition_mozart_in_place.inl
+++ b/include/micm/solver/lu_decomposition_mozart_in_place.inl
@@ -91,18 +91,18 @@ namespace micm
     {
       for (std::size_t j = i + 1; j < n; ++j)
       {
-        if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(j, i)) != ALU_ids.end())
+        if (ALU_ids.find(std::make_pair(j, i)) != ALU_ids.end())
         {
           ALU_ids.insert(std::make_pair(j, i));
         }
       }
       for (std::size_t k = i + 1; k < n; ++k)
       {
-        if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(i, k)) != ALU_ids.end())
+        if (ALU_ids.find(std::make_pair(i, k)) != ALU_ids.end())
         {
           for (std::size_t j = i + 1; j < n; ++j)
           {
-            if (std::find(ALU_ids.begin(), ALU_ids.end(), std::make_pair(j, i)) != ALU_ids.end())
+            if (ALU_ids.find(std::make_pair(j, i)) != ALU_ids.end())
             {
               ALU_ids.insert(std::make_pair(j, k));
             }

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -107,9 +107,9 @@ namespace micm
 
   inline bool Species::HasProperty(const std::string& key) const
   {
-    return properties_string_.find(key) != properties_string_.end() ||
-           properties_double_.find(key) != properties_double_.end() ||
-           properties_bool_.find(key) != properties_bool_.end() || properties_int_.find(key) != properties_int_.end();
+    return properties_string_.contains(key) ||
+           properties_double_.contains(key) ||
+           properties_bool_.contains(key) || properties_int_.contains(key);
   }
 
   inline void Species::SetThirdBody()

--- a/include/micm/util/constants.hpp
+++ b/include/micm/util/constants.hpp
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-namespace micm
-{
-  namespace constants
+
+  namespace micm::constants
   {
     static constexpr double BOLTZMANN_CONSTANT = 1.380649e-23;                      // J K^{-1}
     static constexpr double AVOGADRO_CONSTANT = 6.02214076e23;                      // # mol^{-1}
     static constexpr double GAS_CONSTANT = BOLTZMANN_CONSTANT * AVOGADRO_CONSTANT;  // J K^{-1} mol^{-1}
-  }  // namespace constants
-}  // namespace micm
+  } // namespace micm::constants
+

--- a/include/micm/util/property_keys.hpp
+++ b/include/micm/util/property_keys.hpp
@@ -4,11 +4,10 @@
 
 #include <string>
 
-namespace micm
-{
-  namespace property_keys
+
+  namespace micm::property_keys
   {
     static constexpr const char* DIFFUSION_COEFFICIENT = "diffusion coefficient [m2 s-1]";
     static constexpr const char* MOLECULAR_WEIGHT = "molecular weight [kg mol-1]";
-  }  // namespace property_keys
-}  // namespace micm
+  } // namespace micm::property_keys
+

--- a/src/process/cuda_rate_constant_kernel.cu
+++ b/src/process/cuda_rate_constant_kernel.cu
@@ -20,9 +20,8 @@
   #define M_PI 3.14159265358979323846
 #endif
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     /// @brief Compute all analytic rate constants for one thread and write to rc_base (interleaved).
     /// @param cp_base   Group base pointer into custom_rate_parameters_ for this thread
@@ -169,5 +168,4 @@ namespace micm
           n_cells,
           L);
     }
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/src/process/process_set.cu
+++ b/src/process/process_set.cu
@@ -3,9 +3,8 @@
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     /// This is the CUDA kernel that calculates the forcing terms on the device
     __global__ void AddForcingTermsKernel(
@@ -399,5 +398,4 @@ namespace micm
           micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(
           rate_constants_param, state_variables_param, forcing_param, devstruct);
     }  // end of AddForcingTermsKernelDriver
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/src/solver/linear_solver_in_place.cu
+++ b/src/solver/linear_solver_in_place.cu
@@ -5,9 +5,8 @@
 
 #include <chrono>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     /// This is the CUDA kernel that performs the "solve" function on the device
     __global__ void
@@ -183,5 +182,4 @@ namespace micm
       SolveKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(
           x_param, ALU_param, devstruct);
     }
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/src/solver/lu_decomposition_mozart_in_place.cu
+++ b/src/solver/lu_decomposition_mozart_in_place.cu
@@ -3,9 +3,8 @@
 #include <micm/cuda/util/cuda_param.hpp>
 #include <micm/cuda/util/cuda_util.cuh>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     /// This is the CUDA kernel that performs LU decomposition on the device
     __global__ void DecomposeKernel(CudaMatrixParam ALU_param, const LuDecomposeParam devstruct)
@@ -167,5 +166,4 @@ namespace micm
       DecomposeKernel<<<number_of_blocks, BLOCK_SIZE, 0, micm::cuda::CudaStreamSingleton::GetInstance().GetCudaStream(0)>>>(
           ALU_param, devstruct);
     }  // end of DecomposeKernelDriver
-  }  // end of namespace cuda
-}  // end of namespace micm
+  }  // end of namespace micm::cuda

--- a/src/solver/rosenbrock.cu
+++ b/src/solver/rosenbrock.cu
@@ -7,9 +7,8 @@
 
 #include <cublas_v2.h>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     /// CUDA kernel to compute alpha - J[i] for each element i at the diagonal of Jacobian matrix
     __global__ void AlphaMinusJacobianKernel(
@@ -358,5 +357,4 @@ namespace micm
       }  // end of if-else for CUDA/CUBLAS implementation
       return std::max(normalized_error, 1.0e-10);
     }  // end of NormalizedErrorDriver function
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/src/util/cuda_matrix.cu
+++ b/src/util/cuda_matrix.cu
@@ -8,9 +8,8 @@
 
 #include <vector>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     template<typename T>
     cudaError_t MallocArray(T*& array, std::size_t num_elements)
@@ -172,5 +171,4 @@ namespace micm
         CudaMatrixParam& vectorMatrixDest,
         const CudaMatrixParam& vectorMatrixSrc);
     template cudaError_t FillCudaMatrix<double>(CudaMatrixParam& param, double val);
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/src/util/cuda_util.cu
+++ b/src/util/cuda_util.cu
@@ -3,9 +3,8 @@
 #include <micm/cuda/util/cuda_util.cuh>
 #include <micm/util/micm_exception.hpp>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     void CheckCudaError(cudaError_t err, const char* file, int line, const std::string& str)
     {
@@ -105,5 +104,4 @@ namespace micm
       std::lock_guard<std::mutex> lock(mutex_);
       cuda_streams_map_.clear();
     }
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/test/integration/test_equilibrium_constraint.cpp
+++ b/test/integration/test_equilibrium_constraint.cpp
@@ -64,10 +64,10 @@ TEST(EquilibriumIntegration, SetConstraintsAPIWorks)
   // Verify constraint metadata
   ASSERT_EQ(state.state_size_, 3);  // A, B, and C
   ASSERT_EQ(state.constraint_size_, 1);
-  ASSERT_TRUE(state.variable_map_.count("A") > 0);
-  ASSERT_TRUE(state.variable_map_.count("B") > 0);
-  ASSERT_TRUE(state.variable_map_.count("C") > 0);
-  ASSERT_TRUE(state.custom_rate_parameter_map_.count("B_C_eq") > 0);
+  ASSERT_TRUE(state.variable_map_.contains("A"));
+  ASSERT_TRUE(state.variable_map_.contains("B"));
+  ASSERT_TRUE(state.variable_map_.contains("C"));
+  ASSERT_TRUE(state.custom_rate_parameter_map_.contains("B_C_eq"));
 
   // Verify mass-matrix diagonal.
   // Size is species only; constrained species rows are algebraic (0), others are ODE (1).

--- a/test/unit/cuda/util/cuda_matrix_utils.cu
+++ b/test/unit/cuda/util/cuda_matrix_utils.cu
@@ -3,9 +3,8 @@
 #include <cstdio>
 #include <iostream>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     __global__ void Square(double* d_data, std::size_t num_elements)
     {
@@ -107,5 +106,4 @@ namespace micm
       DenseMatrixAddOneElement<<<number_of_blocks, 32>>>(
           param.d_data_, number_of_columns, row_id, col_id, cuda_matrix_vector_length);
     }
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda

--- a/test/unit/cuda/util/cuda_matrix_utils.cuh
+++ b/test/unit/cuda/util/cuda_matrix_utils.cuh
@@ -1,8 +1,7 @@
 #include <micm/cuda/util/cuda_param.hpp>
 
-namespace micm
-{
-  namespace cuda
+
+  namespace micm::cuda
   {
     void SquareDriver(CudaMatrixParam& param);
     void AddOneDriver(CudaMatrixParam& param);
@@ -16,5 +15,4 @@ namespace micm
         std::size_t row_id,
         std::size_t col_id,
         const std::size_t cuda_matrix_vector_length);
-  }  // namespace cuda
-}  // namespace micm
+  }  // namespace micm::cuda


### PR DESCRIPTION
Partially addresses #997

Enables modernize-concat-nested-namespaces, performance-inefficient-algorithm, readability-container-contains

ran
```bash
cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
  -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang
run-clang-tidy -p build -fix '/Users/kshores/Documents/micm/(include|src|test)' 
```