### PR TITLE
Clang modernize

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -76,6 +76,7 @@ Checks: |
   readability-implicit-bool-conversion,
   readability-else-after-return,
   modernize-type-traits,
+  modernize-deprecated-headers,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,6 +52,8 @@
 #   Fires on size_t->double in math expressions and unsigned->ptrdiff_t in
 #   std::next calls. All are safe within realistic problem sizes for a chemistry
 #   solver. Too noisy for the benefit.
+# -modernize-return-braced-init-list,
+#   This would remove explicit calls to a constructor using a classname and that feels unnecessary
 
 Checks: |
   # disable all checks
@@ -79,7 +81,9 @@ Checks: |
   modernize-deprecated-headers,
   modernize-use-std-numbers,
   modernize-use-emplace,
+  modernize-use-auto,
   # explicitly disabled checks
+  -modernize-return-braced-init-list,
   -readability-redundant-member-init,
   -readability-identifier-length,
   -readability-convert-member-functions-to-static,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -77,6 +77,7 @@ Checks: |
   readability-else-after-return,
   modernize-type-traits,
   modernize-deprecated-headers,
+  modernize-use-std-numbers,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -75,6 +75,7 @@ Checks: |
   readability-inconsistent-declaration-parameter-name,
   readability-implicit-bool-conversion,
   readability-else-after-return,
+  modernize-type-traits,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -82,6 +82,7 @@ Checks: |
   modernize-use-std-numbers,
   modernize-use-emplace,
   modernize-use-auto,
+  modernize-loop-convert,
   # explicitly disabled checks
   -modernize-return-braced-init-list,
   -readability-redundant-member-init,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -78,6 +78,7 @@ Checks: |
   modernize-type-traits,
   modernize-deprecated-headers,
   modernize-use-std-numbers,
+  modernize-use-emplace,
   # explicitly disabled checks
   -readability-redundant-member-init,
   -readability-identifier-length,

--- a/include/micm/constraint/types/linear_constraint.hpp
+++ b/include/micm/constraint/types/linear_constraint.hpp
@@ -178,9 +178,9 @@ namespace micm
 
       // Copy data to avoid issues when ConstraintSet is moved
       std::vector<double> coeffs;
-      for (std::size_t i = 0; i < this->terms_.size(); ++i)
+      for (const auto & term : this->terms_)
       {
-        coeffs.push_back(this->terms_[i].coefficient_);
+        coeffs.push_back(term.coefficient_);
       }
 
       return SparseMatrixPolicy::Function(

--- a/include/micm/process/rate_constant/rate_constant_functions.hpp
+++ b/include/micm/process/rate_constant/rate_constant_functions.hpp
@@ -25,7 +25,6 @@
 
 #include <cmath>
 #include <cstddef>
-#include <math.h>
 
 // constexpr <cmath> functions (std::exp, std::pow, std::sqrt, etc.) require C++23
 // and compiler support (P1383R2). Guard so MSVC and other compilers that haven't

--- a/include/micm/process/reaction_rate_store.hpp
+++ b/include/micm/process/reaction_rate_store.hpp
@@ -221,7 +221,7 @@ namespace micm
                 "Diffusion coefficient for species '" + p->phase_species_.species_.name_ + "' is not defined");
           }
           data.diffusion_coefficient_ = p->phase_species_.diffusion_coefficient_.value();
-          double mw = p->phase_species_.species_.GetProperty<double>(property_keys::MOLECULAR_WEIGHT);
+          auto mw = p->phase_species_.species_.GetProperty<double>(property_keys::MOLECULAR_WEIGHT);
           data.mean_free_speed_factor_ = 8.0 * constants::GAS_CONSTANT / (M_PI * mw);
           data.reaction_probability_ = p->reaction_probability_;
           data.custom_param_base_index_ = custom_param_off;

--- a/include/micm/process/reaction_rate_store.hpp
+++ b/include/micm/process/reaction_rate_store.hpp
@@ -25,7 +25,6 @@
 #include <cmath>
 #include <cstddef>
 #include <functional>
-#include <math.h>
 #include <type_traits>
 #include <vector>
 

--- a/include/micm/process/reaction_rate_store.hpp
+++ b/include/micm/process/reaction_rate_store.hpp
@@ -143,7 +143,7 @@ namespace micm
           {
             if (reactant.IsParameterized())
             {
-              param_funcs.push_back(reactant.parameterize_);
+              param_funcs.emplace_back(reactant.parameterize_);
             }
           }
 

--- a/include/micm/solver/rosenbrock_solver_parameters.hpp
+++ b/include/micm/solver/rosenbrock_solver_parameters.hpp
@@ -151,7 +151,7 @@ namespace micm
     // an L-stable method, 2 stages, order 2
 
     RosenbrockSolverParameters parameters;
-    double g = 1.0 + 1.0 / std::sqrt(2.0);
+    double g = 1.0 + 1.0 / std::numbers::sqrt2;
 
     parameters.stages_ = 2;
 

--- a/include/micm/solver/rosenbrock_solver_parameters.hpp
+++ b/include/micm/solver/rosenbrock_solver_parameters.hpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <limits>
 #include <vector>
