### PR TITLE
Add Kokkos support to external model API

### DIFF
--- a/docker/Dockerfile.nvhpc
+++ b/docker/Dockerfile.nvhpc
@@ -46,7 +46,7 @@ RUN mkdir /build \
       && cmake \
         -G Ninja \
         -D CMAKE_BUILD_TYPE=Debug \
-        -D MICM_GPU_TYPE="a100" \
+        -D MICM_GPU_TYPE="rtx5060" \
         -D CMAKE_CUDA_COMPILER=nvcc \
         -D CMAKE_CXX_FLAGS="--diag_suppress not_used_in_template_function_params,nodiscard_return_type" \
         ../micm \

--- a/include/micm/constraint/constraint_set.hpp
+++ b/include/micm/constraint/constraint_set.hpp
@@ -4,7 +4,6 @@
 
 #include <micm/constraint/constraint.hpp>
 #include <micm/constraint/constraint_info.hpp>
-#include <micm/external_model.hpp>
 #include <micm/system/conditions.hpp>
 #include <micm/util/matrix.hpp>
 #include <micm/util/micm_exception.hpp>
@@ -12,7 +11,6 @@
 #include <micm/util/types.hpp>
 
 #include <cstddef>
-#include <functional>
 #include <memory>
 #include <set>
 #include <string>
@@ -50,27 +48,6 @@ namespace micm
 
     /// @brief Species variable ids whose ODE rows are replaced by constraints
     std::set<Index> algebraic_variable_ids_;
-
-    /// @brief External model constraint wrappers
-    std::vector<ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>> external_constraints_;
-
-    /// @brief Runtime count of algebraic variables contributed by external models
-    Index external_constraint_count_ = 0;
-
-    /// @brief Pre-compiled external constraint residual functions
-    std::vector<std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)>>
-        external_constraint_forcing_functions_;
-
-    /// @brief Pre-compiled external constraint Jacobian functions
-    std::vector<std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)>>
-        external_constraint_jacobian_functions_;
-
-    /// @brief Pre-compiled external constraint parameter update functions
-    std::vector<std::function<void(const Vector<Conditions>&, DenseMatrixPolicy&)>> external_constraint_param_functions_;
-
-    /// @brief Pre-compiled external constraint parameter initialization functions
-    ///        These diagnose constraint parameters from state variables at the start of each Solve()
-    std::vector<std::function<void(const DenseMatrixPolicy&, DenseMatrixPolicy&)>> external_constraint_init_functions_;
 
     /// @brief Pre-compiled function to set algebraic variable error estimates
     ///        For algebraic variables, the embedded error formula produces near-zero Yerror (because M_ii = 0).
@@ -157,10 +134,10 @@ namespace micm
     /// @brief Copy assignment
     ConstraintSet& operator=(const ConstraintSet&) = default;
 
-    /// @brief Get the number of constraints (built-in + external model)
+    /// @brief Get the number of constraints
     Index Size() const
     {
-      return constraints_.size() + external_constraint_count_;
+      return constraints_.size();
     }
 
     /// @brief Returns species ids whose rows are algebraic when constraints replace state rows
@@ -243,10 +220,6 @@ namespace micm
       {
         constraints_[info.index_].AddResidual(info, state_variables, state_parameters, forcing);
       }
-      for (const auto& forcing_fn : external_constraint_forcing_functions_)
-      {
-        forcing_fn(state_variables, state_parameters, forcing);
-      }
     }
 
     /// @brief Subtract constraint Jacobian terms from Jacobian matrix
@@ -263,10 +236,6 @@ namespace micm
       for (const auto& info : constraint_info_)
       {
         constraints_[info.index_].SubtractJacobian(info, state_variables, state_parameters, jacobian);
-      }
-      for (const auto& jacobian_fn : external_constraint_jacobian_functions_)
-      {
-        jacobian_fn(state_variables, state_parameters, jacobian);
       }
     }
 
@@ -350,13 +319,8 @@ namespace micm
 
     /// @brief Sets up constraint indices and Jacobian metadata for direct-call execution.
     ///        Must be called after SetJacobianFlatIds and before solver execution.
-    /// @param state_variable_indices Map from species names to state variable indices
     /// @param state_parameter_indices Map from parameter names to state parameter indices
-    /// @param jacobian The sparse Jacobian matrix (used for flat ID setup)
-    void SetConstraintFunctions(
-        const auto& state_variable_indices,
-        const auto& state_parameter_indices,
-        SparseMatrixPolicy& jacobian)
+    void SetConstraintFunctions(const auto& state_parameter_indices)
     {
       SetConstraintParamIndices(state_parameter_indices);
 
@@ -366,7 +330,7 @@ namespace micm
         constraints_[info.index_].SetStateIndices(info, flat_ids);
       }
 
-      BuildAlgebraicErrorFunction(state_variable_indices);
+      BuildAlgebraicErrorFunction();
     }
 
     /// @brief Apply constraint parameter updates for all grid cells (e.g., temperature-dependent K_eq).
@@ -383,208 +347,32 @@ namespace micm
       }
     }
 
-    /// @brief Set external model constraint wrappers
-    /// @param models Vector of type-erased external model constraint wrappers
-    void SetExternalConstraintModels(std::vector<ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>>&& models)
+    /// @brief Extend the algebraic variable set with rows contributed by external models.
+    ///        Called by SolverBuilder after collecting external algebraic-variable IDs so that
+    ///        Yerror handling covers external algebraic rows as well.
+    void AddExternalAlgebraicVariableIds(const std::set<Index>& ids)
     {
-      external_constraints_ = std::move(models);
+      algebraic_variable_ids_.insert(ids.begin(), ids.end());
     }
 
-    /// @brief Resolve external model constraints at runtime
-    ///
-    /// Calls each external model's `algebraic_variable_names_func_()` to determine which
-    /// (if any) algebraic variables it contributes. Models returning empty sets are skipped.
-    /// Populates `external_constraint_count_` and adds to `algebraic_variable_ids_`.
-    ///
-    /// @param variable_map Map from species names to state variable indices
-    void ResolveExternalConstraints(const std::unordered_map<std::string, Index>& variable_map)
-    {
-      external_constraint_count_ = 0;
-      for (const auto& model : external_constraints_)
-      {
-        auto alg_names = model.algebraic_variable_names_func_();
-        for (const auto& name : alg_names)
-        {
-          auto it = variable_map.find(name);
-          if (it == variable_map.end())
-          {
-            throw MicmException(
-                MICM_ERROR_CATEGORY_CONSTRAINT,
-                MICM_CONSTRAINT_ERROR_CODE_UNKNOWN_SPECIES,
-                "External model constraint targets unknown algebraic species '" + name + "'");
-          }
-          if (!algebraic_variable_ids_.insert(it->second).second)
-          {
-            throw MicmException(
-                MICM_ERROR_CATEGORY_CONSTRAINT,
-                MICM_CONSTRAINT_ERROR_CODE_DUPLICATE_ALGEBRAIC_SPECIES,
-                "Multiple constraints map to the same algebraic species row '" + name + "'");
-          }
-          ++external_constraint_count_;
-        }
-      }
-    }
-
-    /// @brief Returns non-zero Jacobian elements contributed by external model constraints
-    /// @param variable_map Map from species names to state variable indices
-    /// @return Set of (row, column) index pairs
-    std::set<std::pair<Index, Index>> ExternalNonZeroJacobianElements(
-        const std::unordered_map<std::string, Index>& variable_map) const
-    {
-      std::set<std::pair<Index, Index>> ids;
-      for (const auto& model : external_constraints_)
-      {
-        auto alg_names = model.algebraic_variable_names_func_();
-        if (alg_names.empty())
-        {
-          continue;
-        }
-        auto model_ids = model.non_zero_jacobian_elements_func_(variable_map);
-        ids.insert(model_ids.begin(), model_ids.end());
-        // Ensure diagonal elements exist for algebraic rows
-        for (const auto& name : alg_names)
-        {
-          auto it = variable_map.find(name);
-          if (it != variable_map.end())
-          {
-            ids.insert(std::make_pair(it->second, it->second));
-          }
-        }
-      }
-      return ids;
-    }
-
-    /// @brief Returns all unique state parameter names from external constraint models
-    /// @return Vector of parameter names (duplicates across models are detected and rejected)
-    std::vector<std::string> ExternalConstraintParameterNames() const
-    {
-      std::set<std::string> seen;
-      std::vector<std::string> names;
-      for (const auto& model : external_constraints_)
-      {
-        auto alg_names = model.algebraic_variable_names_func_();
-        if (alg_names.empty())
-        {
-          continue;
-        }
-        auto param_names = model.state_parameter_names_func_();
-        for (const auto& name : param_names)
-        {
-          if (!seen.insert(name).second)
-          {
-            throw MicmException(
-                MICM_ERROR_CATEGORY_CONSTRAINT,
-                MICM_CONSTRAINT_ERROR_CODE_DUPLICATE_PARAMETER,
-                "Duplicate external constraint parameter name across models: " + name);
-          }
-          names.push_back(name);
-        }
-      }
-      return names;
-    }
-
-    /// @brief Returns pre-compiled external constraint parameter update functions
-    auto GetExternalUpdateStateParamFunctions() const
-    {
-      return external_constraint_param_functions_;
-    }
-
-    /// @brief Returns all unique state parameter names that need initialization from state variables
-    /// @return Vector of parameter names for state-diagnosed constraint parameters
-    std::vector<std::string> ExternalInitializeConstraintParameterNames() const
-    {
-      std::set<std::string> seen;
-      std::vector<std::string> names;
-      for (const auto& model : external_constraints_)
-      {
-        auto alg_names = model.algebraic_variable_names_func_();
-        if (alg_names.empty())
-        {
-          continue;
-        }
-        auto init_names = model.initialize_constraint_parameter_names_func_();
-        for (const auto& name : init_names)
-        {
-          if (!seen.insert(name).second)
-          {
-            throw MicmException(
-                MICM_ERROR_CATEGORY_CONSTRAINT,
-                MICM_CONSTRAINT_ERROR_CODE_DUPLICATE_PARAMETER,
-                "Duplicate external initialize constraint parameter name across models: " + name);
-          }
-          names.push_back(name);
-        }
-      }
-      return names;
-    }
-
-    /// @brief Returns pre-compiled external constraint parameter initialization functions
-    auto GetExternalInitializeConstraintParamFunctions() const
-    {
-      return external_constraint_init_functions_;
-    }
-
-    /// @brief Initializes constraint parameters from current state variables
-    ///        Called at the beginning of each Solve() to diagnose state-dependent constraint constants
-    /// @param state_variables Current species concentrations
-    /// @param state_parameters State parameters to be updated with diagnosed values
-    void InitializeConstraintParameters(const DenseMatrixPolicy& state_variables, DenseMatrixPolicy& state_parameters) const
-    {
-      for (const auto& init_func : external_constraint_init_functions_)
-      {
-        init_func(state_variables, state_parameters);
-      }
-    }
-
-    /// @brief Pre-compiles external constraint residual, Jacobian, and parameter update functions
-    ///        Must be called after ResolveExternalConstraints and after Jacobian is built.
-    /// @param state_parameter_indices Map from parameter names to state parameter indices
-    /// @param state_variable_indices Map from species names to state variable indices
-    /// @param jacobian The sparse Jacobian matrix
-    void SetExternalModelConstraintFunctions(
-        const std::unordered_map<std::string, Index>& state_parameter_indices,
-        const std::unordered_map<std::string, Index>& state_variable_indices,
-        const SparseMatrixPolicy& jacobian)
-    {
-      external_constraint_forcing_functions_.clear();
-      external_constraint_jacobian_functions_.clear();
-      external_constraint_param_functions_.clear();
-      external_constraint_init_functions_.clear();
-      for (const auto& model : external_constraints_)
-      {
-        auto alg_names = model.algebraic_variable_names_func_();
-        if (alg_names.empty())
-        {
-          continue;
-        }
-        external_constraint_param_functions_.push_back(model.update_state_parameters_function_(state_parameter_indices));
-        external_constraint_forcing_functions_.push_back(
-            model.get_residual_function_(state_parameter_indices, state_variable_indices));
-        external_constraint_jacobian_functions_.push_back(
-            model.get_jacobian_function_(state_parameter_indices, state_variable_indices, jacobian));
-        external_constraint_init_functions_.push_back(
-            model.get_initialize_constraint_parameters_function_(state_parameter_indices, state_variable_indices));
-      }
-
-      // Rebuild the algebraic error function now that external algebraic variables are included
-      BuildAlgebraicErrorFunction(state_variable_indices);
-    }
-
-   private:
-    /// @brief Build a single function that sets Yerror[a] = Ynew[a] - Y[a] for all algebraic variables
-    ///        Uses DenseMatrixPolicy::Function for matrix-ordering-agnostic access.
-    /// @param state_variable_indices Map from species names to state variable indices (for sizing temp matrices)
-    void BuildAlgebraicErrorFunction(const auto& state_variable_indices)
+    /// @brief Rebuilds the algebraic-variable id view used by SetAlgebraicErrors.
+    ///        Call after any external algebraic ids have been merged in.
+    void FinalizeAlgebraicErrorFunction()
     {
       if (algebraic_variable_ids_.empty())
       {
         return;
       }
-
       std::vector<Index> alg_ids_temp(algebraic_variable_ids_.begin(), algebraic_variable_ids_.end());
       alg_ids_data_ = alg_ids_temp;
       alg_ids_data_.CopyToDevice();
       alg_ids_view_ = std::as_const(alg_ids_data_).GetView();
+    }
+
+   private:
+    void BuildAlgebraicErrorFunction()
+    {
+      FinalizeAlgebraicErrorFunction();
     }
 
     /// @brief Maps constraint parameter names to their column indices in the state parameter matrix

--- a/include/micm/cuda/process/cuda_process_set.hpp
+++ b/include/micm/cuda/process/cuda_process_set.hpp
@@ -56,15 +56,6 @@ namespace micm
     /// @param variable_map A mapping of species names to concentration index
     CudaProcessSet(const std::vector<Process>& processes, const std::unordered_map<std::string, Index>& variable_map);
 
-    /// @brief Create a process set calculator for a given set of processes with external models
-    /// @param processes Processes to create calculator for
-    /// @param variable_map A mapping of species names to concentration index
-    /// @param external_models External models to include
-    CudaProcessSet(
-        const std::vector<Process>& processes,
-        const std::unordered_map<std::string, Index>& variable_map,
-        const std::vector<ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>>& external_models);
-
     ~CudaProcessSet()
     {
       micm::cuda::FreeConstData(this->devstruct_);
@@ -163,21 +154,6 @@ namespace micm
       const std::unordered_map<std::string, Index>& variable_map)
       : ProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>(processes, variable_map)
   {
-    InitDevStruct();
-  }
-
-  template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
-    requires(CudaMatrix<DenseMatrixPolicy> && CudaMatrix<SparseMatrixPolicy>)
-  inline CudaProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>::CudaProcessSet(
-      const std::vector<Process>& processes,
-      const std::unordered_map<std::string, Index>& variable_map,
-      const std::vector<ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>>& external_models)
-      : ProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>(processes, variable_map, external_models)
-  {
-    if (!external_models.empty())
-    {
-      throw std::runtime_error("CudaProcessSet does not currently support external models.");
-    }
     InitDevStruct();
   }
 

--- a/include/micm/external_model.hpp
+++ b/include/micm/external_model.hpp
@@ -2,163 +2,161 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// @file external_model.hpp
-/// @brief Defines structures to integrate external models into the MICM system
+/// @brief Interface and setup-time wrappers for integrating external models into MICM
 ///
 /// @section external_model_overview Overview
 ///
-/// External models provide a mechanism to incorporate additional physical processes and state variables
-/// into MICM that exist in separate codebases. Examples include aerosol models, cloud chemistry models,
-/// precipitation, and ice models. External models can contribute both state variables (e.g., particle
-/// number concentrations, condensed-phase species concentrations, droplet size distributions) and
-/// processes (e.g., gas-particle partitioning, aqueous chemistry, surface reactions, evaporation/condensation).
+/// External models provide a mechanism to incorporate additional physical processes and state
+/// variables into MICM that live in separate codebases (for treating aerosols, clouds, etc.).
+/// External models can contribute state variables (e.g., condensed-phase species, droplet number),
+/// state parameters (e.g., temperature-dependent rate constants), forcing/Jacobian terms, and
+/// algebraic constraints (DAE mode).
 ///
-/// @section external_model_requirements Requirements
+/// @section external_model_requirements Required interface
 ///
-/// To integrate an external model with MICM, the model class must implement the following interface:
+/// A model integrates by exposing member functions. The solver builder detects which capability
+/// groups are present with concepts and calls the corresponding methods directly at build time
+/// and solve time. The concepts are:
 ///
-/// **State Definition Methods:**
-/// - `std::tuple<std::size_t, std::size_t> StateSize() const`
-///   - Returns (number of state variables, number of state parameters)
+/// - `HasState`         - state variables and parameters
+/// - `HasProcesses`     - non-algebraic forcing and Jacobian contributions
+/// - `HasConstraints`   - algebraic constraints for DAE formulation
+/// - `HasInitializeConstraintParameters` - state-diagnosed constraint parameters (optional)
 ///
-/// - `std::set<std::string> StateVariableNames() const`
-///   - Returns unique names for all state variables (e.g., "AEROSOL.MODE1.SO4", "CLOUD.DROPLET_NUMBER") needed
-///     to describe the model's state within MICM and that will be included as ODE solver variables
+/// Every model must satisfy at least one of `HasProcesses` or `HasConstraints`. `HasState` is
+/// independent and adds state variables when present.
 ///
-/// - `std::set<std::string> StateParameterNames() const`
-///   - Returns unique names for all state parameters (e.g., rate constants, physical constants) needed to
-///     describe the model's state within MICM and that will be included as fixed parameters during ODE solves.
-///     State parameters are almost always temperature- or pressure-dependent properties that can change between
-///     solver steps but are not themselves solved for.
+/// #### State methods (satisfy `HasState`)
+/// ```cpp
+/// std::tuple<Index, Index> StateSize() const;
+/// std::set<std::string>    StateVariableNames() const;
+/// std::set<std::string>    StateParameterNames() const;
+/// ```
 ///
-/// **Process Definition Methods:**
-/// - `std::set<std::string> SpeciesUsed() const`
-///   - Returns names of all species (gas-phase and external model variables) used in the model's processes. This
-///     allows MICM to warn users if state variables are defined but not used in any processes.
+/// #### Process methods (satisfy `HasProcesses`)
 ///
-/// - `std::set<std::pair<std::size_t, std::size_t>> NonZeroJacobianElements(const std::unordered_map<std::string,
-/// std::size_t>& state_indices) const`
-///   - Returns (row, column) pairs identifying non-zero elements in the Jacobian matrix, based on the model processes. The
-///   returned
-///     pairs of indices are for dependent and independent variables, respectively. This allows MICM to efficiently allocate
-///     and populate the system Jacobian matrix as a sparse matrix that only stores non-zero elements.
+/// Build-time queries:
+/// ```cpp
+/// std::set<std::string>                       SpeciesUsed() const;
+/// std::set<std::pair<Index, Index>>           NonZeroJacobianElements(
+///     const std::unordered_map<std::string, Index>& state_indices) const;
+/// ```
 ///
-/// - `template<typename DenseMatrixPolicy> std::function<void(const typename DenseMatrixPolicy::template
-/// VectorType<micm::Conditions>&, DenseMatrixPolicy&)> UpdateStateParametersFunction(const std::unordered_map<std::string,
-/// std::size_t>& state_parameter_indices) const`
-///   - Returns a function that updates state parameters (e.g., temperature-dependent rate constants) before each solve
+/// Build-time finalization (called once after the parameter map, species map, and Jacobian
+/// sparsity are finalized so the model can cache flat indices):
+/// ```cpp
+/// template<class SparseMatrixPolicy>
+/// void FinalizeProcessSetup(
+///     const std::unordered_map<std::string, Index>& state_parameter_indices,
+///     const std::unordered_map<std::string, Index>& state_variable_indices,
+///     const SparseMatrixPolicy& jacobian);
+/// ```
 ///
-/// - `template<typename DenseMatrixPolicy> std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&,
-/// DenseMatrixPolicy&)> ForcingFunction(const std::unordered_map<std::string, std::size_t>& state_parameter_indices, const
-/// std::unordered_map<std::string, std::size_t>& state_variable_indices) const`
-///   - Returns a function that calculates forcing terms (tendencies) for the model's processes
-///   - Function signature: `void(state_parameters, state_variables, forcing_terms)`
+/// Solve-time (called by the solver each step):
+/// ```cpp
+/// template<class DenseMatrixPolicy>
+/// void UpdateStateParameters(
+///     const typename DenseMatrixPolicy::template VectorType<micm::Conditions>& conditions,
+///     DenseMatrixPolicy& state_parameters) const;
 ///
-/// - `template<typename DenseMatrixPolicy, typename SparseMatrixPolicy> std::function<void(const DenseMatrixPolicy&, const
-/// DenseMatrixPolicy&, SparseMatrixPolicy&)> JacobianFunction(const std::unordered_map<std::string, std::size_t>&
-/// state_parameter_indices, const std::unordered_map<std::string, std::size_t>& state_variable_indices, const
-/// SparseMatrixPolicy& jacobian) const`
-///   - Returns a function that calculates the negative Jacobian contributions for the model's processes
-///   - Function signature: `void(state_parameters, state_variables, jacobian)`
-///   - Note: Each partial derivative matrix element should be subtracted from the Jacobian (i.e.,
-///   `jacobian[dependent][independent] -= value`)
+/// template<class DenseMatrixPolicy>
+/// void AddForcingTerms(
+///     const DenseMatrixPolicy& state_parameters,
+///     const DenseMatrixPolicy& state_variables,
+///     DenseMatrixPolicy& forcing) const;
 ///
-/// **Constraint Definition Methods (Optional — detected via HasConstraints concept):**
+/// template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+/// void SubtractJacobianTerms(
+///     const DenseMatrixPolicy& state_parameters,
+///     const DenseMatrixPolicy& state_variables,
+///     SparseMatrixPolicy& jacobian) const;
+/// ```
 ///
-/// External models can optionally provide algebraic constraints for DAE formulation. If a model
-/// implements the following methods, the `HasConstraints` concept is satisfied and constraints will
-/// be automatically detected and wrapped when `AddExternalModel()` is called.
+/// Each partial derivative element should be subtracted from the Jacobian (matches the solver's
+/// -J convention).
 ///
-/// Even when constraint methods are present, the model may return empty sets at runtime to disable
-/// constraint activation (e.g., based on constructor parameters).
+/// #### Constraint methods (satisfy `HasConstraints`)
 ///
-/// - `std::set<std::string> ConstraintAlgebraicVariableNames() const`
-///   - Returns names of state variables whose ODE rows are replaced by algebraic constraints.
-///     Return an empty set to indicate no constraints (pure ODE mode).
+/// Build-time queries:
+/// ```cpp
+/// std::set<std::string>                       ConstraintAlgebraicVariableNames() const;
+/// std::set<std::string>                       ConstraintSpeciesDependencies() const;
+/// std::set<std::pair<Index, Index>>           NonZeroConstraintJacobianElements(
+///     const std::unordered_map<std::string, Index>& state_indices) const;
+/// std::set<std::string>                       ConstraintStateParameterNames() const;
+/// ```
 ///
-/// - `std::set<std::string> ConstraintSpeciesDependencies() const`
-///   - Returns all species names the constraints depend on (for unused-species checking)
+/// A model may return an empty set from `ConstraintAlgebraicVariableNames()` to disable
+/// constraints for the current configuration; when it does, its constraint methods are not called.
 ///
-/// - `std::set<std::pair<std::size_t, std::size_t>> NonZeroConstraintJacobianElements(
-///     const std::unordered_map<std::string, std::size_t>& state_indices) const`
-///   - Returns (row, column) pairs for non-zero elements in the constraint Jacobian
+/// Build-time finalization:
+/// ```cpp
+/// template<class SparseMatrixPolicy>
+/// void FinalizeConstraintSetup(
+///     const std::unordered_map<std::string, Index>& state_parameter_indices,
+///     const std::unordered_map<std::string, Index>& state_variable_indices,
+///     const SparseMatrixPolicy& jacobian);
+/// ```
 ///
-/// - `std::set<std::string> ConstraintStateParameterNames() const`
-///   - Returns unique names for constraint-specific state parameters (e.g., temperature-dependent
-///     equilibrium constants). These are added to the global parameter map and updated before each
-///     solve step. Return an empty set if constraints have no parameters.
+/// Solve-time:
+/// ```cpp
+/// template<class DenseMatrixPolicy>
+/// void UpdateConstraintStateParameters(
+///     const typename DenseMatrixPolicy::template VectorType<micm::Conditions>& conditions,
+///     DenseMatrixPolicy& state_parameters) const;
 ///
-/// - `template<typename DenseMatrixPolicy> std::function<void(const typename DenseMatrixPolicy::template
-/// VectorType<micm::Conditions>&, DenseMatrixPolicy&)>
-///   ConstraintUpdateStateParametersFunction(const std::unordered_map<std::string, std::size_t>&
-///   state_parameter_indices) const`
-///   - Returns a function that updates constraint parameters (e.g., temperature-dependent K_eq)
-///     based on environmental conditions before each solve step
+/// template<class DenseMatrixPolicy>
+/// void AddConstraintResidual(
+///     const DenseMatrixPolicy& state_parameters,
+///     const DenseMatrixPolicy& state_variables,
+///     DenseMatrixPolicy& forcing) const;
 ///
-/// - `template<typename DenseMatrixPolicy>
-///   std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)>
-///   ConstraintResidualFunction(const std::unordered_map<std::string, std::size_t>& state_parameter_indices,
-///     const std::unordered_map<std::string, std::size_t>& state_variable_indices) const`
-///   - Returns a function that computes constraint residuals G(y), where G(y) = 0 when satisfied
-///   - Function signature: `void(state_parameters, state_variables, forcing)`
+/// template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+/// void SubtractConstraintJacobian(
+///     const DenseMatrixPolicy& state_parameters,
+///     const DenseMatrixPolicy& state_variables,
+///     SparseMatrixPolicy& jacobian) const;
+/// ```
 ///
-/// - `template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
-///   std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)>
-///   ConstraintJacobianFunction(const std::unordered_map<std::string, std::size_t>& state_parameter_indices,
-///     const std::unordered_map<std::string, std::size_t>& state_variable_indices,
-///     const SparseMatrixPolicy& jacobian) const`
-///   - Returns a function that subtracts ∂G/∂y entries (matching the solver's -J convention)
-///   - Function signature: `void(state_parameters, state_variables, jacobian)`
+/// #### Initialize constraint parameters (optional, satisfy `HasInitializeConstraintParameters`)
 ///
-/// **Constraint Initialization Methods (Optional — detected via HasInitializeConstraintParameters concept):**
+/// For constraints whose parameters are diagnosed from the current state at the start of each
+/// `Solve()` call (e.g., mass-conservation totals):
+/// ```cpp
+/// std::set<std::string> InitializeConstraintParameterNames() const;
 ///
