### PR TITLE
Clang small fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -73,6 +73,7 @@ Checks: |
   modernize-use-constraints,
   cert-oop54-cpp,
   readability-inconsistent-declaration-parameter-name,
+  readability-implicit-bool-conversion,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -69,6 +69,7 @@ Checks: |
   modernize-concat-nested-namespaces,
   performance-inefficient-algorithm,
   readability-container-contains,
+  readability-container-size-empty,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -72,6 +72,7 @@ Checks: |
   readability-container-size-empty,
   modernize-use-constraints,
   cert-oop54-cpp,
+  readability-inconsistent-declaration-parameter-name,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -74,6 +74,7 @@ Checks: |
   cert-oop54-cpp,
   readability-inconsistent-declaration-parameter-name,
   readability-implicit-bool-conversion,
+  readability-else-after-return,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -71,6 +71,7 @@ Checks: |
   readability-container-contains,
   readability-container-size-empty,
   modernize-use-constraints,
+  cert-oop54-cpp,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -70,6 +70,7 @@ Checks: |
   performance-inefficient-algorithm,
   readability-container-contains,
   readability-container-size-empty,
+  modernize-use-constraints,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,10 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up MinGW
-        uses: egor-tensin/setup-mingw@v2
+        uses: egor-tensin/setup-mingw@v3
         with:
           platform: ${{ matrix.architecture }}
-          version: 12.2.0 # https://github.com/egor-tensin/setup-mingw/issues/14
 
       - name: Run Cmake 
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -G "MinGW Makefiles"