+#include <numbers>
 
 namespace micm
 {

--- a/include/micm/system/species.hpp
+++ b/include/micm/system/species.hpp
@@ -119,7 +119,7 @@ namespace micm
   template<class T>
   inline T Species::GetProperty(const std::string& key) const
   {
-    if constexpr (std::is_same<T, std::string>::value)
+    if constexpr (std::is_same_v<T, std::string>)
     {
       try
       {
@@ -133,7 +133,7 @@ namespace micm
             "Species: '" + name_ + "' Property: '" + key + "'");
       }
     }
-    else if constexpr (std::is_same<T, double>::value)
+    else if constexpr (std::is_same_v<T, double>)
     {
       try
       {
@@ -147,7 +147,7 @@ namespace micm
             "Species: '" + name_ + "' Property: '" + key + "'");
       }
     }
-    else if constexpr (std::is_same<T, bool>::value)
+    else if constexpr (std::is_same_v<T, bool>)
     {
       try
       {
@@ -161,7 +161,7 @@ namespace micm
             "Species: '" + name_ + "' Property: '" + key + "'");
       }
     }
-    else if constexpr (std::is_same<T, int>::value)
+    else if constexpr (std::is_same_v<T, int>)
     {
       try
       {
@@ -185,19 +185,19 @@ namespace micm
   template<class T>
   inline void Species::SetProperty(const std::string& key, T value)
   {
-    if constexpr (std::is_same<T, std::string>::value || std::is_same<T, const char*>::value)
+    if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, const char*>)
     {
       properties_string_[key] = value;
     }
-    else if constexpr (std::is_same<T, double>::value)
+    else if constexpr (std::is_same_v<T, double>)
     {
       properties_double_[key] = value;
     }
-    else if constexpr (std::is_same<T, bool>::value)
+    else if constexpr (std::is_same_v<T, bool>)
     {
       properties_bool_[key] = value;
     }
-    else if constexpr (std::is_same<T, int>::value)
+    else if constexpr (std::is_same_v<T, int>)
     {
       properties_int_[key] = value;
     }

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
@@ -171,7 +171,7 @@ namespace micm
       }
 
      private:
-      typename std::conditional<(L > 1), std::array<T, L>, T>::type storage_;
+      std::conditional_t<(L > 1), std::array<T, L>, T>storage_;
     };
 
     /// @brief ConstGroupView provides a const view of a single group of blocks for iteration

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
@@ -177,7 +177,7 @@ namespace micm
       }
 
      private:
-      typename std::conditional<(L > 1), std::array<T, L>, T>::type storage_;
+      std::conditional_t<(L > 1), std::array<T, L>, T>storage_;
     };
 
     /// @brief ConstGroupView provides a const view of a single group of blocks for iteration

--- a/src/process/cuda_rate_constant_kernel.cu
+++ b/src/process/cuda_rate_constant_kernel.cu
@@ -14,7 +14,7 @@
 #include <micm/cuda/util/cuda_util.cuh>
 #include <micm/process/rate_constant/rate_constant_functions.hpp>
 
-#include <math.h>
+#include <cmath>
 
 #ifndef M_PI
   #define M_PI 3.14159265358979323846

--- a/src/util/cuda_util.cu
+++ b/src/util/cuda_util.cu
@@ -47,7 +47,7 @@ namespace micm::cuda
   // Create a cublas handle and return a unique pointer to it
   CublasHandlePtr CreateCublasHandle()
   {
-    cublasHandle_t* handle = new cublasHandle_t;
+    auto* handle = new cublasHandle_t;
     CHECK_CUBLAS_ERROR(cublasCreate(handle), "CUBLAS initialization failed...");
     return CublasHandlePtr(handle, CublasHandleDeleter());
   }
@@ -81,7 +81,7 @@ namespace micm::cuda
   // Create a CUDA stream and return a unique pointer to it
   CudaStreamPtr CudaStreamSingleton::CreateCudaStream()
   {
-    cudaStream_t* cuda_stream = new cudaStream_t;
+    auto* cuda_stream = new cudaStream_t;
     CHECK_CUDA_ERROR(cudaStreamCreate(cuda_stream), "CUDA stream initialization failed...");
     return CudaStreamPtr(cuda_stream, CudaStreamDeleter());
   }

--- a/test/integration/stub_aerosol_1.hpp
+++ b/test/integration/stub_aerosol_1.hpp
@@ -136,15 +136,13 @@ class StubAerosolModel
     auto fo2_mode2_index_it = state_variable_indices.find("STUB1.MODE2.CORGE.FO2");
     if (fo2_gas_index_it != state_variable_indices.end() && fo2_mode2_index_it != state_variable_indices.end())
     {
-      forcing_info.push_back(
-          { fo2_gas_index_it->second, fo2_mode2_index_it->second, rate_constants_.fo2_gas_to_mode2_corge_ });
+      forcing_info.emplace_back( fo2_gas_index_it->second, fo2_mode2_index_it->second, rate_constants_.fo2_gas_to_mode2_corge_ );
     }
     auto baz_mode1_index_it = state_variable_indices.find("STUB1.MODE1.QUUX.BAZ");
     auto baz_mode2_index_it = state_variable_indices.find("STUB1.MODE2.QUUX.BAZ");
     if (baz_mode1_index_it != state_variable_indices.end() && baz_mode2_index_it != state_variable_indices.end())
     {
-      forcing_info.push_back(
-          { baz_mode1_index_it->second, baz_mode2_index_it->second, rate_constants_.baz_mode1_to_mode2_quux_ });
+      forcing_info.emplace_back( baz_mode1_index_it->second, baz_mode2_index_it->second, rate_constants_.baz_mode1_to_mode2_quux_ );
     }
 
     // copy-capture the forcing_info vector in the lambda function that will calculate the forcing terms