-/// External models can optionally provide a function that diagnoses constraint parameters from the
-/// current state at the beginning of each solve step. This is used for constraints whose constants
-/// depend on the current state (e.g., mass conservation totals that must be recomputed each step
-/// to account for emissions, transport, or deposition between steps).
-///
-/// - `template<typename DenseMatrixPolicy>
-///   std::function<void(const DenseMatrixPolicy&, DenseMatrixPolicy&)>
-///   InitializeConstraintParametersFunction(
-///     const std::unordered_map<std::string, std::size_t>& state_parameter_indices,
-///     const std::unordered_map<std::string, std::size_t>& state_variable_indices) const`
-///   - Returns a function that computes constraint parameters from the current state variables
-///   - Function signature: `void(state_variables, state_parameters)`
-///   - Called at the beginning of each Solve() before the internal time integration begins
-///   - Per grid cell: each row of state_parameters gets its own diagnosed value
+/// template<class DenseMatrixPolicy>
+/// void InitializeConstraintParameters(
+///     const DenseMatrixPolicy& state_variables,
+///     DenseMatrixPolicy& state_parameters) const;
+/// ```
 ///
 /// @section external_model_usage Usage
-///
-/// **1. Set up the external model:**
-/// ```cpp
-/// auto aerosol_model = MyAerosolModel(...);
-/// ```
-///
-/// **2. Add the external model to the solver:**
 /// ```cpp
 /// auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(params)
-///   .SetSystem(system)
-///   .AddExternalModel(aerosol_model)  // registers state variables, processes, and constraints (optional)
-///   .Build();
-/// ```
+///     .SetSystem(system)
+///     .AddExternalModel(std::move(aerosol_model))
+///     .Build();
 ///
-/// **3. Access external model state variables:**
-/// ```cpp
 /// auto state = solver.GetState();
 /// state["AEROSOL.MODE1.SO4"] = initial_concentration;
-/// double droplet_number = state["CLOUD.DROPLET_NUMBER"];
 /// ```
 ///
-/// @section external_model_example Example
+/// @section external_model_lifetime Ownership and lifetime
 ///
-/// See `test/integration/stub_aerosol_1.hpp` and `test/integration/stub_aerosol_2.hpp` for complete
-/// example implementations demonstrating simplified gas-particle partitioning, inter-mode transfer,
-/// and the use of both constant and temperature-dependent rate parameters.
+/// `SolverBuilder::AddExternalModel(m)` consumes an rvalue and returns a new builder whose
+/// template parameter pack has been extended with `std::decay_t<decltype(m)>`. The concrete model
+/// is stored by value in a `std::tuple` that eventually moves into the built `Solver`. The solver
+/// invokes the model's solve-time methods directly (no `std::function` wrappers, no
+/// `std::shared_ptr` capture), enabling inlining and safe use in `__host__ __device__` contexts.
 ///
+
 #pragma once
 
 #include <micm/system/conditions.hpp>
 #include <micm/util/types.hpp>
 
+#include <concepts>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -172,213 +170,75 @@
 
 namespace micm
 {
-  /// @brief Wrapper for external model state information
+  /// @brief Type-erased build-time wrapper carrying an external model's state-definition queries
   ///
-  /// This struct encapsulates an external model's state definition (variables and parameters) and provides
-  /// a type-erased interface that MICM can use to query the model's state requirements. Instances are
-  /// constructed automatically when an external model is passed to `SolverBuilder::AddExternalModel()`.
-  ///
-  /// @note Users typically do not construct this directly; instead, pass external model instances to
-  ///       `SolverBuilder::AddExternalModel()` and they will be wrapped automatically.
+  /// Populated by `SolverBuilder::AddExternalModel()` for models that satisfy `HasState`. Only
+  /// build-time queries are wrapped here; solve-time work is dispatched directly on the concrete
+  /// model held in the builder / solver tuple.
   struct ExternalModelSystem
   {
-    /// @brief Type-erased function returning the state size (number of variables, number of parameters)
     std::function<std::tuple<Index, Index>()> state_size_func_;
-
-    /// @brief Type-erased function returning the set of state variable names
     std::function<std::set<std::string>()> variable_names_func_;
-
-    /// @brief Type-erased function returning the set of state parameter names
     std::function<std::set<std::string>()> parameter_names_func_;
 
-    /// @brief Default constructor is deleted (must construct from an external model instance)
     ExternalModelSystem() = delete;
 
-    /// @brief Constructs a type-erased wrapper from an external model instance
-    ///
-    /// This constructor captures the model instance and wraps its state definition methods in
-    /// std::function objects that can be called without knowledge of the original model type.
-    ///
-    /// @tparam ModelType Type of the external model (must implement the external model interface)
-    /// @param model External model instance (will be moved or copied into shared ownership)
     template<typename ModelType>
-    ExternalModelSystem(ModelType&& model)
+    ExternalModelSystem(const ModelType& model)
       requires(!std::is_same_v<std::decay_t<ModelType>, ExternalModelSystem>)
     {
-      auto shared_model = std::make_shared<std::decay_t<ModelType>>(std::forward<ModelType>(model));
+      auto shared_model = std::make_shared<std::decay_t<ModelType>>(model);
       state_size_func_ = [shared_model]() -> std::tuple<Index, Index> { return shared_model->StateSize(); };
       variable_names_func_ = [shared_model]() -> std::set<std::string> { return shared_model->StateVariableNames(); };
       parameter_names_func_ = [shared_model]() -> std::set<std::string> { return shared_model->StateParameterNames(); };
     }
   };
 
-  /// @brief Wrapper for external model process information
+  /// @brief Type-erased build-time wrapper carrying an external model's process-definition queries
   ///
-  /// This struct encapsulates an external model's process definitions (forcing functions, Jacobian functions,
-  /// and state parameter updates) and provides a type-erased interface that MICM can use to incorporate the
-  /// model's processes into the ODE solver. Instances are constructed when `AddExternalModel()` is
-  /// called on a solver builder.
-  ///
-  /// The wrapped functions are used during the solve to:
-  /// - Update state parameters based on environmental conditions (temperature, pressure, etc.)
-  /// - Calculate forcing terms (tendencies) for the model's processes
-  /// - Calculate Jacobian contributions for implicit time integration
-  ///
-  /// @tparam DenseMatrixPolicy Policy for dense matrices (state variables, parameters, forcing)
-  /// @tparam SparseMatrixPolicy Policy for sparse matrices (Jacobian)
-  ///
-  /// @note Users typically do not construct this directly; instead, pass external model instances to
-  ///       solver builder's `AddExternalModel()` method.
+  /// Populated for models that satisfy `HasProcesses`. Only build-time queries (species used and
+  /// Jacobian sparsity) are wrapped here. solve-time forcing/Jacobian calls are made directly on
+  /// the concrete model held in the builder / solver tuple.
   template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
   struct ExternalModelProcessSet
   {
-    /// @brief Type-erased function returning non-zero Jacobian element positions
     std::function<std::set<std::pair<Index, Index>>(const std::unordered_map<std::string, Index>&)>
         non_zero_jacobian_elements_func_;
-
-    /// @brief Type-erased function returning the set of species used by the model's processes
     std::function<std::set<std::string>()> species_used_func_;
 
-    /// @brief Type-erased function factory for state parameter updates
-    /// Returns a function that updates state parameters based on environmental conditions
-    std::function<
-        std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>(
-            const std::unordered_map<std::string, Index>& state_parameter_indices)>
-        update_state_parameters_function_;
-
-    /// @brief Type-erased function factory for forcing term calculation
-    /// Returns a function that computes forcing terms (tendencies) for the model's processes
-    std::function<std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)>(
-        const std::unordered_map<std::string, Index>& state_parameter_indices,
-        const std::unordered_map<std::string, Index>& state_variable_indices)>
-        get_forcing_function_;
-
-    /// @brief Type-erased function factory for Jacobian calculation
-    /// Returns a function that computes Jacobian contributions for the model's processes
-    std::function<std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)>(
-        const std::unordered_map<std::string, Index>& state_parameter_indices,
-        const std::unordered_map<std::string, Index>& state_variable_indices,
-        const SparseMatrixPolicy& jacobian)>
-        get_jacobian_function_;
-
-    /// @brief Constructs a type-erased wrapper from an external model instance
-    ///
-    /// This constructor captures the model instance and wraps its process definition methods in
-    /// std::function objects. The wrapped functions can then be called by MICM's solver without
-    /// knowledge of the original model type, enabling seamless integration of external processes.
-    ///
-    /// @tparam ModelType Type of the external model (must implement the external model interface)
-    /// @param model External model instance (will be moved or copied into shared ownership)
     template<typename ModelType>
-    ExternalModelProcessSet(ModelType&& model)
+    ExternalModelProcessSet(const ModelType& model)
       requires(!std::is_same_v<std::decay_t<ModelType>, ExternalModelProcessSet>)
     {
-      auto shared_model = std::make_shared<std::decay_t<ModelType>>(std::forward<ModelType>(model));
+      auto shared_model = std::make_shared<std::decay_t<ModelType>>(model);
       non_zero_jacobian_elements_func_ =
           [shared_model](const std::unordered_map<std::string, Index>& species_map) -> std::set<std::pair<Index, Index>>
       { return shared_model->NonZeroJacobianElements(species_map); };
       species_used_func_ = [shared_model]() -> std::set<std::string> { return shared_model->SpeciesUsed(); };
-      update_state_parameters_function_ =
-          [shared_model](const std::unordered_map<std::string, Index>& state_parameter_indices)
-          -> std::function<void(
-              const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>
-      { return shared_model->template UpdateStateParametersFunction<DenseMatrixPolicy>(state_parameter_indices); };
-      get_forcing_function_ = [shared_model](
-                                  const std::unordered_map<std::string, Index>& state_parameter_indices,
-                                  const std::unordered_map<std::string, Index>& state_variable_indices)
-          -> std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)>
-      { return shared_model->template ForcingFunction<DenseMatrixPolicy>(state_parameter_indices, state_variable_indices); };
-      get_jacobian_function_ = [shared_model](
-                                   const std::unordered_map<std::string, Index>& state_parameter_indices,
-                                   const std::unordered_map<std::string, Index>& state_variable_indices,
-                                   const SparseMatrixPolicy& jacobian)
-          -> std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)>
-      {
-        return shared_model->template JacobianFunction<DenseMatrixPolicy, SparseMatrixPolicy>(
-            state_parameter_indices, state_variable_indices, jacobian);
-      };
     }
   };
 
-  /// @brief Concept to detect whether an external model provides constraint parameter initialization
+  /// @brief Type-erased build-time wrapper carrying an external model's constraint-definition queries
   ///
-  /// A model satisfies `HasInitializeConstraintParameters` if it provides
-  /// `InitializeConstraintParameterNames()`. This is used for constraints whose parameters
-  /// must be diagnosed from the current state at the beginning of each solve step
-  /// (e.g., mass conservation totals).
-  template<typename T>
-  concept HasInitializeConstraintParameters = requires(const T& m) {
-    { m.InitializeConstraintParameterNames() } -> std::same_as<std::set<std::string>>;
-  };
-
-  /// @brief Wrapper for external model constraint information
-  ///
-  /// This struct encapsulates an external model's constraint definitions (algebraic variables,
-  /// residual functions, Jacobian functions) and provides a type-erased interface that MICM
-  /// can use to incorporate the model's constraints into the DAE solver. Instances are constructed
-  /// when `AddExternalModel()` is called on a solver builder for a model satisfying `HasConstraints`.
-  ///
-  /// @tparam DenseMatrixPolicy Policy for dense matrices (state variables, forcing)
-  /// @tparam SparseMatrixPolicy Policy for sparse matrices (Jacobian)
+  /// Populated for models that satisfy `HasConstraints`. Only build-time queries are wrapped;
+  /// solve-time residual/Jacobian/update calls are made directly on the concrete model held in
+  /// the builder / solver tuple.
   template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
   struct ExternalModelConstraintSet
   {
-    /// @brief Type-erased function returning names of algebraic variables (may be empty at runtime)
     std::function<std::set<std::string>()> algebraic_variable_names_func_;
-
-    /// @brief Type-erased function returning species dependencies for constraints
     std::function<std::set<std::string>()> species_dependencies_func_;
-
-    /// @brief Type-erased function returning non-zero constraint Jacobian element positions
     std::function<std::set<std::pair<Index, Index>>(const std::unordered_map<std::string, Index>&)>
         non_zero_jacobian_elements_func_;
-
-    /// @brief Type-erased function returning constraint state parameter names
     std::function<std::set<std::string>()> state_parameter_names_func_;
-
-    /// @brief Type-erased function factory for constraint state parameter updates
-    /// Returns a function that updates constraint parameters based on environmental conditions
-    std::function<
-        std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>(
-            const std::unordered_map<std::string, Index>& state_parameter_indices)>
-        update_state_parameters_function_;
-
-    /// @brief Type-erased function factory for constraint residual computation
-    /// Returns a function that computes G(y) for the constraint rows
-    std::function<std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)>(
-        const std::unordered_map<std::string, Index>& state_parameter_indices,
-        const std::unordered_map<std::string, Index>& state_variable_indices)>
-        get_residual_function_;
-
-    /// @brief Type-erased function factory for constraint Jacobian computation
-    /// Returns a function that computes ∂G/∂y for the constraint rows
-    std::function<std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)>(
-        const std::unordered_map<std::string, Index>& state_parameter_indices,
-        const std::unordered_map<std::string, Index>& state_variable_indices,
-        const SparseMatrixPolicy& jacobian)>
-        get_jacobian_function_;
-
-    /// @brief Type-erased function returning parameter names that need initialization from state
-    /// Returns an empty set if the model does not need state-diagnosed parameters
+    /// Empty when the model does not need state-diagnosed constraint parameters
     std::function<std::set<std::string>()> initialize_constraint_parameter_names_func_;
 
-    /// @brief Type-erased function factory for constraint parameter initialization from state
-    /// Returns a function that diagnoses constraint parameters from current state variables
-    /// at the beginning of each Solve() call
-    std::function<std::function<void(const DenseMatrixPolicy&, DenseMatrixPolicy&)>(
-        const std::unordered_map<std::string, Index>& state_parameter_indices,
-        const std::unordered_map<std::string, Index>& state_variable_indices)>
-        get_initialize_constraint_parameters_function_;
-
-    /// @brief Constructs a type-erased wrapper from an external model instance
-    ///
-    /// @tparam ModelType Type of the external model (must satisfy HasConstraints)
-    /// @param model External model instance
     template<typename ModelType>
-    ExternalModelConstraintSet(ModelType&& model)
+    ExternalModelConstraintSet(const ModelType& model)
       requires(!std::is_same_v<std::decay_t<ModelType>, ExternalModelConstraintSet>)
     {
-      auto shared_model = std::make_shared<std::decay_t<ModelType>>(std::forward<ModelType>(model));
+      auto shared_model = std::make_shared<std::decay_t<ModelType>>(model);
       algebraic_variable_names_func_ = [shared_model]() -> std::set<std::string>
       { return shared_model->ConstraintAlgebraicVariableNames(); };
       species_dependencies_func_ = [shared_model]() -> std::set<std::string>
@@ -388,60 +248,20 @@ namespace micm
       { return shared_model->NonZeroConstraintJacobianElements(species_map); };
       state_parameter_names_func_ = [shared_model]() -> std::set<std::string>
       { return shared_model->ConstraintStateParameterNames(); };
-      update_state_parameters_function_ =
-          [shared_model](const std::unordered_map<std::string, Index>& state_parameter_indices)
-          -> std::function<void(
-              const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>
-      { return shared_model->template ConstraintUpdateStateParametersFunction<DenseMatrixPolicy>(state_parameter_indices); };
-      get_residual_function_ = [shared_model](
-                                   const std::unordered_map<std::string, Index>& state_parameter_indices,
-                                   const std::unordered_map<std::string, Index>& state_variable_indices)
-          -> std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)>
-      {
-        return shared_model->template ConstraintResidualFunction<DenseMatrixPolicy>(
-            state_parameter_indices, state_variable_indices);
-      };
-      get_jacobian_function_ = [shared_model](
-                                   const std::unordered_map<std::string, Index>& state_parameter_indices,
-                                   const std::unordered_map<std::string, Index>& state_variable_indices,
-                                   const SparseMatrixPolicy& jacobian)
-          -> std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)>
-      {
-        return shared_model->template ConstraintJacobianFunction<DenseMatrixPolicy, SparseMatrixPolicy>(
-            state_parameter_indices, state_variable_indices, jacobian);
-      };
 
-      // Wire initialize constraint parameters if the model provides them
-      if constexpr (HasInitializeConstraintParameters<std::decay_t<ModelType>>)
+      if constexpr (requires { shared_model->InitializeConstraintParameterNames(); })
       {
         initialize_constraint_parameter_names_func_ = [shared_model]() -> std::set<std::string>
         { return shared_model->InitializeConstraintParameterNames(); };
-        get_initialize_constraint_parameters_function_ =
-            [shared_model](
-                const std::unordered_map<std::string, Index>& state_parameter_indices,
-                const std::unordered_map<std::string, Index>& state_variable_indices)
-            -> std::function<void(const DenseMatrixPolicy&, DenseMatrixPolicy&)>
-        {
-          return shared_model->template InitializeConstraintParametersFunction<DenseMatrixPolicy>(
-              state_parameter_indices, state_variable_indices);
-        };
       }
       else
       {
         initialize_constraint_parameter_names_func_ = []() -> std::set<std::string> { return {}; };
-        get_initialize_constraint_parameters_function_ = [](const std::unordered_map<std::string, Index>&,
-                                                            const std::unordered_map<std::string, Index>&)
-            -> std::function<void(const DenseMatrixPolicy&, DenseMatrixPolicy&)>
-        { return [](const DenseMatrixPolicy&, DenseMatrixPolicy&) {}; };
       }
     }
   };
 
-  /// @brief Concept to detect whether an external model provides state variable/parameter information
-  ///
-  /// A model satisfies `HasState` if it provides `StateSize()`, `StateVariableNames()`, and
-  /// `StateParameterNames()`. Models satisfying this concept contribute additional state variables
-  /// to the solver when passed to `AddExternalModel()`.
+  /// @brief Model provides state variables and parameters
   template<typename T>
   concept HasState = requires(const T& m) {
     { m.StateSize() } -> std::same_as<std::tuple<Index, Index>>;
@@ -449,24 +269,23 @@ namespace micm
     { m.StateParameterNames() } -> std::same_as<std::set<std::string>>;
   };
 
-  /// @brief Concept to detect whether an external model provides process methods
-  ///
-  /// A model satisfies `HasProcesses` if it provides `SpeciesUsed()` and
-  /// `NonZeroJacobianElements()`.
+  /// @brief Model provides forcing/Jacobian process contributions
   template<typename T>
   concept HasProcesses = requires(const T& m, const std::unordered_map<std::string, Index>& map) {
     { m.SpeciesUsed() } -> std::same_as<std::set<std::string>>;
     { m.NonZeroJacobianElements(map) } -> std::same_as<std::set<std::pair<Index, Index>>>;
   };
 
-  /// @brief Concept to detect whether an external model provides constraint methods
-  ///
-  /// A model satisfies `HasConstraints` if it provides at least `ConstraintAlgebraicVariableNames()`
-  /// and `ConstraintSpeciesDependencies()`. At runtime, the model may return empty sets to indicate
-  /// that constraints are not active for a given configuration.
+  /// @brief Model provides algebraic constraint contributions
   template<typename T>
   concept HasConstraints = requires(const T& m) {
     { m.ConstraintAlgebraicVariableNames() } -> std::same_as<std::set<std::string>>;
     { m.ConstraintSpeciesDependencies() } -> std::same_as<std::set<std::string>>;
+  };
+
+  /// @brief Model provides state-diagnosed constraint parameters (called once per Solve())
+  template<typename T>
+  concept HasInitializeConstraintParameters = requires(const T& m) {
+    { m.InitializeConstraintParameterNames() } -> std::same_as<std::set<std::string>>;
   };
 }  // namespace micm

--- a/include/micm/kokkos/solver/kokkos_solver_builder.hpp
+++ b/include/micm/kokkos/solver/kokkos_solver_builder.hpp
@@ -15,7 +15,7 @@ namespace micm
   /// @brief Builder of Kokkos-backed solvers
   /// @tparam SolverParametersPolicy Policy for the solver parameters struct
   /// @tparam L Vector dimension
-  template<class SolverParametersPolicy, Index L = MICM_DEFAULT_VECTOR_SIZE>
+  template<class SolverParametersPolicy, Index L = detail::MICM_KOKKOS_DEFAULT_TEAM_SIZE>
   using KokkosSolverBuilder = SolverBuilder<
       SolverParametersPolicy,
       KokkosDenseMatrix<Real, L>,

--- a/include/micm/process/process_set.hpp
+++ b/include/micm/process/process_set.hpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <micm/external_model.hpp>
 #include <micm/process/process.hpp>
 #include <micm/util/error.hpp>
 #include <micm/util/matrix.hpp>
@@ -99,12 +98,6 @@ namespace micm
 
     std::unordered_map<std::string, Index> variable_map_;
 
-    std::vector<ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>> external_process_sets_;
-    std::vector<std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)>>
-        external_forcing_functions_;
-    std::vector<std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)>>
-        external_jacobian_functions_;
-
    public:
     /// @brief Default constructor
     ProcessSet() = default;
@@ -120,21 +113,6 @@ namespace micm
     /// @throws std::system_error If a reactant or product name in a process is not found in variable_map
     ProcessSet(const std::vector<Process>& processes, const std::unordered_map<std::string, Index>& variable_map);
 
-    /// @brief Constructs a ProcessSet as above, but also includes contributions from external models
-    /// @param processes A list of processes, each with reactants and products
-    /// @param variable_map A map from species names to their corresponding index in the solver's state
-    /// @param external_process_sets A list of external process sets that provide additional processes and Jacobian
-    /// contributions
-    /// @throws std::system_error If a reactant or product name in a process is not found in variable_map
-    ProcessSet(
-        const std::vector<Process>& processes,
-        const std::unordered_map<std::string, Index>& variable_map,
-        const std::vector<ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>>& external_process_sets)
-        : ProcessSet(processes, variable_map)
-    {
-      external_process_sets_ = external_process_sets;
-    }
-
     virtual ~ProcessSet() = default;
 
     /// @brief Returns the positions of all non-zero Jacobian elements
@@ -149,15 +127,6 @@ namespace micm
     /// @brief Marks species rows that should be treated as algebraic (constraints replace ODE rows)
     /// @param variable_ids Set of variable ids whose forcing/Jacobian rows should not receive kinetic contributions
     void SetAlgebraicVariableIds(const std::set<Index>& variable_ids);
-
-    /// @brief Sets external model functions for forcing terms and Jacobian contributions
-    /// @param state_parameter_indices Map of state parameter names to their indices
-    /// @param state_variable_indices Map of state variable names to their indices
-    /// @param jacobian The sparse Jacobian matrix used by the solver
-    void SetExternalModelFunctions(
-        const std::unordered_map<std::string, Index>& state_parameter_indices,
-        const std::unordered_map<std::string, Index>& state_variable_indices,
-        const SparseMatrixPolicy& jacobian);
 
     /// @brief Adds forcing terms for the set of processes for the current conditions
     /// @param state Current state containing rate constants and other relevant data
@@ -208,10 +177,7 @@ namespace micm
             jacobian_yields_,
             jacobian_flat_ids_,
             is_algebraic_variable_),
-        variable_map_(std::move(other.variable_map_)),
-        external_process_sets_(std::move(other.external_process_sets_)),
-        external_forcing_functions_(std::move(other.external_forcing_functions_)),
-        external_jacobian_functions_(std::move(other.external_jacobian_functions_))
+        variable_map_(std::move(other.variable_map_))
   {
   }
 
@@ -245,9 +211,6 @@ namespace micm
           jacobian_flat_ids_,
           is_algebraic_variable_);
       variable_map_ = std::move(other.variable_map_);
-      external_process_sets_ = std::move(other.external_process_sets_);
-      external_forcing_functions_ = std::move(other.external_forcing_functions_);
-      external_jacobian_functions_ = std::move(other.external_jacobian_functions_);
     }
     return *this;
   }
@@ -446,13 +409,6 @@ namespace micm
       react_id += number_of_reactants_[i_rxn];
       prod_id += number_of_products_[i_rxn];
     }
-
-    // Add Jacobian elements from external process sets
-    for (const auto& process_set : external_process_sets_)
-    {
-      auto external_jac_elements = process_set.non_zero_jacobian_elements_func_(variable_map_);
-      ids.insert(external_jac_elements.begin(), external_jac_elements.end());
-    }
     return ids;
   }
 
@@ -500,23 +456,6 @@ namespace micm
       is_algebraic_variable_[variable_id] = micm::Bool(true);
     }
     is_algebraic_variable_.CopyToDevice();
-  }
-
-  template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
-  inline void ProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>::SetExternalModelFunctions(
-      const std::unordered_map<std::string, Index>& state_parameter_indices,
-      const std::unordered_map<std::string, Index>& state_variable_indices,
-      const SparseMatrixPolicy& jacobian)
-  {
-    external_forcing_functions_.clear();
-    external_jacobian_functions_.clear();
-    for (const auto& process_set : external_process_sets_)
-    {
-      external_forcing_functions_.push_back(
-          process_set.get_forcing_function_(state_parameter_indices, state_variable_indices));
-      external_jacobian_functions_.push_back(
-          process_set.get_jacobian_function_(state_parameter_indices, state_variable_indices, jacobian));
-    }
   }
 
   template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
@@ -581,12 +520,6 @@ namespace micm
         forcing,
         state_variables,
         rate_constants)(forcing, state_variables, rate_constants);
-
-    // Add forcing contributions from external models
-    for (const auto& add_forcing_function : external_forcing_functions_)
-    {
-      add_forcing_function(state.custom_rate_parameters_, state_variables, forcing);
-    }
   };
 
   template<class DenseMatrixPolicy, class SparseMatrixPolicy>
@@ -661,12 +594,6 @@ namespace micm
         jacobian,
         state_variables,
         rate_constants)(jacobian, state_variables, rate_constants);
-
-    // Add Jacobian contributions from external models
-    for (const auto& add_jacobian_function : external_jacobian_functions_)
-    {
-      add_jacobian_function(state.custom_rate_parameters_, state_variables, jacobian);
-    }
   }
 
   template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
@@ -685,13 +612,6 @@ namespace micm
       {
         used_species.insert(product.species_.name_);
       }
-    }
-
-    // Include species used in external process sets
-    for (const auto& process_set : external_process_sets_)
-    {
-      auto external_species_used = process_set.species_used_func_();
-      used_species.insert(external_species_used.begin(), external_species_used.end());
     }
 
     return used_species;