--- a/include/micm/cuda/util/cuda_dense_matrix.hpp
+++ b/include/micm/cuda/util/cuda_dense_matrix.hpp
@@ -135,6 +135,10 @@ namespace micm
 
     CudaDenseMatrix& operator=(const CudaDenseMatrix& other)
     {
+      if (this == &other)
+      {
+        return *this;
+      }
       VectorMatrix<T, L>::operator=(other);
       if (this->param_.number_of_elements_ != other.param_.number_of_elements_)
       {

--- a/include/micm/cuda/util/cuda_matrix.cuh
+++ b/include/micm/cuda/util/cuda_matrix.cuh
@@ -18,45 +18,45 @@ namespace micm::cuda
   cudaError_t MallocArray(T*& array, std::size_t num_elements);
 
   /// @brief Allocate memory on device
-  /// @param vectorMatrix Reference to struct containing information about allocated memory
-  /// @param num_elements Requested number of elements to allocate
+  /// @param param Reference to struct containing information about allocated memory
+  /// @param number_of_elements Requested number of elements to allocate
   /// @returns Error code from allocating data on the device, if any
   template<typename T>
-  cudaError_t MallocVector(CudaMatrixParam& vectorMatrix, std::size_t num_elements);
+  cudaError_t MallocVector(CudaMatrixParam& param, std::size_t number_of_elements);
 
   template<typename T>
   cudaError_t FreeArray(T*& array);
 
   /// @brief Free memory allocated on device
-  /// @param vectorMatrix Struct containing allocated device memory
+  /// @param param Struct containing allocated device memory
   /// @returns Error code from free-ing data on device, if any
-  cudaError_t FreeVector(CudaMatrixParam& vectorMatrix);
+  cudaError_t FreeVector(CudaMatrixParam& param);
 
   /// @brief Sets all elements in a CUDA matrix to their current value or a specified value, whichever is greater
-  /// @param vectorMatrix Struct containing allocated device memory
+  /// @param param Struct containing allocated device memory
   /// @param val Value to compare with each element in the matrix
   template<typename T>
-  cudaError_t MatrixMax(CudaMatrixParam& vectorMatrix, T val);
+  cudaError_t MatrixMax(CudaMatrixParam& param, T val);
 
   /// @brief Sets all elements in a CUDA matrix to their current value or a specified value, whichever is lesser
-  /// @param vectorMatrix Struct containing allocated device memory
+  /// @param param Struct containing allocated device memory
   /// @param val Value to compare with each element in the matrix
   template<typename T>
-  cudaError_t MatrixMin(CudaMatrixParam& vectorMatrix, T val);
+  cudaError_t MatrixMin(CudaMatrixParam& param, T val);
 
   /// @brief Copies data from the host to the device
-  /// @param vectorMatrix Struct containing allocated device memory
+  /// @param param Struct containing allocated device memory
   /// @param h_data Host data to copy from
   /// @returns Error code from copying to device from the host, if any
   template<typename T>
-  cudaError_t CopyToDevice(CudaMatrixParam& vectorMatrix, const std::vector<T>& h_data);
+  cudaError_t CopyToDevice(CudaMatrixParam& param, const std::vector<T>& h_data);
 
   /// @brief Copies data from the device to the host
-  /// @param vectorMatrix Struct containing allocated device memory
+  /// @param param Struct containing allocated device memory
   /// @param h_data Host data to copy data to
   /// @returns Error code from copying from the device to the host, if any
   template<typename T>
-  cudaError_t CopyToHost(CudaMatrixParam& vectorMatrix, std::vector<T>& h_data);
+  cudaError_t CopyToHost(CudaMatrixParam& param, std::vector<T>& h_data);
 
   /// @brief Copies data to the destination device memory block from the source device memory block
   /// @param vectorMatrixDest Struct containing allocated destination device memory to copy to

--- a/include/micm/cuda/util/cuda_sparse_matrix.hpp
+++ b/include/micm/cuda/util/cuda_sparse_matrix.hpp
@@ -75,6 +75,10 @@ namespace micm
 
     CudaSparseMatrix& operator=(const CudaSparseMatrix& other)
     {
+      if (this == &other)
+      {
+        return *this;
+      }
       SparseMatrix<T, OrderingPolicy>::operator=(other);
       this->param_ = other.param_;
       this->param_.d_data_ = nullptr;

--- a/include/micm/external_model.hpp
+++ b/include/micm/external_model.hpp
@@ -198,9 +198,9 @@ namespace micm
     ///
     /// @tparam ModelType Type of the external model (must implement the external model interface)
     /// @param model External model instance (will be moved or copied into shared ownership)
-    template<typename ModelType, typename = std::enable_if_t<!std::is_same_v<std::decay_t<ModelType>, ExternalModelSystem>>>
+    template<typename ModelType>
     ExternalModelSystem(ModelType&& model)
-    {
+    requires (!std::is_same_v<std::decay_t<ModelType>, ExternalModelSystem>) {
       auto shared_model = std::make_shared<std::decay_t<ModelType>>(std::forward<ModelType>(model));
       state_size_func_ = [shared_model]() -> std::tuple<std::size_t, std::size_t> { return shared_model->StateSize(); };
       variable_names_func_ = [shared_model]() -> std::set<std::string> { return shared_model->StateVariableNames(); };
@@ -265,10 +265,9 @@ namespace micm
     /// @tparam ModelType Type of the external model (must implement the external model interface)
     /// @param model External model instance (will be moved or copied into shared ownership)
     template<
-        typename ModelType,
-        typename = std::enable_if_t<!std::is_same_v<std::decay_t<ModelType>, ExternalModelProcessSet>>>
+        typename ModelType>
     ExternalModelProcessSet(ModelType&& model)
-    {
+    requires (!std::is_same_v<std::decay_t<ModelType>, ExternalModelProcessSet>) {
       auto shared_model = std::make_shared<std::decay_t<ModelType>>(std::forward<ModelType>(model));
       non_zero_jacobian_elements_func_ = [shared_model](const std::unordered_map<std::string, std::size_t>& species_map)
           -> std::set<std::pair<std::size_t, std::size_t>> { return shared_model->NonZeroJacobianElements(species_map); };
@@ -368,10 +367,9 @@ namespace micm
     /// @tparam ModelType Type of the external model (must satisfy HasConstraints)
     /// @param model External model instance
     template<
-        typename ModelType,
-        typename = std::enable_if_t<!std::is_same_v<std::decay_t<ModelType>, ExternalModelConstraintSet>>>
+        typename ModelType>
     ExternalModelConstraintSet(ModelType&& model)
-    {
+    requires (!std::is_same_v<std::decay_t<ModelType>, ExternalModelConstraintSet>) {
       auto shared_model = std::make_shared<std::decay_t<ModelType>>(std::forward<ModelType>(model));
       algebraic_variable_names_func_ = [shared_model]() -> std::set<std::string>
       { return shared_model->ConstraintAlgebraicVariableNames(); };

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -143,7 +143,7 @@ namespace micm
         jacobian_product_ids_(),
         jacobian_yields_(),
         jacobian_flat_ids_(),
-        is_algebraic_variable_(variable_map.size(), false),
+        is_algebraic_variable_(variable_map.size(), 0u),
         variable_map_(variable_map)
   {
     // For each process, look up each reactant name in variable_map and
@@ -333,7 +333,7 @@ namespace micm
     std::fill(is_algebraic_variable_.begin(), is_algebraic_variable_.end(), false);
     for (const auto variable_id : variable_ids)
     {
-      is_algebraic_variable_[variable_id] = true;
+      is_algebraic_variable_[variable_id] = 1u;
     }
   }
 

--- a/include/micm/solver/backward_euler.inl
+++ b/include/micm/solver/backward_euler.inl
@@ -122,12 +122,10 @@ namespace micm
           result.state_ = SolverState::AcceptingUnconvergedIntegration;
           break;
         }
-        else
-        {
-          // if we fail, we need to reset the solution to the last known good solution
-          Yn1.Copy(Yn);
-          H *= time_step_reductions[n_convergence_failures++];
-        }
+
+        // if we fail, we need to reset the solution to the last known good solution
+        Yn1.Copy(Yn);
+        H *= time_step_reductions[n_convergence_failures++];
       }
       else
       {

--- a/include/micm/solver/rosenbrock.hpp
+++ b/include/micm/solver/rosenbrock.hpp
@@ -116,14 +116,14 @@ namespace micm
     template<class DenseMatrixPolicy>
     double NormalizedError(
         const DenseMatrixPolicy& y,
-        const DenseMatrixPolicy& y_new,
+        const DenseMatrixPolicy& Ynew,
         const DenseMatrixPolicy& errors,
         auto& state) const
       requires(!VectorizableDense<DenseMatrixPolicy>);
     template<class DenseMatrixPolicy>
     double NormalizedError(
         const DenseMatrixPolicy& y,
-        const DenseMatrixPolicy& y_new,
+        const DenseMatrixPolicy& Ynew,
         const DenseMatrixPolicy& errors,
         auto& state) const
       requires(VectorizableDense<DenseMatrixPolicy>);

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -231,12 +231,12 @@ namespace micm
           result.state_ = SolverState::NaNDetected;
           break;
         }
-        else if (std::isinf(error) == 1)
+        if (std::isinf(error) == 1)
         {
           result.state_ = SolverState::InfDetected;
           break;
         }
-        else if ((error < 1) || (H < h_min))
+        if ((error < 1) || (H < h_min))
         {
           result.stats_.accepted_ += 1;
           present_time = present_time + H;

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -53,7 +53,7 @@ namespace micm
         used_species.begin(),
         used_species.end(),
         std::inserter(unused_species, unused_species.begin()));
-    if (unused_species.size() > 0)
+    if (!unused_species.empty())
     {
       std::string err_msg = "Unused species in chemical system:";
       for (const auto& species : unused_species)

--- a/include/micm/solver/state.inl
+++ b/include/micm/solver/state.inl
@@ -81,6 +81,10 @@ namespace micm
       State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy, LMatrixPolicy, UMatrixPolicy>::VariableProxy::
       operator=(const VariableProxy& other)
   {
+    if (this == &other)
+    {
+      return *this;
+    }
     if (state_.number_of_grid_cells_ != other.state_.number_of_grid_cells_)
     {
       throw MicmException(

--- a/include/micm/util/matrix.hpp
+++ b/include/micm/util/matrix.hpp
@@ -232,7 +232,7 @@ namespace micm
 
     Matrix(const std::vector<std::vector<T>>& other)
         : x_dim_(other.size()),
-          y_dim_(other.size() == 0 ? 0 : other[0].size()),
+          y_dim_(other.empty() ? 0 : other[0].size()),
           data_(
               [&]() -> std::vector<T>
               {

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -245,7 +245,7 @@ namespace micm
 
     VectorMatrix(const std::vector<std::vector<T>>& other)
         : x_dim_(other.size()),
-          y_dim_(other.size() == 0 ? 0 : other[0].size()),
+          y_dim_(other.empty() ? 0 : other[0].size()),
           data_(
               [&]() -> std::vector<T>
               {

--- a/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
+++ b/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
@@ -192,8 +192,8 @@ namespace micm
     /// @param errors The computed errors
     /// @return
     double ErrorNorm(
-        std::vector<double> original_number_densities,
-        std::vector<double> new_number_densities,
+        std::vector<double> Y,
+        std::vector<double> Ynew,
         std::vector<double> errors);
   };
 

--- a/test/regression/regression_policy.hpp
+++ b/test/regression/regression_policy.hpp
@@ -94,11 +94,10 @@ std::pair<std::vector<std::string>, std::vector<std::vector<double>>> ReadCsv(co
     file.close();
     return { header, data };
   }
-  else
-  {
-    std::cerr << "Error opening file: " << filename << std::endl;
+  
+      std::cerr << "Error opening file: " << filename << std::endl;
     return {};
-  }
+ 
 }
 
 template<class BuilderPolicy>


### PR DESCRIPTION
Partially addresses #997

Enables
- cert-oop54-cpp
- readability-inconsistent-declaration-parameter-name
- readability-implicit-bool-conversion
- [readability-else-after-return](https://clang.llvm.org/extra/clang-tidy/checks/readability/else-after-return.html)
  - this one I'd be happy to undo. commit [`9e74850c09a2e6e10b2a8461334dfacb2944deca`](https://github.com/NCAR/micm/commit/9e74850c09a2e6e10b2a8461334dfacb2944deca) shows what it did
  - the llvm docs for it do show how it can improve readability and I tend to agree, but don't have strong feelings one way or the other

ran
```bash
cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
  -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang
run-clang-tidy -p build -fix '/Users/kshores/Documents/micm/(include|src|test)' 
```