@@ -183,23 +181,23 @@ class StubAerosolModel
     auto fo2_mode2_index_it = state_variable_indices.find("STUB1.MODE2.CORGE.FO2");
     if (fo2_gas_index_it != state_variable_indices.end() && fo2_mode2_index_it != state_variable_indices.end())
     {
-      jacobian_info.push_back({ fo2_gas_index_it->second,
+      jacobian_info.emplace_back( fo2_gas_index_it->second,
                                 fo2_gas_index_it->second,
-                                -rate_constants_.fo2_gas_to_mode2_corge_ });  // reactant partial derivative
-      jacobian_info.push_back({ fo2_mode2_index_it->second,
+                                -rate_constants_.fo2_gas_to_mode2_corge_ );  // reactant partial derivative
+      jacobian_info.emplace_back( fo2_mode2_index_it->second,
                                 fo2_gas_index_it->second,
-                                rate_constants_.fo2_gas_to_mode2_corge_ });  // product partial derivative
+                                rate_constants_.fo2_gas_to_mode2_corge_ );  // product partial derivative
     }
     auto baz_mode1_index_it = state_variable_indices.find("STUB1.MODE1.QUUX.BAZ");
     auto baz_mode2_index_it = state_variable_indices.find("STUB1.MODE2.QUUX.BAZ");
     if (baz_mode1_index_it != state_variable_indices.end() && baz_mode2_index_it != state_variable_indices.end())
     {
-      jacobian_info.push_back({ baz_mode1_index_it->second,
+      jacobian_info.emplace_back( baz_mode1_index_it->second,
                                 baz_mode1_index_it->second,
-                                -rate_constants_.baz_mode1_to_mode2_quux_ });  // reactant partial derivative
-      jacobian_info.push_back({ baz_mode2_index_it->second,
+                                -rate_constants_.baz_mode1_to_mode2_quux_ );  // reactant partial derivative
+      jacobian_info.emplace_back( baz_mode2_index_it->second,
                                 baz_mode1_index_it->second,
-                                rate_constants_.baz_mode1_to_mode2_quux_ });  // product partial derivative
+                                rate_constants_.baz_mode1_to_mode2_quux_ );  // product partial derivative
     }
 
     // copy-capture the jacobian_info vector in the lambda function that will calculate the Jacobian terms

--- a/test/integration/stub_aerosol_2.hpp
+++ b/test/integration/stub_aerosol_2.hpp
@@ -167,7 +167,7 @@ class AnotherStubAerosolModel
     if (fo2_mode2_index_it != state_variable_indices.end() && baz_mode2_index_it != state_variable_indices.end() &&
         fo2_to_baz_param_it != state_parameter_indices.end())
     {
-      forcing_info.push_back({ fo2_mode2_index_it->second, baz_mode2_index_it->second, fo2_to_baz_param_it->second });
+      forcing_info.emplace_back( fo2_mode2_index_it->second, baz_mode2_index_it->second, fo2_to_baz_param_it->second );
     }
     auto baz_mode3_index_it = state_variable_indices.find("STUB2.MODE3.QUUX.BAZ");
     auto qux_mode3_index_it = state_variable_indices.find("STUB2.MODE3.QUUX.QUX");
@@ -175,7 +175,7 @@ class AnotherStubAerosolModel
     if (baz_mode3_index_it != state_variable_indices.end() && qux_mode3_index_it != state_variable_indices.end() &&
         baz_to_qux_param_it != state_parameter_indices.end())
     {
-      forcing_info.push_back({ baz_mode3_index_it->second, qux_mode3_index_it->second, baz_to_qux_param_it->second });
+      forcing_info.emplace_back( baz_mode3_index_it->second, qux_mode3_index_it->second, baz_to_qux_param_it->second );
     }
 
     // copy capture the forcing_info vector in the lambda function that will calculate the forcing terms
@@ -218,14 +218,14 @@ class AnotherStubAerosolModel
     if (fo2_mode2_index_it != state_variable_indices.end() && baz_mode2_index_it != state_variable_indices.end() &&
         fo2_to_baz_param_it != state_parameter_indices.end())
     {
-      jacobian_info.push_back({ fo2_mode2_index_it->second,
+      jacobian_info.emplace_back( fo2_mode2_index_it->second,
                                 fo2_mode2_index_it->second,
                                 fo2_to_baz_param_it->second,
-                                -1.0 });  // reactant partial derivative
-      jacobian_info.push_back({ baz_mode2_index_it->second,
+                                -1.0 );  // reactant partial derivative
+      jacobian_info.emplace_back( baz_mode2_index_it->second,
                                 fo2_mode2_index_it->second,
                                 fo2_to_baz_param_it->second,
-                                1.0 });  // product partial derivative
+                                1.0 );  // product partial derivative
     }
     auto baz_mode3_index_it = state_variable_indices.find("STUB2.MODE3.QUUX.BAZ");
     auto qux_mode3_index_it = state_variable_indices.find("STUB2.MODE3.QUUX.QUX");
