### PR TITLE
Fix the occasionally broken single-precision CI test

### DIFF
--- a/.github/workflows/runner.kokkos.yml
+++ b/.github/workflows/runner.kokkos.yml
@@ -43,7 +43,14 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          ctest --output-on-failure . --verbose -j 10
+          ctest --output-on-failure --verbose --no-tests=error --output-junit ctest-results.xml -j 10
+
+      - name: Upload ctest results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-results-kokkos
+          path: build/ctest-results.xml
 
       # The Kokkos backend registers no standard ordering, so name the vector ones.
       #

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -47,7 +47,14 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          ctest --output-on-failure . --verbose -j 10
+          ctest --output-on-failure --verbose --no-tests=error --output-junit ctest-results.xml -j 10
+
+      - name: Upload ctest results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-results-cuda-double
+          path: build/ctest-results.xml
 
       # The GPU backend registers no standard ordering, so name the vector ones.
       #
@@ -144,4 +151,11 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          ctest --output-on-failure . --verbose -j 10
+          ctest --output-on-failure --verbose --no-tests=error --output-junit ctest-results.xml -j 10
+
+      - name: Upload ctest results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-results-cuda-single
+          path: build/ctest-results.xml

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -35,6 +35,36 @@ jobs:
           cd build
           ctest -C ${{ matrix.build_type }} --rerun-failed --output-on-failure . --verbose -j 10
 
+  gcc_single_precision:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build_type: [Release]
+    env:
+      CC: gcc
+      CXX: g++
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Cmake
+        run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -D MICM_USE_DOUBLE=OFF
+
+      - name: Build
+        run: cmake --build build --parallel 10
+
+      - name: Run tests
+        run: |
+          cd build
+          ctest -C ${{ matrix.build_type }} --output-on-failure --verbose --no-tests=error --output-junit ctest-results.xml -j 10
+
+      - name: Upload ctest results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-results-cpu-single
+          path: build/ctest-results.xml
+
   clang:
     runs-on: ubuntu-latest
     strategy:

--- a/test/regression/RosenbrockChapman/regression_test_dforce_dy_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_dforce_dy_policy.hpp
@@ -5,14 +5,30 @@
 
 #include <micm/util/types.hpp>
 
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
 #include <random>
+#include <string>
 #include <type_traits>
 
 template<class SolverPolicy>
 void TestJacobian(SolverPolicy& solver)
 {
-  std::random_device rnd_device;
-  std::mt19937 engine{ rnd_device() };
+  unsigned int seed = 739;
+  if (const char* seed_env = std::getenv("MICM_TEST_SEED"))
+  {
+    char* end = nullptr;
+    errno = 0;
+    const unsigned long parsed = std::strtoul(seed_env, &end, 10);
+    ASSERT_TRUE(
+        end != seed_env && *end == '\0' && *seed_env != '-' && errno != ERANGE &&
+        parsed <= std::numeric_limits<unsigned int>::max())
+        << "MICM_TEST_SEED must be an unsigned 32-bit integer, got '" << seed_env << "'";
+    seed = static_cast<unsigned int>(parsed);
+  }
+  SCOPED_TRACE("MICM_TEST_SEED=" + std::to_string(seed));
+  std::mt19937 engine{ seed };
   std::lognormal_distribution dist{ -2.0, 4.0 };
 
   micm::ChapmanODESolver fixed_solver{};

--- a/test/regression/RosenbrockChapman/regression_test_p_force_policy.hpp
+++ b/test/regression/RosenbrockChapman/regression_test_p_force_policy.hpp
@@ -5,7 +5,11 @@
 
 #include <micm/util/types.hpp>
 
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
 #include <random>
+#include <string>
 #include <type_traits>
 
 template<class SolverPolicy>
@@ -46,8 +50,20 @@ void TestRateConstants(SolverPolicy& solver)
 template<class MatrixPolicy, class SolverPolicy>
 void TestForcing(SolverPolicy& solver)
 {
-  std::random_device rnd_device;
-  std::mt19937 engine{ rnd_device() };
+  unsigned int seed = 739;
+  if (const char* seed_env = std::getenv("MICM_TEST_SEED"))
+  {
+    char* end = nullptr;
+    errno = 0;
+    const unsigned long parsed = std::strtoul(seed_env, &end, 10);
+    ASSERT_TRUE(
+        end != seed_env && *end == '\0' && *seed_env != '-' && errno != ERANGE &&
+        parsed <= std::numeric_limits<unsigned int>::max())
+        << "MICM_TEST_SEED must be an unsigned 32-bit integer, got '" << seed_env << "'";
+    seed = static_cast<unsigned int>(parsed);
+  }
+  SCOPED_TRACE("MICM_TEST_SEED=" + std::to_string(seed));
+  std::mt19937 engine{ seed };
   std::lognormal_distribution dist(-2.0, 2.0);
 
   micm::ChapmanODESolver fixed_solver{};


### PR DESCRIPTION
The single-precision test can be occasionally broken, depending on the randomly selected seed.

This PR uses a reproducible seed instead and ensures all the tests passed as expected.

Also:
- adds a CI test on the CPU for single precision.
- uploads some test logs for easier diagnostics in the future. 