### PR TITLE
Clang bugprone

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -85,6 +85,8 @@ Checks: |
   modernize-use-auto,
   modernize-loop-convert,
   bugprone-use-after-move,
+  bugprone-reserved-identifier,
+  bugprone-integer-division,
   # explicitly disabled checks
   -modernize-return-braced-init-list,
   -readability-redundant-member-init,
@@ -144,3 +146,8 @@ CheckOptions:
     value:           1
   - key:             readability-braces-around-statements.ShortStatementLines
     value:           0
+    # _USE_MATH_DEFINES is a standard opt-in macro that must be defined before
+    # <cmath>/<math.h> to expose M_PI etc. (required by MSVC); allow the
+    # otherwise reserved (leading-underscore) name.
+  - key:             bugprone-reserved-identifier.AllowedIdentifiers
+    value:           '_USE_MATH_DEFINES'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -87,6 +87,8 @@ Checks: |
   bugprone-use-after-move,
   bugprone-reserved-identifier,
   bugprone-integer-division,
+  cert-flp30-c,
+  readability-redundant-access-specifiers,
   # explicitly disabled checks
   -modernize-return-braced-init-list,
   -readability-redundant-member-init,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,6 +52,7 @@
 #   Fires on size_t->double in math expressions and unsigned->ptrdiff_t in
 #   std::next calls. All are safe within realistic problem sizes for a chemistry
 #   solver. Too noisy for the benefit.
+
 # -modernize-return-braced-init-list,
 #   This would remove explicit calls to a constructor using a classname and that feels unnecessary
 
@@ -83,6 +84,7 @@ Checks: |
   modernize-use-emplace,
   modernize-use-auto,
   modernize-loop-convert,
+  bugprone-use-after-move,
   # explicitly disabled checks
   -modernize-return-braced-init-list,
   -readability-redundant-member-init,

--- a/include/micm/constraint/types/linear_constraint.hpp
+++ b/include/micm/constraint/types/linear_constraint.hpp
@@ -40,7 +40,7 @@ namespace micm
     /// @brief Parameter set (unused for this class, always empty).
     std::vector<std::string> parameters_;
 
-   public:
+   
     /// @brief Default constructor
     LinearConstraint() = default;
 

--- a/include/micm/cuda/process/cuda_process_set.hpp
+++ b/include/micm/cuda/process/cuda_process_set.hpp
@@ -32,6 +32,9 @@ namespace micm
 
     CudaProcessSet(const CudaProcessSet&) = delete;
     CudaProcessSet& operator=(const CudaProcessSet&) = delete;
+    // NOLINTBEGIN(bugprone-use-after-move): moving the base subobject leaves the derived-class
+    // members (devstruct_, cuda_rate_store_) untouched, so moving/swapping them out of `other`
+    // afterward is safe.
     CudaProcessSet(CudaProcessSet&& other) noexcept
         : ProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>(std::move(other)),
           cuda_rate_store_(std::move(other.cuda_rate_store_))
@@ -45,6 +48,7 @@ namespace micm
       cuda_rate_store_ = std::move(other.cuda_rate_store_);
       return *this;
     };
+    // NOLINTEND(bugprone-use-after-move)
 
     /// @brief Create a process set calculator for a given set of processes
     /// @param processes Processes to create calculator for

--- a/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_linear_solver_in_place.hpp
@@ -23,6 +23,8 @@ namespace micm
 
     CudaLinearSolverInPlace(const CudaLinearSolverInPlace&) = delete;
     CudaLinearSolverInPlace& operator=(const CudaLinearSolverInPlace&) = delete;
+    // NOLINTBEGIN(bugprone-use-after-move): moving the base subobject leaves the derived-class
+    // member devstruct_ untouched, so swapping it out of `other` afterward is safe.
     CudaLinearSolverInPlace(CudaLinearSolverInPlace&& other) noexcept
         : LinearSolverInPlace<SparseMatrixPolicy, LuDecompositionPolicy>(std::move(other))
     {
@@ -35,6 +37,7 @@ namespace micm
       std::swap(this->devstruct_, other.devstruct_);
       return *this;
     };