@@ -233,14 +233,14 @@ class AnotherStubAerosolModel
     if (baz_mode3_index_it != state_variable_indices.end() && qux_mode3_index_it != state_variable_indices.end() &&
         baz_to_qux_param_it != state_parameter_indices.end())
     {
-      jacobian_info.push_back({ baz_mode3_index_it->second,
+      jacobian_info.emplace_back( baz_mode3_index_it->second,
                                 baz_mode3_index_it->second,
                                 baz_to_qux_param_it->second,
-                                -1.0 });  // reactant partial derivative
-      jacobian_info.push_back({ qux_mode3_index_it->second,
+                                -1.0 );  // reactant partial derivative
+      jacobian_info.emplace_back( qux_mode3_index_it->second,
                                 baz_mode3_index_it->second,
                                 baz_to_qux_param_it->second,
-                                1.0 });  // product partial derivative
+                                1.0 );  // product partial derivative
     }
 
     // copy-capture the jacobian_info vector in the lambda function that will calculate the Jacobian terms

--- a/test/integration/terminator.hpp
+++ b/test/integration/terminator.hpp
@@ -2,7 +2,7 @@
 
 #include <gtest/gtest.h>
 
-#include <math.h>
+#include <cmath>
 #include <random>
 #include <utility>
 #include <vector>

--- a/test/integration/test_dae_algebraic_error_insensitivity.cpp
+++ b/test/integration/test_dae_algebraic_error_insensitivity.cpp
@@ -71,21 +71,20 @@ namespace
                       .Build();
 
     std::vector<Constraint> constraints;
-    constraints.push_back(EquilibriumConstraint(
+    constraints.emplace_back(EquilibriumConstraint(
         "eq1",
         A_aq,
         std::vector<StoichSpecies>{ { A_gas, 1.0 } },
         std::vector<StoichSpecies>{ { A_aq, 1.0 } },
         VantHoffParam{ .K_HLC_ref_ = K1, .delta_H_ = 0.0 }));
-    constraints.push_back(EquilibriumConstraint(
+    constraints.emplace_back(EquilibriumConstraint(
         "eq2",
         B_aq,
         std::vector<StoichSpecies>{ { A_aq, 1.0 } },
         std::vector<StoichSpecies>{ { B_aq, 1.0 } },
         VantHoffParam{ .K_HLC_ref_ = K2, .delta_H_ = 0.0 }));
     // A_gas is explicitly set as the algebraic balance variable
-    constraints.push_back(
-        LinearConstraint("mass", A_gas, { { A_aq, 1.0 }, { B_aq, 1.0 }, { P, 1.0 }, { A_gas, 1.0 } }, C_total));
+    constraints.emplace_back(LinearConstraint("mass", A_gas, { { A_aq, 1.0 }, { B_aq, 1.0 }, { P, 1.0 }, { A_gas, 1.0 } }, C_total));
 
     auto options = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))

--- a/test/integration/test_dae_constraint_overshoot.cpp
+++ b/test/integration/test_dae_constraint_overshoot.cpp
@@ -58,7 +58,7 @@ TEST(DAEConstraintOvershoot, AlgebraicVariableStaysNonNegative)
   double C_total = 1.0e-6;
 
   std::vector<Constraint> constraints;
-  constraints.push_back(LinearConstraint("mass_conservation", C, { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, C_total));
+  constraints.emplace_back(LinearConstraint("mass_conservation", C, { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, C_total));
 
   auto options = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
@@ -150,7 +150,7 @@ TEST(DAEConstraintOvershoot, EquilibriumPlusConservation)
   std::vector<Constraint> constraints;
 
   // Equilibrium: K_eq * A_gas = A_aq  (A_aq is the explicitly set algebraic species)
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "gas_aq_eq",
       A_aq,
       std::vector<StoichSpecies>{ { A_gas, 1.0 } },
@@ -158,8 +158,7 @@ TEST(DAEConstraintOvershoot, EquilibriumPlusConservation)
       VantHoffParam{ .K_HLC_ref_ = K_eq, .delta_H_ = 0.0 }));
 
   // Conservation: A_gas + A_aq + P = C_total  (A_gas is the algebraic balance variable)
-  constraints.push_back(
-      LinearConstraint("mass_conservation", A_gas, { { A_aq, 1.0 }, { P, 1.0 }, { A_gas, 1.0 } }, C_total));
+  constraints.emplace_back(LinearConstraint("mass_conservation", A_gas, { { A_aq, 1.0 }, { P, 1.0 }, { A_gas, 1.0 } }, C_total));
 
   auto options = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(std::move(options))
@@ -254,7 +253,7 @@ TEST(DAEConstraintOvershoot, AllRosenbrockOrdersConstrained)
 
     constexpr double C_total = 1.0e-6;
     std::vector<Constraint> constraints;
-    constraints.push_back(LinearConstraint("mass_conservation", C, { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, C_total));
+    constraints.emplace_back(LinearConstraint("mass_conservation", C, { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, C_total));
 
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(options)
                       .SetSystem(System(gas_phase))

--- a/test/integration/test_equilibrium_constraint.cpp
+++ b/test/integration/test_equilibrium_constraint.cpp
@@ -43,7 +43,7 @@ TEST(EquilibriumIntegration, SetConstraintsAPIWorks)
   // C is an algebraic variable (not in any kinetic reaction)
   double K_eq = 0.034;
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "B_C_eq",
       C,
       std::vector<StoichSpecies>{ { B, 1.0 } },
@@ -129,13 +129,13 @@ TEST(EquilibriumIntegration, SetConstraintsAPIMultipleConstraints)
   double delta_H2 = -2000.0;
 
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "B_C_eq",
       C,
       std::vector<StoichSpecies>{ { B, 1.0 } },
       std::vector<StoichSpecies>{ { C, 1.0 } },
       VantHoffParam{ .K_HLC_ref_ = K_eq1, .delta_H_ = delta_H1 }));
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "E_F_eq",
       F,
       std::vector<StoichSpecies>{ { E, 1.0 } },
@@ -209,7 +209,7 @@ TEST(EquilibriumIntegration, DAESolveWithConstraint)
   double K_eq = 2.0;
   double delta_H = -2400.0;
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "B_C_eq",
       C,
       std::vector<StoichSpecies>{ { B, 1.0 } },
@@ -307,7 +307,7 @@ TEST(EquilibriumIntegration, DAESolveWithConstraintAndReorderState)
   // Equilibrium constraint: K_eq * B - C = 0, so C = K_eq * B
   double K_eq = 2.0;
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "B_C_eq",
       C,
       std::vector<StoichSpecies>{ { B, 1.0 } },
@@ -383,13 +383,13 @@ TEST(EquilibriumIntegration, DAESolveWithTwoCoupledConstraints)
   double K_eq1 = 3.0;
   double K_eq2 = 5.0;
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "B_C_eq",
       C,
       std::vector<StoichSpecies>{ { B, 1.0 } },
       std::vector<StoichSpecies>{ { C, 1.0 } },
       VantHoffParam{ .K_HLC_ref_ = K_eq1, .delta_H_ = -2400.0 }));
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "B_D_eq",
       D,
       std::vector<StoichSpecies>{ { B, 1.0 } },