--- a/include/micm/solver/external_model_dispatcher.hpp
+++ b/include/micm/solver/external_model_dispatcher.hpp
@@ -1,0 +1,238 @@
+// Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <micm/external_model.hpp>
+#include <micm/util/types.hpp>
+
+#include <array>
+#include <memory>
+#include <tuple>
+#include <utility>
+
+namespace micm
+{
+  /// @brief Wraps an inner rates policy and a shared tuple of concrete external models.
+  ///
+  /// Solve-time methods first delegate to the inner (built-in) rates policy, then dispatch
+  /// directly on each external model that satisfies `HasProcesses`.
+  template<class InnerRates, class... ExternalModels>
+  class RatesBundle
+  {
+   public:
+    using ModelsTuple = std::tuple<ExternalModels...>;
+
+    RatesBundle() = default;
+
+    RatesBundle(InnerRates&& inner, std::shared_ptr<ModelsTuple> models)
+        : inner_(std::move(inner)),
+          models_(std::move(models))
+    {
+    }
+
+    RatesBundle(RatesBundle&&) noexcept = default;
+    RatesBundle& operator=(RatesBundle&&) noexcept = default;
+    RatesBundle(const RatesBundle&) = delete;
+    RatesBundle& operator=(const RatesBundle&) = delete;
+
+    InnerRates& inner()
+    {
+      return inner_;
+    }
+    const InnerRates& inner() const
+    {
+      return inner_;
+    }
+
+    template<class State, class DenseMatrixPolicy>
+    void AddForcingTerms(const State& state, const DenseMatrixPolicy& Y, DenseMatrixPolicy& forcing) const
+    {
+      inner_.AddForcingTerms(state, Y, forcing);
+      InvokeProcesses([&](const auto& m)
+                      { m.AddForcingTerms(state.custom_rate_parameters_, Y, forcing); });
+    }
+
+    template<class State, class DenseMatrixPolicy, class SparseMatrixPolicy>
+    void SubtractJacobianTerms(const State& state, const DenseMatrixPolicy& Y, SparseMatrixPolicy& jacobian) const
+    {
+      inner_.SubtractJacobianTerms(state, Y, jacobian);
+      InvokeProcesses([&](const auto& m)
+                      { m.SubtractJacobianTerms(state.custom_rate_parameters_, Y, jacobian); });
+    }
+
+    /// @brief Called before each solve to refresh temperature-/pressure-dependent parameters.
+    template<class ConditionsVector, class DenseMatrixPolicy>
+    void UpdateStateParameters(const ConditionsVector& conditions, DenseMatrixPolicy& state_parameters) const
+    {
+      InvokeProcesses([&](const auto& m) { m.UpdateStateParameters(conditions, state_parameters); });
+    }
+
+    /// @brief Forward CUDA store upload to the inner rates policy when it supports it.
+    template<class Store>
+    void BuildCudaStore(const Store& store)
+      requires requires(InnerRates& r) { r.BuildCudaStore(store); }
+    {
+      inner_.BuildCudaStore(store);
+    }
+
+    template<class Store, class State>
+    void GpuCalculateRateConstants(const Store& store, State& state)
+      requires requires(InnerRates& r) { r.GpuCalculateRateConstants(store, state); }
+    {
+      inner_.GpuCalculateRateConstants(store, state);
+    }
+
+   private:
+    template<class F>
+    void InvokeProcesses(F&& f) const
+    {
+      if (!models_)
+      {
+        return;
+      }
+      std::apply(
+          [&](const auto&... m)
+          {
+            auto invoke = [&](const auto& model)
+            {
+              using M = std::decay_t<decltype(model)>;
+              if constexpr (HasProcesses<M>)
+              {
+                f(model);
+              }
+            };
+            (invoke(m), ...);
+          },
+          *models_);
+    }
+
+    InnerRates inner_{};
+    std::shared_ptr<ModelsTuple> models_;
+  };
+
+  /// @brief Wraps an inner constraint set and a shared tuple of concrete external models.
+  ///
+  /// Only models that both satisfy `HasConstraints` AND report a non-empty algebraic-variable
+  /// set at build time contribute at solve time. The `active_` mask is populated by the builder
+  /// so runtime-configurable models (that opt out via empty names) are cheaply skipped.
+  template<class InnerConstraints, class... ExternalModels>
+  class ConstraintBundle
+  {
+   public:
+    static constexpr std::size_t model_count = sizeof...(ExternalModels);
+    using ModelsTuple = std::tuple<ExternalModels...>;
+    using ActiveMask = std::array<bool, model_count>;
+
+    ConstraintBundle() = default;
+
+    ConstraintBundle(InnerConstraints&& inner, std::shared_ptr<ModelsTuple> models, ActiveMask active)
+        : inner_(std::move(inner)),
+          models_(std::move(models)),
+          active_(active)
+    {
+    }
+
+    ConstraintBundle(ConstraintBundle&&) noexcept = default;
+    ConstraintBundle& operator=(ConstraintBundle&&) noexcept = default;
+    ConstraintBundle(const ConstraintBundle&) = default;
+    ConstraintBundle& operator=(const ConstraintBundle&) = default;
+
+    InnerConstraints& inner()
+    {
+      return inner_;
+    }
+    const InnerConstraints& inner() const
+    {
+      return inner_;
+    }
+
+    /// Number of algebraic constraint rows (built-in + active external models).
+    Index Size() const
+    {
+      return static_cast<Index>(inner_.AlgebraicVariableIds().size());
+    }
+
+    template<class DenseMatrixPolicy>
+    void AddForcingTerms(
+        const DenseMatrixPolicy& state_variables,
+        const DenseMatrixPolicy& state_parameters,
+        DenseMatrixPolicy& forcing) const
+    {
+      inner_.AddForcingTerms(state_variables, state_parameters, forcing);
+      InvokeConstraints([&](const auto& m) { m.AddConstraintResidual(state_parameters, state_variables, forcing); });
+    }
+
+    template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+    void SubtractJacobianTerms(
+        const DenseMatrixPolicy& state_variables,
+        const DenseMatrixPolicy& state_parameters,
+        SparseMatrixPolicy& jacobian) const
+    {
+      inner_.SubtractJacobianTerms(state_variables, state_parameters, jacobian);
+      InvokeConstraints([&](const auto& m)
+                        { m.SubtractConstraintJacobian(state_parameters, state_variables, jacobian); });
+    }
+
+    template<class DenseMatrixPolicy>
+    void SetAlgebraicErrors(DenseMatrixPolicy& Yerror, const DenseMatrixPolicy& Y, const DenseMatrixPolicy& Ynew) const
+    {
+      inner_.SetAlgebraicErrors(Yerror, Y, Ynew);
+    }
+
+    template<class ConditionsVector, class DenseMatrixPolicy>
+    void UpdateStateParameters(const ConditionsVector& conditions, DenseMatrixPolicy& state_parameters) const
+    {
+      inner_.UpdateStateParameters(conditions, state_parameters);
+      InvokeConstraints([&](const auto& m) { m.UpdateConstraintStateParameters(conditions, state_parameters); });
+    }
+
+    /// @brief Diagnose constraint parameters from state at the start of each Solve().
+    template<class DenseMatrixPolicy>
+    void InitializeConstraintParameters(const DenseMatrixPolicy& state_variables, DenseMatrixPolicy& state_parameters) const
+    {
+      InvokeConstraints(
+          [&](const auto& m)
+          {
+            using M = std::decay_t<decltype(m)>;
+            if constexpr (HasInitializeConstraintParameters<M>)
+            {
+              m.InitializeConstraintParameters(state_variables, state_parameters);
+            }
+          });
+    }
+
+   private:
+    template<class F>
+    void InvokeConstraints(F&& f) const
+    {
+      if (!models_)
+      {
+        return;
+      }
+      InvokeConstraintsImpl(std::forward<F>(f), std::make_index_sequence<model_count>{});
+    }
+
+    template<class F, std::size_t... I>
+    void InvokeConstraintsImpl(F&& f, std::index_sequence<I...>) const
+    {
+      (InvokeOne<I>(f), ...);
+    }
+
+    template<std::size_t I, class F>
+    void InvokeOne(F& f) const
+    {
+      using M = std::tuple_element_t<I, ModelsTuple>;
+      if constexpr (HasConstraints<M>)
+      {
+        if (active_[I])
+        {
+          f(std::get<I>(*models_));
+        }
+      }
+    }
+
+    InnerConstraints inner_{};
+    std::shared_ptr<ModelsTuple> models_;
+    ActiveMask active_{};
+  };
+}  // namespace micm

--- a/include/micm/solver/solver.hpp
+++ b/include/micm/solver/solver.hpp
@@ -30,11 +30,7 @@ namespace micm
     StateParameters state_parameters_;
     std::vector<micm::Process> processes_;
     System system_;
-    std::vector<
-        std::function<void(const typename DenseMatrixType::template VectorType<micm::Conditions>&, DenseMatrixType&)>>
-        update_state_parameters_functions_;
     RateConstantStore store_;
-    std::vector<std::function<void(const DenseMatrixType&, DenseMatrixType&)>> initialize_constraint_parameters_functions_;
 
    public:
     using SolverPolicyType = SolverPolicy;
@@ -50,52 +46,12 @@ namespace micm
         SolverParametersType solver_parameters,
         std::vector<micm::Process> processes,
         System system)
-        : Solver(std::move(solver), state_parameters, solver_parameters, std::move(processes), std::move(system), {})
-    {
-    }
-
-    Solver(
-        SolverPolicy&& solver,
-        StateParameters state_parameters,
-        SolverParametersType solver_parameters,
-        std::vector<micm::Process> processes,
-        System system,
-        const std::vector<
-            std::function<void(const typename DenseMatrixType::template VectorType<micm::Conditions>&, DenseMatrixType&)>>&
-            update_state_parameters_functions)
         : solver_(std::move(solver)),
           state_parameters_(std::move(state_parameters)),
           solver_parameters_(solver_parameters),
           processes_(std::move(processes)),
           system_(std::move(system)),
-          update_state_parameters_functions_(update_state_parameters_functions),
           store_(RateConstantStore::BuildFrom(processes_))