+    // NOLINTEND(bugprone-use-after-move)
 
     /// This constructor takes two arguments: a sparse matrix and its values
     /// The base class here takes three arguments: the third argument is

--- a/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
+++ b/include/micm/cuda/solver/cuda_lu_decomposition_mozart_in_place.hpp
@@ -22,6 +22,8 @@ namespace micm
 
     CudaLuDecompositionMozartInPlace(const CudaLuDecompositionMozartInPlace&) = delete;
     CudaLuDecompositionMozartInPlace& operator=(const CudaLuDecompositionMozartInPlace&) = delete;
+    // NOLINTBEGIN(bugprone-use-after-move): moving the base subobject leaves the derived-class
+    // member devstruct_ untouched, so swapping it out of `other` afterward is safe.
     CudaLuDecompositionMozartInPlace(CudaLuDecompositionMozartInPlace&& other) noexcept
         : LuDecompositionMozartInPlace(std::move(other))
     {
@@ -34,6 +36,7 @@ namespace micm
       std::swap(this->devstruct_, other.devstruct_);
       return *this;
     };
+    // NOLINTEND(bugprone-use-after-move)
 
     /// This is the overloaded constructor that takes one argument called "matrix";
     /// We need to specify the type (e.g., double, int, etc) and

--- a/include/micm/cuda/solver/cuda_state.hpp
+++ b/include/micm/cuda/solver/cuda_state.hpp
@@ -75,6 +75,8 @@ namespace micm
     };
 
     /// @brief Move constructor
+    // NOLINTBEGIN(bugprone-use-after-move): moving the base subobject leaves the derived-class
+    // *_param_ members untouched, so copying/resetting them on `other` afterward is safe.
     CudaState(CudaState&& other) noexcept
         : State<DenseMatrixPolicy, SparseMatrixPolicy, LuDecompositionPolicy>(std::move(other))
     {
@@ -101,6 +103,7 @@ namespace micm
       }
       return *this;
     }
+    // NOLINTEND(bugprone-use-after-move)
 
     void SetAbsoluteTolerances(const std::vector<double>& absoluteTolerance) override
     {

--- a/include/micm/cuda/util/cuda_sparse_matrix.hpp
+++ b/include/micm/cuda/util/cuda_sparse_matrix.hpp
@@ -87,6 +87,8 @@ namespace micm
       return *this;
     }
 
+    // NOLINTBEGIN(bugprone-use-after-move): moving the base subobject leaves the derived-class
+    // member param_ untouched, so swapping it out of `other` afterward is safe.
     CudaSparseMatrix& operator=(CudaSparseMatrix&& other) noexcept
     {
       if (this != &other)
@@ -96,6 +98,7 @@ namespace micm
       }
       return *this;
     }
+    // NOLINTEND(bugprone-use-after-move)
 
     ~CudaSparseMatrix()
     {

--- a/include/micm/solver/rosenbrock.inl
+++ b/include/micm/solver/rosenbrock.inl
@@ -129,7 +129,7 @@ namespace micm
         // Compute the stages
         for (uint64_t stage = 0; stage < parameters.stages_; ++stage)
         {
-          double stage_combinations = ((stage + 1) - 1) * ((stage + 1) - 2) / 2;
+          const std::size_t stage_combinations = ((stage + 1) - 1) * ((stage + 1) - 2) / 2;
           if (stage == 0)
           {
             K[stage].Copy(initial_forcing);

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_column.hpp
@@ -303,7 +303,7 @@ namespace micm
         // Tight loop over blocks in this group for vectorization
         for (std::size_t block_in_group = 0; block_in_group < num_blocks_in_group_; ++block_in_group)
         {
-          func(GetBlockElement(block_in_group, std::forward<Args>(args))...);
+          func(GetBlockElement(block_in_group, std::forward<Args>(args))...);  // NOLINT(bugprone-use-after-move)
         }
       }
 
@@ -460,7 +460,7 @@ namespace micm
         // Tight loop over blocks in this group for vectorization
         for (std::size_t block_in_group = 0; block_in_group < num_blocks_in_group_; ++block_in_group)
         {
-          func(GetBlockElement(block_in_group, std::forward<Args>(args))...);
+          func(GetBlockElement(block_in_group, std::forward<Args>(args))...); // NOLINT(bugprone-use-after-move)
         }
       }
 

--- a/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
+++ b/include/micm/util/sparse_matrix_vector_ordering_compressed_sparse_row.hpp
@@ -309,7 +309,7 @@ namespace micm
         // Tight loop over blocks in this group for vectorization
         for (std::size_t block_in_group = 0; block_in_group < num_blocks_in_group_; ++block_in_group)
         {
-          func(GetBlockElement(block_in_group, std::forward<Args>(args))...);
+          func(GetBlockElement(block_in_group, std::forward<Args>(args))...); // NOLINT(bugprone-use-after-move)
         }
       }
 