@@ -476,7 +476,7 @@ TEST(EquilibriumIntegration, DAESolveWithNonUnitStoichiometry)
   // Equilibrium constraint: K_eq * [A]^2 - [B] = 0
   double K_eq = 10.0;
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "A2_B_eq",
       B,
       std::vector<StoichSpecies>{ { A, 2.0 } },

--- a/test/integration/test_external_model_constraints.cpp
+++ b/test/integration/test_external_model_constraints.cpp
@@ -443,7 +443,7 @@ TEST(ExternalModelConstraints, CombinedBuiltInAndExternalConstraints)
   // Built-in constraint: B <-> C equilibrium
   double K_eq = 5.0;
   std::vector<micm::Constraint> constraints;
-  constraints.push_back(micm::EquilibriumConstraint(
+  constraints.emplace_back(micm::EquilibriumConstraint(
       "B_C_eq",
       C,
       std::vector<micm::StoichSpecies>{ { B, 1.0 } },
@@ -846,7 +846,7 @@ TEST(ExternalModelConstraints, BuiltInVsExternalModelConstraintStepByStep)
 
   // Built-in constraint solver
   std::vector<micm::Constraint> constraints;
-  constraints.push_back(micm::EquilibriumConstraint(
+  constraints.emplace_back(micm::EquilibriumConstraint(
       "B_C_eq",
       C,
       std::vector<micm::StoichSpecies>{ { B, 1.0 } },

--- a/test/integration/test_linear_constraint.cpp
+++ b/test/integration/test_linear_constraint.cpp
@@ -66,8 +66,7 @@ TEST(DAESolveWithConstraint, TerminatorAndRobertson)
   double sum_initial_conc = 1.0;
 
   std::vector<micm::Constraint> constraints;
-  constraints.push_back(
-      micm::LinearConstraint("mass_conservation", C, { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, sum_initial_conc));
+  constraints.emplace_back(micm::LinearConstraint("mass_conservation", C, { { A, 1.0 }, { B, 1.0 }, { C, 1.0 } }, sum_initial_conc));
 
   // ---------------------------------------------------------------------------
   // Solver

--- a/test/unit/constraint/test_constraint_set_policy.hpp
+++ b/test/unit/constraint/test_constraint_set_policy.hpp
@@ -26,7 +26,7 @@ void TestConstruction()
   auto B = Species("B");
   auto AB = Species("AB");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "A_B_eq",
       AB,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
@@ -46,7 +46,7 @@ void TestReplaceStateRowsMapsToAlgebraicSpecies()
   auto B = Species("B");
   auto C = Species("C");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "B_C_eq",
       C,
       std::vector<StoichSpecies>{ StoichSpecies(B, 1.0) },
@@ -74,7 +74,7 @@ void TestNonZeroJacobianElements()
   auto B = Species("B");
   auto AB = Species("AB");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "A_B_eq",
       AB,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
@@ -105,13 +105,13 @@ void TestMultipleConstraints()
   auto C = Species("C");
   auto D = Species("D");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "A_B_eq",
       AB,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
       std::vector<StoichSpecies>{ StoichSpecies(AB, 1.0) },
       VantHoffParam{ .K_HLC_ref_ = 3.3e-2, .delta_H_ = -24000.0 }));
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "C_D_eq",
       D,
       std::vector<StoichSpecies>{ StoichSpecies(C, 1.0) },
@@ -147,7 +147,7 @@ void TestAddForcingTerms()
   auto B = Species("B");
   auto AB = Species("AB");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "A_B_eq",
       AB,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
@@ -204,7 +204,7 @@ void TestSubtractJacobianTerms()
   auto B = Species("B");
   auto AB = Species("AB");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "A_B_eq",
       AB,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
@@ -297,7 +297,7 @@ void TestUnknownSpeciesThrows()
   auto Y = Species("Y");
   auto XY = Species("XY");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "invalid",
       XY,
       std::vector<StoichSpecies>{ StoichSpecies(X, 1.0), StoichSpecies(Y, 1.0) },
@@ -320,7 +320,7 @@ void TestThreeDStateOneConstraint()
   auto X = Species("X");
   auto Y = Species("Y");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "X_Y_eq",
       Y,
       std::vector<StoichSpecies>{ StoichSpecies(X, 1.0) },
@@ -422,7 +422,7 @@ void TestFourDStateTwoConstraints()
   auto B = Species("B");
   auto C = Species("C");
   auto D = Species("D");
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "A_B_eq",
       B,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
@@ -430,7 +430,7 @@ void TestFourDStateTwoConstraints()
       VantHoffParam{ .K_HLC_ref_ = 3.3e-2, .delta_H_ = -24000.0 }));
 
   // Constraint 2: C + D <-> A with K_eq2 = 3.3e-2, algebraic species = A (row 0)
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "CD_A_eq",
       A,
       std::vector<StoichSpecies>{ StoichSpecies(C, 1.0), StoichSpecies(D, 1.0) },
@@ -567,14 +567,14 @@ void TestCoupledConstraintsSharedSpecies()
   auto A = Species("A");
   auto B = Species("B");
   auto C = Species("C");
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "A_B_eq",
       B,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
       std::vector<StoichSpecies>{ StoichSpecies(B, 1.0) },
       VantHoffParam{ .K_HLC_ref_ = 3.3e-2, .delta_H_ = -24000.0 }));
 
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "A_C_eq",
       C,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0) },
@@ -659,7 +659,7 @@ void TestVectorizedMatricesRespectGridCellIndexing()
   auto B = Species("B");
   auto AB = Species("AB");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "A_B_eq",
       AB,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },

--- a/test/unit/constraint/type/test_equilibrium.cpp
+++ b/test/unit/constraint/type/test_equilibrium.cpp
@@ -225,7 +225,7 @@ TEST(EquilibriumConstraint, ResidualComputationThroughConstraintSet)
   auto B = Species("B");
   auto AB = Species("AB");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "A_B_equilibrium",
       AB,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
@@ -302,7 +302,7 @@ TEST(EquilibriumConstraint, JacobianComputationThroughConstraintSet)
   auto B = Species("B");
   auto AB = Species("AB");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "A_B_equilibrium",
       AB,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
@@ -368,7 +368,7 @@ TEST(EquilibriumConstraint, ComplexStoichiometryResidual)
   auto B = Species("B");
   auto C = Species("C");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "dissociation",
       B,
       std::vector<StoichSpecies>{ StoichSpecies(A, 2.0) },
@@ -429,7 +429,7 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianSimple)
   auto B = Species("B");
   auto AB = Species("AB");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "eq",
       AB,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) },
@@ -498,7 +498,7 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianComplexStoichiometry)
   auto B = Species("B");
   auto C = Species("C");
   std::vector<Constraint> constraints;
-  constraints.push_back(EquilibriumConstraint(
+  constraints.emplace_back(EquilibriumConstraint(
       "dissociation",
       B,
       std::vector<StoichSpecies>{ StoichSpecies(A, 2.0) },

--- a/test/unit/constraint/type/test_linear.cpp
+++ b/test/unit/constraint/type/test_linear.cpp
@@ -126,7 +126,7 @@ TEST(LinearConstraint, ResidualComputationThroughConstraintSet)
   auto B = Species("B");
 
   std::vector<Constraint> constraints;
-  constraints.push_back(LinearConstraint(
+  constraints.emplace_back(LinearConstraint(
       "A_B_conservation", B, std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) }, 1.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
@@ -194,7 +194,7 @@ TEST(LinearConstraint, JacobianComputationThroughConstraintSet)
   auto B = Species("B");
 
   std::vector<Constraint> constraints;
-  constraints.push_back(LinearConstraint(
+  constraints.emplace_back(LinearConstraint(
       "A_B_conservation", B, std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) }, 1.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
@@ -250,7 +250,7 @@ TEST(LinearConstraint, WeightedSumResidualAndJacobian)
   auto C = Species("C");
 
   std::vector<Constraint> constraints;
-  constraints.push_back(LinearConstraint(
+  constraints.emplace_back(LinearConstraint(
       "weighted_sum",
       C,
       std::vector<StoichSpecies>{ StoichSpecies(A, 2.0), StoichSpecies(B, 3.0), StoichSpecies(C, -1.0) },
@@ -324,7 +324,7 @@ TEST(LinearConstraint, ThreeSpeciesConservationResidual)
   auto C = Species("C");
 
   std::vector<Constraint> constraints;
-  constraints.push_back(LinearConstraint(
+  constraints.emplace_back(LinearConstraint(
       "ABC_total",
       C,
       std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0), StoichSpecies(C, 1.0) },
@@ -392,8 +392,7 @@ TEST(LinearConstraint, ZeroConstantResidual)
   auto B = Species("B");
 
   std::vector<Constraint> constraints;
-  constraints.push_back(
-      LinearConstraint("A_equals_B", B, std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, -1.0) }, 0.0));
+  constraints.emplace_back(LinearConstraint("A_equals_B", B, std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, -1.0) }, 0.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
 
@@ -455,7 +454,7 @@ TEST(LinearConstraint, FractionalCoefficientsResidualAndJacobian)
   auto B = Species("B");
 
   std::vector<Constraint> constraints;
-  constraints.push_back(LinearConstraint(
+  constraints.emplace_back(LinearConstraint(
       "fractional_conservation", B, std::vector<StoichSpecies>{ StoichSpecies(A, 0.5), StoichSpecies(B, 1.5) }, 2.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
@@ -515,8 +514,7 @@ TEST(LinearConstraint, JacobianIndependentOfConcentrations)
   auto B = Species("B");
 
   std::vector<Constraint> constraints;
-  constraints.push_back(
-      LinearConstraint("A_B_sum", B, std::vector<StoichSpecies>{ StoichSpecies(A, 2.0), StoichSpecies(B, 3.0) }, 1.0));
+  constraints.emplace_back(LinearConstraint("A_B_sum", B, std::vector<StoichSpecies>{ StoichSpecies(A, 2.0), StoichSpecies(B, 3.0) }, 1.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
 
@@ -587,8 +585,7 @@ TEST(LinearConstraint, FiniteDifferenceJacobianSimpleConservation)
   auto B = Species("B");
 
   std::vector<Constraint> constraints;
-  constraints.push_back(
-      LinearConstraint("conservation", B, std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) }, 1.0));
+  constraints.emplace_back(LinearConstraint("conservation", B, std::vector<StoichSpecies>{ StoichSpecies(A, 1.0), StoichSpecies(B, 1.0) }, 1.0));
 
   std::unordered_map<std::string, std::size_t> variable_map = { { "A", 0 }, { "B", 1 } };
   const std::size_t num_species = 2;
@@ -650,7 +647,7 @@ TEST(LinearConstraint, FiniteDifferenceJacobianWeightedSum)
   auto C = Species("C");
 
   std::vector<Constraint> constraints;
-  constraints.push_back(LinearConstraint(
+  constraints.emplace_back(LinearConstraint(
       "weighted",
       C,
       std::vector<StoichSpecies>{ StoichSpecies(A, 2.0), StoichSpecies(B, 3.0), StoichSpecies(C, -1.0) },

--- a/test/unit/cuda/process/test_cuda_rate_constants.cpp
+++ b/test/unit/cuda/process/test_cuda_rate_constants.cpp
@@ -18,7 +18,6 @@
 
 #define _USE_MATH_DEFINES
 #include <cmath>
-#include <math.h>
 #ifndef M_PI
   #define M_PI 3.14159265358979323846
 #endif

--- a/test/unit/cuda/util/test_cuda_dense_matrix.cpp
+++ b/test/unit/cuda/util/test_cuda_dense_matrix.cpp
@@ -720,9 +720,9 @@ void TestSingleBlockMatrixAddOneElement()
   EXPECT_EQ(matrix.GroupVectorSize(), cuda_matrix_vector_length);
   EXPECT_EQ(matrix.GroupSize(), number_of_columns * cuda_matrix_vector_length);
   // Work around NVHPC compiler bug - force runtime evaluation
-  double num_cells_d = static_cast<double>(number_of_grid_cells);
-  double vec_length_d = static_cast<double>(cuda_matrix_vector_length);
-  std::size_t expected_groups = static_cast<std::size_t>(std::ceil(num_cells_d / vec_length_d));
+  auto num_cells_d = static_cast<double>(number_of_grid_cells);
+  auto vec_length_d = static_cast<double>(cuda_matrix_vector_length);
+  auto expected_groups = static_cast<std::size_t>(std::ceil(num_cells_d / vec_length_d));
   EXPECT_EQ(matrix.NumberOfGroups(), expected_groups);
 
   matrix.CopyToDevice();
@@ -755,9 +755,9 @@ void TestMultiBlockMatrixAddOneElement()
   EXPECT_EQ(matrix.GroupVectorSize(), cuda_matrix_vector_length);
   EXPECT_EQ(matrix.GroupSize(), number_of_columns * cuda_matrix_vector_length);
   // Work around NVHPC compiler bug - force runtime evaluation
-  double num_cells_d = static_cast<double>(number_of_grid_cells);
-  double vec_length_d = static_cast<double>(cuda_matrix_vector_length);
-  std::size_t expected_groups = static_cast<std::size_t>(std::ceil(num_cells_d / vec_length_d));
+  auto num_cells_d = static_cast<double>(number_of_grid_cells);
+  auto vec_length_d = static_cast<double>(cuda_matrix_vector_length);
+  auto expected_groups = static_cast<std::size_t>(std::ceil(num_cells_d / vec_length_d));
   EXPECT_EQ(matrix.NumberOfGroups(), expected_groups);
 
   matrix.CopyToDevice();

--- a/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_column.cpp
+++ b/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_column.cpp
@@ -288,8 +288,8 @@ void TestMultiBlockMatrixAddOneElement()
   EXPECT_EQ(matrix.GroupSize(), cuda_matrix_vector_length * 5);
   // Work around NVHPC compiler bug - force runtime evaluation
   double num_cells_d = 53.0;
-  double vec_length_d = static_cast<double>(cuda_matrix_vector_length);
-  std::size_t expected_groups = static_cast<std::size_t>(std::ceil(num_cells_d / vec_length_d));
+  auto vec_length_d = static_cast<double>(cuda_matrix_vector_length);
+  auto expected_groups = static_cast<std::size_t>(std::ceil(num_cells_d / vec_length_d));
   EXPECT_EQ(matrix.NumberOfGroups(53), expected_groups);
 
   matrix.CopyToDevice();

--- a/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_row.cpp
+++ b/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_row.cpp
@@ -288,8 +288,8 @@ void TestMultiBlockMatrixAddOneElement()
   EXPECT_EQ(matrix.GroupSize(), cuda_matrix_vector_length * 5);
   // Work around NVHPC compiler bug - force runtime evaluation
   double num_cells_d = 53.0;
-  double vec_length_d = static_cast<double>(cuda_matrix_vector_length);
-  std::size_t expected_groups = static_cast<std::size_t>(std::ceil(num_cells_d / vec_length_d));
+  auto vec_length_d = static_cast<double>(cuda_matrix_vector_length);
+  auto expected_groups = static_cast<std::size_t>(std::ceil(num_cells_d / vec_length_d));
   EXPECT_EQ(matrix.NumberOfGroups(53), expected_groups);
 
   matrix.CopyToDevice();

--- a/test/unit/process/rate_constant/test_surface_rate_constant.cpp
+++ b/test/unit/process/rate_constant/test_surface_rate_constant.cpp
@@ -10,7 +10,7 @@
 #include <gtest/gtest.h>
 
 #define _USE_MATH_DEFINES
-#include <math.h>
+#include <cmath>
 #ifndef M_PI
   #define M_PI 3.14159265358979323846
 #endif

--- a/test/unit/process/test_process.cpp
+++ b/test/unit/process/test_process.cpp
@@ -17,7 +17,7 @@
 #include <random>
 
 #define _USE_MATH_DEFINES
-#include <math.h>
+#include <cmath>
 #ifndef M_PI
   #define M_PI 3.14159265358979323846
 #endif

--- a/test/unit/process/test_process_set_policy.hpp
+++ b/test/unit/process/test_process_set_policy.hpp
@@ -192,7 +192,7 @@ void TestRandomSystem(std::size_t n_cells, std::size_t n_reactions, std::size_t 
   species_names.reserve(n_species);
   for (std::size_t i = 0; i < n_species; ++i)
   {
-    phase_species.emplace_back(PhaseSpecies(Species(std::to_string(i))));
+    phase_species.emplace_back(Species(std::to_string(i)));
     species_names.emplace_back(std::to_string(i));
   }
   Phase gas_phase{ "gas", phase_species };
@@ -210,7 +210,7 @@ void TestRandomSystem(std::size_t n_cells, std::size_t n_reactions, std::size_t 
     std::vector<Species> reactants{};
     for (std::size_t i_react = 0; i_react < n_react; ++i_react)
     {
-      reactants.push_back({ std::to_string(get_species_id()) });
+      reactants.emplace_back( std::to_string(get_species_id()) );
     }
     auto n_product = get_n_product();
     std::vector<StoichSpecies> products{};

--- a/test/unit/process/test_reaction_rate_store.cpp
+++ b/test/unit/process/test_reaction_rate_store.cpp
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 
 #define _USE_MATH_DEFINES
-#include <math.h>
+#include <cmath>
 #ifndef M_PI
   #define M_PI 3.14159265358979323846
 #endif

--- a/test/unit/solver/test_constraint_initialization.cpp
+++ b/test/unit/solver/test_constraint_initialization.cpp
@@ -39,7 +39,7 @@ struct SimpleConstrainedSystem
 
     // Equilibrium constraint: K_eq * B - C = 0, so C = K_eq * B
     std::vector<Constraint> constraints;
-    constraints.push_back(EquilibriumConstraint(
+    constraints.emplace_back(EquilibriumConstraint(
         "B_C_eq",
         C,
         std::vector<StoichSpecies>{ { B, 1.0 } },

--- a/test/unit/solver/test_rosenbrock.cpp
+++ b/test/unit/solver/test_rosenbrock.cpp
@@ -74,7 +74,7 @@ void TestNormalizedErrorIncludesAllVariables(SolverBuilderPolicy builder, std::s
                                .Build();
 
   std::vector<micm::Constraint> constraints;
-  constraints.push_back(micm::EquilibriumConstraint(
+  constraints.emplace_back(micm::EquilibriumConstraint(
       "B_C_eq",
       C,
       std::vector<micm::StoichSpecies>{ micm::StoichSpecies(B, 1.0) },


### PR DESCRIPTION
Partially addresses #997

Enables
- modernize-type-traits,
- modernize-deprecated-headers,
- modernize-use-std-numbers,
- modernize-use-emplace,
- modernize-use-auto,
- modernize-loop-convert,

Disables
- modernize-return-braced-init-list,

ran
```bash
cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
  -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang
run-clang-tidy -p build -fix '/Users/kshores/Documents/micm/(include|src|test)' 
```