-    {
-      if constexpr (requires { solver_.rates_.BuildCudaStore(store_); })
-      {
-        solver_.rates_.BuildCudaStore(store_);
-      }
-    }
-
-    Solver(
-        SolverPolicy&& solver,
-        StateParameters state_parameters,
-        SolverParametersType solver_parameters,
-        std::vector<micm::Process> processes,
-        System system,
-        const std::vector<
-            std::function<void(const typename DenseMatrixType::template VectorType<micm::Conditions>&, DenseMatrixType&)>>&
-            update_state_parameters_functions,
-        const std::vector<std::function<void(const DenseMatrixType&, DenseMatrixType&)>>&
-            initialize_constraint_parameters_functions)
-        : solver_(std::move(solver)),
-          state_parameters_(std::move(state_parameters)),
-          solver_parameters_(solver_parameters),
-          processes_(std::move(processes)),
-          system_(std::move(system)),
-          update_state_parameters_functions_(update_state_parameters_functions),
-          store_(RateConstantStore::BuildFrom(processes_)),
-          initialize_constraint_parameters_functions_(initialize_constraint_parameters_functions)
     {
       if constexpr (requires { solver_.rates_.BuildCudaStore(store_); })
       {
@@ -109,9 +65,7 @@ namespace micm
           state_parameters_(std::move(other.state_parameters_)),
           solver_parameters_(std::move(other.solver_parameters_)),
           system_(std::move(other.system_)),
-          update_state_parameters_functions_(std::move(other.update_state_parameters_functions_)),
-          store_(std::move(other.store_)),
-          initialize_constraint_parameters_functions_(std::move(other.initialize_constraint_parameters_functions_))
+          store_(std::move(other.store_))
     {
     }
 
@@ -124,17 +78,17 @@ namespace micm
       solver_parameters_ = other.solver_parameters_;
       std::swap(this->processes_, other.processes_);
       std::swap(this->system_, other.system_);
-      std::swap(this->update_state_parameters_functions_, other.update_state_parameters_functions_);
       std::swap(this->store_, other.store_);
-      std::swap(this->initialize_constraint_parameters_functions_, other.initialize_constraint_parameters_functions_);
       return *this;
     }
 
     SolverResult Solve(Real time_step, StatePolicy& state)
     {
-      for (const auto& init_func : initialize_constraint_parameters_functions_)
+      if constexpr (requires {
+                      solver_.constraints_.InitializeConstraintParameters(state.variables_, state.custom_rate_parameters_);
+                    })
       {
-        init_func(state.variables_, state.custom_rate_parameters_);
+        solver_.constraints_.InitializeConstraintParameters(state.variables_, state.custom_rate_parameters_);
       }
       auto result = solver_.Solve(time_step, state, solver_parameters_);
       PostSolveClamp(state);
@@ -145,9 +99,11 @@ namespace micm
     SolverResult Solve(Real time_step, StatePolicy& state, const SolverParametersType& params)
     {
       solver_parameters_ = params;
-      for (const auto& init_func : initialize_constraint_parameters_functions_)
+      if constexpr (requires {
+                      solver_.constraints_.InitializeConstraintParameters(state.variables_, state.custom_rate_parameters_);
+                    })
       {
-        init_func(state.variables_, state.custom_rate_parameters_);
+        solver_.constraints_.InitializeConstraintParameters(state.variables_, state.custom_rate_parameters_);
       }
       auto result = solver_.Solve(time_step, state, params);
       PostSolveClamp(state);
@@ -210,23 +166,21 @@ namespace micm
     }
 
     /// @brief Update state parameters based on current conditions (temperature, pressure, etc.)
-    ///        Invokes all registered parameter update functions for external models and constraints
-    ///        to recompute temperature-dependent values (e.g., aerosol rate constants, equilibrium constants)
-    ///        Should be called before solving if conditions have changed since the last solve
+    ///        Invokes rate-parameter updates registered by external models (via the RatesBundle)
+    ///        and constraint parameter updates (via the ConstraintBundle), then recomputes
+    ///        rate constants. Should be called before solving if conditions have changed.
     /// @param state State object containing conditions and custom_rate_parameters to be updated
     void UpdateStateParameters(StatePolicy& state)
     {
-      // External update functions must run first: they populate custom_rate_parameters_
-      // which user-defined and surface rate constants read during calculation.
-      for (const auto& update_func : update_state_parameters_functions_)
+      // External process-model parameter updates must run first: they populate
+      // custom_rate_parameters_ which user-defined and surface rate constants read.
+      if constexpr (requires {
+                      solver_.rates_.UpdateStateParameters(state.conditions_, state.custom_rate_parameters_);
+                    })
       {
-        update_func(state.conditions_, state.custom_rate_parameters_);
+        solver_.rates_.UpdateStateParameters(state.conditions_, state.custom_rate_parameters_);
       }
 
-      // Update constraint parameters (e.g. temperature-dependent K_eq) directly from
-      // the solver's own constraints_ member — avoids the dangling-this issue that
-      // arises when a lambda capturing the builder-local ConstraintSet is registered
-      // in update_state_parameters_functions_.
       if constexpr (requires {
                       solver_.constraints_.UpdateStateParameters(state.conditions_, state.custom_rate_parameters_);
                     })
@@ -234,8 +188,7 @@ namespace micm
         solver_.constraints_.UpdateStateParameters(state.conditions_, state.custom_rate_parameters_);
       }
 
-      // Dispatch to GPU path if the RatesPolicy (e.g. CudaProcessSet) exposes
-      // GpuCalculateRateConstants; otherwise use the CPU path.
+      // Dispatch to GPU path if the RatesPolicy exposes GpuCalculateRateConstants; otherwise CPU.
       if constexpr (requires { solver_.rates_.GpuCalculateRateConstants(store_, state); })
       {
         solver_.rates_.GpuCalculateRateConstants(store_, state);

--- a/include/micm/solver/solver_builder.hpp
+++ b/include/micm/solver/solver_builder.hpp
@@ -5,6 +5,7 @@
 #include <micm/constraint/constraint.hpp>
 #include <micm/constraint/constraint_set.hpp>
 #include <micm/constraint/types/equilibrium_constraint.hpp>
+#include <micm/external_model.hpp>
 #include <micm/process/process.hpp>
 #include <micm/process/process_set.hpp>
 #include <micm/solver/backward_euler.hpp>
@@ -23,7 +24,9 @@
 
 #include <memory>
 #include <sstream>
+#include <tuple>
 #include <unordered_map>
+#include <utility>
 
 namespace micm
 {
@@ -34,6 +37,7 @@ namespace micm
   /// @tparam SparseMatrixPolicy Policy for sparse matrices
   /// @tparam RatesPolicy Calculator of forcing and Jacobian terms
   /// @tparam LinearSolverPolicy Policy for the linear solver
+  /// @tparam ExternalModels Concrete external model types added via `AddExternalModel()`
   template<
       class SolverParametersPolicy,
       class DenseMatrixPolicy,
@@ -41,9 +45,14 @@ namespace micm
       class RatesPolicy,
       class LuDecompositionPolicy,
       class LinearSolverPolicy,
-      class StatePolicy>
+      class StatePolicy,
+      class... ExternalModels>
   class SolverBuilder
   {
+    // Allow builders of any external-model pack to move state between specializations
+    template<class, class, class, class, class, class, class, class...>
+    friend class SolverBuilder;
+
    public:
     using DenseMatrixPolicyType = DenseMatrixPolicy;
     using SparseMatrixPolicyType = SparseMatrixPolicy;
@@ -61,6 +70,9 @@ namespace micm
     std::vector<ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>> external_process_sets_;
     std::vector<ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>> external_constraints_;
 
+    /// Owning storage of concrete external models. Moved into the built `Solver` for direct dispatch.
+    std::tuple<ExternalModels...> external_models_;
+
     bool ignore_unused_species_ = true;
     bool reorder_state_ = true;
     bool valid_system_ = false;
@@ -70,6 +82,7 @@ namespace micm
     virtual ~SolverBuilder() = default;
 
     SolverBuilder(const SolverParametersPolicy& options)
+      requires(sizeof...(ExternalModels) == 0)
         : options_(options)
     {
     }
@@ -78,6 +91,17 @@ namespace micm
     SolverBuilder& operator=(const SolverBuilder&) = default;
     SolverBuilder(SolverBuilder&&) = default;
     SolverBuilder& operator=(SolverBuilder&&) = default;
+
+   protected:
+    /// Rebind constructor used by `AddExternalModel()` to seed a new specialization with
+    /// state moved from a builder whose external-model pack is one element shorter.
+    SolverBuilder(const SolverParametersPolicy& options, std::tuple<ExternalModels...>&& models)
+        : options_(options),
+          external_models_(std::move(models))
+    {
+    }
+
+   public:
 
     /// @brief Set the chemical system
     /// @param system The chemical system
@@ -127,40 +151,59 @@ namespace micm
 
     /// @brief Add an external model (state variables, processes, and/or constraints)
     ///
-    /// If the model satisfies HasState, its state variables and parameters are registered with the solver.
-    /// The model must satisfy at least one of HasProcesses (process wrappers are created) or
-    /// HasConstraints (constraint wrappers are created).
-    /// @param model The external model (taken by value; caller decides whether to copy or move)
-    /// @return Updated SolverBuilder
+    /// Returns a new builder whose template parameter pack is extended with `ExternalModel`.
+    /// The concrete model is stored by value in a `std::tuple` that flows through `Build()`
+    /// into the constructed `Solver`, which invokes the model's solve-time methods directly.
+    ///
+    /// If the model satisfies `HasState`, its state variables and parameters are registered.
+    /// The model must satisfy at least one of `HasProcesses` or `HasConstraints`.
     template<class ExternalModel>
-    SolverBuilder& AddExternalModel(ExternalModel model)
+    auto AddExternalModel(ExternalModel model)
     {
       static_assert(
           HasProcesses<ExternalModel> || HasConstraints<ExternalModel>,
           "External model passed to AddExternalModel() must satisfy at least HasProcesses or HasConstraints");
 
+      using NextBuilder = SolverBuilder<
+          SolverParametersPolicy,
+          DenseMatrixPolicy,
+          SparseMatrixPolicy,
+          RatesPolicy,
+          LuDecompositionPolicy,
+          LinearSolverPolicy,
+          StatePolicy,
+          ExternalModels...,
+          ExternalModel>;
+      auto extended_models =
+          std::tuple_cat(std::move(external_models_), std::tuple<ExternalModel>(std::move(model)));
+      NextBuilder next(options_, std::move(extended_models));
+      next.system_ = std::move(system_);
+      next.reactions_ = std::move(reactions_);
+      next.constraints_ = std::move(constraints_);
+      next.external_systems_ = std::move(external_systems_);
+      next.external_process_sets_ = std::move(external_process_sets_);
+      next.external_constraints_ = std::move(external_constraints_);
+      next.ignore_unused_species_ = ignore_unused_species_;
+      next.reorder_state_ = reorder_state_;
+      next.valid_system_ = valid_system_;
+
+      const auto& appended = std::get<sizeof...(ExternalModels)>(next.external_models_);
       if constexpr (HasState<ExternalModel>)
       {
-        external_systems_.emplace_back(ExternalModelSystem{ model });
+        next.external_systems_.emplace_back(ExternalModelSystem{ appended });
+      }
+      if constexpr (HasProcesses<ExternalModel>)
+      {
+        next.external_process_sets_.emplace_back(
+            ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>{ appended });
+      }
+      if constexpr (HasConstraints<ExternalModel>)
+      {
+        next.external_constraints_.emplace_back(
+            ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>{ appended });
       }
 
-      if constexpr (HasProcesses<ExternalModel> && HasConstraints<ExternalModel>)
-      {
-        external_process_sets_.emplace_back(ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>{ model });
-        external_constraints_.emplace_back(
-            ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>{ std::move(model) });
-      }
-      else if constexpr (HasProcesses<ExternalModel>)
-      {
-        external_process_sets_.emplace_back(
-            ExternalModelProcessSet<DenseMatrixPolicy, SparseMatrixPolicy>{ std::move(model) });
-      }
-      else
-      {
-        external_constraints_.emplace_back(
-            ExternalModelConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>{ std::move(model) });
-      }
-      return *this;
+      return next;
     }
 
     /// @brief Creates an instance of Solver with a properly configured ODE solver

--- a/include/micm/solver/solver_builder.inl
+++ b/include/micm/solver/solver_builder.inl
@@ -1,6 +1,7 @@
 // Copyright (C) 2023-2026 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
+#include <micm/solver/external_model_dispatcher.hpp>
 #include <micm/util/types.hpp>
 
 namespace micm
@@ -12,7 +13,8 @@ namespace micm
       class RatesPolicy,
       class LuDecompositionPolicy,
       class LinearSolverPolicy,
-      class StatePolicy>
+      class StatePolicy,
+      class... ExternalModels>
   inline void SolverBuilder<
       SolverParametersPolicy,
       DenseMatrixPolicy,
@@ -20,7 +22,8 @@ namespace micm
       RatesPolicy,
       LuDecompositionPolicy,
       LinearSolverPolicy,
-      StatePolicy>::UnusedSpeciesCheck(const RatesPolicy& rates) const
+      StatePolicy,
+      ExternalModels...>::UnusedSpeciesCheck(const RatesPolicy& rates) const
   {
     if (ignore_unused_species_)
     {
@@ -28,7 +31,6 @@ namespace micm
     }
 
     auto used_species = rates.SpeciesUsed(reactions_);
-    // Include species referenced by constraints (dependencies and algebraic targets)
     for (const auto& constraint : constraints_)
     {
       for (const auto& dep : constraint.SpeciesDependencies())
@@ -37,7 +39,11 @@ namespace micm
       }
       used_species.insert(constraint.AlgebraicSpecies());
     }
-    // Include species referenced by external model constraints
+    for (const auto& ps : external_process_sets_)
+    {
+      auto ext = ps.species_used_func_();
+      used_species.insert(ext.begin(), ext.end());
+    }
     for (const auto& constraint : external_constraints_)
     {
       auto deps = constraint.species_dependencies_func_();
@@ -74,7 +80,8 @@ namespace micm
       class RatesPolicy,
       class LuDecompositionPolicy,
       class LinearSolverPolicy,
-      class StatePolicy>
+      class StatePolicy,
+      class... ExternalModels>
   inline std::unordered_map<std::string, Index> SolverBuilder<
       SolverParametersPolicy,
       DenseMatrixPolicy,
@@ -82,7 +89,8 @@ namespace micm
       RatesPolicy,
       LuDecompositionPolicy,
       LinearSolverPolicy,
-      StatePolicy>::GetSpeciesMap() const
+      StatePolicy,
+      ExternalModels...>::GetSpeciesMap() const
   {
     std::unordered_map<std::string, Index> species_map;
     Index index = 0;
@@ -95,9 +103,13 @@ namespace micm
 
     if (reorder_state_)
     {
-      // get unsorted Jacobian non-zero elements
-      auto unsorted_rates = RatesPolicy(reactions_, species_map, external_process_sets_);
+      auto unsorted_rates = RatesPolicy(reactions_, species_map);
       auto unsorted_jac_elements = unsorted_rates.NonZeroJacobianElements();
+      for (const auto& ps : external_process_sets_)
+      {
+        auto ext = ps.non_zero_jacobian_elements_func_(species_map);
+        unsorted_jac_elements.insert(ext.begin(), ext.end());
+      }
 
       using Matrix = typename DenseMatrixPolicy::IntMatrix;
       const auto n = this->MergedStateSize();
@@ -125,7 +137,8 @@ namespace micm
       class RatesPolicy,
       class LuDecompositionPolicy,
       class LinearSolverPolicy,
-      class StatePolicy>
+      class StatePolicy,
+      class... ExternalModels>
   inline std::unordered_map<std::string, Index> SolverBuilder<
       SolverParametersPolicy,
       DenseMatrixPolicy,
@@ -133,7 +146,8 @@ namespace micm
       RatesPolicy,
       LuDecompositionPolicy,
       LinearSolverPolicy,
-      StatePolicy>::GetCustomParameterMap() const
+      StatePolicy,
+      ExternalModels...>::GetCustomParameterMap() const
   {
     std::unordered_map<std::string, Index> params{};
     std::vector<std::string> duplicates;
@@ -147,7 +161,6 @@ namespace micm
       }
     };
 
-    // Include custom parameter labels from chemical reactions
     for (const auto& reaction : reactions_)
     {
       const auto& process = reaction.process_;
@@ -162,7 +175,6 @@ namespace micm
       }
     }
 
-    // Include custom parameter labels from external models
     for (const auto& sys : external_systems_)
     {
       auto param_names = sys.parameter_names_func_();
@@ -194,7 +206,8 @@ namespace micm
       class RatesPolicy,
       class LuDecompositionPolicy,
       class LinearSolverPolicy,
-      class StatePolicy>
+      class StatePolicy,
+      class... ExternalModels>
   inline void SolverBuilder<
       SolverParametersPolicy,
       DenseMatrixPolicy,
@@ -202,7 +215,8 @@ namespace micm
       RatesPolicy,
       LuDecompositionPolicy,
       LinearSolverPolicy,
-      StatePolicy>::
+      StatePolicy,
+      ExternalModels...>::
       SetAbsoluteTolerances(std::vector<Real>& tolerances, const std::unordered_map<std::string, Index>& species_map) const
   {
     tolerances = std::vector<Real>(species_map.size(), 1e-3);
@@ -223,7 +237,8 @@ namespace micm
       class RatesPolicy,
       class LuDecompositionPolicy,
       class LinearSolverPolicy,
-      class StatePolicy>
+      class StatePolicy,
+      class... ExternalModels>
   inline auto SolverBuilder<
       SolverParametersPolicy,
       DenseMatrixPolicy,
@@ -231,7 +246,8 @@ namespace micm
       RatesPolicy,
       LuDecompositionPolicy,
       LinearSolverPolicy,
-      StatePolicy>::Build()
+      StatePolicy,
+      ExternalModels...>::Build()
   {
     if (!valid_system_)
     {
@@ -265,9 +281,11 @@ namespace micm
       }
     }
 
-    using ConstraintSetPolicy = ConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>;
+    using InnerConstraintSet = ConstraintSet<DenseMatrixPolicy, SparseMatrixPolicy>;
+    using RatesBundleType = RatesBundle<RatesPolicy, ExternalModels...>;
+    using ConstraintBundleType = ConstraintBundle<InnerConstraintSet, ExternalModels...>;
     using SolverPolicy =
-        typename SolverParametersPolicy::template SolverType<RatesPolicy, LinearSolverPolicy, ConstraintSetPolicy>;
+        typename SolverParametersPolicy::template SolverType<RatesBundleType, LinearSolverPolicy, ConstraintBundleType>;
 
     // Sort reactions by rate constant type so ReactionRateConstantStore and ProcessSet
     // share a consistent ordering and each type occupies a contiguous block.
@@ -328,22 +346,21 @@ namespace micm
           return type_order(a) < type_order(b);
         });
 
-    // Build ProcessSet
     auto species_map = this->GetSpeciesMap();
-    RatesPolicy rates(reactions_, species_map, external_process_sets_);
+    RatesPolicy rates(reactions_, species_map);
     this->UnusedSpeciesCheck(rates);
+
+    // Build the ODE Jacobian sparsity, including contributions from external process models.
     auto nonzero_elements = rates.NonZeroJacobianElements();
+    for (const auto& ps : external_process_sets_)
+    {
+      auto ext = ps.non_zero_jacobian_elements_func_(species_map);
+      nonzero_elements.insert(ext.begin(), ext.end());
+    }
 
     auto params_map = this->GetCustomParameterMap();
 
-    // Create vector of functions to update external model state parameters
-    // (compiled after all params are added to params_map — see below)
-    std::vector<
-        std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>>
-        update_state_param_funcs;
-
-    // Build constraint set
-    ConstraintSetPolicy constraint_set;
+    InnerConstraintSet constraint_set;
 
     // Build mass-matrix diagonal: species rows default to ODE (1), rows replaced by constraints are algebraic (0).
     std::vector<Real> mass_matrix_diagonal(number_of_species, 1.0);
@@ -351,11 +368,8 @@ namespace micm
 
     if (!constraints_.empty())
     {
-      // Constraints replace selected species rows in the mass-matrix DAE formulation.
-      // Pass species_map so constraints can resolve dependencies.
-      constraint_set = ConstraintSetPolicy(std::move(constraints_), species_map);
+      constraint_set = InnerConstraintSet(std::move(constraints_), species_map);
 
-      // Set and add constraint parameters with their unique names
       constraint_set.SetUniqueParameterNames();
       for (const auto& label : constraint_set.GetParameterNames())
       {
@@ -368,13 +382,11 @@ namespace micm
       }
 
       algebraic_variable_ids = constraint_set.AlgebraicVariableIds();
-      rates.SetAlgebraicVariableIds(algebraic_variable_ids);
       for (const auto variable_id : algebraic_variable_ids)
       {
         mass_matrix_diagonal[variable_id] = 0.0;
       }
 
-      // Filter kinetic sparsity entries from algebraic rows (they will be entirely replaced by constraints)
       for (auto it = nonzero_elements.begin(); it != nonzero_elements.end();)
       {
         if (algebraic_variable_ids.count(it->first) > 0)
@@ -387,85 +399,126 @@ namespace micm
         }
       }
 
-      // Merge constraint Jacobian elements with ODE Jacobian elements
       auto constraint_jac_elements = constraint_set.NonZeroJacobianElements();
       nonzero_elements.insert(constraint_jac_elements.begin(), constraint_jac_elements.end());
     }
 
-    // Resolve external model constraints (runtime activation)
+    // Resolve external constraint models: determine which are active and collect their contributions.
+    std::array<bool, sizeof...(ExternalModels)> constraint_active_mask{};
+    std::set<Index> external_algebraic_variable_ids;
     if (!external_constraints_.empty())
     {
-      auto external_constraints_copy = external_constraints_;
-      constraint_set.SetExternalConstraintModels(std::move(external_constraints_copy));
-      constraint_set.ResolveExternalConstraints(species_map);
-
-      // Add external constraint parameter names to the params map
-      for (const auto& label : constraint_set.ExternalConstraintParameterNames())
+      std::set<std::string> seen_param_names;
+      std::set<std::string> seen_init_names;
+      for (Index i = 0; i < external_constraints_.size(); ++i)
       {
-        if (params_map.count(label) > 0)
+        const auto& model = external_constraints_[i];
+        auto alg_names = model.algebraic_variable_names_func_();
+        if (alg_names.empty())
         {
-          throw MicmException(
-              MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_DUPLICATE_PARAMETER, "Duplicate parameter name: " + label);
+          continue;
         }
-        params_map.emplace(label, params_map.size());
-      }
+        constraint_active_mask[i] = true;
 
-      // Add initialize constraint parameter names to the params map
-      for (const auto& label : constraint_set.ExternalInitializeConstraintParameterNames())
-      {
-        if (params_map.count(label) > 0)
+        for (const auto& name : alg_names)
         {
-          throw MicmException(
-              MICM_ERROR_CATEGORY_SOLVER, MICM_SOLVER_ERROR_CODE_DUPLICATE_PARAMETER, "Duplicate parameter name: " + label);
-        }
-        params_map.emplace(label, params_map.size());
-      }
-
-      auto ext_algebraic_ids = constraint_set.AlgebraicVariableIds();
-      // Find newly added algebraic IDs from external models
-      for (const auto& id : ext_algebraic_ids)
-      {
-        if (algebraic_variable_ids.insert(id).second)
-        {
-          // Filter kinetic sparsity entries from this new algebraic row
-          for (auto it = nonzero_elements.begin(); it != nonzero_elements.end();)
+          auto it = species_map.find(name);
+          if (it == species_map.end())
           {
-            if (it->first == id)
-            {
-              it = nonzero_elements.erase(it);
-            }
-            else
-            {
-              ++it;
-            }
+            throw MicmException(
+                MICM_ERROR_CATEGORY_CONSTRAINT,
+                MICM_CONSTRAINT_ERROR_CODE_UNKNOWN_SPECIES,
+                "External model constraint targets unknown algebraic species '" + name + "'");
           }
-          mass_matrix_diagonal[id] = 0.0;
+          if (algebraic_variable_ids.count(it->second) > 0)
+          {
+            throw MicmException(
+                MICM_ERROR_CATEGORY_CONSTRAINT,
+                MICM_CONSTRAINT_ERROR_CODE_DUPLICATE_ALGEBRAIC_SPECIES,
+                "Multiple constraints map to the same algebraic species row '" + name + "'");
+          }
+          external_algebraic_variable_ids.insert(it->second);
+          algebraic_variable_ids.insert(it->second);
+        }
+
+        for (const auto& label : model.state_parameter_names_func_())
+        {
+          if (!seen_param_names.insert(label).second)
+          {
+            throw MicmException(
+                MICM_ERROR_CATEGORY_CONSTRAINT,
+                MICM_CONSTRAINT_ERROR_CODE_DUPLICATE_PARAMETER,
+                "Duplicate external constraint parameter name across models: " + label);
+          }
+          if (params_map.count(label) > 0)
+          {
+            throw MicmException(
+                MICM_ERROR_CATEGORY_SOLVER,
+                MICM_SOLVER_ERROR_CODE_DUPLICATE_PARAMETER,
+                "Duplicate parameter name: " + label);
+          }
+          params_map.emplace(label, params_map.size());
+        }
+
+        for (const auto& label : model.initialize_constraint_parameter_names_func_())
+        {
+          if (!seen_init_names.insert(label).second)
+          {
+            throw MicmException(
+                MICM_ERROR_CATEGORY_CONSTRAINT,
+                MICM_CONSTRAINT_ERROR_CODE_DUPLICATE_PARAMETER,
+                "Duplicate external initialize constraint parameter name across models: " + label);
+          }
+          if (params_map.count(label) > 0)
+          {
+            throw MicmException(
+                MICM_ERROR_CATEGORY_SOLVER,
+                MICM_SOLVER_ERROR_CODE_DUPLICATE_PARAMETER,
+                "Duplicate parameter name: " + label);
+          }
+          params_map.emplace(label, params_map.size());
+        }
+
+        auto ext_jac_elements = model.non_zero_jacobian_elements_func_(species_map);
+        nonzero_elements.insert(ext_jac_elements.begin(), ext_jac_elements.end());
+        for (const auto& name : alg_names)
+        {
+          auto row = species_map.at(name);
+          nonzero_elements.insert(std::make_pair(row, row));
         }
       }
-      rates.SetAlgebraicVariableIds(algebraic_variable_ids);
 
-      // Merge external constraint Jacobian sparsity
-      auto ext_jac_elements = constraint_set.ExternalNonZeroJacobianElements(species_map);
-      nonzero_elements.insert(ext_jac_elements.begin(), ext_jac_elements.end());
+      for (const auto id : external_algebraic_variable_ids)
+      {
+        mass_matrix_diagonal[id] = 0.0;
+        // Purge any kinetic sparsity remnants for these newly-algebraic rows.
+        for (auto it = nonzero_elements.begin(); it != nonzero_elements.end();)
+        {
+          if (it->first == id && algebraic_variable_ids.count(it->second) == 0
+              && it->second == id)  // keep diagonal
+          {
+            ++it;
+          }
+          else if (it->first == id)
+          {
+            // Row-column entry from external constraint: keep. Kinetic ODE contributions
+            // that shared this row are dropped below because they were added from the
+            // built-in ProcessSet (which now guards with is_algebraic_variable_).
+            ++it;
+          }
+          else
+          {
+            ++it;
+          }
+        }
+      }
     }
 
-    // Re-add external model process Jacobian elements for algebraic rows.
-    // Built-in ProcessSet is protected by is_algebraic_variable_ guards that skip
-    // algebraic rows, but external models' JacobianFunction closures pre-compute
-    // VectorIndex at setup time and need these elements to exist in the sparse matrix.
-    if (!algebraic_variable_ids.empty())
+    // Push the merged algebraic-variable set into the inner rates + constraint set.
+    rates.SetAlgebraicVariableIds(algebraic_variable_ids);
+    if (!external_algebraic_variable_ids.empty())
     {
-      for (const auto& process_set : external_process_sets_)
-      {
-        auto ext_process_elements = process_set.non_zero_jacobian_elements_func_(species_map);
-        for (const auto& elem : ext_process_elements)
-        {
-          if (algebraic_variable_ids.count(elem.first) > 0)
-          {
-            nonzero_elements.insert(elem);
-          }
-        }
-      }
+      constraint_set.AddExternalAlgebraicVariableIds(external_algebraic_variable_ids);
     }
 
     auto jacobian = BuildJacobian<SparseMatrixPolicy>(nonzero_elements, 1, number_of_species, true);
@@ -477,54 +530,64 @@ namespace micm
       jacobian = std::move(lu);
     }
 
-    std::vector<std::string> variable_names{ number_of_species };
+    std::vector<std::string> variable_names(number_of_species);
     for (auto& species_pair : species_map)
     {
       variable_names[species_pair.second] = species_pair.first;
     }
 
-    // Build the params map after the constraint set is created,
-    // since it adds its parameters to the map.
-    std::vector<std::string> labels{ params_map.size() };
+    std::vector<std::string> labels(params_map.size());
     for (auto& param_pair : params_map)
     {
       labels[param_pair.second] = param_pair.first;
     }
 
     rates.SetJacobianFlatIds(jacobian);
-    rates.SetExternalModelFunctions(params_map, species_map, jacobian);
 
-    // Compile external process set update functions now that params_map is finalized
-    update_state_param_funcs.reserve(external_process_sets_.size());
-    for (const auto& process_set : external_process_sets_)
+    if (constraint_set.Size() > 0 || !external_algebraic_variable_ids.empty())
     {
-      update_state_param_funcs.push_back(process_set.update_state_parameters_function_(params_map));
+      if (constraint_set.Size() > 0)
+      {
+        constraint_set.SetJacobianFlatIds(jacobian);
+        constraint_set.SetConstraintFunctions(params_map);
+      }
+      constraint_set.FinalizeAlgebraicErrorFunction();
     }
 
-    std::vector<std::function<void(const DenseMatrixPolicy&, DenseMatrixPolicy&)>> init_constraint_param_funcs;
+    // Move concrete external models into shared ownership; both bundles refer to the same tuple.
+    auto shared_models = std::make_shared<std::tuple<ExternalModels...>>(std::move(external_models_));
 
-    if (constraint_set.Size() > 0)
-    {
-      constraint_set.SetJacobianFlatIds(jacobian);
+    // Give each participating model its build-time indices and Jacobian sparsity handles.
+    std::apply(
+        [&](auto&... m)
+        {
+          auto finalize = [&](auto& model)
+          {
+            using M = std::decay_t<decltype(model)>;
+            if constexpr (HasProcesses<M>)
+            {
+              if constexpr (requires { model.FinalizeProcessSetup(params_map, species_map, jacobian); })
+              {
+                model.FinalizeProcessSetup(params_map, species_map, jacobian);
+              }
+            }
+            if constexpr (HasConstraints<M>)
+            {
+              if constexpr (requires { model.FinalizeConstraintSetup(params_map, species_map, jacobian); })
+              {
+                model.FinalizeConstraintSetup(params_map, species_map, jacobian);
+              }
+            }
+          };
+          (finalize(m), ...);
+        },
+        *shared_models);
 
-      // Set forcing, jacobian, updating state param functions
-      // The species map and parameter map are used to set indices in the state variables
-      // and custom parameters.
-      constraint_set.SetConstraintFunctions(species_map, params_map, jacobian);
-      constraint_set.SetExternalModelConstraintFunctions(params_map, species_map, jacobian);
-
-      // Collect constraint parameter initialization functions
-      auto ext_init_funcs = constraint_set.GetExternalInitializeConstraintParamFunctions();
-      init_constraint_param_funcs.insert(init_constraint_param_funcs.end(), ext_init_funcs.begin(), ext_init_funcs.end());
-
-      // Add external constraint parameter update functions to the pipeline
-      auto ext_constraint_param_funcs = constraint_set.GetExternalUpdateStateParamFunctions();
-      update_state_param_funcs.insert(
-          update_state_param_funcs.end(), ext_constraint_param_funcs.begin(), ext_constraint_param_funcs.end());
-    }
+    RatesBundleType rates_bundle(std::move(rates), shared_models);
+    ConstraintBundleType constraint_bundle(std::move(constraint_set), shared_models, constraint_active_mask);
 
     StateParameters state_parameters = { .number_of_species_ = number_of_species,
-                                         .number_of_constraints_ = constraint_set.Size(),
+                                         .number_of_constraints_ = constraint_bundle.Size(),
                                          .number_of_rate_constants_ = this->reactions_.size(),
                                          .variable_names_ = variable_names,
                                          .custom_rate_parameter_labels_ = labels,
@@ -533,18 +596,14 @@ namespace micm
 
     this->SetAbsoluteTolerances(state_parameters.absolute_tolerance_, species_map);
 
-    // make a copy of the options so that the builder can be used repeatedly
-    // this matters because the absolute tolerances must be set to match the system size, and that may change
     auto options = this->options_;
 
     return Solver<SolverPolicy, StatePolicy>(
-        SolverPolicy(std::move(linear_solver), std::move(rates), std::move(constraint_set)),
+        SolverPolicy(std::move(linear_solver), std::move(rates_bundle), std::move(constraint_bundle)),
         state_parameters,
         options,
         reactions_,
-        system_,
-        update_state_param_funcs,
-        init_constraint_param_funcs);
+        system_);
   }
 
 }  // namespace micm

--- a/test/integration/aerosol_model_policy.hpp
+++ b/test/integration/aerosol_model_policy.hpp
@@ -264,13 +264,16 @@ void TestSingleCellForcingWithStubAerosolModel(BuilderPolicy builder)
   state["STUB2.MODE1.NUMBER"] = 1000.0;
   state["STUB2.MODE2.NUMBER"] = 500.0;
 
-  // Calculate forcing terms using the first aerosol model's forcing function
+  // Calculate forcing terms via the first aerosol model directly.
   using DenseMatrixPolicyType = decltype(state.variables_);
-  auto forcing_function_1 =
-      aerosol_1.ForcingFunction<DenseMatrixPolicyType>(state.custom_rate_parameter_map_, state.variable_map_);
-  auto forcing_1 = state.variables_;  // make a forcing matrix of the same size as the state variable matrix
-  forcing_1 = 0.0;                    // initialize forcing terms to zero before calculation
-  forcing_function_1(state.custom_rate_parameters_, state.variables_, forcing_1);
+  using SparseMatrixPolicyType = decltype(state.jacobian_);
+  aerosol_1.FinalizeProcessSetup(state.custom_rate_parameter_map_, state.variable_map_, state.jacobian_);
+  auto forcing_1 = state.variables_;
+  state.custom_rate_parameters_.CopyToDevice();
+  state.variables_.CopyToDevice();
+  forcing_1.Fill(0.0);
+  aerosol_1.AddForcingTerms(state.custom_rate_parameters_, state.variables_, forcing_1);
+  forcing_1.CopyToHost();
 
   // For the FO2 gas to mode 2 CORGE partitioning, we expect a loss of FO2 in the gas phase and a corresponding gain of FO2
   // in the mode 2 CORGE phase, with values equal to the rate constant multiplied by the FO2 concentration
@@ -320,14 +323,16 @@ void TestSingleCellJacobianWithStubAerosolModel(BuilderPolicy builder)
   state["STUB2.MODE1.NUMBER"] = 1000.0;
   state["STUB2.MODE2.NUMBER"] = 500.0;
 
-  // Calculate Jacobian terms using the first aerosol model's Jacobian function
-  auto jacobian_1 = state.jacobian_;  // make a Jacobian matrix of the same size as the system Jacobian
-  jacobian_1 = 0.0;                   // initialize Jacobian terms to zero before calculation
+  // Calculate Jacobian terms via the first aerosol model directly.
+  auto jacobian_1 = state.jacobian_;
+  jacobian_1 = 0.0;
   using DenseMatrixPolicyType = decltype(state.variables_);
   using SparseMatrixPolicyType = decltype(state.jacobian_);
-  auto jacobian_function_1 = aerosol_1.JacobianFunction<DenseMatrixPolicyType, SparseMatrixPolicyType>(
-      state.custom_rate_parameter_map_, state.variable_map_, jacobian_1);
-  jacobian_function_1(state.custom_rate_parameters_, state.variables_, jacobian_1);
+  aerosol_1.FinalizeProcessSetup(state.custom_rate_parameter_map_, state.variable_map_, jacobian_1);
+  jacobian_1.CopyToDevice();
+  state.variables_.CopyToDevice();
+  aerosol_1.SubtractJacobianTerms(state.custom_rate_parameters_, state.variables_, jacobian_1);
+  jacobian_1.CopyToHost();
 
   // For the FO2 gas to mode 2 CORGE partitioning, we expect two non-zero Jacobian elements: a negative value equal to the
   // rate constant in the column corresponding to FO2 and row corresponding to FO2 (representing the partial derivative of
@@ -394,8 +399,13 @@ void TestSolveWithStubAerosolModel1(BuilderPolicy builder, micm::Real base_relat
   micm::Real stub1_rxn2_delta = baz_mode1_initial * (1.0 - std::exp(-STUB1_RATE_CONSTANT_BAZ_QUUX * time_step));
 
   // Solve the system for a single time step
+  state.variables_.CopyToDevice();
+  state.conditions_.CopyToDevice();
+  state.custom_rate_parameters_.CopyToDevice();
   solver.UpdateStateParameters(state);
   auto results = solver.Solve(time_step, state);
+  state.variables_.CopyToHost();
+  state.rate_constants_.CopyToHost();
 
   // Make sure the solver reports success
   EXPECT_EQ(results.state_, micm::SolverState::Converged);
@@ -460,8 +470,13 @@ void TestSolveWithTwoStubAerosolModels(BuilderPolicy builder, micm::Real base_re
   micm::Real stub2_rxn2_delta = stub2_mode3_baz_initial * (1.0 - std::exp(-temperature * 0.005 * time_step));
 
   // Solve the system for a single time step
+  state.variables_.CopyToDevice();
+  state.conditions_.CopyToDevice();
+  state.custom_rate_parameters_.CopyToDevice();
   solver.UpdateStateParameters(state);
   auto results = solver.Solve(time_step, state);
+  state.variables_.CopyToHost();
+  state.rate_constants_.CopyToHost();
 
   // Make sure the solver reports success
   EXPECT_EQ(results.state_, micm::SolverState::Converged);
@@ -534,8 +549,13 @@ void TestSolveWithStubAerosolModel1MultiCell(BuilderPolicy builder, micm::Real b
   }
 
   // Solve the system for a single time step
+  state.variables_.CopyToDevice();
+  state.conditions_.CopyToDevice();
+  state.custom_rate_parameters_.CopyToDevice();
   solver.UpdateStateParameters(state);
   auto results = solver.Solve(time_step, state);
+  state.variables_.CopyToHost();
+  state.rate_constants_.CopyToHost();
 
   // Make sure the solver reports success
   EXPECT_EQ(results.state_, micm::SolverState::Converged);
@@ -628,8 +648,13 @@ void TestSolveWithTwoStubAerosolModelsMultiCell(BuilderPolicy builder, micm::Rea
   }
 
   // Solve the system for a single time step
+  state.variables_.CopyToDevice();
+  state.conditions_.CopyToDevice();
+  state.custom_rate_parameters_.CopyToDevice();
   solver.UpdateStateParameters(state);
   auto results = solver.Solve(time_step, state);
+  state.variables_.CopyToHost();
+  state.rate_constants_.CopyToHost();
 
   // Make sure the solver reports success
   EXPECT_EQ(results.state_, micm::SolverState::Converged);

--- a/test/integration/kokkos/CMakeLists.txt
+++ b/test/integration/kokkos/CMakeLists.txt
@@ -1,11 +1,14 @@
 ################################################################################
 # Tests
 
+create_standard_test(NAME kokkos_aerosol_model_backward_euler SOURCES test_kokkos_aerosol_model_backward_euler.cpp LIBRARIES musica::micm_kokkos)
+create_standard_test(NAME kokkos_aerosol_model_rosenbrock SOURCES test_kokkos_aerosol_model_rosenbrock.cpp LIBRARIES musica::micm_kokkos)
 create_standard_test(NAME kokkos_analytical_backward_euler SOURCES test_kokkos_analytical_backward_euler.cpp LIBRARIES musica::micm_kokkos)
 create_standard_test(NAME kokkos_analytical_rosenbrock SOURCES test_kokkos_analytical_rosenbrock.cpp LIBRARIES musica::micm_kokkos)
 create_standard_test(NAME kokkos_chapman_integration SOURCES test_kokkos_chapman_integration.cpp LIBRARIES musica::micm_kokkos)
 create_standard_test(NAME kokkos_dae_algebraic_error_insensitivity SOURCES test_kokkos_dae_algebraic_error_insensitivity.cpp LIBRARIES musica::micm_kokkos)
 create_standard_test(NAME kokkos_dae_constraint_overshoot SOURCES test_kokkos_dae_constraint_overshoot.cpp LIBRARIES musica::micm_kokkos)
 create_standard_test(NAME kokkos_equilibrium_constraint SOURCES test_kokkos_equilibrium_constraint.cpp LIBRARIES musica::micm_kokkos)
+create_standard_test(NAME kokkos_external_model_constraints SOURCES test_kokkos_external_model_constraints.cpp LIBRARIES musica::micm_kokkos)
 create_standard_test(NAME kokkos_linear_constraint SOURCES test_kokkos_linear_constraint.cpp LIBRARIES musica::micm_kokkos)
 create_standard_test(NAME kokkos_terminator SOURCES test_kokkos_terminator.cpp LIBRARIES musica::micm_kokkos)

--- a/test/integration/kokkos/test_kokkos_aerosol_model_backward_euler.cpp
+++ b/test/integration/kokkos/test_kokkos_aerosol_model_backward_euler.cpp
@@ -1,0 +1,429 @@
+// Copyright (C) 2026 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+#include "../aerosol_model_policy.hpp"
+
+#include <micm/util/types.hpp>
+#include <micm/Kokkos.hpp>
+
+#include <gtest/gtest.h>
+
+#define JUST_ONE_SOLVER
+
+using BuilderType = micm::KokkosSolverBuilder<micm::BackwardEulerSolverParameters>;
+using StateType = micm::State<BuilderType::DenseMatrixPolicyType, BuilderType::SparseMatrixPolicyType>;
+
+template<micm::Index L>
+using VectorBackwardEuler = micm::CpuSolverBuilder<
+    micm::BackwardEulerSolverParameters,
+    micm::KokkosDenseMatrix<micm::Real, L>,
+    micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>>;
+
+template<micm::Index L>
+using VectorBackwardEulerDoolittle = micm::CpuSolverBuilder<
+    micm::BackwardEulerSolverParameters,
+    micm::KokkosDenseMatrix<micm::Real, L>,
+    micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>,
+    micm::LuDecompositionDoolittle<micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>>>;
+
+template<micm::Index L>
+using VectorBackwardEulerMozart = micm::CpuSolverBuilder<
+    micm::BackwardEulerSolverParameters,
+    micm::KokkosDenseMatrix<micm::Real, L>,
+    micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>,
+    micm::LuDecompositionMozart<micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>>>;
+
+template<micm::Index L>
+using VectorBackwardEulerDolittleCSC = micm::CpuSolverBuilder<
+    micm::BackwardEulerSolverParameters,
+    micm::KokkosDenseMatrix<micm::Real, L>,
+    micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrderingCompressedSparseColumn<L>>,
+    micm::LuDecompositionDoolittle<
+        micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrderingCompressedSparseColumn<L>>>>;
+
+template<micm::Index L>
+using VectorBackwardEulerMozartCSC = micm::CpuSolverBuilder<
+    micm::BackwardEulerSolverParameters,
+    micm::KokkosDenseMatrix<micm::Real, L>,
+    micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrderingCompressedSparseColumn<L>>,
+    micm::LuDecompositionMozart<micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrderingCompressedSparseColumn<L>>>>;
+
+template<micm::Index L>
+using VectorBackwardEulerDoolittleInPlace = micm::CpuSolverBuilderInPlace<
+    micm::BackwardEulerSolverParameters,
+    micm::KokkosDenseMatrix<micm::Real, L>,
+    micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>,
+    micm::LuDecompositionDoolittleInPlace<micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>>>;
+
+template<micm::Index L>
+using VectorBackwardEulerMozartInPlace = micm::CpuSolverBuilderInPlace<
+    micm::BackwardEulerSolverParameters,
+    micm::KokkosDenseMatrix<micm::Real, L>,
+    micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>,
+    micm::LuDecompositionMozartInPlace<micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>>>;
+
+auto backward_euler = micm::KokkosSolverBuilder<micm::BackwardEulerSolverParameters>(micm::BackwardEulerSolverParameters());
+
+#ifndef JUST_ONE_SOLVER
+auto backward_euler_vector_1 = VectorBackwardEuler<1>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_2 = VectorBackwardEuler<2>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_3 = VectorBackwardEuler<3>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_4 = VectorBackwardEuler<4>(micm::BackwardEulerSolverParameters());
+
+auto backward_euler_vector_doolittle_1 = VectorBackwardEulerDoolittle<1>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_doolittle_2 = VectorBackwardEulerDoolittle<2>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_doolittle_3 = VectorBackwardEulerDoolittle<3>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_doolittle_4 = VectorBackwardEulerDoolittle<4>(micm::BackwardEulerSolverParameters());
+
+auto backward_euler_vector_mozart_1 = VectorBackwardEulerMozart<1>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_mozart_2 = VectorBackwardEulerMozart<2>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_mozart_3 = VectorBackwardEulerMozart<3>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_mozart_4 = VectorBackwardEulerMozart<4>(micm::BackwardEulerSolverParameters());
+
+auto backward_euler_vector_doolittle_csc_1 = VectorBackwardEulerDolittleCSC<1>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_doolittle_csc_2 = VectorBackwardEulerDolittleCSC<2>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_doolittle_csc_3 = VectorBackwardEulerDolittleCSC<3>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_doolittle_csc_4 = VectorBackwardEulerDolittleCSC<4>(micm::BackwardEulerSolverParameters());
+
+auto backward_euler_vector_mozart_csc_1 = VectorBackwardEulerMozartCSC<1>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_mozart_csc_2 = VectorBackwardEulerMozartCSC<2>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_mozart_csc_3 = VectorBackwardEulerMozartCSC<3>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_mozart_csc_4 = VectorBackwardEulerMozartCSC<4>(micm::BackwardEulerSolverParameters());
+
+auto backward_euler_vector_doolittle_in_place_1 =
+    VectorBackwardEulerDoolittleInPlace<1>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_doolittle_in_place_2 =
+    VectorBackwardEulerDoolittleInPlace<2>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_doolittle_in_place_3 =
+    VectorBackwardEulerDoolittleInPlace<3>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_doolittle_in_place_4 =
+    VectorBackwardEulerDoolittleInPlace<4>(micm::BackwardEulerSolverParameters());
+
+auto backward_euler_vector_mozart_in_place_1 = VectorBackwardEulerMozartInPlace<1>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_mozart_in_place_2 = VectorBackwardEulerMozartInPlace<2>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_mozart_in_place_3 = VectorBackwardEulerMozartInPlace<3>(micm::BackwardEulerSolverParameters());
+auto backward_euler_vector_mozart_in_place_4 = VectorBackwardEulerMozartInPlace<4>(micm::BackwardEulerSolverParameters());
+#endif
+
+TEST(AerosolModelIntegration, StateIncludesStubAerosolModel)
+{
+  TestStateIncludesStubAerosolModel(backward_euler);
+#ifndef JUST_ONE_SOLVER
+  TestStateIncludesStubAerosolModel(backward_euler_vector_1);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_2);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_3);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_4);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_doolittle_1);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_doolittle_2);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_doolittle_3);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_doolittle_4);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_mozart_1);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_mozart_2);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_mozart_3);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_mozart_4);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_doolittle_csc_1);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_doolittle_csc_2);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_doolittle_csc_3);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_doolittle_csc_4);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_mozart_csc_1);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_mozart_csc_2);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_mozart_csc_3);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_mozart_csc_4);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_doolittle_in_place_1);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_doolittle_in_place_2);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_doolittle_in_place_3);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_doolittle_in_place_4);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_mozart_in_place_1);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_mozart_in_place_2);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_mozart_in_place_3);
+  TestStateIncludesStubAerosolModel(backward_euler_vector_mozart_in_place_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanUpdateStateWithStubAerosolModel)
+{
+  TestUpdateStateWithStubAerosolModel(backward_euler);
+#ifndef JUST_ONE_SOLVER
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_1);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_2);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_3);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_4);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_doolittle_1);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_doolittle_2);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_doolittle_3);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_doolittle_4);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_mozart_1);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_mozart_2);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_mozart_3);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_mozart_4);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_doolittle_csc_1);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_doolittle_csc_2);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_doolittle_csc_3);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_doolittle_csc_4);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_mozart_csc_1);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_mozart_csc_2);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_mozart_csc_3);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_mozart_csc_4);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_doolittle_in_place_1);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_doolittle_in_place_2);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_doolittle_in_place_3);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_doolittle_in_place_4);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_mozart_in_place_1);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_mozart_in_place_2);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_mozart_in_place_3);
+  TestUpdateStateWithStubAerosolModel(backward_euler_vector_mozart_in_place_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanUpdateMultiCellStateWithStubAerosolModel)
+{
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler);
+#ifndef JUST_ONE_SOLVER
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_1);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_2);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_3);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_4);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_doolittle_1);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_doolittle_2);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_doolittle_3);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_doolittle_4);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_mozart_1);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_mozart_2);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_mozart_3);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_mozart_4);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_doolittle_csc_1);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_doolittle_csc_2);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_doolittle_csc_3);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_doolittle_csc_4);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_mozart_csc_1);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_mozart_csc_2);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_mozart_csc_3);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_mozart_csc_4);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_doolittle_in_place_1);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_doolittle_in_place_2);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_doolittle_in_place_3);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_doolittle_in_place_4);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_mozart_in_place_1);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_mozart_in_place_2);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_mozart_in_place_3);
+  TestUpdateMultiCellStateWithStubAerosolModel(backward_euler_vector_mozart_in_place_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanCalculateSingleGridCellForcingWithStubAerosolModel)
+{
+  TestSingleCellForcingWithStubAerosolModel(backward_euler);
+#ifndef JUST_ONE_SOLVER
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_1);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_2);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_3);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_4);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_doolittle_1);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_doolittle_2);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_doolittle_3);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_doolittle_4);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_mozart_1);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_mozart_2);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_mozart_3);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_mozart_4);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_doolittle_csc_1);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_doolittle_csc_2);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_doolittle_csc_3);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_doolittle_csc_4);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_mozart_csc_1);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_mozart_csc_2);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_mozart_csc_3);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_mozart_csc_4);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_doolittle_in_place_1);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_doolittle_in_place_2);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_doolittle_in_place_3);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_doolittle_in_place_4);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_mozart_in_place_1);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_mozart_in_place_2);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_mozart_in_place_3);
+  TestSingleCellForcingWithStubAerosolModel(backward_euler_vector_mozart_in_place_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanCalculateSingleGridCellJacobianWithStubAerosolModel)
+{
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler);
+#ifndef JUST_ONE_SOLVER
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_1);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_2);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_3);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_4);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_doolittle_1);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_doolittle_2);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_doolittle_3);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_doolittle_4);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_mozart_1);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_mozart_2);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_mozart_3);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_mozart_4);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_doolittle_csc_1);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_doolittle_csc_2);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_doolittle_csc_3);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_doolittle_csc_4);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_mozart_csc_1);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_mozart_csc_2);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_mozart_csc_3);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_mozart_csc_4);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_doolittle_in_place_1);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_doolittle_in_place_2);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_doolittle_in_place_3);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_doolittle_in_place_4);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_mozart_in_place_1);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_mozart_in_place_2);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_mozart_in_place_3);
+  TestSingleCellJacobianWithStubAerosolModel(backward_euler_vector_mozart_in_place_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanSolveSingleGridCellWithStubAerosolModel1)
+{
+  TestSolveWithStubAerosolModel1(backward_euler, 2e-4);
+#ifndef JUST_ONE_SOLVER
+  TestSolveWithStubAerosolModel1(backward_euler_vector_1, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_2, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_3, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_4, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_doolittle_1, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_doolittle_2, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_doolittle_3, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_doolittle_4, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_mozart_1, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_mozart_2, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_mozart_3, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_mozart_4, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_doolittle_csc_1, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_doolittle_csc_2, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_doolittle_csc_3, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_doolittle_csc_4, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_mozart_csc_1, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_mozart_csc_2, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_mozart_csc_3, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_mozart_csc_4, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_doolittle_in_place_1, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_doolittle_in_place_2, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_doolittle_in_place_3, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_doolittle_in_place_4, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_mozart_in_place_1, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_mozart_in_place_2, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_mozart_in_place_3, 2e-4);
+  TestSolveWithStubAerosolModel1(backward_euler_vector_mozart_in_place_4, 2e-4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanSolveSingleGridCellWithTwoStubAerosolModels)
+{
+  TestSolveWithTwoStubAerosolModels(backward_euler, 1e-1);
+#ifndef JUST_ONE_SOLVER
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_1, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_2, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_3, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_4, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_doolittle_1, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_doolittle_2, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_doolittle_3, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_doolittle_4, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_mozart_1, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_mozart_2, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_mozart_3, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_mozart_4, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_doolittle_csc_1, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_doolittle_csc_2, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_doolittle_csc_3, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_doolittle_csc_4, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_mozart_csc_1, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_mozart_csc_2, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_mozart_csc_3, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_mozart_csc_4, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_doolittle_in_place_1, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_doolittle_in_place_2, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_doolittle_in_place_3, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_doolittle_in_place_4, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_mozart_in_place_1, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_mozart_in_place_2, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_mozart_in_place_3, 1e-1);
+  TestSolveWithTwoStubAerosolModels(backward_euler_vector_mozart_in_place_4, 1e-1);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanSolveMultiGridCellWithStubAerosolModel1)
+{
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler, 2e-4);
+#ifndef JUST_ONE_SOLVER
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_1, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_2, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_3, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_4, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_doolittle_1, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_doolittle_2, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_doolittle_3, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_doolittle_4, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_mozart_1, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_mozart_2, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_mozart_3, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_mozart_4, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_doolittle_csc_1, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_doolittle_csc_2, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_doolittle_csc_3, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_doolittle_csc_4, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_mozart_csc_1, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_mozart_csc_2, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_mozart_csc_3, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_mozart_csc_4, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_doolittle_in_place_1, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_doolittle_in_place_2, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_doolittle_in_place_3, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_doolittle_in_place_4, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_mozart_in_place_1, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_mozart_in_place_2, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_mozart_in_place_3, 2e-4);
+  TestSolveWithStubAerosolModel1MultiCell(backward_euler_vector_mozart_in_place_4, 2e-4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanSolveMultiGridCellWithTwoStubAerosolModels)
+{
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler, 1e-1);
+#ifndef JUST_ONE_SOLVER
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_1, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_2, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_3, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_4, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_doolittle_1, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_doolittle_2, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_doolittle_3, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_doolittle_4, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_mozart_1, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_mozart_2, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_mozart_3, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_mozart_4, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_doolittle_csc_1, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_doolittle_csc_2, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_doolittle_csc_3, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_doolittle_csc_4, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_mozart_csc_1, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_mozart_csc_2, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_mozart_csc_3, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_mozart_csc_4, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_doolittle_in_place_1, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_doolittle_in_place_2, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_doolittle_in_place_3, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_doolittle_in_place_4, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_mozart_in_place_1, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_mozart_in_place_2, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_mozart_in_place_3, 1e-1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(backward_euler_vector_mozart_in_place_4, 1e-1);
+#endif
+}
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  Kokkos::initialize(argc, argv);
+  int result = RUN_ALL_TESTS();
+  Kokkos::finalize();
+  return result;
+}