@@ -466,7 +466,7 @@ namespace micm
         // Tight loop over blocks in this group for vectorization
         for (std::size_t block_in_group = 0; block_in_group < num_blocks_in_group_; ++block_in_group)
         {
-          func(GetBlockElement(block_in_group, std::forward<Args>(args))...);
+          func(GetBlockElement(block_in_group, std::forward<Args>(args))...); // NOLINT(bugprone-use-after-move)
         }
       }
 

--- a/include/micm/util/vector_matrix.hpp
+++ b/include/micm/util/vector_matrix.hpp
@@ -669,7 +669,7 @@ namespace micm
         // Tight loop over L rows in this group for vectorization
         for (std::size_t row_in_group = 0; row_in_group < num_rows_in_group_; ++row_in_group)
         {
-          func(GetRowElement(row_in_group, std::forward<Args>(args))...);
+          func(GetRowElement(row_in_group, std::forward<Args>(args))...); // NOLINT(bugprone-use-after-move)
         }
       }
 
@@ -759,7 +759,7 @@ namespace micm
         // Tight loop over L rows in this group for vectorization
         for (std::size_t row_in_group = 0; row_in_group < num_rows_in_group_; ++row_in_group)
         {
-          func(GetRowElement(row_in_group, std::forward<Args>(args))...);
+          func(GetRowElement(row_in_group, std::forward<Args>(args))...);  // NOLINT(bugprone-use-after-move)
         }
       }
 

--- a/test/integration/terminator.hpp
+++ b/test/integration/terminator.hpp
@@ -58,8 +58,10 @@ void TestTerminator(BuilderPolicy& builder, std::size_t number_of_grid_cells)
   };
 
   auto orig_state_vars = state.variables_;
