### PR TITLE
update python version to correct ci failure

### DIFF
--- a/.github/workflows/readme_example.yml
+++ b/.github/workflows/readme_example.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   test-readme-example:
     runs-on: ${{ matrix.os }}
-    continue-on-error: true 
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -20,9 +19,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.12"
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
I noticed the [readme example for macos was failing on main](https://github.com/NCAR/micm/actions/runs/31534925429/job/93923645712), but only because of an old python version which I guess is no longer available? This updates that