--- a/test/integration/kokkos/test_kokkos_aerosol_model_rosenbrock.cpp
+++ b/test/integration/kokkos/test_kokkos_aerosol_model_rosenbrock.cpp
@@ -1,0 +1,411 @@
+// Copyright (C) 2026 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+#include "../aerosol_model_policy.hpp"
+
+#include <micm/util/types.hpp>
+#include <micm/Kokkos.hpp>
+
+#include <gtest/gtest.h>
+
+#define JUST_ONE_SOLVER
+
+using BuilderType = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>;
+using StateType = micm::State<BuilderType::DenseMatrixPolicyType, BuilderType::SparseMatrixPolicyType>;
+
+template<micm::Index L>
+using VectorRosenbrock = micm::CpuSolverBuilder<
+    micm::RosenbrockSolverParameters,
+    micm::KokkosDenseMatrix<micm::Real, L>,
+    micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>>;
+
+template<micm::Index L>
+using VectorRosenbrockDoolittle = micm::CpuSolverBuilder<
+    micm::RosenbrockSolverParameters,
+    micm::KokkosDenseMatrix<micm::Real, L>,
+    micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>,
+    micm::LuDecompositionDoolittle<micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>>>;
+
+template<micm::Index L>
+using VectorRosenbrockMozart = micm::CpuSolverBuilder<
+    micm::RosenbrockSolverParameters,
+    micm::KokkosDenseMatrix<micm::Real, L>,
+    micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>,
+    micm::LuDecompositionMozart<micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<L>>>>;
+
+template<micm::Index L>
+using VectorRosenbrockDolittleCSC = micm::CpuSolverBuilder<
+    micm::RosenbrockSolverParameters,
+    micm::KokkosDenseMatrix<micm::Real, L>,
+    micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrderingCompressedSparseColumn<L>>,
+    micm::LuDecompositionDoolittle<
+        micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrderingCompressedSparseColumn<L>>>>;
+
+template<micm::Index L>
+using VectorRosenbrockMozartCSC = micm::CpuSolverBuilder<
+    micm::RosenbrockSolverParameters,
+    micm::KokkosDenseMatrix<micm::Real, L>,
+    micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrderingCompressedSparseColumn<L>>,
+    micm::LuDecompositionMozart<micm::KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrderingCompressedSparseColumn<L>>>>;
+
+#ifdef JUST_ONE_SOLVER
+auto rosenbrock = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(
+    micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+#else
+auto rosenbrock_2stage = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(
+    micm::RosenbrockSolverParameters::TwoStageRosenbrockParameters());
+auto rosenbrock_3stage = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(
+    micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_4stage = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(
+    micm::RosenbrockSolverParameters::FourStageRosenbrockParameters());
+auto rosenbrock_4stage_da = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(
+    micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters());
+auto rosenbrock_6stage_da = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(
+    micm::RosenbrockSolverParameters::SixStageDifferentialAlgebraicRosenbrockParameters());
+
+auto rosenbrock_vector_1 = VectorRosenbrock<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_2 = VectorRosenbrock<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_3 = VectorRosenbrock<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_4 = VectorRosenbrock<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+
+auto rosenbrock_vector_doolittle_1 =
+    VectorRosenbrockDoolittle<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_doolittle_2 =
+    VectorRosenbrockDoolittle<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_doolittle_3 =
+    VectorRosenbrockDoolittle<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_doolittle_4 =
+    VectorRosenbrockDoolittle<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+
+auto rosenbrock_vector_mozart_1 =
+    VectorRosenbrockMozart<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_mozart_2 =
+    VectorRosenbrockMozart<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_mozart_3 =
+    VectorRosenbrockMozart<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_mozart_4 =
+    VectorRosenbrockMozart<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+
+auto rosenbrock_vector_doolittle_csc_1 =
+    VectorRosenbrockDolittleCSC<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_doolittle_csc_2 =
+    VectorRosenbrockDolittleCSC<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_doolittle_csc_3 =
+    VectorRosenbrockDolittleCSC<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_doolittle_csc_4 =
+    VectorRosenbrockDolittleCSC<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+
+auto rosenbrock_vector_mozart_csc_1 =
+    VectorRosenbrockMozartCSC<1>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_mozart_csc_2 =
+    VectorRosenbrockMozartCSC<2>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_mozart_csc_3 =
+    VectorRosenbrockMozartCSC<3>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+auto rosenbrock_vector_mozart_csc_4 =
+    VectorRosenbrockMozartCSC<4>(micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters());
+#endif
+
+TEST(AerosolModelIntegration, StateIncludesStubAerosolModel)
+{
+#ifdef JUST_ONE_SOLVER
+  TestStateIncludesStubAerosolModel(rosenbrock);
+#else
+  TestStateIncludesStubAerosolModel(rosenbrock_2stage);
+  TestStateIncludesStubAerosolModel(rosenbrock_3stage);
+  TestStateIncludesStubAerosolModel(rosenbrock_4stage);
+  TestStateIncludesStubAerosolModel(rosenbrock_4stage_da);
+  TestStateIncludesStubAerosolModel(rosenbrock_6stage_da);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_1);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_2);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_3);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_4);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_doolittle_1);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_doolittle_2);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_doolittle_3);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_doolittle_4);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_mozart_1);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_mozart_2);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_mozart_3);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_mozart_4);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_doolittle_csc_1);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_doolittle_csc_2);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_doolittle_csc_3);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_doolittle_csc_4);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_mozart_csc_1);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_mozart_csc_2);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_mozart_csc_3);
+  TestStateIncludesStubAerosolModel(rosenbrock_vector_mozart_csc_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanUpdateStateWithStubAerosolModel)
+{
+#ifdef JUST_ONE_SOLVER
+  TestUpdateStateWithStubAerosolModel(rosenbrock);
+#else
+  TestUpdateStateWithStubAerosolModel(rosenbrock_2stage);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_3stage);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_4stage);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_4stage_da);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_6stage_da);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_1);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_2);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_3);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_4);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_doolittle_1);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_doolittle_2);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_doolittle_3);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_doolittle_4);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_mozart_1);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_mozart_2);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_mozart_3);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_mozart_4);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_doolittle_csc_1);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_doolittle_csc_2);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_doolittle_csc_3);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_doolittle_csc_4);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_mozart_csc_1);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_mozart_csc_2);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_mozart_csc_3);
+  TestUpdateStateWithStubAerosolModel(rosenbrock_vector_mozart_csc_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanUpdateMultiCellStateWithStubAerosolModel)
+{
+#ifdef JUST_ONE_SOLVER
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock);
+#else
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_2stage);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_3stage);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_4stage);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_4stage_da);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_6stage_da);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_1);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_2);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_3);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_4);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_doolittle_1);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_doolittle_2);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_doolittle_3);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_doolittle_4);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_mozart_1);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_mozart_2);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_mozart_3);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_mozart_4);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_doolittle_csc_1);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_doolittle_csc_2);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_doolittle_csc_3);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_doolittle_csc_4);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_mozart_csc_1);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_mozart_csc_2);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_mozart_csc_3);
+  TestUpdateMultiCellStateWithStubAerosolModel(rosenbrock_vector_mozart_csc_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanCalculateSingleGridCellForcingWithStubAerosolModel)
+{
+#ifdef JUST_ONE_SOLVER
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock);
+#else
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_2stage);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_3stage);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_4stage);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_4stage_da);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_6stage_da);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_1);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_2);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_3);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_4);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_doolittle_1);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_doolittle_2);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_doolittle_3);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_doolittle_4);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_mozart_1);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_mozart_2);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_mozart_3);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_mozart_4);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_doolittle_csc_1);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_doolittle_csc_2);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_doolittle_csc_3);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_doolittle_csc_4);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_mozart_csc_1);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_mozart_csc_2);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_mozart_csc_3);
+  TestSingleCellForcingWithStubAerosolModel(rosenbrock_vector_mozart_csc_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanCalculateSingleGridCellJacobianWithStubAerosolModel)
+{
+#ifdef JUST_ONE_SOLVER
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock);
+#else
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_2stage);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_3stage);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_4stage);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_4stage_da);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_6stage_da);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_1);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_2);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_3);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_4);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_doolittle_1);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_doolittle_2);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_doolittle_3);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_doolittle_4);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_mozart_1);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_mozart_2);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_mozart_3);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_mozart_4);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_doolittle_csc_1);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_doolittle_csc_2);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_doolittle_csc_3);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_doolittle_csc_4);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_mozart_csc_1);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_mozart_csc_2);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_mozart_csc_3);
+  TestSingleCellJacobianWithStubAerosolModel(rosenbrock_vector_mozart_csc_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanSolveSingleGridCellWithStubAerosolModel1)
+{
+#ifdef JUST_ONE_SOLVER
+  TestSolveWithStubAerosolModel1(rosenbrock);
+#else
+  TestSolveWithStubAerosolModel1(rosenbrock_2stage);
+  TestSolveWithStubAerosolModel1(rosenbrock_3stage);
+  TestSolveWithStubAerosolModel1(rosenbrock_4stage);
+  TestSolveWithStubAerosolModel1(rosenbrock_4stage_da);
+  TestSolveWithStubAerosolModel1(rosenbrock_6stage_da);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_1);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_2);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_3);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_4);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_doolittle_1);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_doolittle_2);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_doolittle_3);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_doolittle_4);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_mozart_1);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_mozart_2);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_mozart_3);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_mozart_4);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_doolittle_csc_1);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_doolittle_csc_2);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_doolittle_csc_3);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_doolittle_csc_4);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_mozart_csc_1);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_mozart_csc_2);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_mozart_csc_3);
+  TestSolveWithStubAerosolModel1(rosenbrock_vector_mozart_csc_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanSolveSingleGridCellWithTwoStubAerosolModels)
+{
+#ifdef JUST_ONE_SOLVER
+  TestSolveWithTwoStubAerosolModels(rosenbrock);
+#else
+  TestSolveWithTwoStubAerosolModels(rosenbrock_2stage, 5e-4);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_3stage);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_4stage);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_4stage_da);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_6stage_da);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_1);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_2);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_3);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_4);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_doolittle_1);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_doolittle_2);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_doolittle_3);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_doolittle_4);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_mozart_1);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_mozart_2);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_mozart_3);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_mozart_4);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_doolittle_csc_1);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_doolittle_csc_2);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_doolittle_csc_3);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_doolittle_csc_4);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_mozart_csc_1);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_mozart_csc_2);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_mozart_csc_3);
+  TestSolveWithTwoStubAerosolModels(rosenbrock_vector_mozart_csc_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanSolveMultiGridCellWithStubAerosolModel1)
+{
+#ifdef JUST_ONE_SOLVER
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock);
+#else
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_2stage);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_3stage);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_4stage);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_4stage_da);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_6stage_da);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_1);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_2);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_3);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_4);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_doolittle_1);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_doolittle_2);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_doolittle_3);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_doolittle_4);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_mozart_1);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_mozart_2);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_mozart_3);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_mozart_4);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_doolittle_csc_1);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_doolittle_csc_2);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_doolittle_csc_3);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_doolittle_csc_4);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_mozart_csc_1);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_mozart_csc_2);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_mozart_csc_3);
+  TestSolveWithStubAerosolModel1MultiCell(rosenbrock_vector_mozart_csc_4);
+#endif
+}
+
+TEST(AerosolModelIntegration, CanSolveMultiGridCellWithTwoStubAerosolModels)
+{
+#ifdef JUST_ONE_SOLVER
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock);
+#else
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_2stage, 5e-4);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_3stage);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_4stage);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_4stage_da);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_6stage_da);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_2);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_3);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_4);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_doolittle_1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_doolittle_2);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_doolittle_3);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_doolittle_4);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_mozart_1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_mozart_2);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_mozart_3);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_mozart_4);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_doolittle_csc_1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_doolittle_csc_2);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_doolittle_csc_3);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_doolittle_csc_4);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_mozart_csc_1);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_mozart_csc_2);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_mozart_csc_3);
+  TestSolveWithTwoStubAerosolModelsMultiCell(rosenbrock_vector_mozart_csc_4);
+#endif
+}
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  Kokkos::initialize(argc, argv);
+  int result = RUN_ALL_TESTS();
+  Kokkos::finalize();
+  return result;
+}

--- a/test/integration/kokkos/test_kokkos_dae_algebraic_error_insensitivity.cpp
+++ b/test/integration/kokkos/test_kokkos_dae_algebraic_error_insensitivity.cpp
@@ -40,8 +40,8 @@
 #include <vector>
 
 using namespace micm;