-  for (double lon = 0.0; lon < 2.0 * M_PI; lon += 0.3)
+  int steps = std::floor(2.0 * M_PI / 0.3);
+  for (int step = 0; step < steps; ++step)
   {
+    double lon = step * 0.3;
     state.variables_ = orig_state_vars;
     for (std::size_t i_cell = 0; i_cell < number_of_grid_cells; ++i_cell)
     {

--- a/test/integration/test_chapman_integration.cpp
+++ b/test/integration/test_chapman_integration.cpp
@@ -87,7 +87,7 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
   state.conditions_[0].temperature_ = 2;
   state.conditions_[0].pressure_ = 3;
 
-  for (double t{}; t < 100; ++t)
+  for (int t{}; t < 100; ++t)
   {
     state.custom_rate_parameters_[0] = photo_rates;
     solver.UpdateStateParameters(state);

--- a/test/integration/test_integrated_reaction_rates.cpp
+++ b/test/integration/test_integrated_reaction_rates.cpp
@@ -56,7 +56,7 @@ TEST(ChapmanIntegration, CanBuildChapmanSystem)
   state.conditions_[0].temperature_ = 273;
   state.conditions_[0].pressure_ = 1000;
 
-  for (double t{}; t < 100; ++t)
+  for (int t{}; t < 100; ++t)
   {
     if (t > 50)
     {

--- a/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
+++ b/test/regression/RosenbrockChapman/chapman_ode_solver.hpp
@@ -369,7 +369,7 @@ namespace micm
           }
           else
           {
-            double stage_combinations = ((stage + 1) - 1) * ((stage + 1) - 2) / 2;
+            const std::size_t stage_combinations = ((stage + 1) - 1) * ((stage + 1) - 2) / 2;
             if (parameters_.new_function_evaluation_[stage])
             {
               auto new_Y{ Y };

--- a/test/unit/cuda/util/test_cuda_dense_matrix.cpp
+++ b/test/unit/cuda/util/test_cuda_dense_matrix.cpp
@@ -419,7 +419,7 @@ TEST(CudaDenseMatrix, MoveConstructor)
   EXPECT_EQ(matrix[1][1], 4);
 
   auto matrix2 = std::move(matrix);
-  if (matrix.AsDeviceParam().d_data_ != nullptr)
+  if (matrix.AsDeviceParam().d_data_ != nullptr)  // NOLINT(bugprone-use-after-move): checks moved-from state
   {
     throw std::runtime_error(
         "The 'd_data_' pointer of matrix2 is not initialized to a null pointer in the move constructor.");

--- a/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_column.cpp
+++ b/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_column.cpp
@@ -154,7 +154,7 @@ TEST(CudaSparseMatrix, MoveAssignmentConstZeroMatrixAddOne)
   micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrderingCompressedSparseColumn<1>> matrix{ builder };
 
   auto oneMatrix = std::move(matrix);
-  if (matrix.AsDeviceParam().d_data_ != nullptr)
+  if (matrix.AsDeviceParam().d_data_ != nullptr)  // NOLINT(bugprone-use-after-move): checks moved-from state
   {
     throw std::runtime_error(
         "The 'd_data_' pointer of oneMatrix is not initialized to a null pointer in the move constructor.");
@@ -208,7 +208,7 @@ TEST(CudaSparseMatrix, MoveAssignmentZeroMatrixAddOne)
   }
 
   auto oneMatrix = std::move(matrix);
-  if (matrix.AsDeviceParam().d_data_ != nullptr)
+  if (matrix.AsDeviceParam().d_data_ != nullptr)  // NOLINT(bugprone-use-after-move): checks moved-from state
   {
     throw std::runtime_error(
         "The 'd_data_' pointer of oneMatrix is not initialized to a null pointer in the move constructor.");

--- a/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_row.cpp
+++ b/test/unit/cuda/util/test_cuda_sparse_matrix_vector_ordering_row.cpp
@@ -154,7 +154,7 @@ TEST(CudaSparseMatrix, MoveAssignmentConstZeroMatrixAddOne)
   micm::CudaSparseMatrix<double, micm::SparseMatrixVectorOrderingCompressedSparseRow<1>> matrix{ builder };
 
   auto oneMatrix = std::move(matrix);
-  if (matrix.AsDeviceParam().d_data_ != nullptr)
+  if (matrix.AsDeviceParam().d_data_ != nullptr)  // NOLINT(bugprone-use-after-move): checks moved-from state
   {
     throw std::runtime_error(
         "The 'd_data_' pointer of oneMatrix is not initialized to a null pointer in the move constructor.");
@@ -208,7 +208,7 @@ TEST(CudaSparseMatrix, MoveAssignmentZeroMatrixAddOne)
   }
 
   auto oneMatrix = std::move(matrix);
-  if (matrix.AsDeviceParam().d_data_ != nullptr)
+  if (matrix.AsDeviceParam().d_data_ != nullptr)  // NOLINT(bugprone-use-after-move): checks moved-from state
   {
     throw std::runtime_error(
         "The 'd_data_' pointer of oneMatrix is not initialized to a null pointer in the move constructor.");


### PR DESCRIPTION
Finally closes #997

Enables
- bugprone-use-after-move,
  - I disabled the linter in a few places here because it was a false positive. The matrices use `std::forward` which try to return an rvalue reference, but the result is only ever returning references to existing storage, so even a copy wouldn't matter becuase it's a refernce
- bugprone-reserved-identifier,
- bugprone-integer-division,
- cert-flp30-c,
- readability-redundant-access-specifiers,

ran
```bash
cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
  -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang
run-clang-tidy -p build -fix '/Users/kshores/Documents/micm/(include|src|test)' 
```