-using DenseMatrix = KokkosDenseMatrix<Real, MICM_DEFAULT_VECTOR_SIZE>;
-using StdSparseMatrix = KokkosSparseMatrix<Real, SparseMatrixVectorOrdering<MICM_DEFAULT_VECTOR_SIZE>>;
+using DenseMatrix = KokkosDenseMatrix<Real>;
+using StdSparseMatrix = KokkosSparseMatrix<Real>;
 
 namespace
 {

--- a/test/integration/kokkos/test_kokkos_dae_constraint_overshoot.cpp
+++ b/test/integration/kokkos/test_kokkos_dae_constraint_overshoot.cpp
@@ -36,8 +36,8 @@
 constexpr micm::Real kAbsTol = std::is_same_v<micm::Real, double> ? 1.0e-12 : 1.0e-10;
 
 using namespace micm;
-using DenseMatrix = KokkosDenseMatrix<Real, MICM_DEFAULT_VECTOR_SIZE>;
-using StdSparseMatrix = KokkosSparseMatrix<Real, SparseMatrixVectorOrdering<MICM_DEFAULT_VECTOR_SIZE>>;
+using DenseMatrix = KokkosDenseMatrix<Real>;
+using StdSparseMatrix = KokkosSparseMatrix<Real>;
 
 /// @brief Verify that conservation-constrained algebraic variables stay non-negative
 ///        when fast kinetics drain the pool.

--- a/test/integration/kokkos/test_kokkos_equilibrium_constraint.cpp
+++ b/test/integration/kokkos/test_kokkos_equilibrium_constraint.cpp
@@ -22,8 +22,8 @@
 
 using namespace micm;
 
-using DenseMatrix = KokkosDenseMatrix<micm::Real, MICM_DEFAULT_VECTOR_SIZE>;
-using StdSparseMatrix = KokkosSparseMatrix<micm::Real, micm::SparseMatrixVectorOrdering<MICM_DEFAULT_VECTOR_SIZE>>;
+using DenseMatrix = KokkosDenseMatrix<micm::Real>;
+using StdSparseMatrix = KokkosSparseMatrix<micm::Real>;
 
 /// @brief Helper function to compute temperature-dependent equilibrium constant using Van't Hoff equation
 micm::Real ComputeEquilibriumConstant(micm::Real K_HLC_ref, micm::Real delta_H, micm::Real T)

--- a/test/integration/kokkos/test_kokkos_external_model_constraints.cpp
+++ b/test/integration/kokkos/test_kokkos_external_model_constraints.cpp
@@ -1,9 +1,9 @@
 // Copyright (C) 2026 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 
-#include "stub_aerosol_with_constraints.hpp"
+#include "../stub_aerosol_with_constraints.hpp"
 
-#include <micm/CPU.hpp>
+#include <micm/Kokkos.hpp>
 #include <micm/constraint/constraint.hpp>
 #include <micm/constraint/types/equilibrium_constraint.hpp>
 #include <micm/util/jacobian_verification.hpp>
@@ -18,8 +18,8 @@
 
 using namespace micm;
 
-using DenseMatrix = Matrix<micm::Real>;
-using StdSparseMatrix = SparseMatrix<micm::Real, micm::SparseMatrixStandardOrdering>;
+using DenseMatrix = KokkosDenseMatrix<micm::Real>;
+using StdSparseMatrix = KokkosSparseMatrix<micm::Real>;
 
 /// @brief Constraint-only external model that enforces K_eq * [reactant] - [product] = 0
 ///
@@ -382,8 +382,9 @@ class MassConservationModel
     using Vector = typename DenseMatrixPolicy::template VectorType<int>;
     const micm::Index i_ctrl = i_ctrl_;
     const micm::Real total = total_;
-    const Vector indices = indices_;
-    indices.CopyToDevice();
+    const Vector indices_data = indices_;
+    indices_data.CopyToDevice();
+    const auto indices = indices_data.GetView();
     DenseMatrixPolicy::Function(
         MICM_LAMBDA(
             const typename DenseMatrixPolicy::ViewType& forcing_view,
@@ -411,8 +412,9 @@ class MassConservationModel
       SparseMatrixPolicy& jacobian) const
   {
     using Vector = typename DenseMatrixPolicy::template VectorType<int>;
-    const Vector flat_ids = flat_ids_;
-    flat_ids.CopyToDevice();
+    const Vector flat_ids_data = flat_ids_;
+    flat_ids_data.CopyToDevice();
+    const auto flat_ids = flat_ids_data.GetView();
     SparseMatrixPolicy::Function(
         MICM_LAMBDA(const typename SparseMatrixPolicy::ViewType& jacobian_view) {
           for (auto flat : flat_ids)
@@ -445,7 +447,7 @@ TEST(ExternalModelConstraints, AddExternalModelWithConstraints)
   auto system = micm::System(gas_phase);
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
-  auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+  auto solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                     .SetSystem(system)
                     .SetReactions({})
                     .AddExternalModel(aerosol)
@@ -477,7 +479,7 @@ TEST(ExternalModelConstraints, AddExternalModelProcessOnly)
   auto system = micm::System(gas_phase);
 
   auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
-  auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+  auto solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                     .SetSystem(system)
                     .SetReactions({})
                     .AddExternalModel(aerosol)
@@ -507,7 +509,7 @@ TEST(ExternalModelConstraints, DAESolveEnforcesConservation)
   auto system = micm::System(gas_phase);
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
-  auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+  auto solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                     .SetSystem(system)
                     .SetReactions({})
                     .AddExternalModel(aerosol)
@@ -570,7 +572,7 @@ TEST(ExternalModelConstraints, CombinedBuiltInAndExternalConstraints)
   auto system = micm::System(gas_phase);
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
-  auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+  auto solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                     .SetSystem(system)
                     .SetReactions({ rxn })
                     .SetConstraints(std::move(constraints))
@@ -602,7 +604,7 @@ TEST(ExternalModelConstraints, AddExternalModelOnlyStandardRosenbrock)
 
   auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
   // Add only processes (constraints are not enabled with standard Rosenbrock parameters)
-  auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+  auto solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                     .SetSystem(system)
                     .SetReactions({})
                     .AddExternalModel(aerosol)
@@ -625,7 +627,7 @@ TEST(ExternalModelConstraints, AddExternalModelConstraintsOnly)
   auto system = micm::System(gas_phase);
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
-  auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+  auto solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                     .SetSystem(system)
                     .SetReactions({})
                     .AddExternalModel(aerosol)
@@ -666,7 +668,7 @@ TEST(ExternalModelConstraints, MultiGridCell)
   auto system = micm::System(gas_phase);
 
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
-  auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+  auto solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                     .SetSystem(system)
                     .SetReactions({})
                     .AddExternalModel(aerosol)
@@ -764,7 +766,7 @@ namespace
                                .Build();
 
     auto options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
-    auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+    auto solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                       .SetSystem(micm::System(gas_phase))
                       .SetReactions({ rxn_ab, rxn_bc, rxn_cb })
                       .SetReorderState(false)
@@ -828,7 +830,7 @@ namespace
     {
       options.constraint_init_tolerance_ = 1.0e-5;
     }
-    auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+    auto solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                       .SetSystem(micm::System(gas_phase))
                       .SetReactions({ rxn_ab })
                       .AddExternalModel(eq_model)
@@ -889,7 +891,7 @@ namespace
     {
       options.constraint_init_tolerance_ = 1.0e-5;
     }
-    auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+    auto solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                       .SetSystem(micm::System(gas_phase))
                       .SetReactions({ rxn_ab })
                       .AddExternalModel(eq_model)
@@ -1013,7 +1015,7 @@ TEST(ExternalModelConstraints, BuiltInVsExternalModelConstraintStepByStep)
   {
     options.constraint_init_tolerance_ = 1.0e-5;
   }
-  auto builtin_solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+  auto builtin_solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                             .SetSystem(micm::System(gas_phase))
                             .SetReactions({ rxn_ab })
                             .SetConstraints(std::move(constraints))
@@ -1022,7 +1024,7 @@ TEST(ExternalModelConstraints, BuiltInVsExternalModelConstraintStepByStep)
 
   // External model constraint solver
   EquilibriumConstraintModel eq_model("B", "C", K_EQ);
-  auto ext_solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+  auto ext_solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                         .SetSystem(micm::System(gas_phase))
                         .SetReactions({ rxn_ab })
                         .AddExternalModel(eq_model)
@@ -1141,7 +1143,7 @@ TEST(ExternalModelConstraints, MultiEquilibriumKineticVsComposedConstraints)
                              .Build();
 
   auto kin_options = micm::RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
-  auto kin_solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(kin_options)
+  auto kin_solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(kin_options)
                         .SetSystem(system)
                         .SetReactions({ rxn_ab, rxn_bc, rxn_cb, rxn_bd, rxn_db })
                         .SetReorderState(false)
@@ -1161,7 +1163,7 @@ TEST(ExternalModelConstraints, MultiEquilibriumKineticVsComposedConstraints)
   {
     dae_options.constraint_init_tolerance_ = 1.0e-5;
   }
-  auto ext_solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(dae_options)
+  auto ext_solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(dae_options)
                         .SetSystem(system)
                         .SetReactions({ rxn_ab })
                         .AddExternalModel(eq_bc)
@@ -1263,7 +1265,7 @@ TEST(ExternalModelConstraints, ProcessJacobianElementInAlgebraicRowSurvivesFilte
   auto options = micm::RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
 
   // This Build() call would throw "Zero element access" without the fix
-  auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+  auto solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                     .SetSystem(system)
                     .SetReactions({})
                     .AddExternalModel(aerosol)
@@ -1302,8 +1304,8 @@ TEST(ExternalModelConstraints, ProcessJacobianElementInAlgebraicRowSurvivesFilte
 // Finite-Difference Jacobian Verification for External Models
 // ═══════════════════════════════════════════════════════════════
 
-using DenseMatrix = micm::Matrix<micm::Real>;
-using SparseMatrixFD = micm::SparseMatrix<micm::Real, micm::SparseMatrixStandardOrdering>;
+using FdDenseMatrix = micm::KokkosDenseMatrix<micm::Real>;
+using SparseMatrixFD = micm::KokkosSparseMatrix<micm::Real>;
 
 /// Verify StubAerosolWithConstraints process forcing/Jacobian
 TEST(ExternalModelFiniteDifferenceJacobian, ProcessForcingJacobian)
@@ -1325,29 +1327,29 @@ TEST(ExternalModelFiniteDifferenceJacobian, ProcessForcingJacobian)
   SparseMatrixFD analytical_jac{ builder };
   aerosol.FinalizeProcessSetup(param_map, var_map, analytical_jac);
 
-  DenseMatrix variables(2, num_species, 0.0);
+  FdDenseMatrix variables(2, num_species, 0.0);
   variables[0][0] = 0.8;
   variables[0][1] = 0.2;
   variables[1][0] = 0.3;
   variables[1][1] = 0.7;
 
-  DenseMatrix params(2, 0, 0.0);
+  FdDenseMatrix params(2, 0, 0.0);
 
   aerosol.SubtractJacobianTerms(params, variables, analytical_jac);
 
-  auto fd_wrapper = [&](const DenseMatrix& vars, DenseMatrix& forcing)
+  auto fd_wrapper = [&](const FdDenseMatrix& vars, FdDenseMatrix& forcing)
   { aerosol.AddForcingTerms(params, vars, forcing); };
 
-  auto fd_jac = micm::FiniteDifferenceJacobian<DenseMatrix>(fd_wrapper, variables, num_species);
+  auto fd_jac = micm::FiniteDifferenceJacobian<FdDenseMatrix>(fd_wrapper, variables, num_species);
 
   auto comparison =
-      micm::CompareJacobianToFiniteDifference<DenseMatrix, SparseMatrixFD>(analytical_jac, fd_jac, num_species);
+      micm::CompareJacobianToFiniteDifference<FdDenseMatrix, SparseMatrixFD>(analytical_jac, fd_jac, num_species);
 
   EXPECT_TRUE(comparison.passed_) << "Process Jacobian mismatch: block=" << comparison.worst_block_
                                   << " row=" << comparison.worst_row_ << " col=" << comparison.worst_col_
                                   << " analytical=" << comparison.worst_analytical_ << " fd=" << comparison.worst_fd_;
 
-  auto sparsity = micm::CheckJacobianSparsityCompleteness<DenseMatrix, SparseMatrixFD>(analytical_jac, fd_jac, num_species);
+  auto sparsity = micm::CheckJacobianSparsityCompleteness<FdDenseMatrix, SparseMatrixFD>(analytical_jac, fd_jac, num_species);
 
   EXPECT_TRUE(sparsity.passed_) << "Missing sparsity at block=" << sparsity.worst_block_ << " row=" << sparsity.worst_row_
                                 << " col=" << sparsity.worst_col_ << " fd_value=" << sparsity.worst_fd_;
@@ -1374,22 +1376,22 @@ TEST(ExternalModelFiniteDifferenceJacobian, ConstraintResidualJacobian)
   SparseMatrixFD analytical_jac{ builder };
   aerosol.FinalizeConstraintSetup(param_map, var_map, analytical_jac);
 
-  DenseMatrix variables(2, num_species, 0.0);
+  FdDenseMatrix variables(2, num_species, 0.0);
   variables[0][0] = 0.6;
   variables[0][1] = 0.4;
   variables[1][0] = 0.2;
   variables[1][1] = 0.8;
-  DenseMatrix dummy_params(2, 1, 0.0);
+  FdDenseMatrix dummy_params(2, 1, 0.0);
 
   aerosol.SubtractConstraintJacobian(dummy_params, variables, analytical_jac);
 
-  auto fd_wrapper = [&](const DenseMatrix& vars, DenseMatrix& forcing)
+  auto fd_wrapper = [&](const FdDenseMatrix& vars, FdDenseMatrix& forcing)
   { aerosol.AddConstraintResidual(dummy_params, vars, forcing); };
 
-  auto fd_jac = micm::FiniteDifferenceJacobian<DenseMatrix>(fd_wrapper, variables, num_species);
+  auto fd_jac = micm::FiniteDifferenceJacobian<FdDenseMatrix>(fd_wrapper, variables, num_species);
 
   auto comparison =
-      micm::CompareJacobianToFiniteDifference<DenseMatrix, SparseMatrixFD>(analytical_jac, fd_jac, num_species);
+      micm::CompareJacobianToFiniteDifference<FdDenseMatrix, SparseMatrixFD>(analytical_jac, fd_jac, num_species);
 
   EXPECT_TRUE(comparison.passed_) << "Constraint Jacobian mismatch: block=" << comparison.worst_block_
                                   << " row=" << comparison.worst_row_ << " col=" << comparison.worst_col_
@@ -1416,26 +1418,26 @@ TEST(ExternalModelFiniteDifferenceJacobian, EquilibriumConstraintModelJacobian)
   SparseMatrixFD analytical_jac{ builder };
   model.FinalizeConstraintSetup(param_map, var_map, analytical_jac);
 
-  DenseMatrix variables(1, num_species, 0.0);
+  FdDenseMatrix variables(1, num_species, 0.0);
   variables[0][0] = 3.0;
   variables[0][1] = 5.0;
-  DenseMatrix dummy_params(1, 1, 0.0);
+  FdDenseMatrix dummy_params(1, 1, 0.0);
 
   model.SubtractConstraintJacobian(dummy_params, variables, analytical_jac);
 
-  auto fd_wrapper = [&](const DenseMatrix& vars, DenseMatrix& forcing)
+  auto fd_wrapper = [&](const FdDenseMatrix& vars, FdDenseMatrix& forcing)
   { model.AddConstraintResidual(dummy_params, vars, forcing); };
 
-  auto fd_jac = micm::FiniteDifferenceJacobian<DenseMatrix>(fd_wrapper, variables, num_species);
+  auto fd_jac = micm::FiniteDifferenceJacobian<FdDenseMatrix>(fd_wrapper, variables, num_species);
 
   auto comparison =
-      micm::CompareJacobianToFiniteDifference<DenseMatrix, SparseMatrixFD>(analytical_jac, fd_jac, num_species);
+      micm::CompareJacobianToFiniteDifference<FdDenseMatrix, SparseMatrixFD>(analytical_jac, fd_jac, num_species);
 
   EXPECT_TRUE(comparison.passed_) << "EquilibriumConstraintModel Jacobian mismatch: block=" << comparison.worst_block_
                                   << " row=" << comparison.worst_row_ << " col=" << comparison.worst_col_
                                   << " analytical=" << comparison.worst_analytical_ << " fd=" << comparison.worst_fd_;
 
-  auto sparsity = micm::CheckJacobianSparsityCompleteness<DenseMatrix, SparseMatrixFD>(analytical_jac, fd_jac, num_species);
+  auto sparsity = micm::CheckJacobianSparsityCompleteness<FdDenseMatrix, SparseMatrixFD>(analytical_jac, fd_jac, num_species);
 
   EXPECT_TRUE(sparsity.passed_) << "Missing sparsity at block=" << sparsity.worst_block_ << " row=" << sparsity.worst_row_
                                 << " col=" << sparsity.worst_col_ << " fd_value=" << sparsity.worst_fd_;
@@ -1631,7 +1633,7 @@ TEST(ExternalModelConstraints, TemperatureDependentConstraintParameter)
   {
     options.constraint_init_tolerance_ = 1.0e-5;
   }
-  auto solver = micm::CpuSolverBuilder<micm::RosenbrockSolverParameters>(options)
+  auto solver = micm::KokkosSolverBuilder<micm::RosenbrockSolverParameters>(options)
                     .SetSystem(micm::System(gas_phase))
                     .SetReactions({ rxn_ab })
                     .AddExternalModel(eq_model)
@@ -1696,4 +1698,13 @@ TEST(ExternalModelConstraints, TemperatureDependentConstraintParameter)
     EXPECT_GT(K_eq_350, K_EQ_REF) << "K_eq should increase with temperature for positive delta_H";
     EXPECT_NEAR(C_val / B_val, K_eq_350, 1e-4) << "At T=350K, [C]/[B] should equal K_eq(350)";
   }
+}
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  Kokkos::initialize(argc, argv);
+  int result = RUN_ALL_TESTS();
+  Kokkos::finalize();
+  return result;
 }

--- a/test/integration/kokkos/test_kokkos_linear_constraint.cpp
+++ b/test/integration/kokkos/test_kokkos_linear_constraint.cpp
@@ -18,8 +18,8 @@
 #include <type_traits>
 
 using namespace micm;
-using DenseMatrix = KokkosDenseMatrix<Real, MICM_DEFAULT_VECTOR_SIZE>;
-using StdSparseMatrix = KokkosSparseMatrix<Real, SparseMatrixVectorOrdering<MICM_DEFAULT_VECTOR_SIZE>>;
+using DenseMatrix = KokkosDenseMatrix<Real>;
+using StdSparseMatrix = KokkosSparseMatrix<Real>;
 
 TEST(DAESolveWithConstraint, TerminatorAndRobertson)
 {

--- a/test/integration/stub_aerosol_1.hpp
+++ b/test/integration/stub_aerosol_1.hpp
@@ -11,8 +11,6 @@
 
 #include <gtest/gtest.h>
 
-#include <functional>
-#include <map>
 #include <set>
 #include <string>
 #include <tuple>
@@ -20,22 +18,23 @@
 #include <utility>
 #include <vector>
 
-// some parameters used in the test
+// Rate constants used by the test
 constexpr micm::Real STUB1_RATE_CONSTANT_FO2_CORGE = 1e-3;
 constexpr micm::Real STUB1_RATE_CONSTANT_BAZ_QUUX = 2e-3;
 
 // First stubbed aerosol model implementation
 //
-// This model mimics a single moment two-mode aerosol model
-// The first mode contains only the first phase, and the second mode contains both phases
+// Mimics a single-moment two-mode aerosol model. Mode 1 contains only the first phase;
+// mode 2 contains both phases. Two processes: FO2 gas → FO2 mode2 CORGE, and BAZ mode1 → BAZ mode2.
 class StubAerosolModel
 {
  public:
   struct RateConstants
   {
-    micm::Real fo2_gas_to_mode2_corge_;   // rate constant for FO2 gas to mode 2 CORGE partitioning
-    micm::Real baz_mode1_to_mode2_quux_;  // rate constant for baz mode 1 to baz mode 2 conversion
+    micm::Real fo2_gas_to_mode2_corge_;
+    micm::Real baz_mode1_to_mode2_quux_;
   };
+
   StubAerosolModel() = delete;
   StubAerosolModel(std::string name, const std::vector<micm::Phase>& phases, const RateConstants& rate_constants)
       : name_(std::move(name)),
@@ -43,17 +42,19 @@ class StubAerosolModel
         rate_constants_(rate_constants)
   {
   }
+
+  // State definition
+
   std::tuple<micm::Index, micm::Index> StateSize() const
   {
     EXPECT_EQ(phases_.size(), 2);
-    // First mode: first phase only
-    // Second mode: both phases
     micm::Index size = 0;
-    size += phases_[0].StateSize();  // mode 1
-    size += phases_[0].StateSize();  // mode 2, first phase
-    size += phases_[1].StateSize();  // mode 2, second phase
-    return { size, 0 };              // Return the number of state variables and parameters (0 for this stub model)
+    size += phases_[0].StateSize();
+    size += phases_[0].StateSize();
+    size += phases_[1].StateSize();
+    return { size, 0 };
   }
+
   std::set<std::string> StateVariableNames() const
   {
     std::set<std::string> names;
@@ -74,158 +75,147 @@ class StubAerosolModel
     }
     return names;
   }
+
   std::set<std::string> StateParameterNames() const
   {
     return {};
   }
+
   std::string Species(const micm::Index mode, const micm::Phase& phase, const micm::Species& species) const
   {
     return name_ + ".MODE" + std::to_string(mode + 1) + "." + phase.name_ + "." + species.name_;
   }
 
-  // We'll pretend all the species in the aerosol model are involved in processes
+  // Process definition
+
   std::set<std::string> SpeciesUsed() const
   {
     return StateVariableNames();
   }
 
-  // We'll assume this model includes gas-aerosol conversion of FO2 to mode 2, and
-  // an aerosol-aerosol conversion of baz from mode 1 to mode 2
-
   std::set<std::pair<micm::Index, micm::Index>> NonZeroJacobianElements(
       const std::unordered_map<std::string, micm::Index>& state_indices) const
   {
     std::set<std::pair<micm::Index, micm::Index>> elements;
-    // FO2 gas to mode 2 condensed in CORGE
-    auto fo2_gas_index_it = state_indices.find("FO2");
-    auto fo2_mode2_index_it = state_indices.find("STUB1.MODE2.CORGE.FO2");
-    if (fo2_gas_index_it != state_indices.end() && fo2_mode2_index_it != state_indices.end())
+    auto fo2_gas_it = state_indices.find("FO2");
+    auto fo2_mode2_it = state_indices.find("STUB1.MODE2.CORGE.FO2");
+    if (fo2_gas_it != state_indices.end() && fo2_mode2_it != state_indices.end())
     {
-      elements.insert({ fo2_mode2_index_it->second, fo2_gas_index_it->second });
+      elements.insert({ fo2_gas_it->second, fo2_gas_it->second });
+      elements.insert({ fo2_mode2_it->second, fo2_gas_it->second });
     }
-    // baz mode 1 to baz mode 2 in QUUX
-    auto baz_mode1_index_it = state_indices.find("STUB1.MODE1.QUUX.BAZ");
-    auto baz_mode2_index_it = state_indices.find("STUB1.MODE2.QUUX.BAZ");
-    if (baz_mode1_index_it != state_indices.end() && baz_mode2_index_it != state_indices.end())
+    auto baz_mode1_it = state_indices.find("STUB1.MODE1.QUUX.BAZ");
+    auto baz_mode2_it = state_indices.find("STUB1.MODE2.QUUX.BAZ");
+    if (baz_mode1_it != state_indices.end() && baz_mode2_it != state_indices.end())
     {
-      elements.insert({ baz_mode2_index_it->second, baz_mode1_index_it->second });
+      elements.insert({ baz_mode1_it->second, baz_mode1_it->second });
+      elements.insert({ baz_mode2_it->second, baz_mode1_it->second });
     }
     return elements;
   }
 
-  // We have no parameters for this stub model
-  template<typename DenseMatrixPolicy>
-  std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>
-  UpdateStateParametersFunction(const std::unordered_map<std::string, micm::Index>& state_parameter_indices) const
-  {
-    // No parameters to update in this stub model
-    return [](const typename DenseMatrixPolicy::template VectorType<micm::Conditions>& conditions,
-              DenseMatrixPolicy& state_parameters)
-    {
-      // Do nothing
-    };
-  }
-
-  template<typename DenseMatrixPolicy>
-  std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)> ForcingFunction(
-      const std::unordered_map<std::string, micm::Index>& state_parameter_indices,
-      const std::unordered_map<std::string, micm::Index>& state_variable_indices) const
-  {
-    // We'll store the information needed to calculate the forcing terms in a vector of tuples
-    // Each tuple will include: reactant state variable index, product state variable index, and the rate constant
-    std::vector<std::tuple<micm::Index, micm::Index, micm::Real>> forcing_info;
-    auto fo2_gas_index_it = state_variable_indices.find("FO2");
-    auto fo2_mode2_index_it = state_variable_indices.find("STUB1.MODE2.CORGE.FO2");
-    if (fo2_gas_index_it != state_variable_indices.end() && fo2_mode2_index_it != state_variable_indices.end())
-    {
-      forcing_info.emplace_back(
-          fo2_gas_index_it->second, fo2_mode2_index_it->second, rate_constants_.fo2_gas_to_mode2_corge_);
-    }
-    auto baz_mode1_index_it = state_variable_indices.find("STUB1.MODE1.QUUX.BAZ");
-    auto baz_mode2_index_it = state_variable_indices.find("STUB1.MODE2.QUUX.BAZ");
-    if (baz_mode1_index_it != state_variable_indices.end() && baz_mode2_index_it != state_variable_indices.end())
-    {
-      forcing_info.emplace_back(
-          baz_mode1_index_it->second, baz_mode2_index_it->second, rate_constants_.baz_mode1_to_mode2_quux_);
-    }
-
-    // copy-capture the forcing_info vector in the lambda function that will calculate the forcing terms
-    return [forcing_info](
-               const DenseMatrixPolicy& state_parameters,
-               const DenseMatrixPolicy& state_variables,
-               DenseMatrixPolicy& forcing_terms)
-    {
-      for (const auto& [reactant_index, product_index, rate_constant] : forcing_info)
-      {
-        // We'll naively assume the underlying forcing vector is column-major
-        // the square-bracket syntax is always [grid_cell][variable_index] regardless of the actual memory layout of the
-        // DenseMatrixPolicy
-        for (micm::Index i_cell = 0; i_cell < state_variables.NumRows(); ++i_cell)
-        {
-          // Subtract from reactant
-          forcing_terms[i_cell][reactant_index] -= rate_constant * state_variables[i_cell][reactant_index];
-          // Add to product
-          forcing_terms[i_cell][product_index] += rate_constant * state_variables[i_cell][reactant_index];
-        }
-      }
-    };
-  }
-  template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
-  std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)> JacobianFunction(
-      const std::unordered_map<std::string, micm::Index>& state_parameter_indices,
+  /// Cache reactant/product state indices and pre-compute Jacobian flat indices for block 0.
+  template<class SparseMatrixPolicy>
+  void FinalizeProcessSetup(
+      const std::unordered_map<std::string, micm::Index>& /*state_parameter_indices*/,
       const std::unordered_map<std::string, micm::Index>& state_variable_indices,
-      const SparseMatrixPolicy& jacobian) const
+      const SparseMatrixPolicy& jacobian)
   {
-    // For this simple implementation, we'll use the dependent and independent variable indices with the square-bracket
-    // syntax of the jacobian matrix. In a real implementation, we should want to get the underlying vector indices of the
-    // jacobian elements, and iterate over blocks in the block diagonal sparse matrix in the most efficient way for the
-    // specific SparseMatrixPolicy.
-    std::vector<std::tuple<micm::Index, micm::Index, micm::Real>> jacobian_info;  // (dependent id, independent id, value)
-    auto fo2_gas_index_it = state_variable_indices.find("FO2");
-    auto fo2_mode2_index_it = state_variable_indices.find("STUB1.MODE2.CORGE.FO2");
-    if (fo2_gas_index_it != state_variable_indices.end() && fo2_mode2_index_it != state_variable_indices.end())
+    forcing_info_.clear();
+    auto add = [&](const std::string& r, const std::string& p, micm::Real k)
     {
-      jacobian_info.emplace_back(
-          fo2_gas_index_it->second,
-          fo2_gas_index_it->second,
-          -rate_constants_.fo2_gas_to_mode2_corge_);  // reactant partial derivative
-      jacobian_info.emplace_back(
-          fo2_mode2_index_it->second,
-          fo2_gas_index_it->second,
-          rate_constants_.fo2_gas_to_mode2_corge_);  // product partial derivative
-    }
-    auto baz_mode1_index_it = state_variable_indices.find("STUB1.MODE1.QUUX.BAZ");
-    auto baz_mode2_index_it = state_variable_indices.find("STUB1.MODE2.QUUX.BAZ");
-    if (baz_mode1_index_it != state_variable_indices.end() && baz_mode2_index_it != state_variable_indices.end())
-    {
-      jacobian_info.emplace_back(
-          baz_mode1_index_it->second,
-          baz_mode1_index_it->second,
-          -rate_constants_.baz_mode1_to_mode2_quux_);  // reactant partial derivative
-      jacobian_info.emplace_back(
-          baz_mode2_index_it->second,
-          baz_mode1_index_it->second,
-          rate_constants_.baz_mode1_to_mode2_quux_);  // product partial derivative
-    }
-
-    // copy-capture the jacobian_info vector in the lambda function that will calculate the Jacobian terms
-    return [jacobian_info](
-               const DenseMatrixPolicy& state_parameters,
-               const DenseMatrixPolicy& state_variables,
-               SparseMatrixPolicy& jacobian)
-    {
-      for (micm::Index i_block = 0; i_block < jacobian.NumberOfBlocks(); ++i_block)
+      auto ri = state_variable_indices.find(r);
+      auto pi = state_variable_indices.find(p);
+      if (ri != state_variable_indices.end() && pi != state_variable_indices.end())
       {
-        for (const auto& [dependent_id, independent_id, value] : jacobian_info)
-        {
-          jacobian[i_block][dependent_id][independent_id] -= value;
-        }
+        forcing_info_.push_back({ ri->second,
+                                  pi->second,
+                                  k,
+                                  jacobian.VectorIndex(0, ri->second, ri->second),
+                                  jacobian.VectorIndex(0, pi->second, ri->second) });
       }
     };
+    add("FO2", "STUB1.MODE2.CORGE.FO2", rate_constants_.fo2_gas_to_mode2_corge_);
+    add("STUB1.MODE1.QUUX.BAZ", "STUB1.MODE2.QUUX.BAZ", rate_constants_.baz_mode1_to_mode2_quux_);
+  }
+
+  template<class DenseMatrixPolicy>
+  void UpdateStateParameters(
+      const typename DenseMatrixPolicy::template VectorType<micm::Conditions>& /*conditions*/,
+      DenseMatrixPolicy& /*state_parameters*/) const
+  {
+  }
+
+  template<class DenseMatrixPolicy>
+  void AddForcingTerms(
+      const DenseMatrixPolicy& /*state_parameters*/,
+      const DenseMatrixPolicy& state_variables,
+      DenseMatrixPolicy& forcing) const
+  {
+    for (const auto& info : forcing_info_)
+    {
+      const micm::Index reactant_idx = info.reactant_index_;
+      const micm::Index product_idx = info.product_index_;
+      const micm::Real k = info.rate_constant_;
+      DenseMatrixPolicy::Function(
+          MICM_LAMBDA(
+              const typename DenseMatrixPolicy::ViewType& forcing_view,
+              const typename DenseMatrixPolicy::ConstViewType& state_view) {
+            forcing_view.ForEachRow(
+                [k](micm::Real& f_reactant, micm::Real& f_product, const micm::Real& reactant)
+                {
+                  micm::Real rate = k * reactant;
+                  f_reactant -= rate;
+                  f_product += rate;
+                },
+                forcing_view.GetColumnView(reactant_idx),
+                forcing_view.GetColumnView(product_idx),
+                state_view.GetConstColumnView(reactant_idx));
+          },
+          forcing,
+          state_variables)(forcing, state_variables);
+    }
+  }
+
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  void SubtractJacobianTerms(
+      const DenseMatrixPolicy& /*state_parameters*/,
+      const DenseMatrixPolicy& state_variables,
+      SparseMatrixPolicy& jacobian) const
+  {
+    for (const auto& info : forcing_info_)
+    {
+      const micm::Real k = info.rate_constant_;
+      const micm::Index reactant_flat = info.reactant_reactant_flat_;
+      const micm::Index product_flat = info.product_reactant_flat_;
+      SparseMatrixPolicy::Function(
+          MICM_LAMBDA(const typename SparseMatrixPolicy::ViewType& jacobian_view) {
+            jacobian_view.ForEachBlock(
+                [k](micm::Real& j_reactant, micm::Real& j_product)
+                {
+                  j_reactant -= -k;
+                  j_product -= k;
+                },
+                jacobian_view.GetBlockView(reactant_flat),
+                jacobian_view.GetBlockView(product_flat));
+          },
+          jacobian)(jacobian);
+    }
+    (void)state_variables;
   }
 
  private:
+  struct ForcingInfo
+  {
+    micm::Index reactant_index_;
+    micm::Index product_index_;
+    micm::Real rate_constant_;
+    micm::Index reactant_reactant_flat_;  // Jacobian flat id for (reactant, reactant)
+    micm::Index product_reactant_flat_;   // Jacobian flat id for (product,  reactant)
+  };
+
   std::string name_;
   std::vector<micm::Phase> phases_;
   RateConstants rate_constants_;
+  std::vector<ForcingInfo> forcing_info_;
 };

--- a/test/integration/stub_aerosol_2.hpp
+++ b/test/integration/stub_aerosol_2.hpp
@@ -5,14 +5,13 @@
 /// @brief Stub aerosol model for integration testing
 #pragma once
 
+#include <micm/system/conditions.hpp>
 #include <micm/system/phase.hpp>
 #include <micm/system/species.hpp>
 #include <micm/util/types.hpp>
 
 #include <gtest/gtest.h>
 
-#include <functional>
-#include <map>
 #include <set>
 #include <string>
 #include <tuple>
@@ -22,10 +21,7 @@
 
 // Second stubbed aerosol model implementation
 //
-// This model mimics a two-moment three-mode aerosol model
-// The first mode contains only the first phase, the second mode contains the second phase,
-// and the third mode contains both phases. For two-moment schemes, particle number concentration
-// is also included for each mode.
+// Mimics a two-moment three-mode aerosol model with temperature-dependent state parameters.
 class AnotherStubAerosolModel
 {
  public:
@@ -35,239 +31,232 @@ class AnotherStubAerosolModel
         phases_(phases)
   {
   }
+
+  // State definition
+
   std::tuple<micm::Index, micm::Index> StateSize() const
   {
     EXPECT_EQ(phases_.size(), 2);
-    // First mode: first phase only
-    // Second mode: second phase only
-    // Third mode: both phases
     micm::Index size = 0;
-    size += 1;                       // mode 1 number concentration
-    size += phases_[0].StateSize();  // mode 1 species
-    size += 1;                       // mode 2 number concentration
-    size += phases_[1].StateSize();  // mode 2 species
-    size += 1;                       // mode 3 number concentration
-    size += phases_[0].StateSize();  // mode 3, first phase species
-    size += phases_[1].StateSize();  // mode 3, second phase species
-    return { size, 2 };              // Return the number of state variables and parameters (2 for this stub model)
+    size += 1;
+    size += phases_[0].StateSize();
+    size += 1;
+    size += phases_[1].StateSize();
+    size += 1;
+    size += phases_[0].StateSize();
+    size += phases_[1].StateSize();
+    return { size, 2 };
   }
+
   std::set<std::string> StateVariableNames() const
   {
     std::set<std::string> names;
     EXPECT_EQ(phases_.size(), 2);
     auto phase1_names = phases_[0].UniqueNames();
     auto phase2_names = phases_[1].UniqueNames();
-    names.insert(name_ + ".MODE1.NUMBER");  // number concentration for mode 1
-    for (const auto& name : phase1_names)
+    names.insert(name_ + ".MODE1.NUMBER");
+    for (const auto& n : phase1_names)
     {
-      names.insert(name_ + ".MODE1." + name);
+      names.insert(name_ + ".MODE1." + n);
     }
-    names.insert(name_ + ".MODE2.NUMBER");  // number concentration for mode 2
-    for (const auto& name : phase2_names)
+    names.insert(name_ + ".MODE2.NUMBER");
+    for (const auto& n : phase2_names)
     {
-      names.insert(name_ + ".MODE2." + name);
+      names.insert(name_ + ".MODE2." + n);
     }
-    names.insert(name_ + ".MODE3.NUMBER");  // number concentration for mode 3
-    for (const auto& name : phase1_names)
+    names.insert(name_ + ".MODE3.NUMBER");
+    for (const auto& n : phase1_names)
     {
-      names.insert(name_ + ".MODE3." + name);
+      names.insert(name_ + ".MODE3." + n);
     }
-    for (const auto& name : phase2_names)
+    for (const auto& n : phase2_names)
     {
-      names.insert(name_ + ".MODE3." + name);
+      names.insert(name_ + ".MODE3." + n);
     }
     return names;
   }
+
   std::set<std::string> StateParameterNames() const
   {
     std::set<std::string> names;
-
-    // add parameters for the two rate constants used in the model processes
     names.insert(name_ + ".PARAM.MODE2.CORGE.FO2_TO_BAZ_RATE_CONSTANT");
     names.insert(name_ + ".PARAM.MODE3.QUUX.BAZ_TO_QUX_RATE_CONSTANT");
     return names;
   }
+
   std::string Species(const micm::Index mode, const micm::Phase& phase, const micm::Species& species) const
   {
     return name_ + ".MODE" + std::to_string(mode + 1) + "." + phase.name_ + "." + species.name_;
   }
+
   std::string Number(const micm::Index mode) const
   {
     return name_ + ".MODE" + std::to_string(mode + 1) + ".NUMBER";
   }
 
-  // We'll assume all the species in the aerosol model are involved in processes
+  // Process definition
+
   std::set<std::string> SpeciesUsed() const
   {
     return StateVariableNames();
   }
 
-  // We'll assume this model includes two processes:
-  // 1) conversion of FO2 to BAZ in mode 2 CORGE phase
-  // 2) conversion of BAZ to QUX in mode 3 QUUX phase
-
   std::set<std::pair<micm::Index, micm::Index>> NonZeroJacobianElements(
       const std::unordered_map<std::string, micm::Index>& state_indices) const
   {
     std::set<std::pair<micm::Index, micm::Index>> elements;
-    // FO2 to BAZ in mode 2 CORGE
-    auto fo2_mode2_index_it = state_indices.find("STUB2.MODE2.CORGE.FO2");
-    auto baz_mode2_index_it = state_indices.find("STUB2.MODE2.CORGE.BAZ");
-    if (fo2_mode2_index_it != state_indices.end() && baz_mode2_index_it != state_indices.end())
+    auto fo2_mode2_it = state_indices.find("STUB2.MODE2.CORGE.FO2");
+    auto baz_mode2_it = state_indices.find("STUB2.MODE2.CORGE.BAZ");
+    if (fo2_mode2_it != state_indices.end() && baz_mode2_it != state_indices.end())
     {
-      elements.insert({ baz_mode2_index_it->second, fo2_mode2_index_it->second });
+      elements.insert({ fo2_mode2_it->second, fo2_mode2_it->second });
+      elements.insert({ baz_mode2_it->second, fo2_mode2_it->second });
     }
-    // BAZ to QUX in mode 3 QUUX
-    auto baz_mode3_index_it = state_indices.find("STUB2.MODE3.QUUX.BAZ");
-    auto qux_mode3_index_it = state_indices.find("STUB2.MODE3.QUUX.QUX");
-    if (baz_mode3_index_it != state_indices.end() && qux_mode3_index_it != state_indices.end())
+    auto baz_mode3_it = state_indices.find("STUB2.MODE3.QUUX.BAZ");
+    auto qux_mode3_it = state_indices.find("STUB2.MODE3.QUUX.QUX");
+    if (baz_mode3_it != state_indices.end() && qux_mode3_it != state_indices.end())
     {
-      elements.insert({ qux_mode3_index_it->second, baz_mode3_index_it->second });
+      elements.insert({ baz_mode3_it->second, baz_mode3_it->second });
+      elements.insert({ qux_mode3_it->second, baz_mode3_it->second });
     }
     return elements;
   }
 
-  // We have parameters for this stub model, one of which we will update based on temperature
-  template<typename DenseMatrixPolicy>
-  std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>
-  UpdateStateParametersFunction(const std::unordered_map<std::string, micm::Index>& state_parameter_indices) const
-  {
-    // Create a function that updates the BAZ-to-QUX rate constant based on temperature for each grid cell
-    auto baz_to_qux_param_it = state_parameter_indices.find(name_ + ".PARAM.MODE3.QUUX.BAZ_TO_QUX_RATE_CONSTANT");
-    EXPECT_NE(baz_to_qux_param_it, state_parameter_indices.end());
-    if (baz_to_qux_param_it == state_parameter_indices.end())
-    {
-      // If the parameter is missing, return a no-op updater to avoid undefined behavior.
-      return [](const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&) {};
-    }
-    micm::Index baz_to_qux_param_index = baz_to_qux_param_it->second;
-    return [baz_to_qux_param_index](
-               const typename DenseMatrixPolicy::template VectorType<micm::Conditions>& conditions,
-               DenseMatrixPolicy& state_parameters)
-    {
-      for (micm::Index cell = 0; cell < conditions.size(); ++cell)
-      {
-        // Simple linear dependence on temperature for this stub model
-        micm::Real temperature = conditions[cell].temperature_;
-        micm::Real rate_constant = 0.005 * temperature;  // simple function for testing
-        state_parameters[cell][baz_to_qux_param_index] = rate_constant;
-      }
-    };
-  }
-
-  template<typename DenseMatrixPolicy>
-  std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)> ForcingFunction(
-      const std::unordered_map<std::string, micm::Index>& state_parameter_indices,
-      const std::unordered_map<std::string, micm::Index>& state_variable_indices) const
-  {
-    // We'll store the information needed to calculate the forcing terms in a vector of tuples
-    // Each tuple will include: reactant state variable index, product state variable index, and the index of the rate
-    // constant parameter
-    std::vector<std::tuple<micm::Index, micm::Index, micm::Index>> forcing_info;
-    auto fo2_mode2_index_it = state_variable_indices.find("STUB2.MODE2.CORGE.FO2");
-    auto baz_mode2_index_it = state_variable_indices.find("STUB2.MODE2.CORGE.BAZ");
-    auto fo2_to_baz_param_it = state_parameter_indices.find(name_ + ".PARAM.MODE2.CORGE.FO2_TO_BAZ_RATE_CONSTANT");
-    if (fo2_mode2_index_it != state_variable_indices.end() && baz_mode2_index_it != state_variable_indices.end() &&
-        fo2_to_baz_param_it != state_parameter_indices.end())
-    {
-      forcing_info.emplace_back(fo2_mode2_index_it->second, baz_mode2_index_it->second, fo2_to_baz_param_it->second);
-    }
-    auto baz_mode3_index_it = state_variable_indices.find("STUB2.MODE3.QUUX.BAZ");
-    auto qux_mode3_index_it = state_variable_indices.find("STUB2.MODE3.QUUX.QUX");
-    auto baz_to_qux_param_it = state_parameter_indices.find(name_ + ".PARAM.MODE3.QUUX.BAZ_TO_QUX_RATE_CONSTANT");
-    if (baz_mode3_index_it != state_variable_indices.end() && qux_mode3_index_it != state_variable_indices.end() &&
-        baz_to_qux_param_it != state_parameter_indices.end())
-    {
-      forcing_info.emplace_back(baz_mode3_index_it->second, qux_mode3_index_it->second, baz_to_qux_param_it->second);
-    }
-
-    // copy capture the forcing_info vector in the lambda function that will calculate the forcing terms
-    return [forcing_info](
-               const DenseMatrixPolicy& state_parameters,
-               const DenseMatrixPolicy& state_variables,
-               DenseMatrixPolicy& forcing_terms)
-    {
-      // We'll naively assume the underlying forcing vector is column-major
-      // the square-bracket syntax is always [grid_cell][variable_index] regardless of the actual memory layout of the
-      // DenseMatrixPolicy
-      for (const auto& [reactant_index, product_index, rate_param_index] : forcing_info)
-      {
-        for (micm::Index i_cell = 0; i_cell < state_variables.NumRows(); ++i_cell)
-        {
-          micm::Real rate_constant = state_parameters[i_cell][rate_param_index];
-          // Subtract from reactant
-          forcing_terms[i_cell][reactant_index] -= rate_constant * state_variables[i_cell][reactant_index];
-          // Add to product
-          forcing_terms[i_cell][product_index] += rate_constant * state_variables[i_cell][reactant_index];
-        }
-      }
-    };
-  }
-  template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
-  std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)> JacobianFunction(
+  template<class SparseMatrixPolicy>
+  void FinalizeProcessSetup(
       const std::unordered_map<std::string, micm::Index>& state_parameter_indices,
       const std::unordered_map<std::string, micm::Index>& state_variable_indices,
-      const SparseMatrixPolicy& jacobian) const
+      const SparseMatrixPolicy& jacobian)
   {
-    // For this simple implementation, we'll use the dependent and independent variable indices with the square-bracket
-    // syntax of the jacobian matrix. In a real implementation, we should want to get the underlying vector indices of the
-    // jacobian elements, and iterate over blocks in the block diagonal sparse matrix in the most efficient way for the
-    // specific SparseMatrixPolicy.
-    std::vector<std::tuple<micm::Index, micm::Index, micm::Index, micm::Real>>
-        jacobian_info;  // (dependent id, independent id, rate param id, multiplier)
-    auto fo2_mode2_index_it = state_variable_indices.find("STUB2.MODE2.CORGE.FO2");
-    auto baz_mode2_index_it = state_variable_indices.find("STUB2.MODE2.CORGE.BAZ");
-    auto fo2_to_baz_param_it = state_parameter_indices.find(name_ + ".PARAM.MODE2.CORGE.FO2_TO_BAZ_RATE_CONSTANT");
-    if (fo2_mode2_index_it != state_variable_indices.end() && baz_mode2_index_it != state_variable_indices.end() &&
-        fo2_to_baz_param_it != state_parameter_indices.end())
+    forcing_info_.clear();
+    auto add = [&](const std::string& r, const std::string& p, const std::string& param)
     {
-      jacobian_info.emplace_back(
-          fo2_mode2_index_it->second,
-          fo2_mode2_index_it->second,
-          fo2_to_baz_param_it->second,
-          -1.0);  // reactant partial derivative
-      jacobian_info.emplace_back(
-          baz_mode2_index_it->second,
-          fo2_mode2_index_it->second,
-          fo2_to_baz_param_it->second,
-          1.0);  // product partial derivative
-    }
-    auto baz_mode3_index_it = state_variable_indices.find("STUB2.MODE3.QUUX.BAZ");
-    auto qux_mode3_index_it = state_variable_indices.find("STUB2.MODE3.QUUX.QUX");
-    auto baz_to_qux_param_it = state_parameter_indices.find(name_ + ".PARAM.MODE3.QUUX.BAZ_TO_QUX_RATE_CONSTANT");
-    if (baz_mode3_index_it != state_variable_indices.end() && qux_mode3_index_it != state_variable_indices.end() &&
-        baz_to_qux_param_it != state_parameter_indices.end())
-    {
-      jacobian_info.emplace_back(
-          baz_mode3_index_it->second,
-          baz_mode3_index_it->second,
-          baz_to_qux_param_it->second,
-          -1.0);  // reactant partial derivative
-      jacobian_info.emplace_back(
-          qux_mode3_index_it->second,
-          baz_mode3_index_it->second,
-          baz_to_qux_param_it->second,
-          1.0);  // product partial derivative
-    }
-
-    // copy-capture the jacobian_info vector in the lambda function that will calculate the Jacobian terms
-    return [jacobian_info](
-               const DenseMatrixPolicy& state_parameters,
-               const DenseMatrixPolicy& state_variables,
-               SparseMatrixPolicy& jacobian)
-    {
-      for (micm::Index i_block = 0; i_block < jacobian.NumberOfBlocks(); ++i_block)
+      auto ri = state_variable_indices.find(r);
+      auto pi = state_variable_indices.find(p);
+      auto pri = state_parameter_indices.find(param);
+      if (ri != state_variable_indices.end() && pi != state_variable_indices.end() &&
+          pri != state_parameter_indices.end())
       {
-        for (const auto& [dependent_id, independent_id, rate_param_id, multiplier] : jacobian_info)
-        {
-          micm::Real rate_constant = state_parameters[i_block][rate_param_id];
-          jacobian[i_block][dependent_id][independent_id] -= multiplier * rate_constant;
-        }
+        forcing_info_.push_back({ ri->second,
+                                  pi->second,
+                                  pri->second,
+                                  jacobian.VectorIndex(0, ri->second, ri->second),
+                                  jacobian.VectorIndex(0, pi->second, ri->second) });
       }
     };
+    add("STUB2.MODE2.CORGE.FO2", "STUB2.MODE2.CORGE.BAZ", name_ + ".PARAM.MODE2.CORGE.FO2_TO_BAZ_RATE_CONSTANT");
+    add("STUB2.MODE3.QUUX.BAZ", "STUB2.MODE3.QUUX.QUX", name_ + ".PARAM.MODE3.QUUX.BAZ_TO_QUX_RATE_CONSTANT");
+
+    baz_to_qux_param_index_ = -1;
+    auto it = state_parameter_indices.find(name_ + ".PARAM.MODE3.QUUX.BAZ_TO_QUX_RATE_CONSTANT");
+    if (it != state_parameter_indices.end())
+    {
+      baz_to_qux_param_index_ = it->second;
+    }
+  }
+
+  template<class DenseMatrixPolicy>
+  void UpdateStateParameters(
+      const typename DenseMatrixPolicy::template VectorType<micm::Conditions>& conditions,
+      DenseMatrixPolicy& state_parameters) const
+  {
+    if (baz_to_qux_param_index_ < 0)
+    {
+      return;
+    }
+    const micm::Index idx = baz_to_qux_param_index_;
+    DenseMatrixPolicy::Function(
+        MICM_LAMBDA(
+            const typename DenseMatrixPolicy::template VectorType<micm::Conditions>::ConstViewType& conditions_view,
+            const typename DenseMatrixPolicy::ViewType& state_param_view) {
+          state_param_view.ForEachRow(
+              [](const micm::Conditions& cond, micm::Real& rate) { rate = 0.005 * cond.temperature_; },
+              conditions_view,
+              state_param_view.GetColumnView(idx));
+        },
+        conditions,
+        state_parameters)(conditions, state_parameters);
+  }
+
+  template<class DenseMatrixPolicy>
+  void AddForcingTerms(
+      const DenseMatrixPolicy& state_parameters,
+      const DenseMatrixPolicy& state_variables,
+      DenseMatrixPolicy& forcing) const
+  {
+    for (const auto& info : forcing_info_)
+    {
+      const micm::Index reactant_idx = info.reactant_index_;
+      const micm::Index product_idx = info.product_index_;
+      const micm::Index param_idx = info.rate_param_index_;
+      DenseMatrixPolicy::Function(
+          MICM_LAMBDA(
+              const typename DenseMatrixPolicy::ViewType& forcing_view,
+              const typename DenseMatrixPolicy::ConstViewType& state_view,
+              const typename DenseMatrixPolicy::ConstViewType& param_view) {
+            forcing_view.ForEachRow(
+                [](micm::Real& f_reactant,
+                   micm::Real& f_product,
+                   const micm::Real& reactant,
+                   const micm::Real& rate_constant)
+                {
+                  micm::Real rate = rate_constant * reactant;
+                  f_reactant -= rate;
+                  f_product += rate;
+                },
+                forcing_view.GetColumnView(reactant_idx),
+                forcing_view.GetColumnView(product_idx),
+                state_view.GetConstColumnView(reactant_idx),
+                param_view.GetConstColumnView(param_idx));
+          },
+          forcing,
+          state_variables,
+          state_parameters)(forcing, state_variables, state_parameters);
+    }
+  }
+
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  void SubtractJacobianTerms(
+      const DenseMatrixPolicy& state_parameters,
+      const DenseMatrixPolicy& /*state_variables*/,
+      SparseMatrixPolicy& jacobian) const
+  {
+    for (const auto& info : forcing_info_)
+    {
+      const micm::Index param_idx = info.rate_param_index_;
+      const micm::Index reactant_flat = info.reactant_reactant_flat_;
+      const micm::Index product_flat = info.product_reactant_flat_;
+      SparseMatrixPolicy::Function(
+          MICM_LAMBDA(
+              const typename SparseMatrixPolicy::ViewType& jacobian_view,
+              const typename DenseMatrixPolicy::ConstViewType& param_view) {
+            jacobian_view.ForEachBlock(
+                [](micm::Real& j_reactant, micm::Real& j_product, const micm::Real& rate_constant)
+                {
+                  j_reactant -= -rate_constant;
+                  j_product -= rate_constant;
+                },
+                jacobian_view.GetBlockView(reactant_flat),
+                jacobian_view.GetBlockView(product_flat),
+                param_view.GetConstColumnView(param_idx));
+          },
+          jacobian,
+          state_parameters)(jacobian, state_parameters);
+    }
   }
 
  private:
+  struct ForcingInfo
+  {
+    micm::Index reactant_index_;
+    micm::Index product_index_;
+    micm::Index rate_param_index_;
+    micm::Index reactant_reactant_flat_;
+    micm::Index product_reactant_flat_;
+  };
+
   std::string name_;
   std::vector<micm::Phase> phases_;
+  std::vector<ForcingInfo> forcing_info_;
+  int baz_to_qux_param_index_ = -1;
 };

--- a/test/integration/stub_aerosol_with_constraints.hpp
+++ b/test/integration/stub_aerosol_with_constraints.hpp
@@ -10,7 +10,6 @@
 #include <micm/system/species.hpp>
 #include <micm/util/types.hpp>
 
-#include <functional>
 #include <optional>
 #include <set>
 #include <string>
@@ -19,13 +18,10 @@
 #include <utility>
 #include <vector>
 
-/// A stub external model that provides both processes and constraints.
+/// A stub external model providing both processes and constraints.
 ///
-/// Simulates gas-to-aerosol partitioning: A_GAS -> A_AQ with rate k,
-/// and optionally enforces mass conservation: [A_GAS] + [A_AQ] = total.
-///
-/// When `total_mass` is provided, the constraint is active (DAE mode).
-/// When `total_mass` is std::nullopt, no constraint is active (ODE mode).
+/// A_GAS → A_AQ at rate k. When `total_mass` is provided, adds the mass-conservation
+/// constraint [A_GAS] + [A_AQ] = total (DAE mode).
 class StubAerosolWithConstraints
 {
  public:
@@ -37,24 +33,22 @@ class StubAerosolWithConstraints
   {
   }
 
-  // ──── State definition methods ────
+  // State definition
 
   std::tuple<micm::Index, micm::Index> StateSize() const
   {
-    return { 1, 0 };  // 1 state variable (A_AQ), 0 parameters
+    return { 1, 0 };
   }
-
   std::set<std::string> StateVariableNames() const
   {
     return { "AEROSOL.A_AQ" };
   }
-
   std::set<std::string> StateParameterNames() const
   {
     return {};
   }
 
-  // ──── Process definition methods ────
+  // Process definition
 
   std::set<std::string> SpeciesUsed() const
   {
@@ -69,59 +63,83 @@ class StubAerosolWithConstraints
     auto i_aq = state_indices.find("AEROSOL.A_AQ");
     if (i_gas != state_indices.end() && i_aq != state_indices.end())
     {
-      // d(A_GAS)/d(A_GAS) and d(A_AQ)/d(A_GAS)
       elements.insert({ i_gas->second, i_gas->second });
       elements.insert({ i_aq->second, i_gas->second });
     }
     return elements;
   }
 
-  template<typename DenseMatrixPolicy>
-  std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>
-  UpdateStateParametersFunction(const std::unordered_map<std::string, micm::Index>& state_parameter_indices) const
-  {
-    return [](const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&) {};
-  }
-
-  template<typename DenseMatrixPolicy>
-  std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)> ForcingFunction(
-      const std::unordered_map<std::string, micm::Index>&,
-      const std::unordered_map<std::string, micm::Index>& state_variable_indices) const
-  {
-    auto i_gas = state_variable_indices.at("A_GAS");
-    auto i_aq = state_variable_indices.at("AEROSOL.A_AQ");
-    micm::Real k = rate_constant_;
-    return [=](const DenseMatrixPolicy&, const DenseMatrixPolicy& state, DenseMatrixPolicy& forcing)
-    {
-      for (micm::Index i = 0; i < state.NumRows(); ++i)
-      {
-        micm::Real rate = k * state[i][i_gas];
-        forcing[i][i_gas] -= rate;
-        forcing[i][i_aq] += rate;
-      }
-    };
-  }
-
-  template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
-  std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)> JacobianFunction(
-      const std::unordered_map<std::string, micm::Index>&,
+  template<class SparseMatrixPolicy>
+  void FinalizeProcessSetup(
+      const std::unordered_map<std::string, micm::Index>& /*state_parameter_indices*/,
       const std::unordered_map<std::string, micm::Index>& state_variable_indices,
-      const SparseMatrixPolicy& jacobian) const
+      const SparseMatrixPolicy& jacobian)
   {
-    auto i_gas = state_variable_indices.at("A_GAS");
-    auto i_aq = state_variable_indices.at("AEROSOL.A_AQ");
-    micm::Real k = rate_constant_;
-    return [=](const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy& jac)
-    {
-      for (micm::Index i_block = 0; i_block < jac.NumberOfBlocks(); ++i_block)
-      {
-        jac[i_block][i_gas][i_gas] -= (-k);
-        jac[i_block][i_aq][i_gas] -= k;
-      }
-    };
+    i_gas_ = state_variable_indices.at("A_GAS");
+    i_aq_ = state_variable_indices.at("AEROSOL.A_AQ");
+    gas_gas_flat_ = jacobian.VectorIndex(0, i_gas_, i_gas_);
+    aq_gas_flat_ = jacobian.VectorIndex(0, i_aq_, i_gas_);
   }
 
-  // ──── Constraint definition methods (optional — satisfies HasConstraints concept) ────
+  template<class DenseMatrixPolicy>
+  void UpdateStateParameters(
+      const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&,
+      DenseMatrixPolicy&) const
+  {
+  }
+
+  template<class DenseMatrixPolicy>
+  void AddForcingTerms(
+      const DenseMatrixPolicy& /*state_parameters*/,
+      const DenseMatrixPolicy& state_variables,
+      DenseMatrixPolicy& forcing) const
+  {
+    const micm::Index gas = i_gas_;
+    const micm::Index aq = i_aq_;
+    const micm::Real k = rate_constant_;
+    DenseMatrixPolicy::Function(
+        MICM_LAMBDA(
+            const typename DenseMatrixPolicy::ViewType& forcing_view,
+            const typename DenseMatrixPolicy::ConstViewType& state_view) {
+          forcing_view.ForEachRow(
+              [k](micm::Real& f_gas, micm::Real& f_aq, const micm::Real& gas_val)
+              {
+                micm::Real rate = k * gas_val;
+                f_gas -= rate;
+                f_aq += rate;
+              },
+              forcing_view.GetColumnView(gas),
+              forcing_view.GetColumnView(aq),
+              state_view.GetConstColumnView(gas));
+        },
+        forcing,
+        state_variables)(forcing, state_variables);
+  }
+
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  void SubtractJacobianTerms(
+      const DenseMatrixPolicy& /*state_parameters*/,
+      const DenseMatrixPolicy& /*state_variables*/,
+      SparseMatrixPolicy& jacobian) const
+  {
+    const micm::Real k = rate_constant_;
+    const micm::Index gg = gas_gas_flat_;
+    const micm::Index ag = aq_gas_flat_;
+    SparseMatrixPolicy::Function(
+        MICM_LAMBDA(const typename SparseMatrixPolicy::ViewType& jacobian_view) {
+          jacobian_view.ForEachBlock(
+              [k](micm::Real& j_gg, micm::Real& j_ag)
+              {
+                j_gg -= -k;
+                j_ag -= k;
+              },
+              jacobian_view.GetBlockView(gg),
+              jacobian_view.GetBlockView(ag));
+        },
+        jacobian)(jacobian);
+  }
+
+  // Constraint definition
 
   std::set<std::string> ConstraintAlgebraicVariableNames() const
   {
@@ -150,7 +168,6 @@ class StubAerosolWithConstraints
     }
     auto i_gas = state_indices.at("A_GAS");
     auto i_aq = state_indices.at("AEROSOL.A_AQ");
-    // Constraint row is i_aq, depends on both A_GAS and A_AQ
     return { { i_aq, i_gas }, { i_aq, i_aq } };
   }
 
@@ -159,64 +176,93 @@ class StubAerosolWithConstraints
     return {};
   }
 
-  template<typename DenseMatrixPolicy>
-  std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>
-  ConstraintUpdateStateParametersFunction(const std::unordered_map<std::string, micm::Index>&) const
-  {
-    return [](const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&) {};
-  }
-
-  /// Constraint residual: G(y) = [A_GAS] + [A_AQ] - total = 0
-  template<typename DenseMatrixPolicy>
-  std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)> ConstraintResidualFunction(
-      const std::unordered_map<std::string, micm::Index>&,
-      const std::unordered_map<std::string, micm::Index>& state_variable_indices) const
-  {
-    auto i_gas = state_variable_indices.at("A_GAS");
-    auto i_aq = state_variable_indices.at("AEROSOL.A_AQ");
-    micm::Real total = total_mass_.value();
-    return [=](const DenseMatrixPolicy& state, const DenseMatrixPolicy&, DenseMatrixPolicy& forcing)
-    {
-      for (micm::Index i = 0; i < state.NumRows(); ++i)
-      {
-        forcing[i][i_aq] = state[i][i_gas] + state[i][i_aq] - total;
-      }
-    };
-  }
-
-  /// Constraint Jacobian: dG/d[A_GAS] = 1, dG/d[A_AQ] = 1
-  /// Subtracted per solver convention: jacobian -= dG/dy
-  template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
-  std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)> ConstraintJacobianFunction(
-      const std::unordered_map<std::string, micm::Index>&,
+  template<class SparseMatrixPolicy>
+  void FinalizeConstraintSetup(
+      const std::unordered_map<std::string, micm::Index>& /*state_parameter_indices*/,
       const std::unordered_map<std::string, micm::Index>& state_variable_indices,
-      const SparseMatrixPolicy& jacobian) const
+      const SparseMatrixPolicy& jacobian)
   {
-    auto i_gas = state_variable_indices.at("A_GAS");
-    auto i_aq = state_variable_indices.at("AEROSOL.A_AQ");
-    return [=](const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy& jac)
+    if (!total_mass_.has_value())
     {
-      for (micm::Index i_block = 0; i_block < jac.NumberOfBlocks(); ++i_block)
-      {
-        jac[i_block][i_aq][i_gas] -= 1.0;
-        jac[i_block][i_aq][i_aq] -= 1.0;
-      }
-    };
+      return;
+    }
+    i_gas_ = state_variable_indices.at("A_GAS");
+    i_aq_ = state_variable_indices.at("AEROSOL.A_AQ");
+    aq_gas_flat_ = jacobian.VectorIndex(0, i_aq_, i_gas_);
+    aq_aq_flat_ = jacobian.VectorIndex(0, i_aq_, i_aq_);
+  }
+
+  template<class DenseMatrixPolicy>
+  void UpdateConstraintStateParameters(
+      const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&,
+      DenseMatrixPolicy&) const
+  {
+  }
+
+  /// G(y) = [A_GAS] + [A_AQ] - total = 0
+  template<class DenseMatrixPolicy>
+  void AddConstraintResidual(
+      const DenseMatrixPolicy& /*state_parameters*/,
+      const DenseMatrixPolicy& state_variables,
+      DenseMatrixPolicy& forcing) const
+  {
+    const micm::Index gas = i_gas_;
+    const micm::Index aq = i_aq_;
+    const micm::Real total = total_mass_.value();
+    DenseMatrixPolicy::Function(
+        MICM_LAMBDA(
+            const typename DenseMatrixPolicy::ViewType& forcing_view,
+            const typename DenseMatrixPolicy::ConstViewType& state_view) {
+          forcing_view.ForEachRow(
+              [total](micm::Real& f_aq, const micm::Real& gas_val, const micm::Real& aq_val)
+              { f_aq = gas_val + aq_val - total; },
+              forcing_view.GetColumnView(aq),
+              state_view.GetConstColumnView(gas),
+              state_view.GetConstColumnView(aq));
+        },
+        forcing,
+        state_variables)(forcing, state_variables);
+  }
+
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  void SubtractConstraintJacobian(
+      const DenseMatrixPolicy& /*state_parameters*/,
+      const DenseMatrixPolicy& /*state_variables*/,
+      SparseMatrixPolicy& jacobian) const
+  {
+    const micm::Index ag = aq_gas_flat_;
+    const micm::Index aa = aq_aq_flat_;
+    SparseMatrixPolicy::Function(
+        MICM_LAMBDA(const typename SparseMatrixPolicy::ViewType& jacobian_view) {
+          jacobian_view.ForEachBlock(
+              [](micm::Real& j_ag, micm::Real& j_aa)
+              {
+                j_ag -= 1.0;
+                j_aa -= 1.0;
+              },
+              jacobian_view.GetBlockView(ag),
+              jacobian_view.GetBlockView(aa));
+        },
+        jacobian)(jacobian);
   }
 
  private:
   micm::Real rate_constant_;
   std::optional<micm::Real> total_mass_;
+  int i_gas_ = -1;
+  int i_aq_ = -1;
+  int gas_gas_flat_ = -1;
+  int aq_gas_flat_ = -1;
+  int aq_aq_flat_ = -1;
 };
 
-/// A variant of StubAerosolWithConstraints that adds a solvent species `S` dependency.
+/// A variant of `StubAerosolWithConstraints` that adds solvent species `S`.
 ///
 /// Process: A_GAS → A_AQ, rate = k * [A_GAS] * [S]
 /// Process Jacobian row for A_AQ includes (A_AQ, S), but the constraint only
-/// declares (A_AQ, A_GAS) and (A_AQ, A_AQ).
-///
-/// This exercises the case where an external model process has a Jacobian element
-/// in an algebraic row that is NOT also declared by a constraint element.
+/// declares (A_AQ, A_GAS) and (A_AQ, A_AQ). Exercises the case where an external
+/// model process has a Jacobian element in an algebraic row not declared by any
+/// constraint element.
 class StubAerosolWithSolvent
 {
  public:
@@ -228,24 +274,22 @@ class StubAerosolWithSolvent
   {
   }
 
-  // ──── State definition methods ────
+  // State definition
 
   std::tuple<micm::Index, micm::Index> StateSize() const
   {
-    return { 1, 0 };  // 1 state variable (A_AQ), 0 parameters
+    return { 1, 0 };
   }
-
   std::set<std::string> StateVariableNames() const
   {
     return { "AEROSOL.A_AQ" };
   }
-
   std::set<std::string> StateParameterNames() const
   {
     return {};
   }
 
-  // ──── Process definition methods ────
+  // Process definition
 
   std::set<std::string> SpeciesUsed() const
   {
@@ -259,75 +303,117 @@ class StubAerosolWithSolvent
     auto i_gas = state_indices.at("A_GAS");
     auto i_aq = state_indices.at("AEROSOL.A_AQ");
     auto i_s = state_indices.at("S");
-    // d(A_GAS)/d(A_GAS), d(A_GAS)/d(S)
     elements.insert({ i_gas, i_gas });
     elements.insert({ i_gas, i_s });
-    // d(A_AQ)/d(A_GAS), d(A_AQ)/d(S)  <-- (A_AQ, S) is NOT in constraint elements
     elements.insert({ i_aq, i_gas });
     elements.insert({ i_aq, i_s });
     return elements;
   }
 
-  template<typename DenseMatrixPolicy>
-  std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>
-  UpdateStateParametersFunction(const std::unordered_map<std::string, micm::Index>& state_parameter_indices) const
-  {
-    return [](const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&) {};
-  }
-
-  template<typename DenseMatrixPolicy>
-  std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)> ForcingFunction(
-      const std::unordered_map<std::string, micm::Index>&,
-      const std::unordered_map<std::string, micm::Index>& state_variable_indices) const
-  {
-    auto i_gas = state_variable_indices.at("A_GAS");
-    auto i_aq = state_variable_indices.at("AEROSOL.A_AQ");
-    auto i_s = state_variable_indices.at("S");
-    micm::Real k = rate_constant_;
-    return [=](const DenseMatrixPolicy&, const DenseMatrixPolicy& state, DenseMatrixPolicy& forcing)
-    {
-      for (micm::Index i = 0; i < state.NumRows(); ++i)
-      {
-        micm::Real rate = k * state[i][i_gas] * state[i][i_s];
-        forcing[i][i_gas] -= rate;
-        forcing[i][i_aq] += rate;
-      }
-    };
-  }
-
-  template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
-  std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)> JacobianFunction(
-      const std::unordered_map<std::string, micm::Index>&,
+  template<class SparseMatrixPolicy>
+  void FinalizeProcessSetup(
+      const std::unordered_map<std::string, micm::Index>& /*state_parameter_indices*/,
       const std::unordered_map<std::string, micm::Index>& state_variable_indices,
-      const SparseMatrixPolicy& jacobian) const
+      const SparseMatrixPolicy& jacobian)
   {
-    auto i_gas = state_variable_indices.at("A_GAS");
-    auto i_aq = state_variable_indices.at("AEROSOL.A_AQ");
-    auto i_s = state_variable_indices.at("S");
-    micm::Real k = rate_constant_;
-    return [=](const DenseMatrixPolicy&, const DenseMatrixPolicy& state, SparseMatrixPolicy& jac)
-    {
-      for (micm::Index i_block = 0; i_block < jac.NumberOfBlocks(); ++i_block)
-      {
-        micm::Real s_val = state[i_block][i_s];
-        micm::Real gas_val = state[i_block][i_gas];
-        // d(rate)/d(A_GAS) = k * [S]
-        jac[i_block][i_gas][i_gas] -= (-k * s_val);
-        jac[i_block][i_aq][i_gas] -= k * s_val;
-        // d(rate)/d(S) = k * [A_GAS]
-        jac[i_block][i_gas][i_s] -= (-k * gas_val);
-        jac[i_block][i_aq][i_s] -= k * gas_val;  // accesses (A_AQ, S) — triggers bug without fix
-      }
-    };
+    i_gas_ = state_variable_indices.at("A_GAS");
+    i_aq_ = state_variable_indices.at("AEROSOL.A_AQ");
+    i_s_ = state_variable_indices.at("S");
+    gas_gas_flat_ = jacobian.VectorIndex(0, i_gas_, i_gas_);
+    gas_s_flat_ = jacobian.VectorIndex(0, i_gas_, i_s_);
+    aq_gas_flat_ = jacobian.VectorIndex(0, i_aq_, i_gas_);
+    aq_s_flat_ = jacobian.VectorIndex(0, i_aq_, i_s_);
   }
 
-  // ──── Constraint definition methods ────
+  template<class DenseMatrixPolicy>
+  void UpdateStateParameters(
+      const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&,
+      DenseMatrixPolicy&) const
+  {
+  }
+
+  template<class DenseMatrixPolicy>
+  void AddForcingTerms(
+      const DenseMatrixPolicy& /*state_parameters*/,
+      const DenseMatrixPolicy& state_variables,
+      DenseMatrixPolicy& forcing) const
+  {
+    const micm::Index gas = i_gas_;
+    const micm::Index aq = i_aq_;
+    const micm::Index s = i_s_;
+    const micm::Real k = rate_constant_;
+    DenseMatrixPolicy::Function(
+        MICM_LAMBDA(
+            const typename DenseMatrixPolicy::ViewType& forcing_view,
+            const typename DenseMatrixPolicy::ConstViewType& state_view) {
+          forcing_view.ForEachRow(
+              [k](
+                  micm::Real& f_gas,
+                  micm::Real& f_aq,
+                  const micm::Real& gas_val,
+                  const micm::Real& s_val)
+              {
+                micm::Real rate = k * gas_val * s_val;
+                f_gas -= rate;
+                f_aq += rate;
+              },
+              forcing_view.GetColumnView(gas),
+              forcing_view.GetColumnView(aq),
+              state_view.GetConstColumnView(gas),
+              state_view.GetConstColumnView(s));
+        },
+        forcing,
+        state_variables)(forcing, state_variables);
+  }
+
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  void SubtractJacobianTerms(
+      const DenseMatrixPolicy& /*state_parameters*/,
+      const DenseMatrixPolicy& state_variables,
+      SparseMatrixPolicy& jacobian) const
+  {
+    const micm::Index gas = i_gas_;
+    const micm::Index s = i_s_;
+    const micm::Real k = rate_constant_;
+    const micm::Index gg = gas_gas_flat_;
+    const micm::Index gs = gas_s_flat_;
+    const micm::Index ag = aq_gas_flat_;
+    const micm::Index as = aq_s_flat_;
+    SparseMatrixPolicy::Function(
+        MICM_LAMBDA(
+            const typename SparseMatrixPolicy::ViewType& jacobian_view,
+            const typename DenseMatrixPolicy::ConstViewType& state_view) {
+          jacobian_view.ForEachBlock(
+              [k](
+                  micm::Real& j_gg,
+                  micm::Real& j_gs,
+                  micm::Real& j_ag,
+                  micm::Real& j_as,
+                  const micm::Real& gas_val,
+                  const micm::Real& s_val)
+              {
+                j_gg -= -k * s_val;
+                j_ag -= k * s_val;
+                j_gs -= -k * gas_val;
+                j_as -= k * gas_val;
+              },
+              jacobian_view.GetBlockView(gg),
+              jacobian_view.GetBlockView(gs),
+              jacobian_view.GetBlockView(ag),
+              jacobian_view.GetBlockView(as),
+              state_view.GetConstColumnView(gas),
+              state_view.GetConstColumnView(s));
+        },
+        jacobian,
+        state_variables)(jacobian, state_variables);
+  }
+
+  // Constraint definition
 
   std::set<std::string> ConstraintAlgebraicVariableNames() const
   {
     return { "AEROSOL.A_AQ" };
   }
-
   std::set<std::string> ConstraintSpeciesDependencies() const
   {
     return { "A_GAS", "AEROSOL.A_AQ" };
@@ -338,7 +424,6 @@ class StubAerosolWithSolvent
   {
     auto i_gas = state_indices.at("A_GAS");
     auto i_aq = state_indices.at("AEROSOL.A_AQ");
-    // Constraint row is i_aq, depends on A_GAS and A_AQ only — NOT S
     return { { i_aq, i_gas }, { i_aq, i_aq } };
   }
 
@@ -347,49 +432,80 @@ class StubAerosolWithSolvent
     return {};
   }
 
-  template<typename DenseMatrixPolicy>
-  std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>
-  ConstraintUpdateStateParametersFunction(const std::unordered_map<std::string, micm::Index>&) const
-  {
-    return [](const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&) {};
-  }
-
-  template<typename DenseMatrixPolicy>
-  std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)> ConstraintResidualFunction(
-      const std::unordered_map<std::string, micm::Index>&,
-      const std::unordered_map<std::string, micm::Index>& state_variable_indices) const
-  {
-    auto i_gas = state_variable_indices.at("A_GAS");
-    auto i_aq = state_variable_indices.at("AEROSOL.A_AQ");
-    micm::Real total = total_mass_;
-    return [=](const DenseMatrixPolicy& state, const DenseMatrixPolicy&, DenseMatrixPolicy& forcing)
-    {
-      for (micm::Index i = 0; i < state.NumRows(); ++i)
-      {
-        forcing[i][i_aq] = state[i][i_gas] + state[i][i_aq] - total;
-      }
-    };
-  }
-
-  template<typename DenseMatrixPolicy, typename SparseMatrixPolicy>
-  std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy&)> ConstraintJacobianFunction(
-      const std::unordered_map<std::string, micm::Index>&,
+  template<class SparseMatrixPolicy>
+  void FinalizeConstraintSetup(
+      const std::unordered_map<std::string, micm::Index>& /*state_parameter_indices*/,
       const std::unordered_map<std::string, micm::Index>& state_variable_indices,
-      const SparseMatrixPolicy& jacobian) const
+      const SparseMatrixPolicy& jacobian)
   {
-    auto i_gas = state_variable_indices.at("A_GAS");
-    auto i_aq = state_variable_indices.at("AEROSOL.A_AQ");
-    return [=](const DenseMatrixPolicy&, const DenseMatrixPolicy&, SparseMatrixPolicy& jac)
-    {
-      for (micm::Index i_block = 0; i_block < jac.NumberOfBlocks(); ++i_block)
-      {
-        jac[i_block][i_aq][i_gas] -= 1.0;
-        jac[i_block][i_aq][i_aq] -= 1.0;
-      }
-    };
+    i_gas_ = state_variable_indices.at("A_GAS");
+    i_aq_ = state_variable_indices.at("AEROSOL.A_AQ");
+    aq_gas_flat_ = jacobian.VectorIndex(0, i_aq_, i_gas_);
+    aq_aq_flat_ = jacobian.VectorIndex(0, i_aq_, i_aq_);
+  }
+
+  template<class DenseMatrixPolicy>
+  void UpdateConstraintStateParameters(
+      const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&,
+      DenseMatrixPolicy&) const
+  {
+  }
+
+  template<class DenseMatrixPolicy>
+  void AddConstraintResidual(
+      const DenseMatrixPolicy& /*state_parameters*/,
+      const DenseMatrixPolicy& state_variables,
+      DenseMatrixPolicy& forcing) const
+  {
+    const micm::Index gas = i_gas_;
+    const micm::Index aq = i_aq_;
+    const micm::Real total = total_mass_;
+    DenseMatrixPolicy::Function(
+        MICM_LAMBDA(
+            const typename DenseMatrixPolicy::ViewType& forcing_view,
+            const typename DenseMatrixPolicy::ConstViewType& state_view) {
+          forcing_view.ForEachRow(
+              [total](micm::Real& f_aq, const micm::Real& gas_val, const micm::Real& aq_val)
+              { f_aq = gas_val + aq_val - total; },
+              forcing_view.GetColumnView(aq),
+              state_view.GetConstColumnView(gas),
+              state_view.GetConstColumnView(aq));
+        },
+        forcing,
+        state_variables)(forcing, state_variables);
+  }
+
+  template<class DenseMatrixPolicy, class SparseMatrixPolicy>
+  void SubtractConstraintJacobian(
+      const DenseMatrixPolicy& /*state_parameters*/,
+      const DenseMatrixPolicy& /*state_variables*/,
+      SparseMatrixPolicy& jacobian) const
+  {
+    const micm::Index ag = aq_gas_flat_;
+    const micm::Index aa = aq_aq_flat_;
+    SparseMatrixPolicy::Function(
+        MICM_LAMBDA(const typename SparseMatrixPolicy::ViewType& jacobian_view) {
+          jacobian_view.ForEachBlock(
+              [](micm::Real& j_ag, micm::Real& j_aa)
+              {
+                j_ag -= 1.0;
+                j_aa -= 1.0;
+              },
+              jacobian_view.GetBlockView(ag),
+              jacobian_view.GetBlockView(aa));
+        },
+        jacobian)(jacobian);
   }
 
  private:
   micm::Real rate_constant_;
   micm::Real total_mass_;
+  int i_gas_ = -1;
+  int i_aq_ = -1;
+  int i_s_ = -1;
+  int gas_gas_flat_ = -1;
+  int gas_s_flat_ = -1;
+  int aq_gas_flat_ = -1;
+  int aq_s_flat_ = -1;
+  int aq_aq_flat_ = -1;
 };

--- a/test/unit/constraint/test_constraint_set_policy.hpp
+++ b/test/unit/constraint/test_constraint_set_policy.hpp
@@ -180,7 +180,7 @@ void TestAddForcingTerms()
   set.SetJacobianFlatIds(jacobian);
 
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "A_B_eq", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // State with 2 grid cells
   DenseMatrixPolicy state(2, num_species);
@@ -246,7 +246,7 @@ void TestSubtractJacobianTerms()
   set.SetJacobianFlatIds(jacobian);
 
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "A_B_eq", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // State with 1 grid cell
   DenseMatrixPolicy state(1, num_species);
@@ -377,7 +377,7 @@ void TestThreeDStateOneConstraint()
   set.SetJacobianFlatIds(jacobian);
 
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "X_Y_eq", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // State with 2 grid cells
   DenseMatrixPolicy state(2, num_species);
@@ -502,7 +502,7 @@ void TestFourDStateTwoConstraints()
   set.SetJacobianFlatIds(jacobian);
 
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "A_B_eq", 0 }, { "CD_A_eq", 1 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // State with 3 grid cells
   DenseMatrixPolicy state(3, num_species);
@@ -655,7 +655,7 @@ void TestCoupledConstraintsSharedSpecies()
   set.SetJacobianFlatIds(jacobian);
 
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "A_B_eq", 0 }, { "A_C_eq", 1 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // State at dual equilibrium: [B]/[A] = 3.3e-2, [C]/[A] = 3.3e-2
   DenseMatrixPolicy state(1, num_species);
@@ -733,7 +733,7 @@ void TestVectorizedMatricesRespectGridCellIndexing()
   set.SetJacobianFlatIds(jacobian);
 
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "A_B_eq", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrixPolicy state(3, num_species, 0.0);
   state[0] = { 0.01, 0.02, 0.05 };

--- a/test/unit/constraint/type/test_equilibrium.cpp
+++ b/test/unit/constraint/type/test_equilibrium.cpp
@@ -256,7 +256,7 @@ TEST(EquilibriumConstraint, ResidualComputationThroughConstraintSet)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "A_B_equilibrium", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // Create state matrix with 1 grid cell and 3 species
   DenseMatrix state(1, 3);
@@ -332,7 +332,7 @@ TEST(EquilibriumConstraint, JacobianComputationThroughConstraintSet)
 
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "A_B_equilibrium", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // Create state matrix
   DenseMatrix state(1, 3);
@@ -395,7 +395,7 @@ TEST(EquilibriumConstraint, ComplexStoichiometryResidual)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "dissociation", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix state(1, 3);
   DenseMatrix forcing(1, 3);
@@ -450,7 +450,7 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianSimple)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "eq", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix variables(2, num_species, 0.0);
   variables[0][0] = 0.02;  // A
@@ -518,7 +518,7 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianComplexStoichiometry)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "dissociation", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix variables(1, num_species, 0.0);
   variables[0][0] = 0.15;  // A

--- a/test/unit/constraint/type/test_linear.cpp
+++ b/test/unit/constraint/type/test_linear.cpp
@@ -153,7 +153,7 @@ TEST(LinearConstraint, ResidualComputationThroughConstraintSet)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // Create state matrix with 1 grid cell and 2 species
   DenseMatrix state(1, 2);
@@ -220,7 +220,7 @@ TEST(LinearConstraint, JacobianComputationThroughConstraintSet)
 
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // Create state matrix
   DenseMatrix state(1, 2);
@@ -276,7 +276,7 @@ TEST(LinearConstraint, WeightedSumResidualAndJacobian)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix state(1, 3);
   DenseMatrix forcing(1, 3);
@@ -348,7 +348,7 @@ TEST(LinearConstraint, ThreeSpeciesConservationResidual)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix state(1, 3);
   DenseMatrix forcing(1, 3);
@@ -411,7 +411,7 @@ TEST(LinearConstraint, ZeroConstantResidual)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix state(1, 2);
   DenseMatrix forcing(1, 2);
@@ -472,7 +472,7 @@ TEST(LinearConstraint, FractionalCoefficientsResidualAndJacobian)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix state(1, 2);
   DenseMatrix forcing(1, 2);
@@ -530,7 +530,7 @@ TEST(LinearConstraint, JacobianIndependentOfConcentrations)
 
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // Test at two different concentration points
   DenseMatrix state1(1, 2);
@@ -595,7 +595,7 @@ TEST(LinearConstraint, FiniteDifferenceJacobianSimpleConservation)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix variables(2, num_species, 0.0);
   variables[0][0] = 0.3;
@@ -660,7 +660,7 @@ TEST(LinearConstraint, FiniteDifferenceJacobianWeightedSum)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix variables(1, num_species, 0.0);
   variables[0][0] = 1.5;

--- a/test/unit/kokkos/constraint/type/test_kokkos_equilibrium.cpp
+++ b/test/unit/kokkos/constraint/type/test_kokkos_equilibrium.cpp
@@ -256,7 +256,7 @@ TEST(EquilibriumConstraint, ResidualComputationThroughConstraintSet)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "A_B_equilibrium", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // Create state matrix with 1 grid cell and 3 species
   DenseMatrix state(1, 3);
@@ -340,7 +340,7 @@ TEST(EquilibriumConstraint, JacobianComputationThroughConstraintSet)
 
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "A_B_equilibrium", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // Create state matrix
   DenseMatrix state(1, 3);
@@ -407,7 +407,7 @@ TEST(EquilibriumConstraint, ComplexStoichiometryResidual)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "dissociation", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix state(1, 3);
   DenseMatrix forcing(1, 3);
@@ -466,7 +466,7 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianSimple)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "eq", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix variables(2, num_species, 0.0);
   variables[0][0] = 0.02;  // A
@@ -541,7 +541,7 @@ TEST(EquilibriumConstraint, FiniteDifferenceJacobianComplexStoichiometry)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices = { { "dissociation", 0 } };
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix variables(1, num_species, 0.0);
   variables[0][0] = 0.15;  // A

--- a/test/unit/kokkos/constraint/type/test_kokkos_linear.cpp
+++ b/test/unit/kokkos/constraint/type/test_kokkos_linear.cpp
@@ -153,7 +153,7 @@ TEST(LinearConstraint, ResidualComputationThroughConstraintSet)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // Create state matrix with 1 grid cell and 2 species
   DenseMatrix state(1, 2);
@@ -228,7 +228,7 @@ TEST(LinearConstraint, JacobianComputationThroughConstraintSet)
 
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // Create state matrix
   DenseMatrix state(1, 2);
@@ -288,7 +288,7 @@ TEST(LinearConstraint, WeightedSumResidualAndJacobian)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix state(1, 3);
   DenseMatrix forcing(1, 3);
@@ -368,7 +368,7 @@ TEST(LinearConstraint, ThreeSpeciesConservationResidual)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix state(1, 3);
   DenseMatrix forcing(1, 3);
@@ -439,7 +439,7 @@ TEST(LinearConstraint, ZeroConstantResidual)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix state(1, 2);
   DenseMatrix forcing(1, 2);
@@ -508,7 +508,7 @@ TEST(LinearConstraint, FractionalCoefficientsResidualAndJacobian)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix state(1, 2);
   DenseMatrix forcing(1, 2);
@@ -574,7 +574,7 @@ TEST(LinearConstraint, JacobianIndependentOfConcentrations)
 
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;  // Empty for linear constraints
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   // Test at two different concentration points
   DenseMatrix state1(1, 2);
@@ -647,7 +647,7 @@ TEST(LinearConstraint, FiniteDifferenceJacobianSimpleConservation)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix variables(2, num_species, 0.0);
   variables[0][0] = 0.3;
@@ -719,7 +719,7 @@ TEST(LinearConstraint, FiniteDifferenceJacobianWeightedSum)
   StdSparseMatrix jacobian{ builder };
   set.SetJacobianFlatIds(jacobian);
   std::unordered_map<std::string, micm::Index> state_parameter_indices;
-  set.SetConstraintFunctions(variable_map, state_parameter_indices, jacobian);
+  set.SetConstraintFunctions(state_parameter_indices);
 
   DenseMatrix variables(1, num_species, 0.0);
   variables[0][0] = 1.5;


### PR DESCRIPTION
This PR updates the external model API to allow use of Kokkos-backed matrices with external models.

In draft as a relate MIAM PR is prepared.